### PR TITLE
Remove GraalJS from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,15 +133,6 @@ jobs:
       hostName: engine262
       hostArgs: --features=all
     <<: [*execution_steps]
-  "GraalJS: New or modified tests execution":
-    docker:
-      - image: *node_latest
-    working_directory: ~/test262
-    environment:
-      hostType: graaljs
-      hostPath: graaljs
-      hostName: graaljs
-    <<: [*execution_steps]
 workflows:
   version: 2
   Tools:
@@ -156,4 +147,3 @@ workflows:
       - "V8 --harmony: New or modified tests execution"
       - "XS: New or modified tests execution"
       - "engine262: New or modified tests execution"
-      - "GraalJS: New or modified tests execution"


### PR DESCRIPTION
This is broken again. I don't think we should have this in CI unless it's going to keep working.