### PR TITLE
Work around Node 20 / ICU 73.1 calendar bug

### DIFF
--- a/test/staging/Intl402/Temporal/old/japanese-era.js
+++ b/test/staging/Intl402/Temporal/old/japanese-era.js
@@ -69,6 +69,7 @@ var date = Temporal.PlainDate.from({
 assert.sameValue(`${ date }`, "2019-01-01[u-ca=japanese]");
 assert.sameValue(date.era, "heisei");
 assert.sameValue(date.eraYear, 31);
+
 date = Temporal.PlainDate.from({
   era: "heisei",
   eraYear: 1,
@@ -89,6 +90,7 @@ date = Temporal.PlainDate.from({
 assert.sameValue(`${ date }`, "1926-01-01[u-ca=japanese]");
 assert.sameValue(date.era, "taisho");
 assert.sameValue(date.eraYear, 15);
+
 date = Temporal.PlainDate.from({
   era: "taisho",
   eraYear: 1,
@@ -99,6 +101,7 @@ date = Temporal.PlainDate.from({
 assert.sameValue(`${ date }`, "1912-01-01[u-ca=japanese]");
 assert.sameValue(date.era, "meiji");
 assert.sameValue(date.eraYear, 45);
+
 date = Temporal.PlainDate.from({
   era: "meiji",
   eraYear: 1,
@@ -109,10 +112,26 @@ date = Temporal.PlainDate.from({
 assert.sameValue(`${ date }`, "1868-01-01[u-ca=japanese]");
 assert.sameValue(date.era, "ce");
 assert.sameValue(date.eraYear, 1868);
-assert.throws(RangeError, () => Temporal.PlainDate.from({
+
+// Verify that CE and BCE eras (before Meiji) are recognized
+date = Temporal.PlainDate.from({
+  era: "ce",
+  eraYear: 1000,
+  month: 1,
+  day: 1,
+  calendar: "japanese"
+});
+assert.sameValue(`${date}`, "1000-01-01[u-ca=japanese]");
+assert.sameValue(date.era, "ce");
+assert.sameValue(date.eraYear, 1000);
+
+date = Temporal.PlainDate.from({
   era: "bce",
   eraYear: 1,
   month: 1,
   day: 1,
   calendar: "japanese"
-}));
+});
+assert.sameValue(`${date}`, "0000-01-01[u-ca=japanese]");
+assert.sameValue(date.era, "bce");
+assert.sameValue(date.eraYear, 1);

--- a/test/staging/Intl402/Temporal/old/non-iso-calendars.js
+++ b/test/staging/Intl402/Temporal/old/non-iso-calendars.js
@@ -46,7 +46,39 @@ var year2000Content = getLocalizedDates("2000-01-01T00:00Z");
 var year1Content = getLocalizedDates("0001-01-01T00:00Z");
 var year2000Snapshot = "iso8601: 1/1/2000\n" + "buddhist: 1/1/2543 BE\n" + "chinese: 11/25/1999\n" + "coptic: 4/22/1716 ERA1\n" + "dangi: 11/25/1999\n" + "ethioaa: 4/22/7492 ERA0\n" + "ethiopic: 4/22/1992 ERA1\n" + "gregory: 1/1/2000\n" + "hebrew: 23 Tevet 5760\n" + "indian: 10/11/1921 Saka\n" + "islamic: 9/25/1420 AH\n" + "islamic-umalqura: 9/24/1420 AH\n" + "islamic-tbla: 9/25/1420 AH\n" + "islamic-civil: 9/24/1420 AH\n" + "islamic-rgsa: 9/25/1420 AH\n" + "islamicc: 9/24/1420 AH\n" + "japanese: 1/1/12 H\n" + "persian: 10/11/1378 AP\n" + "roc: 1/1/89 Minguo";
 assert.sameValue(year2000Content, year2000Snapshot);
-var year1Snapshot = "iso8601: 1/1/1\n" + "buddhist: 1/3/544 BE\n" + "chinese: 11/21/0\n" + "coptic: 5/8/284 ERA0\n" + "dangi: 11/21/0\n" + "ethioaa: 5/8/5493 ERA0\n" + "ethiopic: 5/8/5493 ERA0\n" + "gregory: 1/1/1\n" + "hebrew: 18 Tevet 3761\n" + "indian: 10/11/-78 Saka\n" + "islamic: 5/20/-640 AH\n" + "islamic-umalqura: 5/18/-640 AH\n" + "islamic-tbla: 5/19/-640 AH\n" + "islamic-civil: 5/18/-640 AH\n" + "islamic-rgsa: 5/20/-640 AH\n" + "islamicc: 5/18/-640 AH\n" + "japanese: 1/3/-643 Taika (645\u2013650)\n" + "persian: 10/11/-621 AP\n" + "roc: 1/3/1911 B.R.O.C.";
+
+// Several calendars based on the Gregorian calendar use Julian dates (not
+// proleptic Gregorian dates) before the Gregorian switchover in Oct 1582. See
+// https://bugs.chromium.org/p/chromium/issues/detail?id=1173158. The code below
+// allows these tests to pass regardless of the bug, while still remaining
+// sensitive to other bugs that may crop up.
+const yearOneMonthDay = new Map(
+  ["iso8601", "gregory", "roc", "buddhist", "japanese"].map(calendar => {
+    hasGregorianSwitchoverBug = new Date("+001001-01-01T00:00Z")
+      .toLocaleDateString(`en-US-u-ca-${calendar}`, { timeZone: "UTC" })
+      .startsWith("12");
+    return [calendar, hasGregorianSwitchoverBug ? "1/3" : "1/1"]
+  }));
+var year1Snapshot = 
+  `iso8601: ${yearOneMonthDay.get("iso8601")}/1\n` + 
+  `buddhist: ${yearOneMonthDay.get("buddhist")}/544 BE\n` +
+  "chinese: 11/21/0\n" +
+  "coptic: 5/8/284 ERA0\n" +
+  "dangi: 11/21/0\n" +
+  "ethioaa: 5/8/5493 ERA0\n" +
+  "ethiopic: 5/8/5493 ERA0\n" +
+  `gregory: ${yearOneMonthDay.get("gregory")}/1\n` +
+  "hebrew: 18 Tevet 3761\n" +
+  "indian: 10/11/-78 Saka\n" +
+  "islamic: 5/20/-640 AH\n" +
+  "islamic-umalqura: 5/18/-640 AH\n" +
+  "islamic-tbla: 5/19/-640 AH\n" +
+  "islamic-civil: 5/18/-640 AH\n" +
+  "islamic-rgsa: 5/20/-640 AH\n" +
+  "islamicc: 5/18/-640 AH\n" +
+  `japanese: ${yearOneMonthDay.get("japanese")}/-643 Taika (645\u2013650)\n` +
+  "persian: 10/11/-621 AP\n" +
+  `roc: ${yearOneMonthDay.get("roc")}/1911 B.R.O.C.`;
 assert.sameValue(year1Content, year1Snapshot);
 var fromWithCases = {
   iso8601: {


### PR DESCRIPTION
These tests accompany a Temporal PR that works around a bug in ICU 73.1 (which ships with Node 20). These test changes enable tests to pass in both the buggy state and after the bug is eventually fixed.