### PR TITLE
Delete trailing space after `|`

### DIFF
--- a/test/language/expressions/prefix-decrement/this.js
+++ b/test/language/expressions/prefix-decrement/this.js
@@ -5,7 +5,7 @@
 esid: sec-update-expressions-static-semantics-early-errors
 description: >
     It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple. (this)
-info: | 
+info: |
     sec-static-semantics-assignmenttargettype
 
       PrimaryExpression: this


### PR DESCRIPTION
I'm not sure if YAML disallows it, but test262 avoids it.