### PR TITLE
add Float16Array to all generic TypedArray tests

### DIFF
--- a/harness/testTypedArray.js
+++ b/harness/testTypedArray.js
@@ -4,22 +4,23 @@
 description: |
     Collection of functions used to assert the correctness of TypedArray objects.
 defines:
-  - typedArrayConstructors
   - floatArrayConstructors
   - intArrayConstructors
+  - typedArrayConstructors
   - TypedArray
   - testWithTypedArrayConstructors
+  - nonAtomicsFriendlyTypedArrayConstructors
   - testWithAtomicsFriendlyTypedArrayConstructors
   - testWithNonAtomicsFriendlyTypedArrayConstructors
   - testTypedArrayConversions
 ---*/
 
-/**
- * Array containing every typed array constructor.
- */
-var typedArrayConstructors = [
+var floatArrayConstructors = [
   Float64Array,
-  Float32Array,
+  Float32Array
+];
+
+var intArrayConstructors = [
   Int32Array,
   Int16Array,
   Int8Array,
@@ -29,8 +30,17 @@ var typedArrayConstructors = [
   Uint8ClampedArray
 ];
 
-var floatArrayConstructors = typedArrayConstructors.slice(0, 2);
-var intArrayConstructors = typedArrayConstructors.slice(2, 7);
+// Float16Array is a newer feature
+// adding it to this list unconditionally would cause implementations lacking it to fail every test which uses it
+if (typeof Float16Array !== 'undefined') {
+  floatArrayConstructors.push(Float16Array);
+}
+
+/**
+ * Array containing every non-bigint typed array constructor.
+ */
+
+var typedArrayConstructors = floatArrayConstructors.concat(intArrayConstructors);
 
 /**
  * The %TypedArray% intrinsic constructor function.
@@ -63,6 +73,7 @@ function testWithTypedArrayConstructors(f, selected) {
   }
 }
 
+var nonAtomicsFriendlyTypedArrayConstructors = floatArrayConstructors.concat([Uint8ClampedArray]);
 /**
  * Calls the provided function for every non-"Atomics Friendly" typed array constructor.
  *
@@ -70,11 +81,7 @@ function testWithTypedArrayConstructors(f, selected) {
  * @param {Array} selected - An optional Array with filtered typed arrays
  */
 function testWithNonAtomicsFriendlyTypedArrayConstructors(f) {
-  testWithTypedArrayConstructors(f, [
-    Float64Array,
-    Float32Array,
-    Uint8ClampedArray
-  ]);
+  testWithTypedArrayConstructors(f, nonAtomicsFriendlyTypedArrayConstructors);
 }
 
 /**

--- a/harness/testTypedArray.js
+++ b/harness/testTypedArray.js
@@ -127,3 +127,31 @@ function testTypedArrayConversions(byteConversionValues, fn) {
     });
   });
 }
+
+/**
+ * Checks if the given argument is one of the float-based TypedArray constructors.
+ *
+ * @param {constructor} ctor - the value to check
+ * @returns {boolean}
+ */
+function isFloatTypedArrayConstructor(arg) {
+  return floatArrayConstructors.indexOf(arg) !== -1;
+}
+
+/**
+ * Determines the precision of the given float-based TypedArray constructor.
+ *
+ * @param {constructor} ctor - the value to check
+ * @returns {string} "half", "single", or "double" for Float16Array, Float32Array, and Float64Array respectively.
+ */
+function floatTypedArrayConstructorPrecision(FA) {
+  if (typeof Float16Array !== "undefined" && FA === Float16Array) {
+    return "half";
+  } else if (FA === Float32Array) {
+    return "single";
+  } else if (FA === Float64Array) {
+    return "double";
+  } else {
+    throw new Error("Malformed test - floatTypedArrayConstructorPrecision called with non-float TypedArray");
+  }
+}

--- a/test/built-ins/Array/prototype/concat/Array.prototype.concat_large-typed-array.js
+++ b/test/built-ins/Array/prototype/concat/Array.prototype.concat_large-typed-array.js
@@ -37,6 +37,7 @@ function concatTypedArray(type, elems, modulo) {
   assert.compareArray([].concat(ta), expected);
 }
 
+// Float16Array cannot be included in this because it cannot precisely represent integers above 2048
 var max = [Math.pow(2, 8), Math.pow(2, 16), Math.pow(2, 32), false, false];
 [
   Uint8Array,

--- a/test/built-ins/Array/prototype/concat/Array.prototype.concat_small-typed-array.js
+++ b/test/built-ins/Array/prototype/concat/Array.prototype.concat_small-typed-array.js
@@ -37,12 +37,18 @@ function concatTypedArray(type, elems, modulo) {
   assert.compareArray([].concat(ta), expected);
 }
 var max = [Math.pow(2, 8), Math.pow(2, 16), Math.pow(2, 32), false, false];
-[
+var TAs = [
   Uint8Array,
   Uint16Array,
   Uint32Array,
   Float32Array,
   Float64Array
-].forEach(function(ctor, i) {
+];
+if (typeof Float16Array !== 'undefined') {
+  max.push(false);
+  TAs.push(Float16Array);
+}
+
+TAs.forEach(function(ctor, i) {
   concatTypedArray(ctor, 1, max[i]);
 });

--- a/test/built-ins/Atomics/add/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/add/validate-arraytype-before-index-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.add(typedArray, index, 0);

--- a/test/built-ins/Atomics/add/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/add/validate-arraytype-before-value-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var value = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.add(typedArray, 0, value);

--- a/test/built-ins/Atomics/and/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/and/validate-arraytype-before-index-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.and(typedArray, index, 0);

--- a/test/built-ins/Atomics/and/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/and/validate-arraytype-before-value-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var value = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.and(typedArray, 0, value);

--- a/test/built-ins/Atomics/compareExchange/validate-arraytype-before-expectedValue-coercion.js
+++ b/test/built-ins/Atomics/compareExchange/validate-arraytype-before-expectedValue-coercion.js
@@ -19,6 +19,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -28,11 +29,7 @@ var expectedValue = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.compareExchange(typedArray, 0, expectedValue, 0);

--- a/test/built-ins/Atomics/compareExchange/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/compareExchange/validate-arraytype-before-index-coercion.js
@@ -19,6 +19,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -28,11 +29,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.compareExchange(typedArray, index, 0, 0);

--- a/test/built-ins/Atomics/compareExchange/validate-arraytype-before-replacementValue-coercion.js
+++ b/test/built-ins/Atomics/compareExchange/validate-arraytype-before-replacementValue-coercion.js
@@ -19,6 +19,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -28,11 +29,7 @@ var replacementValue = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.compareExchange(typedArray, 0, 0, replacementValue);

--- a/test/built-ins/Atomics/exchange/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/exchange/validate-arraytype-before-index-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.exchange(typedArray, index, 0);

--- a/test/built-ins/Atomics/exchange/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/exchange/validate-arraytype-before-value-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var value = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.exchange(typedArray, 0, value);

--- a/test/built-ins/Atomics/load/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/load/validate-arraytype-before-index-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.load(typedArray, index);

--- a/test/built-ins/Atomics/notify/non-int32-typedarray-throws.js
+++ b/test/built-ins/Atomics/notify/non-int32-typedarray-throws.js
@@ -35,6 +35,15 @@ assert.throws(TypeError, function() {
   Atomics.notify(view, poisoned, poisoned);
 }, '`const view = new Float32Array( new SharedArrayBuffer(Float32Array.BYTES_PER_ELEMENT * 4) ); Atomics.notify(view, poisoned, poisoned)` throws TypeError');
 
+if (typeof Float16Array !== 'undefined') {
+  assert.throws(TypeError, function() {
+    const view = new Float16Array(
+      new SharedArrayBuffer(Float16Array.BYTES_PER_ELEMENT * 2)
+    );
+    Atomics.notify(view, poisoned, poisoned);
+  }, '`const view = new Float16Array( new SharedArrayBuffer(Float16Array.BYTES_PER_ELEMENT * 2) ); Atomics.notify(view, poisoned, poisoned)` throws TypeError');
+}
+
 assert.throws(TypeError, function() {
   const view = new Int16Array(
     new SharedArrayBuffer(Int16Array.BYTES_PER_ELEMENT * 2)

--- a/test/built-ins/Atomics/notify/validate-arraytype-before-count-coercion.js
+++ b/test/built-ins/Atomics/notify/validate-arraytype-before-count-coercion.js
@@ -19,6 +19,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -28,10 +29,7 @@ var count = {
   }
 };
 
-var badArrayTypes = [
-  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
-  Uint8ClampedArray, Float32Array, Float64Array
-];
+var badArrayTypes = typedArrayConstructors.filter(function(TA) { return TA !== Int32Array; });
 
 for (var badArrayType of badArrayTypes) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));

--- a/test/built-ins/Atomics/notify/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/notify/validate-arraytype-before-index-coercion.js
@@ -19,6 +19,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -28,10 +29,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
-  Uint8ClampedArray, Float32Array, Float64Array
-];
+var badArrayTypes = typedArrayConstructors.filter(function(TA) { return TA !== Int32Array; });
 
 for (var badArrayType of badArrayTypes) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));

--- a/test/built-ins/Atomics/or/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/or/validate-arraytype-before-index-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.or(typedArray, index, 0);

--- a/test/built-ins/Atomics/or/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/or/validate-arraytype-before-value-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var value = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.or(typedArray, 0, value);

--- a/test/built-ins/Atomics/store/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/store/validate-arraytype-before-index-coercion.js
@@ -19,6 +19,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -28,11 +29,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.store(typedArray, index, 0);

--- a/test/built-ins/Atomics/store/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/store/validate-arraytype-before-value-coercion.js
@@ -19,6 +19,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -28,11 +29,7 @@ var value = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.store(typedArray, 0, value);

--- a/test/built-ins/Atomics/sub/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/sub/validate-arraytype-before-index-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.sub(typedArray, index, 0);

--- a/test/built-ins/Atomics/sub/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/sub/validate-arraytype-before-value-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var value = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.sub(typedArray, 0, value);

--- a/test/built-ins/Atomics/wait/non-int32-typedarray-throws.js
+++ b/test/built-ins/Atomics/wait/non-int32-typedarray-throws.js
@@ -35,6 +35,15 @@ assert.throws(TypeError, function() {
   Atomics.wait(view, poisoned, poisoned, poisoned);
 }, '`const view = new Float32Array( new SharedArrayBuffer(Float32Array.BYTES_PER_ELEMENT * 4) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
 
+if (typeof Float16Array !== 'undefined') {
+  assert.throws(TypeError, function() {
+    const view = new Float16Array(
+      new SharedArrayBuffer(Float16Array.BYTES_PER_ELEMENT * 2)
+    );
+    Atomics.wait(view, poisoned, poisoned, poisoned);
+  }, '`const view = new Float16Array( new SharedArrayBuffer(Float16Array.BYTES_PER_ELEMENT * 2) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
+}
+
 assert.throws(TypeError, function() {
   const view = new Int16Array(
     new SharedArrayBuffer(Int16Array.BYTES_PER_ELEMENT * 2)

--- a/test/built-ins/Atomics/wait/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/wait/validate-arraytype-before-index-coercion.js
@@ -19,6 +19,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -28,10 +29,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
-  Uint8ClampedArray, Float32Array, Float64Array
-];
+var badArrayTypes = typedArrayConstructors.filter(function(TA) { return TA !== Int32Array; });
 
 for (var badArrayType of badArrayTypes) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));

--- a/test/built-ins/Atomics/wait/validate-arraytype-before-timeout-coercion.js
+++ b/test/built-ins/Atomics/wait/validate-arraytype-before-timeout-coercion.js
@@ -19,6 +19,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -28,10 +29,7 @@ var timeout = {
   }
 };
 
-var badArrayTypes = [
-  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
-  Uint8ClampedArray, Float32Array, Float64Array
-];
+var badArrayTypes = typedArrayConstructors.filter(function(TA) { return TA !== Int32Array; });
 
 for (var badArrayType of badArrayTypes) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));

--- a/test/built-ins/Atomics/wait/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/wait/validate-arraytype-before-value-coercion.js
@@ -19,6 +19,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -28,10 +29,7 @@ var value = {
   }
 };
 
-var badArrayTypes = [
-  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
-  Uint8ClampedArray, Float32Array, Float64Array
-];
+var badArrayTypes = typedArrayConstructors.filter(function(TA) { return TA !== Int32Array; });
 
 for (var badArrayType of badArrayTypes) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));

--- a/test/built-ins/Atomics/waitAsync/non-int32-typedarray-throws.js
+++ b/test/built-ins/Atomics/waitAsync/non-int32-typedarray-throws.js
@@ -42,6 +42,15 @@ assert.throws(TypeError, () => {
   Atomics.waitAsync(view, poisoned, poisoned, poisoned);
 }, '`const view = new Float32Array( new SharedArrayBuffer(Float32Array.BYTES_PER_ELEMENT * 4) ); Atomics.waitAsync(view, poisoned, poisoned, poisoned)` throws a TypeError exception');
 
+if (typeof Float16Array !== 'undefined') {
+  assert.throws(TypeError, function() {
+    const view = new Float16Array(
+      new SharedArrayBuffer(Float16Array.BYTES_PER_ELEMENT * 2)
+    );
+    Atomics.waitAsync(view, poisoned, poisoned, poisoned);
+  }, '`const view = new Float16Array( new SharedArrayBuffer(Float16Array.BYTES_PER_ELEMENT * 2) ); Atomics.waitAsync(view, poisoned, poisoned, poisoned)` throws a TypeError exception');
+}
+
 assert.throws(TypeError, () => {
   const view = new Int16Array(
     new SharedArrayBuffer(Int16Array.BYTES_PER_ELEMENT * 2)

--- a/test/built-ins/Atomics/waitAsync/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/waitAsync/validate-arraytype-before-index-coercion.js
@@ -27,6 +27,7 @@ info: |
   9. If IsSharedArrayBuffer(buffer) is false, throw a TypeError exception.
   10. Return buffer.
 
+includes: [testTypedArray.js]
 features: [Atomics.waitAsync, Atomics, TypedArray, SharedArrayBuffer]
 ---*/
 assert.sameValue(typeof Atomics.waitAsync, 'function', 'The value of `typeof Atomics.waitAsync` is "function"');
@@ -37,10 +38,7 @@ const index = {
   }
 };
 
-const nonSharedArrayTypes = [
-  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
-  Uint8ClampedArray, Float32Array, Float64Array
-];
+var nonSharedArrayTypes = typedArrayConstructors.filter(function(TA) { return TA !== Int32Array; });
 
 for (const nonSharedArrayType of nonSharedArrayTypes) {
   const typedArray = new nonSharedArrayType(new SharedArrayBuffer(8));

--- a/test/built-ins/Atomics/waitAsync/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/waitAsync/validate-arraytype-before-value-coercion.js
@@ -27,6 +27,7 @@ info: |
   9. If IsSharedArrayBuffer(buffer) is false, throw a TypeError exception.
   10. Return buffer.
 
+includes: [testTypedArray.js]
 features: [Atomics.waitAsync, Atomics, TypedArray, SharedArrayBuffer]
 ---*/
 assert.sameValue(typeof Atomics.waitAsync, 'function', 'The value of `typeof Atomics.waitAsync` is "function"');
@@ -37,10 +38,7 @@ const value = {
   }
 };
 
-const nonSharedArrayTypes = [
-  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
-  Uint8ClampedArray, Float32Array, Float64Array
-];
+var nonSharedArrayTypes = typedArrayConstructors.filter(function(TA) { return TA !== Int32Array; });
 
 for (const nonSharedArrayType of nonSharedArrayTypes) {
   const typedArray = new nonSharedArrayType(new SharedArrayBuffer(8));

--- a/test/built-ins/Atomics/xor/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/xor/validate-arraytype-before-index-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var index = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.xor(typedArray, index, 0);

--- a/test/built-ins/Atomics/xor/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/xor/validate-arraytype-before-value-coercion.js
@@ -22,6 +22,7 @@ info: |
       a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
          or "Uint32Array", throw a TypeError exception.
     ...
+includes: [testTypedArray.js]
 features: [Atomics, TypedArray]
 ---*/
 
@@ -31,11 +32,7 @@ var value = {
   }
 };
 
-var badArrayTypes = [
-  Uint8ClampedArray, Float32Array, Float64Array
-];
-
-for (var badArrayType of badArrayTypes) {
+for (var badArrayType of nonAtomicsFriendlyTypedArrayConstructors) {
   var typedArray = new badArrayType(new SharedArrayBuffer(8));
   assert.throws(TypeError, function() {
     Atomics.xor(typedArray, 0, value);

--- a/test/built-ins/ShadowRealm/prototype/evaluate/globalthis-available-properties.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/globalthis-available-properties.js
@@ -61,6 +61,7 @@ let properties = [
   'Error',
   'EvalError',
   'FinalizationRegistry',
+  'Float16Array',
   'Float32Array',
   'Float64Array',
   'Function',

--- a/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
@@ -41,4 +41,4 @@ function body(FloatArray) {
   assert(compareArray(originalBytes, copiedBytes));
 }
 
-testWithTypedArrayConstructors(body, [Float32Array, Float64Array]);
+testWithTypedArrayConstructors(body, floatArrayConstructors);

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-operations-consistent-nan.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-operations-consistent-nan.js
@@ -73,12 +73,7 @@ features: [TypedArray]
 ---*/
 
 testWithTypedArrayConstructors(function(FA) {
-  var precision =
-    FA === Float32Array
-    ? "single"
-    : (typeof Float16Array !== "undefined" && TA === Float16Array)
-    ? "half"
-    : "double";
+  var precision = floatTypedArrayConstructorPrecision(FA);
   var samples = new FA(3);
   var controls, idx, aNaN;
 

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-operations-consistent-nan.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-operations-consistent-nan.js
@@ -73,7 +73,12 @@ features: [TypedArray]
 ---*/
 
 testWithTypedArrayConstructors(function(FA) {
-  var precision = FA === Float32Array ? "single" : "double";
+  var precision =
+    FA === Float32Array
+    ? "single"
+    : (typeof Float16Array !== "undefined" && TA === Float16Array)
+    ? "half"
+    : "double";
   var samples = new FA(3);
   var controls, idx, aNaN;
 
@@ -98,4 +103,4 @@ testWithTypedArrayConstructors(function(FA) {
       );
     }
   }
-}, [Float32Array, Float64Array]);
+}, floatArrayConstructors);

--- a/test/built-ins/TypedArray/prototype/filter/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/filter/callbackfn-resize.js
@@ -15,7 +15,7 @@ assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
 
 testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
-  var NaNvalue = (TA === Float32Array || TA === Float64Array) ? NaN : 0;
+  var NaNvalue = (TA === Float32Array || TA === Float64Array || (typeof Float16Array !== 'undefined' && TA === Float16Array)) ? NaN : 0;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
   var sample = new TA(buffer);
   var finalElement, finalResult, expectedElements, expectedIndices, expectedArrays;

--- a/test/built-ins/TypedArray/prototype/filter/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/filter/callbackfn-resize.js
@@ -15,7 +15,7 @@ assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
 
 testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
-  var NaNvalue = (TA === Float32Array || TA === Float64Array || (typeof Float16Array !== 'undefined' && TA === Float16Array)) ? NaN : 0;
+  var NaNvalue = isFloatTypedArrayConstructor(TA) ? NaN : 0;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
   var sample = new TA(buffer);
   var finalElement, finalResult, expectedElements, expectedIndices, expectedArrays;

--- a/test/built-ins/TypedArray/prototype/includes/samevaluezero.js
+++ b/test/built-ins/TypedArray/prototype/includes/samevaluezero.js
@@ -41,4 +41,4 @@ testWithTypedArrayConstructors(function(TA) {
 testWithTypedArrayConstructors(function(FloatArray) {
   var sample = new FloatArray([42, 0, 1, undefined, NaN]);
   assert.sameValue(sample.includes(NaN), true, "NaN");
-}, [Float32Array, Float64Array]);
+}, floatArrayConstructors);

--- a/test/built-ins/TypedArray/prototype/map/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/map/callbackfn-resize.js
@@ -15,7 +15,7 @@ assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
 
 testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
-  var NaNvalue = (TA === Float32Array || TA === Float64Array || (typeof Float16Array !== 'undefined' && TA === Float16Array)) ? NaN : 0;
+  var NaNvalue = isFloatTypedArrayConstructor(TA) ? NaN : 0;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
   var sample = new TA(buffer);
   var finalElement, expectedElements, expectedIndices, expectedArrays;

--- a/test/built-ins/TypedArray/prototype/map/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/map/callbackfn-resize.js
@@ -15,7 +15,7 @@ assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
 
 testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
-  var NaNvalue = (TA === Float32Array || TA === Float64Array) ? NaN : 0;
+  var NaNvalue = (TA === Float32Array || TA === Float64Array || (typeof Float16Array !== 'undefined' && TA === Float16Array)) ? NaN : 0;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
   var sample = new TA(buffer);
   var finalElement, expectedElements, expectedIndices, expectedArrays;

--- a/test/built-ins/TypedArray/prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArray/prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
@@ -68,4 +68,4 @@ function body(FloatArray) {
   assert(compareArray(sampleBytes, resultBytes));
 }
 
-testWithTypedArrayConstructors(body, [Float32Array, Float64Array]);
+testWithTypedArrayConstructors(body, floatArrayConstructors);

--- a/test/built-ins/TypedArray/prototype/set/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/set/bit-precision.js
@@ -32,4 +32,4 @@ function body(FA) {
   assert(compareArray(sourceBytes, targetBytes))
 }
 
-testWithTypedArrayConstructors(body, [Float32Array, Float64Array]);
+testWithTypedArrayConstructors(body, floatArrayConstructors);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js
@@ -11,7 +11,7 @@ features: [SharedArrayBuffer]
 ---*/
 
 testTypedArrayConversions(byteConversionValues, function(TA, value, expected, initial) {
-  if (TA === Float64Array || TA === Float32Array || TA === Uint8ClampedArray) {
+  if (TA === Float64Array || TA === Float32Array || (typeof Float16Array !== 'undefined' && TA === Float16Array) || TA === Uint8ClampedArray) {
     return;
   }
   if (TA === Int32Array) {

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
@@ -34,6 +34,7 @@ features: [TypedArray]
 var expected = {
   Float64Array: [1.0000002464512363, 42, 1.875, 4, 5, 6, 7, 8],
   Float32Array: [0, 42, 512.0001220703125, 4, 5, 6, 7, 8],
+  Float16Array: [0, 42, 513, 4, 5, 6, 7, 8],
   Int32Array: [1109917696, 42, 0, 4, 5, 6, 7, 8],
   Int16Array: [0, 42, 0, 4, 5, 6, 7, 8],
   Int8Array: [0, 42, 0, 66, 5, 6, 7, 8],
@@ -44,11 +45,6 @@ var expected = {
 };
 
 testWithTypedArrayConstructors(function(TA) {
-  if (typeof Float16Array !== 'undefined' && TA === Float16Array) {
-    // TODO(bakkot) work out bit patterns here
-    return;
-  }
-
   var other = TA === Float32Array ? Float64Array : Float32Array;
 
   var sample = new TA([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
@@ -44,6 +44,11 @@ var expected = {
 };
 
 testWithTypedArrayConstructors(function(TA) {
+  if (typeof Float16Array !== 'undefined' && TA === Float16Array) {
+    // TODO(bakkot) work out bit patterns here
+    return;
+  }
+
   var other = TA === Float32Array ? Float64Array : Float32Array;
 
   var sample = new TA([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/test/built-ins/TypedArray/prototype/slice/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/slice/bit-precision.js
@@ -36,4 +36,4 @@ function body(FloatArray) {
   assert(compareArray(subjectBytes, slicedBytes));
 }
 
-testWithTypedArrayConstructors(body, [Float32Array, Float64Array]);
+testWithTypedArrayConstructors(body, floatArrayConstructors);

--- a/test/built-ins/TypedArray/prototype/sort/sorted-values-nan.js
+++ b/test/built-ins/TypedArray/prototype/sort/sorted-values-nan.js
@@ -35,4 +35,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(sample[4], Infinity, "#2 [4]");
   assert.sameValue(sample[5], NaN, "#2 [5]");
   assert.sameValue(sample[6], NaN, "#2 [6]");
-}, [Float64Array, Float32Array]);
+}, floatArrayConstructors);

--- a/test/built-ins/TypedArray/prototype/sort/sorted-values.js
+++ b/test/built-ins/TypedArray/prototype/sort/sorted-values.js
@@ -40,7 +40,7 @@ testWithTypedArrayConstructors(function(TA) {
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA([-4, 3, 4, -3, 2, -2, 1, 0]).sort();
   assert(compareArray(sample, [-4, -3, -2, 0, 1, 2, 3, 4]), "negative values");
-}, [Float64Array, Float32Array, Int8Array, Int16Array, Int32Array]);
+}, floatArrayConstructors.concat([Int8Array, Int16Array, Int32Array]);
 
 testWithTypedArrayConstructors(function(TA) {
   var sample;
@@ -54,4 +54,4 @@ testWithTypedArrayConstructors(function(TA) {
   sample = new TA([3, 4, Infinity, -Infinity, 1, 2]).sort();
   assert(compareArray(sample, [-Infinity, 1, 2, 3, 4, Infinity]), "infinities");
 
-}, [Float64Array, Float32Array]);
+}, floatArrayConstructors);

--- a/test/built-ins/TypedArray/prototype/sort/sorted-values.js
+++ b/test/built-ins/TypedArray/prototype/sort/sorted-values.js
@@ -40,7 +40,7 @@ testWithTypedArrayConstructors(function(TA) {
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA([-4, 3, 4, -3, 2, -2, 1, 0]).sort();
   assert(compareArray(sample, [-4, -3, -2, 0, 1, 2, 3, 4]), "negative values");
-}, floatArrayConstructors.concat([Int8Array, Int16Array, Int32Array]);
+}, floatArrayConstructors.concat([Int8Array, Int16Array, Int32Array]));
 
 testWithTypedArrayConstructors(function(TA) {
   var sample;

--- a/test/built-ins/TypedArrayConstructors/ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js
@@ -35,4 +35,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(RangeError, function() {
     new TA(buffer, 0, undefined);
   });
-}, [ Float64Array, Float32Array, Int32Array, Int16Array, Uint32Array, Uint16Array ]);
+}, floatArrayConstructors.concat([ Int32Array, Int16Array, Uint32Array, Uint16Array ]));

--- a/test/built-ins/TypedArrayConstructors/ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size.js
@@ -29,4 +29,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(RangeError, function() {
     new TA(buffer, 0, undefined);
   });
-}, [ Float64Array, Float32Array, Int32Array, Int16Array, Uint32Array, Uint16Array ]);
+}, floatArrayConstructors.concat([ Int32Array, Int16Array, Uint32Array, Uint16Array ]));

--- a/test/built-ins/TypedArrayConstructors/ctors/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js
@@ -31,5 +31,5 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(RangeError, function() {
     new TA(buffer, 7);
   });
-}, [ Float64Array, Float32Array, Int32Array, Int16Array, Uint32Array, Uint16Array ]);
+}, floatArrayConstructors.concat([ Int32Array, Int16Array, Uint32Array, Uint16Array ]));
 

--- a/test/built-ins/TypedArrayConstructors/ctors/buffer-arg/byteoffset-throws-from-modulo-element-size.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/buffer-arg/byteoffset-throws-from-modulo-element-size.js
@@ -24,4 +24,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(RangeError, function() {
     new TA(buffer, 7);
   });
-}, [ Float64Array, Float32Array, Int32Array, Int16Array, Uint32Array, Uint16Array ]);
+}, floatArrayConstructors.concat([ Int32Array, Int16Array, Uint32Array, Uint16Array ]));

--- a/test/built-ins/TypedArrayConstructors/ctors/object-arg/conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/object-arg/conversion-operation-consistent-nan.js
@@ -67,4 +67,4 @@ function body(FloatArray) {
   assert(compareArray(firstBytes, secondBytes));
 }
 
-testWithTypedArrayConstructors(body, [Float32Array, Float64Array]);
+testWithTypedArrayConstructors(body, floatArrayConstructors);

--- a/test/built-ins/TypedArrayConstructors/ctors/object-arg/returns.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/object-arg/returns.js
@@ -35,7 +35,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(typedArray.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(typedArray), TA.prototype);
 
-  if (TA === Float32Array || TA === Float64Array || (typeof Float16Array !== 'undefined' && TA === Float16Array)) {
+  if (isFloatTypedArrayConstructor(TA)) {
     assert.sameValue(typedArray[1], NaN);
     assert.sameValue(typedArray[4], NaN);
   } else {

--- a/test/built-ins/TypedArrayConstructors/ctors/object-arg/returns.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/object-arg/returns.js
@@ -35,7 +35,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(typedArray.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(typedArray), TA.prototype);
 
-  if (TA === Float32Array || TA === Float64Array) {
+  if (TA === Float32Array || TA === Float64Array || (typeof Float16Array !== 'undefined' && TA === Float16Array)) {
     assert.sameValue(typedArray[1], NaN);
     assert.sameValue(typedArray[4], NaN);
   } else {

--- a/test/built-ins/TypedArrayConstructors/from/nan-conversion.js
+++ b/test/built-ins/TypedArrayConstructors/from/nan-conversion.js
@@ -33,10 +33,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Float32Array,
-  Float64Array
-]);
+floatArrayConstructors);
 
 testWithTypedArrayConstructors(function(TA) {
   var result = TA.from([NaN, undefined]);
@@ -46,13 +43,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Int8Array,
-  Int32Array,
-  Int16Array,
-  Int8Array,
-  Uint32Array,
-  Uint16Array,
-  Uint8Array,
-  Uint8ClampedArray
-]);
+floatArrayConstructors);

--- a/test/built-ins/TypedArrayConstructors/from/nan-conversion.js
+++ b/test/built-ins/TypedArrayConstructors/from/nan-conversion.js
@@ -43,4 +43,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-floatArrayConstructors);
+intArrayConstructors);

--- a/test/built-ins/TypedArrayConstructors/from/new-instance-from-ordinary-object.js
+++ b/test/built-ins/TypedArrayConstructors/from/new-instance-from-ordinary-object.js
@@ -25,10 +25,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Float32Array,
-  Float64Array
-]);
+floatArrayConstructors);
 
 testWithTypedArrayConstructors(function(TA) {
   var result = TA.from(source);
@@ -41,13 +38,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Int8Array,
-  Int32Array,
-  Int16Array,
-  Int8Array,
-  Uint32Array,
-  Uint16Array,
-  Uint8Array,
-  Uint8ClampedArray
-]);
+intArrayConstructors);

--- a/test/built-ins/TypedArrayConstructors/from/new-instance-from-sparse-array.js
+++ b/test/built-ins/TypedArrayConstructors/from/new-instance-from-sparse-array.js
@@ -23,10 +23,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Float32Array,
-  Float64Array
-]);
+floatArrayConstructors);
 
 testWithTypedArrayConstructors(function(TA) {
   var result = TA.from(source);
@@ -41,13 +38,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Int8Array,
-  Int32Array,
-  Int16Array,
-  Int8Array,
-  Uint32Array,
-  Uint16Array,
-  Uint8Array,
-  Uint8ClampedArray
-]);
+intArrayConstructors);

--- a/test/built-ins/TypedArrayConstructors/from/new-instance-from-zero.js
+++ b/test/built-ins/TypedArrayConstructors/from/new-instance-from-zero.js
@@ -16,10 +16,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Float32Array,
-  Float64Array
-]);
+floatArrayConstructors);
 
 testWithTypedArrayConstructors(function(TA) {
   var result = TA.from([-0, +0]);
@@ -29,12 +26,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Int16Array,
-  Int32Array,
-  Int8Array,
-  Uint16Array,
-  Uint32Array,
-  Uint8Array,
-  Uint8ClampedArray
-]);
+intArrayConstructors);

--- a/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/conversion-operation-consistent-nan.js
@@ -69,7 +69,12 @@ features: [TypedArray]
 ---*/
 
 testWithTypedArrayConstructors(function(FA) {
-  var precision = FA === Float32Array ? "single" : "double";
+  var precision =
+    FA === Float32Array
+    ? "single"
+    : (typeof Float16Array !== "undefined" && TA === Float16Array)
+    ? "half"
+    : "double";
   var samples = new FA(1);
   var controls, idx, aNaN;
 
@@ -94,5 +99,5 @@ testWithTypedArrayConstructors(function(FA) {
       );
     }
   }
-}, [Float32Array, Float64Array]);
+}, floatArrayConstructors);
 

--- a/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/conversion-operation-consistent-nan.js
@@ -69,12 +69,7 @@ features: [TypedArray]
 ---*/
 
 testWithTypedArrayConstructors(function(FA) {
-  var precision =
-    FA === Float32Array
-    ? "single"
-    : (typeof Float16Array !== "undefined" && TA === Float16Array)
-    ? "half"
-    : "double";
+  var precision = floatTypedArrayConstructorPrecision(FA);
   var samples = new FA(1);
   var controls, idx, aNaN;
 

--- a/test/built-ins/TypedArrayConstructors/internals/Set/conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/conversion-operation-consistent-nan.js
@@ -76,12 +76,7 @@ features: [align-detached-buffer-semantics-with-web-reality, TypedArray]
 ---*/
 
 testWithTypedArrayConstructors(function(FA) {
-  var precision =
-    FA === Float32Array
-    ? "single"
-    : (typeof Float16Array !== "undefined" && TA === Float16Array)
-    ? "half"
-    : "double";
+  var precision = floatTypedArrayConstructorPrecision(FA);
   var samples = new FA(1);
   var controls, idx, aNaN;
 
@@ -97,12 +92,12 @@ testWithTypedArrayConstructors(function(FA) {
 
       assert(
         samples[i] !== samples[i],
-        'The result of `(samples[i] !== samples[i])` is true'
+        `The result of \`(samples[i] !== samples[i])\` is true (${precision} precision)`
       );
 
       assert(
         controls[i] !== controls[i],
-        'The result of `(controls[i] !== controls[i])` is true'
+        `The result of \`(controls[i] !== controls[i])\` is true (${precision} precision)`
       );
     }
   }

--- a/test/built-ins/TypedArrayConstructors/internals/Set/conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/conversion-operation-consistent-nan.js
@@ -76,7 +76,12 @@ features: [align-detached-buffer-semantics-with-web-reality, TypedArray]
 ---*/
 
 testWithTypedArrayConstructors(function(FA) {
-  var precision = FA === Float32Array ? "single" : "double";
+  var precision =
+    FA === Float32Array
+    ? "single"
+    : (typeof Float16Array !== "undefined" && TA === Float16Array)
+    ? "half"
+    : "double";
   var samples = new FA(1);
   var controls, idx, aNaN;
 
@@ -101,5 +106,5 @@ testWithTypedArrayConstructors(function(FA) {
       );
     }
   }
-}, [Float32Array, Float64Array]);
+}, floatArrayConstructors);
 

--- a/test/built-ins/TypedArrayConstructors/of/nan-conversion.js
+++ b/test/built-ins/TypedArrayConstructors/of/nan-conversion.js
@@ -34,10 +34,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Float32Array,
-  Float64Array
-]);
+floatArrayConstructors);
 
 testWithTypedArrayConstructors(function(TA) {
   var result = TA.of(NaN, undefined);
@@ -47,13 +44,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Int8Array,
-  Int32Array,
-  Int16Array,
-  Int8Array,
-  Uint32Array,
-  Uint16Array,
-  Uint8Array,
-  Uint8ClampedArray
-]);
+intArrayConstructors);

--- a/test/built-ins/TypedArrayConstructors/of/new-instance-from-zero.js
+++ b/test/built-ins/TypedArrayConstructors/of/new-instance-from-zero.js
@@ -16,10 +16,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Float32Array,
-  Float64Array
-]);
+floatArrayConstructors);
 
 testWithTypedArrayConstructors(function(TA) {
   var result = TA.of(-0, +0);
@@ -29,12 +26,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(result), TA.prototype);
 },
-[
-  Int16Array,
-  Int32Array,
-  Int8Array,
-  Uint16Array,
-  Uint32Array,
-  Uint8Array,
-  Uint8ClampedArray
-]);
+intArrayConstructors);

--- a/test/language/statements/class/subclass/builtin-objects/TypedArray/regular-subclassing.js
+++ b/test/language/statements/class/subclass/builtin-objects/TypedArray/regular-subclassing.js
@@ -14,20 +14,11 @@ info: |
   call to the TypedArray constructor to create and initialize the subclass
   instance with the internal state necessary to support the
   %TypedArray%.prototype built-in methods.
+includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-[
-  Int8Array,
-  Uint8Array,
-  Uint8ClampedArray,
-  Int16Array,
-  Uint16Array,
-  Int32Array,
-  Uint32Array,
-  Float32Array,
-  Float64Array
-].forEach(function(Constructor) {
+testWithTypedArrayConstructors(function(Constructor) {
   class Typed extends Constructor {}
 
   var arr = new Typed(2);

--- a/test/language/statements/class/subclass/builtin-objects/TypedArray/super-must-be-called.js
+++ b/test/language/statements/class/subclass/builtin-objects/TypedArray/super-must-be-called.js
@@ -14,20 +14,11 @@ info: |
   call to the TypedArray constructor to create and initialize the subclass
   instance with the internal state necessary to support the
   %TypedArray%.prototype built-in methods.
+includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-[
-  Int8Array,
-  Uint8Array,
-  Uint8ClampedArray,
-  Int16Array,
-  Uint16Array,
-  Int32Array,
-  Uint32Array,
-  Float32Array,
-  Float64Array
-].forEach(function(Constructor) {
+testWithTypedArrayConstructors(function(Constructor) {
   class Typed extends Constructor {
     constructor() {}
   }


### PR DESCRIPTION
First step of #3828.

I've updated `harness/testTypedArray.js` so that it includes Float16Array iff it is available as a global, so as to not render all tests using it useless for any implementation which has not yet implemented Float16Array. I've also updated a bunch of tests which weren't using that helper to use it, so that they wouldn't require separate updates for Float16Array.

In principle these should behave identically on existing implementations as prior to this PR.

I'll have a follow-up adding Float16Array-specific tests.