### PR TITLE
Temporal tests for "stop coercing non-string primitives to strings" (tc39/proposal-temporal#2574)

### DIFF
--- a/test/built-ins/Temporal/Calendar/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/argument-wrong-type.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar
+description: RangeError thrown when constructor invoked with the wrong type
+features: [Temporal]
+---*/
+
+const tests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+  [Symbol(), "symbol"],
+  [{}, "object not implementing any protocol"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
+  [Temporal.ZonedDateTime.from("2020-01-01T00:00Z[UTC]"), "ZonedDateTime instance"],
+];
+
+for (const [arg, description] of tests) {
+  assert.throws(
+    typeof (arg) === "string" ? RangeError : TypeError,
+    () => new Temporal.Calendar(arg),
+    `${description} is not accepted by this constructor`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/from/calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/from/calendar-number.js
@@ -3,25 +3,21 @@
 
 /*---
 esid: sec-temporal.calendar.from
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
-
-const arg = 19761118;
-
-const result = Temporal.Calendar.from(arg);
-assert.sameValue(result.id, "iso8601", "19761118 is a valid ISO string for Calendar");
 
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.Calendar.from(arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/from/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/from/calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,8 +17,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Calendar.from(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.Calendar.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/missing-arguments.js
+++ b/test/built-ins/Temporal/Calendar/missing-arguments.js
@@ -7,5 +7,5 @@ description: RangeError thrown when constructor invoked with no argument
 features: [Temporal]
 ---*/
 
-assert.throws(RangeError, () => new Temporal.Calendar());
-assert.throws(RangeError, () => new Temporal.Calendar(undefined));
+assert.throws(TypeError, () => new Temporal.Calendar());
+assert.throws(TypeError, () => new Temporal.Calendar(undefined));

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-number.js
@@ -3,28 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.dateadd
-description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.dateAdd(arg, new Temporal.Duration());
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.dateAdd(arg, new Temporal.Duration()),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-propertybag-calendar-number.js
@@ -3,30 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.dateadd
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.Calendar("iso8601");
-
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.dateAdd(arg, new Temporal.Duration());
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19970327 is a valid ISO string for calendar");
+const instance = new Temporal.PlainDate(1976, 11, 18);
 
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
-
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.dateAdd(arg, new Temporal.Duration()),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.dateAdd(arg, new Temporal.Duration()), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.dateAdd(arg, new Temporal.Duration()),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.dateAdd(arg, new Temporal.Duration()), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.dateAdd(arg, new Temporal.Duration()),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-number.js
@@ -3,35 +3,28 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.dateuntil
-description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result1 = instance.dateUntil(arg, new Temporal.PlainDate(1976, 11, 19));
-TemporalHelpers.assertDuration(result1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDate (first argument)");
-const result2 = instance.dateUntil(new Temporal.PlainDate(1976, 11, 19), arg);
-TemporalHelpers.assertDuration(result2, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDate (second argument)");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 18)),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate (first argument)`
+    "A number is not a valid ISO string for PlainDate (first argument)"
   );
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 18), arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate (second argument)`
+    "A number is not a valid ISO string for PlainDate (second argument)"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-number.js
@@ -3,23 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.dateuntil
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result1 = instance.dateUntil(arg, new Temporal.PlainDate(1976, 11, 19));
-TemporalHelpers.assertDuration(result1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (first argument)");
-const result2 = instance.dateUntil(new Temporal.PlainDate(1976, 11, 19), arg);
-TemporalHelpers.assertDuration(result2, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (second argument)");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -27,13 +19,13 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)),
-    `Number ${calendar} does not convert to a valid ISO string for calendar (first argument)`
+    "A number is not a valid ISO string for calendar (first argument)"
   );
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar (second argument)`
+    "A number is not a valid ISO string for calendar (second argument)"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,10 +20,18 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg), `${description} does not convert to a valid ISO string (second argument)`);
+  assert.throws(
+    typeof calendar === "string" ? RangeError : TypeError,
+    () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof calendar === "string" ? RangeError : TypeError,
+    () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -21,9 +21,17 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg), `${description} does not convert to a valid ISO string (first argument)`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [
@@ -34,6 +42,6 @@ const typeErrorTests = [
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+  assert.throws(TypeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `${description} is not a valid property bag and does not convert to a string (first argument)`);
   assert.throws(TypeError, () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.day
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.day(arg);
-assert.sameValue(result, 18, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.day(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.day
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.day(arg);
-assert.sameValue(result, 18, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.day(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.day(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.day(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.day(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.day(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.dayofweek
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.dayOfWeek(arg);
-assert.sameValue(result, 4, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.dayOfWeek(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.dayofweek
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.dayOfWeek(arg);
-assert.sameValue(result, 4, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.dayOfWeek(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.dayOfWeek(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.dayOfWeek(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.dayOfWeek(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.dayOfWeek(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.dayofyear
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.dayOfYear(arg);
-assert.sameValue(result, 323, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.dayOfYear(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.dayofyear
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.dayOfYear(arg);
-assert.sameValue(result, 323, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.dayOfYear(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.dayOfYear(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.dayOfYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.dayOfYear(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.dayOfYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.daysinmonth
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.daysInMonth(arg);
-assert.sameValue(result, 30, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.daysInMonth(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.daysinmonth
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.daysInMonth(arg);
-assert.sameValue(result, 30, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.daysInMonth(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.daysInMonth(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.daysInMonth(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.daysInMonth(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.daysInMonth(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.daysinweek
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.daysInWeek(arg);
-assert.sameValue(result, 7, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.daysInWeek(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.daysinweek
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.daysInWeek(arg);
-assert.sameValue(result, 7, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.daysInWeek(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.daysInWeek(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.daysInWeek(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.daysInWeek(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.daysInWeek(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.daysinyear
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.daysInYear(arg);
-assert.sameValue(result, 366, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.daysInYear(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.daysinyear
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.daysInYear(arg);
-assert.sameValue(result, 366, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.daysInYear(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.daysInYear(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.daysInYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.daysInYear(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.daysInYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.inleapyear
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.inLeapYear(arg);
-assert.sameValue(result, true, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.inLeapYear(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.inleapyear
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.inLeapYear(arg);
-assert.sameValue(result, true, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.inLeapYear(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.inLeapYear(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.inLeapYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.inLeapYear(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.inLeapYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.month
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.month(arg);
-assert.sameValue(result, 11, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.month(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.month
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.month(arg);
-assert.sameValue(result, 11, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.month(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.month(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.month(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.month(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.month(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.monthcode
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.monthCode(arg);
-assert.sameValue(result, "M11", "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.monthCode(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.monthcode
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.monthCode(arg);
-assert.sameValue(result, "M11", "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.monthCode(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.monthCode(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.monthCode(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.monthCode(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.monthCode(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.monthsinyear
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.monthsInYear(arg);
-assert.sameValue(result, 12, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.monthsInYear(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.monthsinyear
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.monthsInYear(arg);
-assert.sameValue(result, 12, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.monthsInYear(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.monthsInYear(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.monthsInYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.monthsInYear(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.monthsInYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.weekofyear
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.weekOfYear(arg);
-assert.sameValue(result, 47, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.weekOfYear(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.weekofyear
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.weekOfYear(arg);
-assert.sameValue(result, 47, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.weekOfYear(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.weekOfYear(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.weekOfYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.weekOfYear(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.weekOfYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.year
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.year(arg);
-assert.sameValue(result, 1976, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.year(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.year
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.year(arg);
-assert.sameValue(result, 1976, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.year(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.year(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.year(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.year(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.year(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.yearofweek
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.yearOfWeek(arg);
-assert.sameValue(result, 1976, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.yearOfWeek(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.yearofweek
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.yearOfWeek(arg);
-assert.sameValue(result, 1976, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.yearOfWeek(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.yearOfWeek(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.yearOfWeek(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.yearOfWeek(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.yearOfWeek(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-invalid-offset-string.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-invalid-offset-string.js
@@ -15,9 +15,16 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  1000,       // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 badOffsets.forEach((offset) => {
   const relativeTo = { year: 2021, month: 10, day: 28, offset, timeZone };
-  assert.throws(RangeError, () => Temporal.Duration.compare(d1, d2, { relativeTo }), `"${offset} is not a valid offset string`);
+  assert.throws(
+    typeof(offset) === 'string' ? RangeError : TypeError,
+    () => Temporal.Duration.compare(d1, d2, { relativeTo }),
+    `"${offset} is not a valid offset string`
+  );
 });

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/from/argument-non-string.js
+++ b/test/built-ins/Temporal/Duration/from/argument-non-string.js
@@ -7,9 +7,9 @@ description: Appropriate error thrown if primitive input cannot convert to a val
 features: [Temporal]
 ---*/
 
-assert.throws(RangeError, () => Temporal.Duration.from(undefined), "undefined");
-assert.throws(RangeError, () => Temporal.Duration.from(null), "null");
-assert.throws(RangeError, () => Temporal.Duration.from(true), "boolean");
+assert.throws(TypeError, () => Temporal.Duration.from(undefined), "undefined");
+assert.throws(TypeError, () => Temporal.Duration.from(null), "null");
+assert.throws(TypeError, () => Temporal.Duration.from(true), "boolean");
 assert.throws(TypeError, () => Temporal.Duration.from(Symbol()), "Symbol");
-assert.throws(RangeError, () => Temporal.Duration.from(5), "number");
-assert.throws(RangeError, () => Temporal.Duration.from(5n), "bigint");
+assert.throws(TypeError, () => Temporal.Duration.from(5), "number");
+assert.throws(TypeError, () => Temporal.Duration.from(5n), "bigint");

--- a/test/built-ins/Temporal/Duration/prototype/add/argument-not-object.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.Duration(0, 0, 0, 1, 2, 3, 4, 987, 654, 321);
-assert.throws(RangeError, () => instance.add(undefined), "undefined");
-assert.throws(RangeError, () => instance.add(null), "null");
-assert.throws(RangeError, () => instance.add(true), "boolean");
+assert.throws(TypeError, () => instance.add(undefined), "undefined");
+assert.throws(TypeError, () => instance.add(null), "null");
+assert.throws(TypeError, () => instance.add(true), "boolean");
 assert.throws(RangeError, () => instance.add(""), "empty string");
 assert.throws(TypeError, () => instance.add(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.add(7), "number");
-assert.throws(RangeError, () => instance.add(7n), "bigint");
+assert.throws(TypeError, () => instance.add(7), "number");
+assert.throws(TypeError, () => instance.add(7n), "bigint");
 assert.throws(TypeError, () => instance.add([]), "array");
 assert.throws(TypeError, () => instance.add(() => {}), "function");

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-number.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-temporal.duration.prototype.add
 description: A number as relativeTo option is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
@@ -12,18 +11,16 @@ const instance = new Temporal.Duration(1, 0, 0, 1);
 
 const relativeTo = 20191101;
 
-const result = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
-TemporalHelpers.assertDuration(result, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "20191101 is a valid ISO string for relativeTo");
-
 const numbers = [
   1,
   -20191101,
+  20191101,
   1234567890,
 ];
 
 for (const relativeTo of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }),
     `Number ${relativeTo} does not convert to a valid ISO string for relativeTo`
   );

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-number.js
@@ -4,20 +4,14 @@
 /*---
 esid: sec-temporal.duration.prototype.add
 description: A number as calendar in relativeTo property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Duration(1, 0, 0, 1);
 
-const calendar = 19970327;
-
-const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
-const result = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
-TemporalHelpers.assertDuration(result, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for relativeTo.calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -25,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }),
-    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar`
+    "A number is not a valid ISO string for relativeTo.calendar"
   );
 }

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Duration(1, 0, 0, 1);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-invalid-offset-string.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-invalid-offset-string.js
@@ -14,9 +14,16 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  0,          // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 badOffsets.forEach((offset) => {
   const relativeTo = { year: 2021, month: 10, day: 28, offset, timeZone };
-  assert.throws(RangeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), `"${offset} is not a valid offset string`);
+  assert.throws(
+    typeof(offset) === 'string' ? RangeError : TypeError,
+    () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }),
+    `"${offset} is not a valid offset string`
+  );
 });

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Duration(1);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Duration(1, 0, 0, 1);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -21,8 +21,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [relativeTo, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), `${description} does not convert to a valid ISO string`);
+for (const [relativeTo, description] of primitiveTests) {
+  assert.throws(
+    typeof relativeTo === 'string' || typeof relativeTo === 'undefined' ? RangeError : TypeError,
+    () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-number.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-temporal.duration.prototype.round
 description: A number as relativeTo option is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
@@ -12,18 +11,16 @@ const instance = new Temporal.Duration(1, 0, 0, 0, 24);
 
 const relativeTo = 20191101;
 
-const result = instance.round({ largestUnit: "years", relativeTo });
-TemporalHelpers.assertDuration(result, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, "20191101 is a valid ISO string for relativeTo");
-
 const numbers = [
   1,
+  20191101,
   -20191101,
   1234567890,
 ];
 
 for (const relativeTo of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.round({ largestUnit: "years", relativeTo }),
     `Number ${relativeTo} does not convert to a valid ISO string for relativeTo`
   );

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-number.js
@@ -3,21 +3,15 @@
 
 /*---
 esid: sec-temporal.duration.prototype.round
-description: A number as calendar in relativeTo property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in relativeTo property bag is invalid
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Duration(1, 0, 0, 0, 24);
 
-const calendar = 19970327;
-
-const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
-const result = instance.round({ largestUnit: "years", relativeTo });
-TemporalHelpers.assertDuration(result, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for relativeTo.calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -25,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.round({ largestUnit: "years", relativeTo }),
-    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar`
+    "A number is not a valid ISO string for relativeTo.calendar"
   );
 }

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Duration(1, 0, 0, 0, 24);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.round({ largestUnit: "years", relativeTo }), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.round({ largestUnit: "years", relativeTo }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-invalid-offset-string.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-invalid-offset-string.js
@@ -14,9 +14,16 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  0,          // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 badOffsets.forEach((offset) => {
   const relativeTo = { year: 2021, month: 10, day: 28, offset, timeZone };
-  assert.throws(RangeError, () => instance.round({ largestUnit: "years", relativeTo }), `"${offset} is not a valid offset string`);
+  assert.throws(
+    typeof(offset) === 'string' ? RangeError : TypeError,
+    () => instance.round({ largestUnit: "years", relativeTo }),
+    `"${offset} is not a valid offset string`
+  );
 });

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Duration(1);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-wrong-type.js
@@ -9,31 +9,39 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const timeZone = new Temporal.TimeZone("UTC");
+const timeZone = new Temporal.TimeZone('UTC');
 const instance = new Temporal.Duration(1, 0, 0, 0, 24);
 
-const rangeErrorTests = [
-  [undefined, "undefined"],
-  [null, "null"],
-  [true, "boolean"],
-  ["", "empty string"],
+const primitiveTests = [
+  [undefined, 'undefined'],
+  [null, 'null'],
+  [true, 'boolean'],
+  ['', 'empty string'],
   [1, "number that doesn't convert to a valid ISO string"],
-  [1n, "bigint"],
+  [1n, 'bigint']
 ];
 
-for (const [relativeTo, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.round({ largestUnit: "years", relativeTo }), `${description} does not convert to a valid ISO string`);
+for (const [relativeTo, description] of primitiveTests) {
+  assert.throws(
+    typeof relativeTo === 'string' || typeof relativeTo === 'undefined' ? RangeError : TypeError,
+    () => instance.round({ largestUnit: 'years', relativeTo }),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
 }
 
 const typeErrorTests = [
-  [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainDate, "Temporal.PlainDate, object"],
-  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
-  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
-  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+  [Symbol(), 'symbol'],
+  [{}, 'plain object'],
+  [Temporal.PlainDate, 'Temporal.PlainDate, object'],
+  [Temporal.PlainDate.prototype, 'Temporal.PlainDate.prototype, object'],
+  [Temporal.ZonedDateTime, 'Temporal.ZonedDateTime, object'],
+  [Temporal.ZonedDateTime.prototype, 'Temporal.ZonedDateTime.prototype, object']
 ];
 
 for (const [relativeTo, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.round({ largestUnit: "years", relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(
+    TypeError,
+    () => instance.round({ largestUnit: 'years', relativeTo }),
+    `${description} is not a valid property bag and does not convert to a string`
+  );
 }

--- a/test/built-ins/Temporal/Duration/prototype/subtract/argument-not-object.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.Duration(0, 0, 0, 1, 2, 3, 4, 987, 654, 321);
-assert.throws(RangeError, () => instance.subtract(undefined), "undefined");
-assert.throws(RangeError, () => instance.subtract(null), "null");
-assert.throws(RangeError, () => instance.subtract(true), "boolean");
+assert.throws(TypeError, () => instance.subtract(undefined), "undefined");
+assert.throws(TypeError, () => instance.subtract(null), "null");
+assert.throws(TypeError, () => instance.subtract(true), "boolean");
 assert.throws(RangeError, () => instance.subtract(""), "empty string");
 assert.throws(TypeError, () => instance.subtract(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.subtract(7), "number");
-assert.throws(RangeError, () => instance.subtract(7n), "bigint");
+assert.throws(TypeError, () => instance.subtract(7), "number");
+assert.throws(TypeError, () => instance.subtract(7n), "bigint");
 assert.throws(TypeError, () => instance.subtract([]), "array");
 assert.throws(TypeError, () => instance.subtract(() => {}), "function");

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-number.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-temporal.duration.prototype.subtract
 description: A number as relativeTo option is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
@@ -12,18 +11,16 @@ const instance = new Temporal.Duration(1, 0, 0, 1);
 
 const relativeTo = 20191101;
 
-const result = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
-TemporalHelpers.assertDuration(result, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "20191101 is a valid ISO string for relativeTo");
-
 const numbers = [
   1,
+  20191101,
   -20191101,
   1234567890,
 ];
 
 for (const relativeTo of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }),
     `Number ${relativeTo} does not convert to a valid ISO string for relativeTo`
   );

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-number.js
@@ -3,8 +3,7 @@
 
 /*---
 esid: sec-temporal.duration.prototype.subtract
-description: A number as calendar in relativeTo property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in relativeTo property bag is invalid
 features: [Temporal]
 ---*/
 
@@ -12,12 +11,9 @@ const instance = new Temporal.Duration(1, 0, 0, 1);
 
 const calendar = 19970327;
 
-const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
-const result = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
-TemporalHelpers.assertDuration(result, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for relativeTo.calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -25,8 +21,8 @@ const numbers = [
 for (const calendar of numbers) {
   const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }),
-    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar`
+    "A number is not a valid ISO string for relativeTo.calendar"
   );
 }

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Duration(1, 0, 0, 1);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-invalid-offset-string.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-invalid-offset-string.js
@@ -14,9 +14,16 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  0,          // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 badOffsets.forEach((offset) => {
   const relativeTo = { year: 2021, month: 10, day: 28, offset, timeZone };
-  assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `"${offset} is not a valid offset string`);
+  assert.throws(
+    typeof(offset) === 'string' ? RangeError : TypeError,
+    () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24),
+    { relativeTo }), `"${offset} is not a valid offset string`
+  );
 });

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Duration(1);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-wrong-type.js
@@ -9,31 +9,39 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const timeZone = new Temporal.TimeZone("UTC");
+const timeZone = new Temporal.TimeZone('UTC');
 const instance = new Temporal.Duration(1, 0, 0, 1);
 
-const rangeErrorTests = [
-  [undefined, "undefined"],
-  [null, "null"],
-  [true, "boolean"],
-  ["", "empty string"],
+const primitiveTests = [
+  [undefined, 'undefined'],
+  [null, 'null'],
+  [true, 'boolean'],
+  ['', 'empty string'],
   [1, "number that doesn't convert to a valid ISO string"],
-  [1n, "bigint"],
+  [1n, 'bigint']
 ];
 
-for (const [relativeTo, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `${description} does not convert to a valid ISO string`);
+for (const [relativeTo, description] of primitiveTests) {
+  assert.throws(
+    typeof relativeTo === 'string' || typeof relativeTo === 'undefined' ? RangeError : TypeError,
+    () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
 }
 
 const typeErrorTests = [
-  [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainDate, "Temporal.PlainDate, object"],
-  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
-  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
-  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+  [Symbol(), 'symbol'],
+  [{}, 'plain object'],
+  [Temporal.PlainDate, 'Temporal.PlainDate, object'],
+  [Temporal.PlainDate.prototype, 'Temporal.PlainDate.prototype, object'],
+  [Temporal.ZonedDateTime, 'Temporal.ZonedDateTime, object'],
+  [Temporal.ZonedDateTime.prototype, 'Temporal.ZonedDateTime.prototype, object']
 ];
 
 for (const [relativeTo, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(
+    TypeError,
+    () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }),
+    `${description} is not a valid property bag and does not convert to a string`
+  );
 }

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-number.js
@@ -11,18 +11,16 @@ const instance = new Temporal.Duration(1, 0, 0, 0, 24);
 
 const relativeTo = 20191101;
 
-const result = instance.total({ unit: "days", relativeTo });
-assert.sameValue(result, 367, "20191101 is a valid ISO string for relativeTo");
-
 const numbers = [
   1,
+  20191101,
   -20191101,
   1234567890,
 ];
 
 for (const relativeTo of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.total({ unit: "days", relativeTo }),
     `Number ${relativeTo} does not convert to a valid ISO string for relativeTo`
   );

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.duration.prototype.total
-description: A number as calendar in relativeTo property bag is converted to a string, then to a calendar
+description: A number as calendar in relativeTo property bag is invalid
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Duration(1, 0, 0, 0, 24);
 
-const calendar = 19970327;
-
-const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
-const result = instance.total({ unit: "days", relativeTo });
-assert.sameValue(result, 367, "19970327 is a valid ISO string for relativeTo.calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.total({ unit: "days", relativeTo }),
-    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar`
+    "A number is not a valid ISO string for relativeTo.calendar"
   );
 }

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Duration(1, 0, 0, 0, 24);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.total({ unit: "days", relativeTo }), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.total({ unit: "days", relativeTo }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-invalid-offset-string.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-invalid-offset-string.js
@@ -14,9 +14,16 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  0,          // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 badOffsets.forEach((offset) => {
   const relativeTo = { year: 2021, month: 10, day: 28, offset, timeZone };
-  assert.throws(RangeError, () => instance.total({ unit: "days", relativeTo }), `"${offset} is not a valid offset string`);
+  assert.throws(
+    typeof(offset) === 'string' ? RangeError : TypeError,
+    () => instance.total({ unit: "days", relativeTo }),
+    `"${offset} is not a valid offset string`
+  );
 });

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Duration(1);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-wrong-type.js
@@ -9,31 +9,39 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const timeZone = new Temporal.TimeZone("UTC");
+const timeZone = new Temporal.TimeZone('UTC');
 const instance = new Temporal.Duration(1, 0, 0, 0, 24);
 
-const rangeErrorTests = [
-  [undefined, "undefined"],
-  [null, "null"],
-  [true, "boolean"],
-  ["", "empty string"],
+const primitiveTests = [
+  [undefined, 'undefined'],
+  [null, 'null'],
+  [true, 'boolean'],
+  ['', 'empty string'],
   [1, "number that doesn't convert to a valid ISO string"],
-  [1n, "bigint"],
+  [1n, 'bigint']
 ];
 
-for (const [relativeTo, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.total({ unit: "days", relativeTo }), `${description} does not convert to a valid ISO string`);
+for (const [relativeTo, description] of primitiveTests) {
+  assert.throws(
+    typeof relativeTo === 'string' || typeof relativeTo === 'undefined' ? RangeError : TypeError,
+    () => instance.total({ unit: 'days', relativeTo }),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
 }
 
 const typeErrorTests = [
-  [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainDate, "Temporal.PlainDate, object"],
-  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
-  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
-  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+  [Symbol(), 'symbol'],
+  [{}, 'plain object'],
+  [Temporal.PlainDate, 'Temporal.PlainDate, object'],
+  [Temporal.PlainDate.prototype, 'Temporal.PlainDate.prototype, object'],
+  [Temporal.ZonedDateTime, 'Temporal.ZonedDateTime, object'],
+  [Temporal.ZonedDateTime.prototype, 'Temporal.ZonedDateTime.prototype, object']
 ];
 
 for (const [relativeTo, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.total({ unit: "days", relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(
+    TypeError,
+    () => instance.total({ unit: 'days', relativeTo }),
+    `${description} is not a valid property bag and does not convert to a string`
+  );
 }

--- a/test/built-ins/Temporal/Instant/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/compare/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const other = new Temporal.Instant(0n);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,20 +20,40 @@ const rangeErrorTests = [
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
   [{}, "plain object"],
-  [Temporal.Instant, "Temporal.Instant, object"],
+  [Temporal.Instant, "Temporal.Instant, object"]
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Instant.compare(arg, other), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.Instant.compare(other, arg), `${description} does not convert to a valid ISO string (second argument)`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === "string" || (typeof arg === "object" && arg !== null) || typeof arg === "function"
+      ? RangeError
+      : TypeError,
+    () => Temporal.Instant.compare(arg, other),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof arg === "string" || (typeof arg === "object" && arg !== null) || typeof arg === "function"
+      ? RangeError
+      : TypeError,
+    () => Temporal.Instant.compare(other, arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [Temporal.Instant.prototype, "Temporal.Instant.prototype, object"],  // fails brand check in toString()
+  [Temporal.Instant.prototype, "Temporal.Instant.prototype, object"] // fails brand check in toString()
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => Temporal.Instant.compare(arg, other), `${description} does not convert to a string (first argument)`);
-  assert.throws(TypeError, () => Temporal.Instant.compare(other, arg), `${description} does not convert to a string (second argument)`);
+  assert.throws(
+    TypeError,
+    () => Temporal.Instant.compare(arg, other),
+    `${description} does not convert to a string (first argument)`
+  );
+  assert.throws(
+    TypeError,
+    () => Temporal.Instant.compare(other, arg),
+    `${description} does not convert to a string (second argument)`
+  );
 }

--- a/test/built-ins/Temporal/Instant/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/from/argument-wrong-type.js
@@ -9,25 +9,31 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
-  [undefined, "undefined"],
-  [null, "null"],
-  [true, "boolean"],
-  ["", "empty string"],
+const primitiveTests = [
+  [undefined, 'undefined'],
+  [null, 'null'],
+  [true, 'boolean'],
+  ['', 'empty string'],
   [1, "number that doesn't convert to a valid ISO string"],
-  [19761118, "number that would convert to a valid ISO string in other contexts"],
-  [1n, "bigint"],
-  [{}, "plain object"],
-  [Temporal.Instant, "Temporal.Instant, object"],
+  [19761118, 'number that would convert to a valid ISO string in other contexts'],
+  [1n, 'bigint'],
+  [{}, 'plain object'],
+  [Temporal.Instant, 'Temporal.Instant, object']
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Instant.from(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' || (typeof arg === 'object' && arg !== null) || typeof arg === 'function'
+      ? RangeError
+      : TypeError,
+    () => Temporal.Instant.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [
-  [Symbol(), "symbol"],
-  [Temporal.Instant.prototype, "Temporal.Instant.prototype, object"],  // fails brand check in toString()
+  [Symbol(), 'symbol'],
+  [Temporal.Instant.prototype, 'Temporal.Instant.prototype, object'] // fails brand check in toString()
 ];
 
 for (const [arg, description] of typeErrorTests) {

--- a/test/built-ins/Temporal/Instant/prototype/add/argument-not-object.js
+++ b/test/built-ins/Temporal/Instant/prototype/add/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
-assert.throws(RangeError, () => instance.add(undefined), "undefined");
-assert.throws(RangeError, () => instance.add(null), "null");
-assert.throws(RangeError, () => instance.add(true), "boolean");
+assert.throws(TypeError, () => instance.add(undefined), "undefined");
+assert.throws(TypeError, () => instance.add(null), "null");
+assert.throws(TypeError, () => instance.add(true), "boolean");
 assert.throws(RangeError, () => instance.add(""), "empty string");
 assert.throws(TypeError, () => instance.add(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.add(7), "number");
-assert.throws(RangeError, () => instance.add(7n), "bigint");
+assert.throws(TypeError, () => instance.add(7), "number");
+assert.throws(TypeError, () => instance.add(7n), "bigint");
 assert.throws(TypeError, () => instance.add([]), "array");
 assert.throws(TypeError, () => instance.add(() => {}), "function");

--- a/test/built-ins/Temporal/Instant/prototype/equals/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Instant(0n);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -23,8 +23,14 @@ const rangeErrorTests = [
   [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === "string" || (typeof arg === "object" && arg !== null) || typeof arg === "function"
+      ? RangeError
+      : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Instant/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Instant(0n);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -23,8 +23,14 @@ const rangeErrorTests = [
   [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === "string" || (typeof arg === "object" && arg !== null) || typeof arg === "function"
+      ? RangeError
+      : TypeError,
+    () => instance.since(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Instant/prototype/subtract/argument-not-object.js
+++ b/test/built-ins/Temporal/Instant/prototype/subtract/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
-assert.throws(RangeError, () => instance.subtract(undefined), "undefined");
-assert.throws(RangeError, () => instance.subtract(null), "null");
-assert.throws(RangeError, () => instance.subtract(true), "boolean");
+assert.throws(TypeError, () => instance.subtract(undefined), "undefined");
+assert.throws(TypeError, () => instance.subtract(null), "null");
+assert.throws(TypeError, () => instance.subtract(true), "boolean");
 assert.throws(RangeError, () => instance.subtract(""), "empty string");
 assert.throws(TypeError, () => instance.subtract(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.subtract(7), "number");
-assert.throws(RangeError, () => instance.subtract(7n), "bigint");
+assert.throws(TypeError, () => instance.subtract(7), "number");
+assert.throws(TypeError, () => instance.subtract(7n), "bigint");
 assert.throws(TypeError, () => instance.subtract([]), "array");
 assert.throws(TypeError, () => instance.subtract(() => {}), "function");

--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Instant(0n);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toString({ timeZone }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.toString({ timeZone }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-number.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.instant.prototype.tozoneddatetime
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
 
-const arg = 19761118;
-
-const result = instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" });
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
-
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" }),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -19,8 +19,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" }), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Instant(0n);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toZonedDateTime({ timeZone, calendar: "iso8601" }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.toZonedDateTime({ timeZone, calendar: "iso8601" }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Instant(0n);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toZonedDateTimeISO(timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.toZonedDateTimeISO(timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Instant/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Instant(0n);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -23,8 +23,14 @@ const rangeErrorTests = [
   [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === "string" || (typeof arg === "object" && arg !== null) || typeof arg === "function"
+      ? RangeError
+      : TypeError,
+    () => instance.until(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Now/plainDate/calendar-number.js
+++ b/test/built-ins/Temporal/Now/plainDate/calendar-number.js
@@ -3,25 +3,21 @@
 
 /*---
 esid: sec-temporal.now.plaindate
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
-
-const arg = 19761118;
-
-const result = Temporal.Now.plainDate(arg);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
 
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.Now.plainDate(arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/Now/plainDate/calendar-undefined.js
+++ b/test/built-ins/Temporal/Now/plainDate/calendar-undefined.js
@@ -7,5 +7,5 @@ description: Throws when the calendar argument is undefined
 features: [Temporal]
 ---*/
 
-assert.throws(RangeError, () => Temporal.Now.plainDate(), "implicit");
-assert.throws(RangeError, () => Temporal.Now.plainDate(undefined), "implicit");
+assert.throws(TypeError, () => Temporal.Now.plainDate(), "implicit");
+assert.throws(TypeError, () => Temporal.Now.plainDate(undefined), "implicit");

--- a/test/built-ins/Temporal/Now/plainDate/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDate/calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,8 +17,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Now.plainDate(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.Now.plainDate(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Now/plainDate/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDate/timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Now.plainDate("iso8601", timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.Now.plainDate("iso8601", timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Now/plainDateISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateISO/timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Now.plainDateISO(timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.Now.plainDateISO(timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Now/plainDateTime/calendar-number.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/calendar-number.js
@@ -3,25 +3,21 @@
 
 /*---
 esid: sec-temporal.now.plaindatetime
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
-
-const arg = 19761118;
-
-const result = Temporal.Now.plainDateTime(arg);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
 
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.Now.plainDateTime(arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/Now/plainDateTime/calendar-undefined.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/calendar-undefined.js
@@ -7,5 +7,5 @@ description: Throws when the calendar argument is undefined
 features: [Temporal]
 ---*/
 
-assert.throws(RangeError, () => Temporal.Now.plainDateTime(), "implicit");
-assert.throws(RangeError, () => Temporal.Now.plainDateTime(undefined), "implicit");
+assert.throws(TypeError, () => Temporal.Now.plainDateTime(), "implicit");
+assert.throws(TypeError, () => Temporal.Now.plainDateTime(undefined), "implicit");

--- a/test/built-ins/Temporal/Now/plainDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,8 +17,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Now.plainDateTime(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.Now.plainDateTime(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Now/plainDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Now.plainDateTime("iso8601", timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.Now.plainDateTime("iso8601", timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO(timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.Now.plainDateTimeISO(timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Now/plainTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainTimeISO/timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Now.plainTimeISO(timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.Now.plainTimeISO(timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Now/zonedDateTime/calendar-number.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/calendar-number.js
@@ -3,25 +3,21 @@
 
 /*---
 esid: sec-temporal.now.zoneddatetime
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
-
-const arg = 19761118;
-
-const result = Temporal.Now.zonedDateTime(arg);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
 
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.Now.zonedDateTime(arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/Now/zonedDateTime/calendar-undefined.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/calendar-undefined.js
@@ -7,5 +7,5 @@ description: Throws when the calendar argument is undefined
 features: [Temporal]
 ---*/
 
-assert.throws(RangeError, () => Temporal.Now.zonedDateTime(), "implicit");
-assert.throws(RangeError, () => Temporal.Now.zonedDateTime(undefined), "implicit");
+assert.throws(TypeError, () => Temporal.Now.zonedDateTime(), "implicit");
+assert.throws(TypeError, () => Temporal.Now.zonedDateTime(undefined), "implicit");

--- a/test/built-ins/Temporal/Now/zonedDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,8 +17,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Now.zonedDateTime(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.Now.zonedDateTime(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Now/zonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Now.zonedDateTime("iso8601", timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.Now.zonedDateTime("iso8601", timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.Now.zonedDateTimeISO(timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.Now.zonedDateTimeISO(timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/calendar-number.js
@@ -3,25 +3,21 @@
 
 /*---
 esid: sec-temporal.plaindate
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
-
-const arg = 19761118;
-
-const result = new Temporal.PlainDate(2000, 5, 2, arg);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
 
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => new Temporal.PlainDate(2000, 5, 2, arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDate/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,8 +17,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => new Temporal.PlainDate(2000, 5, 2, arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => new Temporal.PlainDate(2000, 5, 2, arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/compare/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-number.js
@@ -3,32 +3,26 @@
 
 /*---
 esid: sec-temporal.plaindate.compare
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
-const arg = 19761118;
-
-const result1 = Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18));
-assert.sameValue(result1, 0, "19761118 is a valid ISO string for PlainDate (first argument)");
-const result2 = Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg);
-assert.sameValue(result2, 0, "19761118 is a valid ISO string for PlainDate (second argument)");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate (first argument)`
+    "A number is not a valid ISO string for PlainDate (first argument)"
   );
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate (second argument)`
+    "A number is not a valid ISO string for PlainDate (second argument)"
   );
 }

--- a/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-number.js
@@ -3,20 +3,13 @@
 
 /*---
 esid: sec-temporal.plaindate.compare
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result1 = Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18));
-assert.sameValue(result1, 0, "19970327 is a valid ISO string for calendar (first argument)");
-const result2 = Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg);
-assert.sameValue(result2, 0, "19970327 is a valid ISO string for calendar (first argument)");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,13 +17,13 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)),
-    `Number ${calendar} does not convert to a valid ISO string for calendar (first argument)`
+    "A number is not a valid ISO string for calendar (first argument)"
   );
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar (second argument)`
+    "A number is not a valid ISO string for calendar (second argument)"
   );
 }

--- a/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,10 +17,18 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg), `${description} does not convert to a valid ISO string (second argument)`);
+  assert.throws(
+    typeof calendar === "string" ? RangeError : TypeError,
+    () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof calendar === "string" ? RangeError : TypeError,
+    () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -18,9 +18,17 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg), `${description} does not convert to a valid ISO string (second argument)`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/from/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-number.js
@@ -3,26 +3,21 @@
 
 /*---
 esid: sec-temporal.plaindate.from
-description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
-const arg = 19761118;
-
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDate.from(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-number.js
@@ -3,19 +3,13 @@
 
 /*---
 esid: sec-temporal.plaindate.from
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -23,8 +17,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDate.from(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,9 +17,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => Temporal.PlainDate.from(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainDate.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.PlainDate.from(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainDate.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/from/observable-get-overflow-argument-string.js
+++ b/test/built-ins/Temporal/PlainDate/from/observable-get-overflow-argument-string.js
@@ -29,5 +29,5 @@ assert.compareArray(actual, expected, "Successful call");
 TemporalHelpers.assertPlainDate(result, 2021, 5, "M05", 17);
 
 actual.splice(0);  // empty it for the next check
-assert.throws(RangeError, () => Temporal.PlainDate.from(7, object));
+assert.throws(TypeError, () => Temporal.PlainDate.from(7, object));
 assert.compareArray(actual, expected, "Failing call");

--- a/test/built-ins/Temporal/PlainDate/prototype/add/argument-not-object.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/add/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
-assert.throws(RangeError, () => instance.add(undefined), "undefined");
-assert.throws(RangeError, () => instance.add(null), "null");
-assert.throws(RangeError, () => instance.add(true), "boolean");
+assert.throws(TypeError, () => instance.add(undefined), "undefined");
+assert.throws(TypeError, () => instance.add(null), "null");
+assert.throws(TypeError, () => instance.add(true), "boolean");
 assert.throws(RangeError, () => instance.add(""), "empty string");
 assert.throws(TypeError, () => instance.add(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.add(7), "number");
-assert.throws(RangeError, () => instance.add(7n), "bigint");
+assert.throws(TypeError, () => instance.add(7), "number");
+assert.throws(TypeError, () => instance.add(7n), "bigint");
 assert.throws(TypeError, () => instance.add([]), "array");
 assert.throws(TypeError, () => instance.add(() => {}), "function");

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindate.prototype.equals
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDate(1976, 11, 18);
 
-const arg = 19761118;
-
-const result = instance.equals(arg);
-assert.sameValue(result, true, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.equals(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.plaindate.prototype.equals
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDate(1976, 11, 18);
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.equals(arg);
-assert.sameValue(result, true, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.equals(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainDate(2000, 5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-number.js
@@ -3,28 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindate.prototype.since
-description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDate(1976, 11, 18);
 
-const arg = 19761118;
-
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.since(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-number.js
@@ -3,30 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindate.prototype.since
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDate(1976, 11, 18);
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
-
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.since(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainDate(2000, 5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.since(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.since(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/prototype/subtract/argument-not-object.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/subtract/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
-assert.throws(RangeError, () => instance.subtract(undefined), "undefined");
-assert.throws(RangeError, () => instance.subtract(null), "null");
-assert.throws(RangeError, () => instance.subtract(true), "boolean");
+assert.throws(TypeError, () => instance.subtract(undefined), "undefined");
+assert.throws(TypeError, () => instance.subtract(null), "null");
+assert.throws(TypeError, () => instance.subtract(true), "boolean");
 assert.throws(RangeError, () => instance.subtract(""), "empty string");
 assert.throws(TypeError, () => instance.subtract(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.subtract(7), "number");
-assert.throws(RangeError, () => instance.subtract(7n), "bigint");
+assert.throws(TypeError, () => instance.subtract(7), "number");
+assert.throws(TypeError, () => instance.subtract(7n), "bigint");
 assert.throws(TypeError, () => instance.subtract([]), "array");
 assert.throws(TypeError, () => instance.subtract(() => {}), "function");

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-number.js
@@ -3,17 +3,11 @@
 
 /*---
 esid: sec-temporal.plaindate.prototype.toplaindatetime
-description: A number is converted to a string, then to Temporal.PlainTime
-includes: [temporalHelpers.js]
+description: A number is invalid in place of an ISO string for Temporal.PlainTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
-
-const arg = 123456.987654321;
-
-const result = instance.toPlainDateTime(arg);
-TemporalHelpers.assertPlainDateTime(result, 2000, 5, "M05", 2, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -24,8 +18,8 @@ const numbers = [
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.toPlainDateTime(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainTime`
+    "A number is not a valid ISO string for PlainTime"
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -19,8 +19,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toPlainDateTime(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.toPlainDateTime(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-number.js
@@ -3,16 +3,11 @@
 
 /*---
 esid: sec-temporal.plaindate.prototype.tozoneddatetime
-description: A number is converted to a string, then to Temporal.PlainTime
+description: A number is invalid in place of an ISO string for Temporal.PlainTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
-
-const arg = 123456.987654321;
-
-const result = instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" });
-assert.sameValue(result.epochNanoseconds, 957270896_987_654_321n, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -23,8 +18,8 @@ const numbers = [
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }),
-    `Number ${arg} does not convert to a valid ISO string for PlainTime`
+    "A number is not a valid ISO string for PlainTime"
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -19,8 +19,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toZonedDateTime(timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.toZonedDateTime(timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-number.js
@@ -3,28 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindate.prototype.until
-description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDate(1976, 11, 18);
 
-const arg = 19761118;
-
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.until(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-number.js
@@ -3,30 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindate.prototype.until
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDate(1976, 11, 18);
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
-
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.until(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainDate(2000, 5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.until(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.until(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-number.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-temporal.plaindate.prototype.withcalendar
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
 
@@ -31,21 +31,17 @@ const instance = new Temporal.PlainDate(1976, 11, 18, {
   yearOfWeek() {},
 });
 
-const arg = 19761118;
-
-const result = instance.withCalendar(arg);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
-
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.withCalendar(arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-wrong-type.js
@@ -33,7 +33,7 @@ const instance = new Temporal.PlainDate(1976, 11, 18, {
   yearOfWeek() {},
 });
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -41,8 +41,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.withCalendar(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.withCalendar(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDate/prototype/withCalendar/missing-argument.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/withCalendar/missing-argument.js
@@ -3,10 +3,10 @@
 
 /*---
 esid: sec-temporal.plaindate.prototype.withcalendar
-description: RangeError thrown when calendar argument not given
+description: TypeError thrown when calendar argument not given
 features: [Temporal]
 ---*/
 
 const plainDate = Temporal.PlainDate.from("1976-11-18");
-assert.throws(RangeError, () => plainDate.withCalendar(), "missing argument");
-assert.throws(RangeError, () => plainDate.withCalendar(undefined), "undefined argument");
+assert.throws(TypeError, () => plainDate.withCalendar(), "missing argument");
+assert.throws(TypeError, () => plainDate.withCalendar(undefined), "undefined argument");

--- a/test/built-ins/Temporal/PlainDateTime/calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/calendar-number.js
@@ -3,25 +3,21 @@
 
 /*---
 esid: sec-temporal.plaindatetime
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
-
-const arg = 19761118;
-
-const result = new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
 
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,8 +17,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-number.js
@@ -3,32 +3,26 @@
 
 /*---
 esid: sec-temporal.plaindatetime.compare
-description: A number is converted to a string, then to Temporal.PlainDateTime
+description: A number cannot be used in place of a Temporal.PlainDateTime
 features: [Temporal]
 ---*/
 
-let arg = 19761118;
-
-const result1 = Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18));
-assert.sameValue(result1, 0, "19761118 is a valid ISO string for PlainDateTime (first argument)");
-const result2 = Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg);
-assert.sameValue(result2, 0, "19761118 is a valid ISO string for PlainDateTime (second argument)");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)),
-    `Number ${arg} does not convert to a valid ISO string for PlainDateTime (first argument)`
+    "A number is not a valid ISO string for PlainDateTime (first argument)"
   );
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDateTime (second argument)`
+    "A number is not a valid ISO string for PlainDateTime (second argument)"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-number.js
@@ -3,20 +3,13 @@
 
 /*---
 esid: sec-temporal.plaindatetime.compare
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result1 = Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18));
-assert.sameValue(result1, 0, "19970327 is a valid ISO string for calendar (first argument)");
-const result2 = Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg);
-assert.sameValue(result2, 0, "19970327 is a valid ISO string for calendar (second argument)");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,13 +17,13 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)),
-    `Number ${calendar} does not convert to a valid ISO string for calendar (first argument)`
+    "A number is not a valid ISO string for calendar (first argument)"
   );
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar (second argument)`
+    "A number is not a valid ISO string for calendar (second argument)"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,10 +17,18 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg), `${description} does not convert to a valid ISO string (second argument)`);
+    assert.throws(
+      typeof calendar === "string" ? RangeError : TypeError,
+      () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)),
+      `${description} does not convert to a valid ISO string (first argument)`
+    );
+  assert.throws(
+    typeof calendar === "string" ? RangeError : TypeError,
+    () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -18,9 +18,17 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg), `${description} does not convert to a valid ISO string (second argument)`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-number.js
@@ -3,26 +3,21 @@
 
 /*---
 esid: sec-temporal.plaindatetime.from
-description: A number is converted to a string, then to Temporal.PlainDateTime
-includes: [temporalHelpers.js]
+description: A number cannot be used in place of a Temporal.PlainDateTime
 features: [Temporal]
 ---*/
 
-let arg = 19761118;
-
-const result = Temporal.PlainDateTime.from(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDateTime");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDateTime.from(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
+    "A number is not a valid ISO string for PlainDateTime"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-number.js
@@ -3,19 +3,13 @@
 
 /*---
 esid: sec-temporal.plaindatetime.from
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = Temporal.PlainDateTime.from(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -23,8 +17,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainDateTime.from(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,9 +17,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => Temporal.PlainDateTime.from(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainDateTime.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.PlainDateTime.from(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainDateTime.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/add/argument-not-object.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/add/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 15, 30, 45, 987, 654, 321);
-assert.throws(RangeError, () => instance.add(undefined), "undefined");
-assert.throws(RangeError, () => instance.add(null), "null");
-assert.throws(RangeError, () => instance.add(true), "boolean");
+assert.throws(TypeError, () => instance.add(undefined), "undefined");
+assert.throws(TypeError, () => instance.add(null), "null");
+assert.throws(TypeError, () => instance.add(true), "boolean");
 assert.throws(RangeError, () => instance.add(""), "empty string");
 assert.throws(TypeError, () => instance.add(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.add(7), "number");
-assert.throws(RangeError, () => instance.add(7n), "bigint");
+assert.throws(TypeError, () => instance.add(7), "number");
+assert.throws(TypeError, () => instance.add(7n), "bigint");
 assert.throws(TypeError, () => instance.add([]), "array");
 assert.throws(TypeError, () => instance.add(() => {}), "function");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.equals
-description: A number is converted to a string, then to Temporal.PlainDateTime
+description: A number cannot be used in place of a Temporal.PlainDateTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18);
 
-let arg = 19761118;
-
-const result = instance.equals(arg);
-assert.sameValue(result, true, "19761118 is a valid ISO string for PlainDateTime");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.equals(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
+    "A number is not a valid ISO string for PlainDateTime"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.equals
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18);
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.equals(arg);
-assert.sameValue(result, true, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.equals(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-number.js
@@ -3,28 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.since
-description: A number is converted to a string, then to Temporal.PlainDateTime
-includes: [temporalHelpers.js]
+description: A number cannot be used in place of a Temporal.PlainDateTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18);
 
-let arg = 19761118;
-
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDateTime");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.since(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
+    "A number is not a valid ISO string for PlainDateTime"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-number.js
@@ -3,30 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.since
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(1976, 11, 18);
-
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+const instance = new Temporal.PlainDate(1976, 11, 18);
 
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
-
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.since(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.since(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.since(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/subtract/argument-not-object.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/subtract/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 15, 30, 45, 987, 654, 321);
-assert.throws(RangeError, () => instance.subtract(undefined), "undefined");
-assert.throws(RangeError, () => instance.subtract(null), "null");
-assert.throws(RangeError, () => instance.subtract(true), "boolean");
+assert.throws(TypeError, () => instance.subtract(undefined), "undefined");
+assert.throws(TypeError, () => instance.subtract(null), "null");
+assert.throws(TypeError, () => instance.subtract(true), "boolean");
 assert.throws(RangeError, () => instance.subtract(""), "empty string");
 assert.throws(TypeError, () => instance.subtract(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.subtract(7), "number");
-assert.throws(RangeError, () => instance.subtract(7n), "bigint");
+assert.throws(TypeError, () => instance.subtract(7), "number");
+assert.throws(TypeError, () => instance.subtract(7n), "bigint");
 assert.throws(TypeError, () => instance.subtract([]), "array");
 assert.throws(TypeError, () => instance.subtract(() => {}), "function");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toZonedDateTime(timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.toZonedDateTime(timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-number.js
@@ -3,28 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.until
-description: A number is converted to a string, then to Temporal.PlainDateTime
-includes: [temporalHelpers.js]
+description: A number cannot be used in place of a Temporal.PlainDateTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18);
 
-let arg = 19761118;
-
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDateTime");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.until(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
+    "A number is not a valid ISO string for PlainDateTime"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-number.js
@@ -3,30 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.until
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(1976, 11, 18);
-
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+const instance = new Temporal.PlainDate(1976, 11, 18);
 
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
-
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.until(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.until(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.until(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-number.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.withcalendar
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
 
@@ -31,21 +31,17 @@ const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 456, 
   yearOfWeek() {},
 });
 
-const arg = 19761118;
-
-const result = instance.withCalendar(arg);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
-
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.withCalendar(arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-wrong-type.js
@@ -33,7 +33,7 @@ const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 456, 
   yearOfWeek() {},
 });
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -41,8 +41,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.withCalendar(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.withCalendar(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/missing-argument.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/missing-argument.js
@@ -3,10 +3,10 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.withcalendar
-description: RangeError thrown when calendar argument not given
+description: TypeError thrown when calendar argument not given
 features: [Temporal]
 ---*/
 
 const plainDateTime = Temporal.PlainDateTime.from("1976-11-18T14:00:00");
-assert.throws(RangeError, () => plainDateTime.withCalendar(), "missing argument");
-assert.throws(RangeError, () => plainDateTime.withCalendar(undefined), "undefined argument");
+assert.throws(TypeError, () => plainDateTime.withCalendar(), "missing argument");
+assert.throws(TypeError, () => plainDateTime.withCalendar(undefined), "undefined argument");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-number.js
@@ -3,28 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.withplaindate
-description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
-const arg = 19761118;
-
-const result = instance.withPlainDate(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.withPlainDate(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-number.js
@@ -3,30 +3,23 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.withplaindate
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
-
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.withPlainDate(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "19970327 is a valid ISO string for calendar");
+const instance = new Temporal.PlainDate(1976, 11, 18);
 
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
-
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.withPlainDate(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.withPlainDate(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.withPlainDate(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.withPlainDate(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.withPlainDate(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-number.js
@@ -3,17 +3,11 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.withplaintime
-description: A number is converted to a string, then to Temporal.PlainTime
-includes: [temporalHelpers.js]
+description: A number is invalid in place of an ISO string for Temporal.PlainTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2);
-
-const arg = 123456.987654321;
-
-const result = instance.withPlainTime(arg);
-TemporalHelpers.assertPlainDateTime(result, 2000, 5, "M05", 2, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -24,8 +18,8 @@ const numbers = [
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.withPlainTime(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainTime`
+    "A number is not a valid ISO string for PlainTime"
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -19,8 +19,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.withPlainTime(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.withPlainTime(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainMonthDay/calendar-number.js
+++ b/test/built-ins/Temporal/PlainMonthDay/calendar-number.js
@@ -3,25 +3,21 @@
 
 /*---
 esid: sec-temporal.plainmonthday
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
-
-const arg = 19761118;
-
-const result = new Temporal.PlainMonthDay(12, 15, arg, 1972);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
 
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => new Temporal.PlainMonthDay(12, 15, arg, 1972),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainMonthDay/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,8 +17,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => new Temporal.PlainMonthDay(12, 15, arg, 1972), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => new Temporal.PlainMonthDay(12, 15, arg, 1972),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-number.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-number.js
@@ -3,26 +3,23 @@
 
 /*---
 esid: sec-temporal.plainmonthday.from
-description: A number is converted to a string, then to Temporal.PlainMonthDay
-includes: [temporalHelpers.js]
+description: A number is invalid in place of an ISO string for Temporal.PlainMonthDay
 features: [Temporal]
 ---*/
 
 const arg = 1118;
 
-const result = Temporal.PlainMonthDay.from(arg);
-TemporalHelpers.assertPlainMonthDay(result, "M11", 18, "1118 is a valid ISO string for PlainMonthDay");
-
 const numbers = [
   1,
+  1118,
   -1118,
   12345,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainMonthDay.from(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainMonthDay`
+    "A number is not a valid ISO string for PlainMonthDay"
   );
 }

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-number.js
@@ -3,19 +3,13 @@
 
 /*---
 esid: sec-temporal.plainmonthday.from
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const calendar = 19970327;
-
-const arg = { monthCode: "M11", day: 18, calendar };
-const result = Temporal.PlainMonthDay.from(arg);
-TemporalHelpers.assertPlainMonthDay(result, "M11", 18, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -23,8 +17,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainMonthDay.from(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,9 +17,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => Temporal.PlainMonthDay.from(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainMonthDay.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.PlainMonthDay.from(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainMonthDay.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-number.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.plainmonthday.prototype.equals
-description: A number is converted to a string, then to Temporal.PlainMonthDay
+description: A number is invalid in place of an ISO string for Temporal.PlainMonthDay
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainMonthDay(11, 18);
 
-const arg = 1118;
-
-const result = instance.equals(arg);
-assert.sameValue(result, true, "1118 is a valid ISO string for PlainMonthDay");
-
 const numbers = [
   1,
+  1118,
   -1118,
   12345,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.equals(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainMonthDay`
+    "A number is not a valid ISO string for PlainMonthDay"
   );
 }

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.plainmonthday.prototype.equals
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainMonthDay(11, 18);
 
-const calendar = 19970327;
-
-const arg = { monthCode: "M11", day: 18, calendar };
-const result = instance.equals(arg);
-assert.sameValue(result, true, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.equals(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainMonthDay(5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainMonthDay(5, 2);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainTime/compare/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-number.js
@@ -3,16 +3,9 @@
 
 /*---
 esid: sec-temporal.plaintime.compare
-description: A number is converted to a string, then to Temporal.PlainTime
+description: A number is invalid in place of an ISO string for Temporal.PlainTime
 features: [Temporal]
 ---*/
-
-const arg = 123456.987654321;
-
-const result1 = Temporal.PlainTime.compare(arg, new Temporal.PlainTime(12, 34, 56, 987, 654, 321));
-assert.sameValue(result1, 0, "123456.987654321 is a valid ISO string for PlainTime (first argument)");
-const result2 = Temporal.PlainTime.compare(new Temporal.PlainTime(12, 34, 56, 987, 654, 321), arg);
-assert.sameValue(result2, 0, "123456.987654321 is a valid ISO string for PlainTime (second argument)");
 
 const numbers = [
   1,
@@ -23,13 +16,13 @@ const numbers = [
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(12, 34, 56, 987, 654, 321)),
-    `Number ${arg} does not convert to a valid ISO string for PlainTime (first argument)`
+    "A number is not a valid ISO string for PlainTime (first argument)"
   );
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainTime.compare(new Temporal.PlainTime(12, 34, 56, 987, 654, 321), arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainTime (second argument)`
+    "A number is not a valid ISO string for PlainTime (second argument)"
   );
 }

--- a/test/built-ins/Temporal/PlainTime/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -18,9 +18,17 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(12, 34, 56, 987, 654, 321)), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.PlainTime.compare(new Temporal.PlainTime(12, 34, 56, 987, 654, 321), arg), `${description} does not convert to a valid ISO string (second argument)`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(12, 34, 56, 987, 654, 321)),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainTime.compare(new Temporal.PlainTime(12, 34, 56, 987, 654, 321), arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainTime/from/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-number.js
@@ -3,15 +3,9 @@
 
 /*---
 esid: sec-temporal.plaintime.from
-description: A number is converted to a string, then to Temporal.PlainTime
-includes: [temporalHelpers.js]
+description: A number is invalid in place of an ISO string for Temporal.PlainTime
 features: [Temporal]
 ---*/
-
-const arg = 123456.987654321;
-
-const result = Temporal.PlainTime.from(arg);
-TemporalHelpers.assertPlainTime(result, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -22,8 +16,8 @@ const numbers = [
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainTime.from(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainTime`
+    "A number is not a valid ISO string for PlainTime"
   );
 }

--- a/test/built-ins/Temporal/PlainTime/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.PlainTime.from(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainTime.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainTime/prototype/add/argument-not-object.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/add/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.PlainTime(15, 30, 45, 987, 654, 321);
-assert.throws(RangeError, () => instance.add(undefined), "undefined");
-assert.throws(RangeError, () => instance.add(null), "null");
-assert.throws(RangeError, () => instance.add(true), "boolean");
+assert.throws(TypeError, () => instance.add(undefined), "undefined");
+assert.throws(TypeError, () => instance.add(null), "null");
+assert.throws(TypeError, () => instance.add(true), "boolean");
 assert.throws(RangeError, () => instance.add(""), "empty string");
 assert.throws(TypeError, () => instance.add(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.add(7), "number");
-assert.throws(RangeError, () => instance.add(7n), "bigint");
+assert.throws(TypeError, () => instance.add(7), "number");
+assert.throws(TypeError, () => instance.add(7n), "bigint");
 assert.throws(TypeError, () => instance.add([]), "array");
 assert.throws(TypeError, () => instance.add(() => {}), "function");

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-number.js
@@ -3,16 +3,11 @@
 
 /*---
 esid: sec-temporal.plaintime.prototype.equals
-description: A number is converted to a string, then to Temporal.PlainTime
+description: A number is invalid in place of an ISO string for Temporal.PlainTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
-const arg = 123456.987654321;
-
-const result = instance.equals(arg);
-assert.sameValue(result, true, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -23,8 +18,8 @@ const numbers = [
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.equals(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainTime`
+    "A number is not a valid ISO string for PlainTime"
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-number.js
@@ -3,17 +3,11 @@
 
 /*---
 esid: sec-temporal.plaintime.prototype.since
-description: A number is converted to a string, then to Temporal.PlainTime
-includes: [temporalHelpers.js]
+description: A number is invalid in place of an ISO string for Temporal.PlainTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
-const arg = 123456.987654321;
-
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -24,8 +18,8 @@ const numbers = [
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.since(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainTime`
+    "A number is not a valid ISO string for PlainTime"
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.since(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainTime/prototype/subtract/argument-not-object.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/subtract/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.PlainTime(15, 30, 45, 987, 654, 321);
-assert.throws(RangeError, () => instance.subtract(undefined), "undefined");
-assert.throws(RangeError, () => instance.subtract(null), "null");
-assert.throws(RangeError, () => instance.subtract(true), "boolean");
+assert.throws(TypeError, () => instance.subtract(undefined), "undefined");
+assert.throws(TypeError, () => instance.subtract(null), "null");
+assert.throws(TypeError, () => instance.subtract(true), "boolean");
 assert.throws(RangeError, () => instance.subtract(""), "empty string");
 assert.throws(TypeError, () => instance.subtract(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.subtract(7), "number");
-assert.throws(RangeError, () => instance.subtract(7n), "bigint");
+assert.throws(TypeError, () => instance.subtract(7), "number");
+assert.throws(TypeError, () => instance.subtract(7n), "bigint");
 assert.throws(TypeError, () => instance.subtract([]), "array");
 assert.throws(TypeError, () => instance.subtract(() => {}), "function");

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-number.js
@@ -3,28 +3,23 @@
 
 /*---
 esid: sec-temporal.plaintime.prototype.toplaindatetime
-description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
-const arg = 19761118;
-
-const result = instance.toPlainDateTime(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.toPlainDateTime(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-number.js
@@ -3,30 +3,23 @@
 
 /*---
 esid: sec-temporal.plaintime.prototype.toplaindatetime
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.toPlainDateTime(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "19970327 is a valid ISO string for calendar");
+const instance = new Temporal.PlainDate(1976, 11, 18);
 
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
-
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.toPlainDateTime(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.toPlainDateTime(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.toPlainDateTime(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toPlainDateTime(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.toPlainDateTime(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.plaintime.prototype.tozoneddatetime
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
-const arg = 19761118;
-
-const result = instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
-assert.sameValue(result.epochNanoseconds, 217_168_496_987_654_321n, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.plaintime.prototype.tozoneddatetime
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
-assert.sameValue(result.epochNanoseconds, 217_168_496_987_654_321n, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -19,8 +19,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainTime();
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-number.js
@@ -3,17 +3,11 @@
 
 /*---
 esid: sec-temporal.plaintime.prototype.until
-description: A number is converted to a string, then to Temporal.PlainTime
-includes: [temporalHelpers.js]
+description: A number is invalid in place of an ISO string for Temporal.PlainTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
-const arg = 123456.987654321;
-
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -24,8 +18,8 @@ const numbers = [
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.until(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainTime`
+    "A number is not a valid ISO string for PlainTime"
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.until(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/calendar-number.js
@@ -3,25 +3,21 @@
 
 /*---
 esid: sec-temporal.plainyearmonth
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
-
-const arg = 19761118;
-
-const result = new Temporal.PlainYearMonth(2000, 5, arg, 1);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
 
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => new Temporal.PlainYearMonth(2000, 5, arg, 1),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,8 +17,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => new Temporal.PlainYearMonth(2000, 5, arg, 1), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => new Temporal.PlainYearMonth(2000, 5, arg, 1),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-number.js
@@ -3,32 +3,28 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.compare
-description: A number is converted to a string, then to Temporal.PlainYearMonth
+description: A number is invalid in place of an ISO string for Temporal.PlainYearMonth
 features: [Temporal]
 ---*/
 
 const arg = 201906;
 
-const result1 = Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6));
-assert.sameValue(result1, 0, "201906 is a valid ISO string for PlainYearMonth (first argument)");
-const result2 = Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg);
-assert.sameValue(result2, 0, "201906 is a valid ISO string for PlainYearMonth (second argument)");
-
 const numbers = [
   1,
+  201906,
   -201906,
   1234567,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)),
-    `Number ${arg} does not convert to a valid ISO string for PlainYearMonth (first argument)`
+    "A number is not a valid ISO string for PlainYearMonth (first argument)"
   );
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainYearMonth (first argument)`
+    "A number is not a valid ISO string for PlainYearMonth (first argument)"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-number.js
@@ -3,20 +3,13 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.compare
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const calendar = 19970327;
-
-const arg = { year: 2019, monthCode: "M06", calendar };
-const result1 = Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6));
-assert.sameValue(result1, 0, "19970327 is a valid ISO string for calendar (first argument)");
-const result2 = Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg);
-assert.sameValue(result2, 0, "19970327 is a valid ISO string for calendar (second argument)");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,13 +17,13 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 2019, monthCode: "M06", calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)),
-    `Number ${calendar} does not convert to a valid ISO string for calendar (first argument)`
+    "A number is not a valid ISO string for calendar (first argument)"
   );
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar (second argument)`
+    "A number is not a valid ISO string for calendar (second argument)"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,10 +17,18 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg), `${description} does not convert to a valid ISO string (second argument)`);
+  assert.throws(
+    typeof calendar === "string" ? RangeError : TypeError,
+    () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof calendar === "string" ? RangeError : TypeError,
+    () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -18,9 +18,17 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg), `${description} does not convert to a valid ISO string (second argument)`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-number.js
@@ -3,26 +3,21 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.from
-description: A number is converted to a string, then to Temporal.PlainYearMonth
-includes: [temporalHelpers.js]
+description: A number is invalid in place of an ISO string for Temporal.PlainYearMonth
 features: [Temporal]
 ---*/
 
-const arg = 201906;
-
-const result = Temporal.PlainYearMonth.from(arg);
-TemporalHelpers.assertPlainYearMonth(result, 2019, 6, "M06", "201906 is a valid ISO string for PlainYearMonth");
-
 const numbers = [
   1,
+  201906,
   -201906,
   1234567,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainYearMonth.from(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainYearMonth`
+    "A number is not a valid ISO string for PlainYearMonth"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-number.js
@@ -3,19 +3,13 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.from
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const calendar = 19970327;
-
-const arg = { year: 2019, monthCode: "M06", calendar };
-const result = Temporal.PlainYearMonth.from(arg);
-TemporalHelpers.assertPlainYearMonth(result, 2019, 6, "M06", "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -23,8 +17,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 2019, monthCode: "M06", calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.PlainYearMonth.from(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,9 +17,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => Temporal.PlainYearMonth.from(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainYearMonth.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.PlainYearMonth.from(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.PlainYearMonth.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-not-object.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.PlainYearMonth(2000, 5);
-assert.throws(RangeError, () => instance.add(undefined), "undefined");
-assert.throws(RangeError, () => instance.add(null), "null");
-assert.throws(RangeError, () => instance.add(true), "boolean");
+assert.throws(TypeError, () => instance.add(undefined), "undefined");
+assert.throws(TypeError, () => instance.add(null), "null");
+assert.throws(TypeError, () => instance.add(true), "boolean");
 assert.throws(RangeError, () => instance.add(""), "empty string");
 assert.throws(TypeError, () => instance.add(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.add(7), "number");
-assert.throws(RangeError, () => instance.add(7n), "bigint");
+assert.throws(TypeError, () => instance.add(7), "number");
+assert.throws(TypeError, () => instance.add(7n), "bigint");
 assert.throws(TypeError, () => instance.add([]), "array");
 assert.throws(TypeError, () => instance.add(() => {}), "function");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.prototype.equals
-description: A number is converted to a string, then to Temporal.PlainYearMonth
+description: A number is invalid in place of an ISO string for Temporal.PlainYearMonth
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainYearMonth(2019, 6);
 
-const arg = 201906;
-
-const result = instance.equals(arg);
-assert.sameValue(result, true, "201906 is a valid ISO string for PlainYearMonth");
-
 const numbers = [
   1,
+  201906,
   -201906,
   1234567,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.equals(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainYearMonth`
+    "A number is not a valid ISO string for PlainYearMonth"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.prototype.equals
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainYearMonth(2019, 6);
 
-const calendar = 19970327;
-
-const arg = { year: 2019, monthCode: "M06", calendar };
-const result = instance.equals(arg);
-assert.sameValue(result, true, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 2019, monthCode: "M06", calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.equals(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainYearMonth(2000, 5);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainYearMonth(2000, 5);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-number.js
@@ -3,28 +3,23 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.prototype.since
-description: A number is converted to a string, then to Temporal.PlainYearMonth
-includes: [temporalHelpers.js]
+description: A number is invalid in place of an ISO string for Temporal.PlainYearMonth
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainYearMonth(2019, 6);
 
-const arg = 201906;
-
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "201906 is a valid ISO string for PlainYearMonth");
-
 const numbers = [
   1,
+  201906,
   -201906,
   1234567,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.since(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainYearMonth`
+    "A number is not a valid ISO string for PlainYearMonth"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-number.js
@@ -3,30 +3,23 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.prototype.since
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainYearMonth(2019, 6);
-
-const calendar = 19970327;
-
-const arg = { year: 2019, monthCode: "M06", calendar };
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+const instance = new Temporal.PlainDate(1976, 11, 18);
 
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
-
 for (const calendar of numbers) {
   const arg = { year: 2019, monthCode: "M06", calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.since(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainYearMonth(2000, 5);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.since(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainYearMonth(2000, 5);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.since(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-not-object.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.PlainYearMonth(2000, 5);
-assert.throws(RangeError, () => instance.subtract(undefined), "undefined");
-assert.throws(RangeError, () => instance.subtract(null), "null");
-assert.throws(RangeError, () => instance.subtract(true), "boolean");
+assert.throws(TypeError, () => instance.subtract(undefined), "undefined");
+assert.throws(TypeError, () => instance.subtract(null), "null");
+assert.throws(TypeError, () => instance.subtract(true), "boolean");
 assert.throws(RangeError, () => instance.subtract(""), "empty string");
 assert.throws(TypeError, () => instance.subtract(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.subtract(7), "number");
-assert.throws(RangeError, () => instance.subtract(7n), "bigint");
+assert.throws(TypeError, () => instance.subtract(7), "number");
+assert.throws(TypeError, () => instance.subtract(7n), "bigint");
 assert.throws(TypeError, () => instance.subtract([]), "array");
 assert.throws(TypeError, () => instance.subtract(() => {}), "function");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-number.js
@@ -3,28 +3,23 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.prototype.until
-description: A number is converted to a string, then to Temporal.PlainYearMonth
-includes: [temporalHelpers.js]
+description: A number is invalid in place of an ISO string for Temporal.PlainYearMonth
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.PlainYearMonth(2019, 6);
 
-const arg = 201906;
-
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "201906 is a valid ISO string for PlainYearMonth");
-
 const numbers = [
   1,
+  201906,
   -201906,
   1234567,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.until(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainYearMonth`
+    "A number is not a valid ISO string for PlainYearMonth"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-number.js
@@ -3,30 +3,23 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.prototype.until
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainYearMonth(2019, 6);
-
-const calendar = 19970327;
-
-const arg = { year: 2019, monthCode: "M06", calendar };
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+const instance = new Temporal.PlainDate(1976, 11, 18);
 
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
-
 for (const calendar of numbers) {
   const arg = { year: 2019, monthCode: "M06", calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.until(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.PlainYearMonth(2000, 5);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.until(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.PlainYearMonth(2000, 5);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.until(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/argument-wrong-type.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone
+description: RangeError thrown when constructor invoked with the wrong type
+features: [Temporal]
+---*/
+
+const tests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+  [Symbol(), "symbol"],
+  [{}, "object not implementing any protocol"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
+  [Temporal.ZonedDateTime.from("2020-01-01T00:00Z[UTC]"), "ZonedDateTime instance"],
+];
+
+for (const [arg, description] of tests) {
+  assert.throws(
+    typeof (arg) === "string" ? RangeError : TypeError,
+    () => new Temporal.TimeZone(arg),
+    `${description} is not accepted by this constructor`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/from/argument-primitive.js
+++ b/test/built-ins/Temporal/TimeZone/from/argument-primitive.js
@@ -37,7 +37,7 @@ const thisValues = [
 
 for (const thisValue of thisValues) {
   for (const primitive of primitives) {
-    assert.throws(RangeError, () => Temporal.TimeZone.from.call(thisValue, primitive));
+    assert.throws(typeof primitive === 'string' ? RangeError : TypeError, () => Temporal.TimeZone.from.call(thisValue, primitive));
   }
 
   const symbol = Symbol();

--- a/test/built-ins/Temporal/TimeZone/from/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/from/timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.TimeZone.from(timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.TimeZone.from(timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/missing-arguments.js
+++ b/test/built-ins/Temporal/TimeZone/missing-arguments.js
@@ -3,9 +3,9 @@
 
 /*---
 esid: sec-temporal.timezone
-description: RangeError thrown when constructor invoked with no argument
+description: TypeError thrown when constructor invoked with no argument
 features: [Temporal]
 ---*/
 
-assert.throws(RangeError, () => new Temporal.TimeZone());
-assert.throws(RangeError, () => new Temporal.TimeZone(undefined));
+assert.throws(TypeError, () => new Temporal.TimeZone());
+assert.throws(TypeError, () => new Temporal.TimeZone(undefined));

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-not-datetime.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-not-datetime.js
@@ -8,11 +8,11 @@ features: [Temporal]
 ---*/
 
 const timeZone = Temporal.TimeZone.from("UTC");
-assert.throws(RangeError, () => timeZone.getInstantFor(undefined), "undefined");
-assert.throws(RangeError, () => timeZone.getInstantFor(null), "null");
-assert.throws(RangeError, () => timeZone.getInstantFor(true), "boolean");
+assert.throws(TypeError, () => timeZone.getInstantFor(undefined), "undefined");
+assert.throws(TypeError, () => timeZone.getInstantFor(null), "null");
+assert.throws(TypeError, () => timeZone.getInstantFor(true), "boolean");
 assert.throws(RangeError, () => timeZone.getInstantFor(""), "empty string");
 assert.throws(TypeError, () => timeZone.getInstantFor(Symbol()), "Symbol");
-assert.throws(RangeError, () => timeZone.getInstantFor(5), "number");
-assert.throws(RangeError, () => timeZone.getInstantFor(5n), "bigint");
+assert.throws(TypeError, () => timeZone.getInstantFor(5), "number");
+assert.throws(TypeError, () => timeZone.getInstantFor(5n), "bigint");
 assert.throws(TypeError, () => timeZone.getInstantFor({ year: 2020 }), "plain object");

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-number.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.timezone.prototype.getinstantfor
-description: A number is converted to a string, then to Temporal.PlainDateTime
+description: A number cannot be used in place of a Temporal.PlainDateTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.TimeZone("UTC");
 
-let arg = 19761118;
-
-const result = instance.getInstantFor(arg);
-assert.sameValue(result.epochNanoseconds, 217_123_200_000_000_000n, "19761118 is a valid ISO string for PlainDateTime");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.getInstantFor(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
+    "A number is not a valid ISO string for PlainDateTime"
   );
 }

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.timezone.prototype.getinstantfor
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.TimeZone("UTC");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.getInstantFor(arg);
-assert.sameValue(result.epochNanoseconds, 217_123_200_000_000_000n, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.getInstantFor(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.TimeZone("UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.getInstantFor(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.getInstantFor(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.TimeZone("UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.getInstantFor(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.getInstantFor(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.TimeZone("UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -23,8 +23,14 @@ const rangeErrorTests = [
   [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.getNextTransition(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === "string" || (typeof arg === "object" && arg !== null) || typeof arg === "function"
+      ? RangeError
+      : TypeError,
+    () => instance.getNextTransition(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.TimeZone("UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -23,8 +23,14 @@ const rangeErrorTests = [
   [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.getOffsetNanosecondsFor(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === "string" || (typeof arg === "object" && arg !== null) || typeof arg === "function"
+      ? RangeError
+      : TypeError,
+    () => instance.getOffsetNanosecondsFor(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-not-absolute-getOffsetNanosecondsFor-override.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-not-absolute-getOffsetNanosecondsFor-override.js
@@ -10,12 +10,12 @@ features: [Temporal]
 const timeZone = Temporal.TimeZone.from("UTC");
 let called = false;
 timeZone.getOffsetNanosecondsFor = () => called = true;
-assert.throws(RangeError, () => timeZone.getOffsetStringFor(undefined), "undefined");
-assert.throws(RangeError, () => timeZone.getOffsetStringFor(null), "null");
-assert.throws(RangeError, () => timeZone.getOffsetStringFor(true), "boolean");
+assert.throws(TypeError, () => timeZone.getOffsetStringFor(undefined), "undefined");
+assert.throws(TypeError, () => timeZone.getOffsetStringFor(null), "null");
+assert.throws(TypeError, () => timeZone.getOffsetStringFor(true), "boolean");
 assert.throws(RangeError, () => timeZone.getOffsetStringFor(""), "empty string");
 assert.throws(TypeError, () => timeZone.getOffsetStringFor(Symbol()), "Symbol");
-assert.throws(RangeError, () => timeZone.getOffsetStringFor(5), "number");
-assert.throws(RangeError, () => timeZone.getOffsetStringFor(5n), "bigint");
+assert.throws(TypeError, () => timeZone.getOffsetStringFor(5), "number");
+assert.throws(TypeError, () => timeZone.getOffsetStringFor(5n), "bigint");
 assert.throws(RangeError, () => timeZone.getOffsetStringFor({}), "plain object");
 assert.sameValue(called, false);

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.TimeZone("UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -23,8 +23,14 @@ const rangeErrorTests = [
   [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.getOffsetStringFor(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === "string" || (typeof arg === "object" && arg !== null) || typeof arg === "function"
+      ? RangeError
+      : TypeError,
+    () => instance.getOffsetStringFor(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-not-absolute-getOffsetNanosecondsFor-override.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-not-absolute-getOffsetNanosecondsFor-override.js
@@ -10,12 +10,12 @@ features: [Temporal]
 const timeZone = Temporal.TimeZone.from("UTC");
 let called = false;
 timeZone.getOffsetNanosecondsFor = () => called = true;
-assert.throws(RangeError, () => timeZone.getPlainDateTimeFor(undefined), "undefined");
-assert.throws(RangeError, () => timeZone.getPlainDateTimeFor(null), "null");
-assert.throws(RangeError, () => timeZone.getPlainDateTimeFor(true), "boolean");
+assert.throws(TypeError, () => timeZone.getPlainDateTimeFor(undefined), "undefined");
+assert.throws(TypeError, () => timeZone.getPlainDateTimeFor(null), "null");
+assert.throws(TypeError, () => timeZone.getPlainDateTimeFor(true), "boolean");
 assert.throws(RangeError, () => timeZone.getPlainDateTimeFor(""), "empty string");
 assert.throws(TypeError, () => timeZone.getPlainDateTimeFor(Symbol()), "Symbol");
-assert.throws(RangeError, () => timeZone.getPlainDateTimeFor(5), "number");
-assert.throws(RangeError, () => timeZone.getPlainDateTimeFor(5n), "bigint");
+assert.throws(TypeError, () => timeZone.getPlainDateTimeFor(5), "number");
+assert.throws(TypeError, () => timeZone.getPlainDateTimeFor(5n), "bigint");
 assert.throws(RangeError, () => timeZone.getPlainDateTimeFor({}), "plain object");
 assert.sameValue(called, false);

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.TimeZone("UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -23,8 +23,14 @@ const rangeErrorTests = [
   [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.getPlainDateTimeFor(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === "string" || (typeof arg === "object" && arg !== null) || typeof arg === "function"
+      ? RangeError
+      : TypeError,
+    () => instance.getPlainDateTimeFor(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-number.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.timezone.prototype.getplaindatetimefor
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.TimeZone("UTC");
 
-const arg = 19761118;
-
-const result = instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
-
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.TimeZone("UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -19,8 +19,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-not-datetime.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-not-datetime.js
@@ -8,11 +8,11 @@ features: [Temporal]
 ---*/
 
 const timeZone = Temporal.TimeZone.from("UTC");
-assert.throws(RangeError, () => timeZone.getPossibleInstantsFor(undefined), "undefined");
-assert.throws(RangeError, () => timeZone.getPossibleInstantsFor(null), "null");
-assert.throws(RangeError, () => timeZone.getPossibleInstantsFor(true), "boolean");
+assert.throws(TypeError, () => timeZone.getPossibleInstantsFor(undefined), "undefined");
+assert.throws(TypeError, () => timeZone.getPossibleInstantsFor(null), "null");
+assert.throws(TypeError, () => timeZone.getPossibleInstantsFor(true), "boolean");
 assert.throws(RangeError, () => timeZone.getPossibleInstantsFor(""), "empty string");
 assert.throws(TypeError, () => timeZone.getPossibleInstantsFor(Symbol()), "Symbol");
-assert.throws(RangeError, () => timeZone.getPossibleInstantsFor(5), "number");
-assert.throws(RangeError, () => timeZone.getPossibleInstantsFor(5n), "bigint");
+assert.throws(TypeError, () => timeZone.getPossibleInstantsFor(5), "number");
+assert.throws(TypeError, () => timeZone.getPossibleInstantsFor(5n), "bigint");
 assert.throws(TypeError, () => timeZone.getPossibleInstantsFor({}), "plain object");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-number.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-number.js
@@ -3,28 +3,23 @@
 
 /*---
 esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
-description: A number is converted to a string, then to Temporal.PlainDateTime
-includes: [compareArray.js]
+description: A number cannot be used in place of a Temporal.PlainDateTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.TimeZone("UTC");
 
-let arg = 19761118;
-
-const result = instance.getPossibleInstantsFor(arg);
-assert.compareArray(result.map(i => i.epochNanoseconds), [217_123_200_000_000_000n], "19761118 is a valid ISO string for PlainDateTime");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.getPossibleInstantsFor(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
+    "A number is not a valid ISO string for PlainDateTime"
   );
 }

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-propertybag-calendar-number.js
@@ -3,21 +3,15 @@
 
 /*---
 esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [compareArray.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.TimeZone("UTC");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.getPossibleInstantsFor(arg);
-assert.compareArray(result.map(i => i.epochNanoseconds), [217_123_200_000_000_000n], "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -25,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.getPossibleInstantsFor(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.TimeZone("UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.getPossibleInstantsFor(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.getPossibleInstantsFor(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.TimeZone("UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.getPossibleInstantsFor(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.getPossibleInstantsFor(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.TimeZone("UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -23,8 +23,14 @@ const rangeErrorTests = [
   [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.getPreviousTransition(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === "string" || (typeof arg === "object" && arg !== null) || typeof arg === "function"
+      ? RangeError
+      : TypeError,
+    () => instance.getPreviousTransition(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/calendar-number.js
@@ -3,25 +3,21 @@
 
 /*---
 esid: sec-temporal.zoneddatetime
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
-
-const arg = 19761118;
-
-const result = new Temporal.ZonedDateTime(0n, "UTC", arg);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
 
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => new Temporal.ZonedDateTime(0n, "UTC", arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,8 +17,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => new Temporal.ZonedDateTime(0n, "UTC", arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => new Temporal.ZonedDateTime(0n, "UTC", arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-number.js
@@ -3,23 +3,16 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.compare
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
-
-const calendar = 19970327;
 
 const timeZone = new Temporal.TimeZone("UTC");
 const datetime = new Temporal.ZonedDateTime(0n, timeZone);
 
-const arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
-const result1 = Temporal.ZonedDateTime.compare(arg, datetime);
-assert.sameValue(result1, 0, "19970327 is a valid ISO string for calendar (first argument)");
-const result2 = Temporal.ZonedDateTime.compare(datetime, arg);
-assert.sameValue(result2, 0, "19970327 is a valid ISO string for calendar (second argument)");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -27,13 +20,13 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.ZonedDateTime.compare(arg, datetime),
-    `Number ${calendar} does not convert to a valid ISO string for calendar (first argument)`
+    "A number is not a valid ISO string for calendar (first argument)"
   );
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.ZonedDateTime.compare(datetime, arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar (second argument)`
+    "A number is not a valid ISO string for calendar (second argument)"
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const datetime = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -19,10 +19,18 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(arg, datetime), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(datetime, arg), `${description} does not convert to a valid ISO string (second argument)`);
+  assert.throws(
+    typeof calendar === "string" ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.compare(arg, datetime),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof calendar === "string" ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.compare(datetime, arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-invalid-offset-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-invalid-offset-string.js
@@ -14,10 +14,21 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  0,          // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 badOffsets.forEach((offset) => {
   const arg = { year: 2021, month: 10, day: 28, offset, timeZone };
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(arg, datetime), `"${offset} is not a valid offset string (second argument)`);
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(datetime, arg), `"${offset} is not a valid offset string (second argument)`);
+  assert.throws(
+    typeof(offset) === 'string' ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.compare(arg, datetime),
+    `"${offset} is not a valid offset string (second argument)`
+  );
+  assert.throws(
+    typeof(offset) === 'string' ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.compare(datetime, arg),
+    `"${offset} is not a valid offset string (second argument)`
+  );
 });

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-timezone-string-multiple-offsets.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-timezone-string-multiple-offsets.js
@@ -14,4 +14,4 @@ const timeZone = "2021-08-19T17:30:45.123456789+01:46[+01:45:30.987654321]";
 const result1 = Temporal.ZonedDateTime.compare({ year: 2020, month: 5, day: 2, timeZone }, instance);
 assert.sameValue(result1, 0, "Time zone string determined from bracket name (first argument)");
 const result2 = Temporal.ZonedDateTime.compare(instance, { year: 2020, month: 5, day: 2, timeZone });
-assert.sameValue(result2, 0, "Time zone string determined from bracket name (first argument)");
+assert.sameValue(result2, 0, "Time zone string determined from bracket name (second argument)");

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const datetime = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,17 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare({ year: 2020, month: 5, day: 2, timeZone }, datetime), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(datetime, { year: 2020, month: 5, day: 2, timeZone }), `${description} does not convert to a valid ISO string (second argument)`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.compare({ year: 2020, month: 5, day: 2, timeZone }, datetime),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.compare(datetime, { year: 2020, month: 5, day: 2, timeZone }),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const other = new Temporal.ZonedDateTime(0n, timeZone);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -22,9 +22,17 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(arg, other), `${description} does not convert to a valid ISO string (first argument)`);
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(other, arg), `${description} does not convert to a valid ISO string (second argument)`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.compare(arg, other),
+    `${description} does not convert to a valid ISO string (first argument)`
+  );
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.compare(other, arg),
+    `${description} does not convert to a valid ISO string (second argument)`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/compare/calendar-datefromfields-called-with-null-prototype-fields.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/calendar-datefromfields-called-with-null-prototype-fields.js
@@ -20,4 +20,4 @@ assert.sameValue(calendar.dateFromFieldsCallCount, 1, "dateFromFields should be 
 calendar.dateFromFieldsCallCount = 0;
 
 Temporal.ZonedDateTime.compare(arg2, arg1);
-assert.sameValue(calendar.dateFromFieldsCallCount, 1, "dateFromFields should be called on the property bag's calendar (first argument)");
+assert.sameValue(calendar.dateFromFieldsCallCount, 1, "dateFromFields should be called on the property bag's calendar (second argument)");

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-number.js
@@ -3,19 +3,15 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.from
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
-const calendar = 19970327;
-
 const timeZone = new Temporal.TimeZone("UTC");
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
-const result = Temporal.ZonedDateTime.from(arg);
-assert.sameValue(result.calendarId, "iso8601", "19970327 is a valid ISO string for calendar");
 
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -23,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => Temporal.ZonedDateTime.from(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -17,9 +17,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.from(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-invalid-offset-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-invalid-offset-string.js
@@ -15,13 +15,16 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  0,          // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 offsetOptions.forEach((offsetOption) => {
   badOffsets.forEach((offset) => {
     const arg = { year: 2021, month: 10, day: 28, offset, timeZone };
     assert.throws(
-      RangeError,
+      typeof(offset) === 'string' ? RangeError : TypeError,
       () => Temporal.ZonedDateTime.from(arg, { offset: offsetOption }),
       `"${offset} is not a valid offset string (with offset option ${offsetOption})`
     );

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -19,8 +19,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => Temporal.ZonedDateTime.from(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => Temporal.ZonedDateTime.from(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/add/argument-not-object.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/add/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
-assert.throws(RangeError, () => instance.add(undefined), "undefined");
-assert.throws(RangeError, () => instance.add(null), "null");
-assert.throws(RangeError, () => instance.add(true), "boolean");
+assert.throws(TypeError, () => instance.add(undefined), "undefined");
+assert.throws(TypeError, () => instance.add(null), "null");
+assert.throws(TypeError, () => instance.add(true), "boolean");
 assert.throws(RangeError, () => instance.add(""), "empty string");
 assert.throws(TypeError, () => instance.add(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.add(7), "number");
-assert.throws(RangeError, () => instance.add(7n), "bigint");
+assert.throws(TypeError, () => instance.add(7), "number");
+assert.throws(TypeError, () => instance.add(7n), "bigint");
 assert.throws(TypeError, () => instance.add([]), "array");
 assert.throws(TypeError, () => instance.add(() => {}), "function");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-number.js
@@ -3,21 +3,16 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.prototype.equals
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const calendar = 19970327;
-
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
-const result = instance.equals(arg);
-assert.sameValue(result, true, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -25,8 +20,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.equals(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-invalid-offset-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-invalid-offset-string.js
@@ -14,9 +14,16 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  0,          // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 badOffsets.forEach((offset) => {
   const arg = { year: 2021, month: 10, day: 28, offset, timeZone };
-  assert.throws(RangeError, () => instance.equals(arg), `"${offset} is not a valid offset string`);
+  assert.throws(
+    typeof(offset) === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `"${offset} is not a valid offset string`
+  );
 });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals({ year: 2020, month: 5, day: 2, timeZone }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.equals({ year: 2020, month: 5, day: 2, timeZone }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -22,8 +22,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.equals(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-number.js
@@ -3,22 +3,16 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.prototype.since
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const calendar = 19970327;
-
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -26,8 +20,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.since(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.since(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-invalid-offset-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-invalid-offset-string.js
@@ -14,9 +14,16 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  0,          // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 badOffsets.forEach((offset) => {
   const arg = { year: 2021, month: 10, day: 28, offset, timeZone };
-  assert.throws(RangeError, () => instance.since(arg), `"${offset} is not a valid offset string`);
+  assert.throws(
+    typeof(offset) === 'string' ? RangeError : TypeError,
+    () => instance.since(arg),
+    `"${offset} is not a valid offset string`
+  );
 });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.since({ year: 2020, month: 5, day: 2, timeZone }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.since({ year: 2020, month: 5, day: 2, timeZone }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -22,8 +22,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.since(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/argument-not-object.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/argument-not-object.js
@@ -8,12 +8,12 @@ features: [Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
-assert.throws(RangeError, () => instance.subtract(undefined), "undefined");
-assert.throws(RangeError, () => instance.subtract(null), "null");
-assert.throws(RangeError, () => instance.subtract(true), "boolean");
+assert.throws(TypeError, () => instance.subtract(undefined), "undefined");
+assert.throws(TypeError, () => instance.subtract(null), "null");
+assert.throws(TypeError, () => instance.subtract(true), "boolean");
 assert.throws(RangeError, () => instance.subtract(""), "empty string");
 assert.throws(TypeError, () => instance.subtract(Symbol()), "Symbol");
-assert.throws(RangeError, () => instance.subtract(7), "number");
-assert.throws(RangeError, () => instance.subtract(7n), "bigint");
+assert.throws(TypeError, () => instance.subtract(7), "number");
+assert.throws(TypeError, () => instance.subtract(7n), "bigint");
 assert.throws(TypeError, () => instance.subtract([]), "array");
 assert.throws(TypeError, () => instance.subtract(() => {}), "function");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-number.js
@@ -3,22 +3,16 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.prototype.until
-description: A number as calendar in a property bag is converted to a string, then to a calendar
-includes: [temporalHelpers.js]
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const calendar = 19970327;
-
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -26,8 +20,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.until(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.until(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-invalid-offset-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-invalid-offset-string.js
@@ -14,9 +14,16 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  0,          // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 badOffsets.forEach((offset) => {
   const arg = { year: 2021, month: 10, day: 28, offset, timeZone };
-  assert.throws(RangeError, () => instance.until(arg), `"${offset} is not a valid offset string`);
+  assert.throws(
+    typeof(offset) === 'string' ? RangeError : TypeError,
+    () => instance.until(arg),
+    `"${offset} is not a valid offset string`
+  );
 });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.until({ year: 2020, month: 5, day: 2, timeZone }), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.until({ year: 2020, month: 5, day: 2, timeZone }),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -22,8 +22,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.until(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/offset-property-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/offset-property-invalid-string.js
@@ -16,12 +16,15 @@ const badOffsets = [
   "00:00",    // missing sign
   "+0",       // too short
   "-000:00",  // too long
-  0,          // converts to a string that is invalid
+  0,          // must be a string
+  null,       // must be a string
+  true,       // must be a string
+  1000n,      // must be a string
 ];
 offsetOptions.forEach((offsetOption) => {
   badOffsets.forEach((offset) => {
     assert.throws(
-      RangeError,
+      typeof(offset) === 'string' ? RangeError : TypeError,
       () => instance.with({ offset }, { offset: offsetOption }),
       `"${offset} is not a valid offset string (with ${offsetOption} offset option)`,
     );

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-number.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.prototype.withcalendar
-description: A number is converted to a string, then to Temporal.Calendar
+description: A number is not allowed to be a calendar
 features: [Temporal]
 ---*/
 
@@ -31,21 +31,17 @@ const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", {
   yearOfWeek() {},
 });
 
-const arg = 19761118;
-
-const result = instance.withCalendar(arg);
-assert.sameValue(result.calendarId, "iso8601", "19761118 is a valid ISO string for Calendar");
-
 const numbers = [
   1,
   -19761118,
+  19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.withCalendar(arg),
-    `Number ${arg} does not convert to a valid ISO string for Calendar`
+    "A number is not a valid ISO string for Calendar"
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-wrong-type.js
@@ -33,7 +33,7 @@ const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", {
   yearOfWeek() {},
 });
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -41,8 +41,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.withCalendar(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.withCalendar(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/missing-argument.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/missing-argument.js
@@ -3,10 +3,10 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.prototype.withcalendar
-description: RangeError thrown when calendar argument not given
+description: TypeError thrown when calendar argument not given
 features: [Temporal]
 ---*/
 
 const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
-assert.throws(RangeError, () => zonedDateTime.withCalendar(), "missing argument");
-assert.throws(RangeError, () => zonedDateTime.withCalendar(undefined), "undefined argument");
+assert.throws(TypeError, () => zonedDateTime.withCalendar(), "missing argument");
+assert.throws(TypeError, () => zonedDateTime.withCalendar(undefined), "undefined argument");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.prototype.withplaindate
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 
-const arg = 19761118;
-
-const result = instance.withPlainDate(arg);
-assert.sameValue(result.epochNanoseconds, 217_129_600_000_000_000n, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.withPlainDate(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-propertybag-calendar-number.js
@@ -3,21 +3,16 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.prototype.withplaindate
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, timeZone);
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.withPlainDate(arg);
-assert.sameValue(result.epochNanoseconds, 217_129_600_000_000_000n, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -25,8 +20,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.withPlainDate(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, timeZone);
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.withPlainDate(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.withPlainDate(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.withPlainDate(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.withPlainDate(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-number.js
@@ -3,16 +3,11 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.prototype.withplaintime
-description: A number is converted to a string, then to Temporal.PlainTime
+description: A number is invalid in place of an ISO string for Temporal.PlainTime
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
-
-const arg = 123456.987654321;
-
-const result = instance.withPlainTime(arg);
-assert.sameValue(result.epochNanoseconds, 1000038896_987_654_321n, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -23,8 +18,8 @@ const numbers = [
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.withPlainTime(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainTime`
+    "A number is not a valid ISO string for PlainTime"
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -19,8 +19,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.withPlainTime(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.withPlainTime(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone/timezone-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.withTimeZone(timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => instance.withTimeZone(timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/built-ins/Temporal/ZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/timezone-wrong-type.js
@@ -9,7 +9,7 @@ description: >
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -18,8 +18,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [timeZone, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => new Temporal.ZonedDateTime(0n, timeZone), `${description} does not convert to a valid ISO string`);
+for (const [timeZone, description] of primitiveTests) {
+  assert.throws(
+    typeof timeZone === 'string' ? RangeError : TypeError,
+    () => new Temporal.ZonedDateTime(0n, timeZone),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-number.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.era
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.era(arg);
-assert.sameValue(result, undefined, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.era(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-number.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.era
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.era(arg);
-assert.sameValue(result, undefined, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.era(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-wrong-type.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.era(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.era(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-wrong-type.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.era(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.era(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-number.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-number.js
@@ -3,27 +3,23 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.erayear
-description: A number is converted to a string, then to Temporal.PlainDate
+description: A number cannot be used in place of a Temporal.PlainDate
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const arg = 19761118;
-
-const result = instance.eraYear(arg);
-assert.sameValue(result, undefined, "19761118 is a valid ISO string for PlainDate");
-
 const numbers = [
   1,
+  19761118,
   -19761118,
   1234567890,
 ];
 
 for (const arg of numbers) {
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.eraYear(arg),
-    `Number ${arg} does not convert to a valid ISO string for PlainDate`
+    'Numbers cannot be used in place of an ISO string for PlainDate'
   );
 }

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-number.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-number.js
@@ -3,20 +3,15 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.erayear
-description: A number as calendar in a property bag is converted to a string, then to a calendar
+description: A number as calendar in a property bag is not accepted
 features: [Temporal]
 ---*/
 
 const instance = new Temporal.Calendar("iso8601");
 
-const calendar = 19970327;
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.eraYear(arg);
-assert.sameValue(result, undefined, "19970327 is a valid ISO string for calendar");
-
 const numbers = [
   1,
+  19970327,
   -19970327,
   1234567890,
 ];
@@ -24,8 +19,8 @@ const numbers = [
 for (const calendar of numbers) {
   const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
   assert.throws(
-    RangeError,
+    TypeError,
     () => instance.eraYear(arg),
-    `Number ${calendar} does not convert to a valid ISO string for calendar`
+    "Numbers cannot be used as a calendar"
   );
 }

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-wrong-type.js
@@ -12,7 +12,7 @@ features: [BigInt, Symbol, Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -20,9 +20,13 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [calendar, description] of rangeErrorTests) {
+for (const [calendar, description] of primitiveTests) {
   const arg = { year: 2019, monthCode: "M11", day: 1, calendar };
-  assert.throws(RangeError, () => instance.eraYear(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(
+    typeof calendar === 'string' ? RangeError : TypeError,
+    () => instance.eraYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-wrong-type.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-wrong-type.js
@@ -11,7 +11,7 @@ features: [BigInt, Symbol, Temporal]
 
 const instance = new Temporal.Calendar("iso8601");
 
-const rangeErrorTests = [
+const primitiveTests = [
   [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
@@ -20,8 +20,12 @@ const rangeErrorTests = [
   [1n, "bigint"],
 ];
 
-for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.eraYear(arg), `${description} does not convert to a valid ISO string`);
+for (const [arg, description] of primitiveTests) {
+  assert.throws(
+    typeof arg === 'string' ? RangeError : TypeError,
+    () => instance.eraYear(arg),
+    `${description} does not convert to a valid ISO string`
+  );
 }
 
 const typeErrorTests = [

--- a/test/staging/Temporal/Duration/old/round.js
+++ b/test/staging/Temporal/Duration/old/round.js
@@ -194,11 +194,11 @@ assert.sameValue(`${ hours25.round({
   }
 }) }`, "P1DT1H");
 
-// accepts datetime string equivalents or fields for relativeTo
+// accepts datetime strings or fields for relativeTo
 [
   "2020-01-01",
+  "20200101",
   "2020-01-01T00:00:00.000000000",
-  20200101n,
   {
     year: 2020,
     month: 1,
@@ -209,6 +209,18 @@ assert.sameValue(`${ hours25.round({
     smallestUnit: "seconds",
     relativeTo
   }) }`, "P5Y5M5W5DT5H5M5S");
+});
+
+// does not accept non-string primitives for relativeTo
+[
+  20200101,
+  20200101n,
+  null,
+  true,
+].forEach(relativeTo => {
+  assert.throws(
+    TypeError, () => d.round({ smallestUnit: "seconds", relativeTo})
+  );
 });
 
 // throws on wrong offset for ZonedDateTime relativeTo string

--- a/test/staging/Temporal/Duration/old/total.js
+++ b/test/staging/Temporal/Duration/old/total.js
@@ -35,11 +35,11 @@ var s = Temporal.Duration.from({
 }).total({ unit: "seconds" });
 assert.sameValue(s, 0.002031);
 
-// accepts datetime string equivalents or fields for relativeTo
+// accepts datetime strings or fields for relativeTo
 [
   "2020-01-01",
+  "20200101",
   "2020-01-01T00:00:00.000000000",
-  20200101n,
   {
     year: 2020,
     month: 1,
@@ -56,6 +56,18 @@ assert.sameValue(s, 0.002031);
     relativeTo
   });
   assert.sameValue(total.toPrecision(15), totalMonths.toPrecision(15));
+});
+
+// does not accept non-string primitives for relativeTo
+[
+  20200101,
+  20200101n,
+  null,
+  true,
+].forEach(relativeTo => {
+  assert.throws(
+    TypeError, () => d.total({ unit: "months", relativeTo})
+  );
 });
 
 // throws on wrong offset for ZonedDateTime relativeTo string

--- a/test/staging/Temporal/Instant/old/toZonedDateTimeISO.js
+++ b/test/staging/Temporal/Instant/old/toZonedDateTimeISO.js
@@ -10,7 +10,7 @@ features: [Temporal]
 var inst = Temporal.Instant.from("1976-11-18T14:23:30.123456789Z");
 
 // throws without parameter
-assert.throws(RangeError, () => inst.toZonedDateTimeISO());
+assert.throws(TypeError, () => inst.toZonedDateTimeISO());
 
 // time zone parameter UTC
 var tz = Temporal.TimeZone.from("UTC");

--- a/test/staging/Temporal/ZonedDateTime/old/property-bags.js
+++ b/test/staging/Temporal/ZonedDateTime/old/property-bags.js
@@ -73,15 +73,29 @@ assert.sameValue(`${ Temporal.ZonedDateTime.from({
   hours: 12
 }) }`, "1976-11-18T00:00:00+01:00[+01:00]");
 
-// casts offset property
-var zdt = Temporal.ZonedDateTime.from({
-  year: 1976,
-  month: 11,
-  day: 18,
-  offset: -1030,
-  timeZone: Temporal.TimeZone.from("-10:30")
+// does not accept non-string offset property
+[
+  null,
+  true,
+  1000,
+  1000n,
+  Symbol(),
+  {}
+].forEach(offset => {
+  assert.throws(
+    typeof offset === "string" || (typeof offset === "object" && offset !== null) || typeof offset === "function"
+      ? RangeError
+      : TypeError,
+    () => Temporal.ZonedDateTime.from({
+      year: 1976,
+      month: 11,
+      day: 18,
+      offset: offset,
+      timeZone: Temporal.TimeZone.from("+10:00")
+    })
+  )
 });
-assert.sameValue(`${ zdt }`, "1976-11-18T00:00:00-10:30[-10:30]");
+
 
 // overflow options
 var bad = {


### PR DESCRIPTION
Test changes to support https://github.com/tc39/proposal-temporal/pull/2574.
