### PR TITLE
Add tests for the Explicit Resource Management proposal

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -108,6 +108,10 @@ json-parse-with-source
 # https://github.com/tc39/proposal-iterator-helpers
 iterator-helpers
 
+# Explicit Resource Management
+# https://github.com/tc39/proposal-explicit-resource-management
+explicit-resource-management
+
 ## Standard language features
 #
 # Language features that have been included in a published version of the

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:diff:spidermonkey": "test262-harness -t 8 --hostType=jsshell --hostPath=spidermonkey $(npm run --silent diff)",
     "test:diff:chakra": "test262-harness -t 8 --hostType=ch --hostPath=chakra $(npm run --silent diff)",
     "test:diff:javascriptcore": "test262-harness -t 8 --hostType=jsc --hostPath=javascriptcore $(npm run --silent diff)",
-    "test:diff:xs": "test262-harness -t 8 --hostType=xs --hostPath=xs $(npm run --silent diff)"
+    "test:diff:xs": "test262-harness -t 8 --hostType=xs --hostPath=xs $(npm run --silent diff)",
+    "test:diff:engine262": "test262-harness -t 8 --hostType=engine262 --hostPath=engine262 $(npm run --silent diff)"
   }
 }

--- a/test/built-ins/AsyncDisposableStack/constructor.js
+++ b/test/built-ins/AsyncDisposableStack/constructor.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack-constructor
+description: >
+  The AsyncDisposableStack constructor is the %AsyncDisposableStack% intrinsic object and the initial
+  value of the AsyncDisposableStack property of the global object.
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(
+  typeof AsyncDisposableStack, 'function',
+  'typeof AsyncDisposableStack is function'
+);

--- a/test/built-ins/AsyncDisposableStack/instance-extensible.js
+++ b/test/built-ins/AsyncDisposableStack/instance-extensible.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: Instances of AsyncDisposableStack are extensible
+info: |
+  AsyncDisposableStack( )
+
+  ...
+  2. Let asyncDisposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  3. Set asyncDisposableStack.[[AsyncDisposableState]] to pending.
+  4. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return asyncDisposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  ObjectCreate ( proto [ , internalSlotsList ] )
+
+  4. Set obj.[[Prototype]] to proto.
+  5. Set obj.[[Extensible]] to true.
+  6. Return obj.
+features: [explicit-resource-management, Reflect]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.sameValue(Object.isExtensible(stack), true);

--- a/test/built-ins/AsyncDisposableStack/is-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/is-a-constructor.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The AsyncDisposableStack constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [explicit-resource-management, AsyncDisposableStack]
+---*/
+
+assert.sameValue(isConstructor(AsyncDisposableStack), true, 'isConstructor(AsyncDisposableStack) must return true');
+new AsyncDisposableStack();
+

--- a/test/built-ins/AsyncDisposableStack/length.js
+++ b/test/built-ins/AsyncDisposableStack/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: AsyncDisposableStack.length property descriptor
+info: |
+  AsyncDisposableStack ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/name.js
+++ b/test/built-ins/AsyncDisposableStack/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: AsyncDisposableStack.name property descriptor
+info: |
+  AsyncDisposableStack ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack, 'name', {
+  value: 'AsyncDisposableStack',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/newtarget-prototype-is-not-object.js
+++ b/test/built-ins/AsyncDisposableStack/newtarget-prototype-is-not-object.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: >
+  [[Prototype]] defaults to %AsyncDisposableStack.prototype% if NewTarget.prototype is not an object.
+info: |
+  AsyncDisposableStack( target )
+
+  ...
+  2. Let asyncDisposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  3. Set asyncDisposableStack.[[AsyncDisposableState]] to pending.
+  4. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return asyncDisposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management, Reflect.construct, Symbol]
+---*/
+
+var stack;
+function newTarget() {}
+
+newTarget.prototype = undefined;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is undefined');
+
+newTarget.prototype = null;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is null');
+
+newTarget.prototype = true;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is a Boolean');
+
+newTarget.prototype = '';
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is a String');
+
+newTarget.prototype = Symbol();
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is a Symbol');
+
+newTarget.prototype = 1;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is a Number');

--- a/test/built-ins/AsyncDisposableStack/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prop-desc.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack-constructor
+description: >
+  Property descriptor of AsyncDisposableStack
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(this, 'AsyncDisposableStack', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/proto-from-ctor-realm.js
+++ b/test/built-ins/AsyncDisposableStack/proto-from-ctor-realm.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+  AsyncDisposableStack( )
+
+  ...
+  2. Let asyncDisposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  3. Set asyncDisposableStack.[[AsyncDisposableState]] to pending.
+  4. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return asyncDisposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management, cross-realm, Reflect, Symbol]
+---*/
+
+var other = $262.createRealm().global;
+var newTarget = new other.Function();
+var stack;
+
+newTarget.prototype = undefined;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.AsyncDisposableStack.prototype, 'newTarget.prototype is undefined');
+
+newTarget.prototype = null;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.AsyncDisposableStack.prototype, 'newTarget.prototype is null');
+
+newTarget.prototype = true;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.AsyncDisposableStack.prototype, 'newTarget.prototype is a Boolean');
+
+newTarget.prototype = '';
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.AsyncDisposableStack.prototype, 'newTarget.prototype is a String');
+
+newTarget.prototype = Symbol();
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.AsyncDisposableStack.prototype, 'newTarget.prototype is a Symbol');
+
+newTarget.prototype = 1;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.AsyncDisposableStack.prototype, 'newTarget.prototype is a Number');
+

--- a/test/built-ins/AsyncDisposableStack/proto.js
+++ b/test/built-ins/AsyncDisposableStack/proto.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-asyncdisposablestack-constructor
+description: >
+  The prototype of AsyncDisposableStack is Function.prototype
+info: |
+  The value of the [[Prototype]] internal slot of the AsyncDisposableStack object is the
+  intrinsic object %FunctionPrototype%.
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(
+  Object.getPrototypeOf(AsyncDisposableStack),
+  Function.prototype,
+  'Object.getPrototypeOf(AsyncDisposableStack) returns the value of `Function.prototype`'
+);

--- a/test/built-ins/AsyncDisposableStack/prototype-from-newtarget-abrupt.js
+++ b/test/built-ins/AsyncDisposableStack/prototype-from-newtarget-abrupt.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: >
+  Return abrupt from getting the NewTarget prototype
+info: |
+  AsyncDisposableStack ( )
+
+  ...
+  2. Let asyncDisposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  3. Set asyncDisposableStack.[[AsyncDisposableState]] to pending.
+  4. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return asyncDisposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+features: [explicit-resource-management, Reflect.construct]
+---*/
+
+var calls = 0;
+var newTarget = function() {}.bind(null);
+Object.defineProperty(newTarget, 'prototype', {
+  get: function() {
+    calls += 1;
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.construct(AsyncDisposableStack, [], newTarget);
+});
+
+assert.sameValue(calls, 1);

--- a/test/built-ins/AsyncDisposableStack/prototype-from-newtarget-custom.js
+++ b/test/built-ins/AsyncDisposableStack/prototype-from-newtarget-custom.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: >
+  The [[Prototype]] internal slot is computed from NewTarget.
+info: |
+  AsyncDisposableStack ( )
+
+  ...
+  2. Let asyncDisposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  3. Set asyncDisposableStack.[[AsyncDisposableState]] to pending.
+  4. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return asyncDisposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management, Reflect.construct]
+---*/
+
+var stack;
+
+stack = Reflect.construct(AsyncDisposableStack, [], Object);
+assert.sameValue(Object.getPrototypeOf(stack), Object.prototype, 'NewTarget is built-in Object constructor');
+
+var newTarget = function() {}.bind(null);
+Object.defineProperty(newTarget, 'prototype', {
+  get: function() {
+    return Array.prototype;
+  }
+});
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), Array.prototype, 'NewTarget is BoundFunction with accessor');

--- a/test/built-ins/AsyncDisposableStack/prototype-from-newtarget.js
+++ b/test/built-ins/AsyncDisposableStack/prototype-from-newtarget.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: >
+  The [[Prototype]] internal slot is computed from NewTarget.
+info: |
+  AsyncDisposableStack ( )
+
+  ...
+  2. Let asyncDisposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  3. Set asyncDisposableStack.[[AsyncDisposableState]] to pending.
+  4. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return asyncDisposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype);

--- a/test/built-ins/AsyncDisposableStack/prototype/Symbol.asyncDispose.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/Symbol.asyncDispose.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-asyncdisposablestack.prototype-@@asyncDispose
+description: Initial state of the Symbol.asyncDispose property
+info: |
+  The initial value of the @@asyncDispose property is the same function object as
+  the initial value of the disposeAsync property.
+
+  Per ES6 section 17, the method should exist on the Array prototype, and it
+  should be writable and configurable, but not enumerable.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(AsyncDisposableStack.prototype[Symbol.asyncDispose], AsyncDisposableStack.prototype.disposeAsync);
+verifyNotEnumerable(AsyncDisposableStack.prototype, Symbol.asyncDispose);
+verifyWritable(AsyncDisposableStack.prototype, Symbol.asyncDispose);
+verifyConfigurable(AsyncDisposableStack.prototype, Symbol.asyncDispose);

--- a/test/built-ins/AsyncDisposableStack/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/Symbol.toStringTag.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype-@@toStringTag
+description: >
+    `Symbol.toStringTag` property descriptor
+info: |
+    The initial value of the @@toStringTag property is the String value
+    'AsyncDisposableStack'.
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management, Symbol, Symbol.toStringTag]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype, Symbol.toStringTag, {
+  value: 'AsyncDisposableStack',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/adds-value-onDisposeAsync.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/adds-value-onDisposeAsync.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: Adds a disposable resource to the stack
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. If IsCallable(onDisposeAsync) is false, throw a TypeError exception.
+  5. Let closure be a new Abstract Closure with no parameters that captures value and onDisposeAsync and performs the following steps when called:
+    a. Perform ? Call(onDisposeAsync, undefined, « value »).
+  6. Let F be CreateBuiltinFunction(closure, 0, "", « »).
+  7. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], undefined, async-dispose, F).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    ...
+  2. Else,
+    a. Assert: V is undefined.
+    b. Let resource be ? CreateDisposableResource(undefined, hint, method).
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var resource = { disposed: false };
+  stack.adopt(resource, async r => { r.disposed = true });
+  await stack.disposeAsync();
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/allows-any-value.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/allows-any-value.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: Allows any 'value'
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. If IsCallable(onDisposeAsync) is false, throw a TypeError exception.
+  5. Let closure be a new Abstract Closure with no parameters that captures value and onDisposeAsync and performs the following steps when called:
+    a. Perform ? Call(onDisposeAsync, undefined, « value »).
+  6. Let F be CreateBuiltinFunction(closure, 0, "", « »).
+  7. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], undefined, async-dispose, F).
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+stack.adopt(null, async _ => {});
+stack.adopt(undefined, async _ => {});
+stack.adopt({}, async _ => {});
+stack.adopt({ async [Symbol.asyncDispose]() {} }, async _ => {});
+stack.adopt(() => {}, async _ => {});
+stack.adopt(true, async _ => {});
+stack.adopt(false, async _ => {});
+stack.adopt(1, async _ => {});
+stack.adopt('object', async _ => {});
+stack.adopt(Symbol(), async _ => {});

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: AsyncDisposableStack.prototype.adopt.length property descriptor
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.adopt, 'length', {
+  value: 2,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: AsyncDisposableStack.prototype.adopt.name property descriptor
+info: |
+  AsyncDisposableStack.prototype.adopt.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.adopt, 'name', {
+  value: 'adopt',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/not-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: >
+  AsyncDisposableStack.prototype.adopt does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(AsyncDisposableStack.prototype.adopt),
+  false,
+  'isConstructor(AsyncDisposableStack.prototype.adopt) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new AsyncDisposableStack({}); new stack.adopt();
+}, '`let stack = new AsyncDisposableStack({}); new stack.adopt()` throws TypeError');
+

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: >
+  Property descriptor of AsyncDisposableStack.prototype.adopt
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.adopt, 'function');
+
+verifyProperty(AsyncDisposableStack.prototype, 'adopt', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/puts-value-onDisposeAsync-on-top-of-stack.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/puts-value-onDisposeAsync-on-top-of-stack.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: Adds a disposable resource to the stack
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. If IsCallable(onDisposeAsync) is false, throw a TypeError exception.
+  5. Let closure be a new Abstract Closure with no parameters that captures value and onDisposeAsync and performs the following steps when called:
+    a. Perform ? Call(onDisposeAsync, undefined, « value »).
+  6. Let F be CreateBuiltinFunction(closure, 0, "", « »).
+  7. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], undefined, async-dispose, F).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    ...
+  2. Else,
+    a. Assert: V is undefined.
+    b. Let resource be ? CreateDisposableResource(undefined, hint, method).
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var disposed = [];
+  var resource1 = {};
+  async function dispose1(res) { disposed.push([res, dispose1]); }
+  var resource2 = {};
+  function dispose2(res) { disposed.push([res, dispose2]); }
+  stack.adopt(resource1, dispose1);
+  stack.adopt(resource2, dispose2);
+  await stack.disposeAsync();
+  assert.sameValue(2, disposed.length);
+  assert.sameValue(disposed[0][0], resource2, 'Expected resource2 to be the first disposed resource');
+  assert.sameValue(disposed[0][1], dispose2, 'Expected dispose2 to be the first onDispose invoked');
+  assert.sameValue(disposed[1][0], resource1, 'Expected resource1 to be the second disposed resource');
+  assert.sameValue(disposed[1][1], dispose1, 'Expected dispose1 to be the second onDispose invoked');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/returns-value.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/returns-value.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: Returns the argument provided.
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  ...
+  8. Return value.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+var resource = {};
+assert.sameValue(stack.adopt(resource, async _ => {}), resource);
+assert.sameValue(stack.adopt(null, async _ => {}), null);
+assert.sameValue(stack.adopt(undefined, async _ => {}), undefined);

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/this-does-not-have-internal-asyncdisposablestate-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/this-does-not-have-internal-asyncdisposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: Throws a TypeError if this does not have a [[AsyncDisposableState]] internal slot
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.adopt, 'function');
+
+var adopt = AsyncDisposableStack.prototype.adopt;
+
+assert.throws(TypeError, function() {
+  adopt.call({ ['[[AsyncDisposableState]]']: {} });
+}, 'Ordinary object without [[AsyncDisposableState]]');
+
+assert.throws(TypeError, function() {
+  adopt.call(AsyncDisposableStack.prototype);
+}, 'AsyncDisposableStack.prototype does not have a [[AsyncDisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  adopt.call(AsyncDisposableStack);
+}, 'AsyncDisposableStack does not have a [[AsyncDisposableState]] internal slot');
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  adopt.call(stack);
+}, 'DisposableStack instance');

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/this-not-object-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: Throws a TypeError if this is not an Object
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.adopt, 'function');
+
+var adopt = AsyncDisposableStack.prototype.adopt;
+
+assert.throws(TypeError, function() {
+  adopt.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  adopt.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  adopt.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  adopt.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  adopt.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  adopt.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  adopt.call(s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/throws-if-onDisposeAsync-not-callable.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/throws-if-onDisposeAsync-not-callable.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: Throws if onDisposeAsync argument not callable
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  ...
+  4. If IsCallable(onDisposeAsync) is false, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.adopt(null, null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, 1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, 'object');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, {});
+}, 'object');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.adopt(null, s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/constructor.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-asyncdisposablestack-prototype-object
+description: AsyncDisposableStack.prototype.constructor
+info: |
+  AsyncDisposableStack.prototype.constructor
+
+  Normative Optional
+
+  The initial value of AsyncDisposableStack.prototype.constructor is the intrinsic object %AsyncDisposableStack%.
+
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+
+  This section is to be treated identically to the "Annex B" of ECMA-262, but to be written in-line with the main specification.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+var actual = AsyncDisposableStack.prototype.hasOwnProperty('constructor');
+
+// If implemented, it should conform to the spec text
+if (actual) {
+  verifyProperty(AsyncDisposableStack.prototype, 'constructor', {
+    value: AsyncDisposableStack,
+    writable: true,
+    enumerable: false,
+    configurable: true
+  });
+}

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/adds-onDisposeAsync.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/adds-onDisposeAsync.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: Adds an onDisposeAsync callback to the stack
+info: |
+  AsyncDisposableStack.prototype.defer ( onDisposeAsync )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. If IsCallable(onDisposeAsync) is false, throw a TypeError exception.
+  5. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], undefined, async-dispose, onDisposeAsync).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    ...
+  2. Else,
+    a. Assert: V is undefined.
+    b. Let resource be ? CreateDisposableResource(undefined, hint, method).
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var disposed = false;
+  stack.defer(async () => { disposed = true });
+  await stack.disposeAsync();
+  assert.sameValue(disposed, true, 'Expected callback to have been called');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: AsyncDisposableStack.prototype.defer.length property descriptor
+info: |
+  AsyncDisposableStack.prototype.defer ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.defer, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: AsyncDisposableStack.prototype.defer.name property descriptor
+info: |
+  AsyncDisposableStack.prototype.defer.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.defer, 'name', {
+  value: 'defer',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/not-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: >
+  AsyncDisposableStack.prototype.defer does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(AsyncDisposableStack.prototype.defer),
+  false,
+  'isConstructor(AsyncDisposableStack.prototype.defer) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new AsyncDisposableStack({}); new stack.defer();
+}, '`let stack = new AsyncDisposableStack({}); new stack.defer()` throws TypeError');
+

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: >
+  Property descriptor of AsyncDisposableStack.prototype.defer
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.defer, 'function');
+
+verifyProperty(AsyncDisposableStack.prototype, 'defer', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/puts-onDisposeAsync-on-top-of-stack.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/puts-onDisposeAsync-on-top-of-stack.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: Adds a disposable resource to the stack
+info: |
+  AsyncDisposableStack.prototype.defer ( onDisposeAsync )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. If IsCallable(onDisposeAsync) is false, throw a TypeError exception.
+  5. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], undefined, async-dispose, onDisposeAsync).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    ...
+  2. Else,
+    a. Assert: V is undefined.
+    b. Let resource be ? CreateDisposableResource(undefined, hint, method).
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var disposed = [];
+  async function dispose1() { disposed.push(dispose1); }
+  function dispose2() { disposed.push(dispose2); }
+  stack.defer(dispose1);
+  stack.defer(dispose2);
+  await stack.disposeAsync();
+  assert.sameValue(2, disposed.length);
+  assert.sameValue(disposed[0], dispose2, 'Expected dispose2 to be the first onDisposeAsync invoked');
+  assert.sameValue(disposed[1], dispose1, 'Expected dispose1 to be the second onDisposeAsync invoked');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/returns-undefined.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/returns-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: Returns the argument provided.
+info: |
+  AsyncDisposableStack.prototype.defer ( onDisposeAsync )
+
+  ...
+  6. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.sameValue(stack.defer(_ => {}), undefined);

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/this-does-not-have-internal-asyncdisposablestate-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/this-does-not-have-internal-asyncdisposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: Throws a TypeError if this does not have a [[AsyncDisposableState]] internal slot
+info: |
+  AsyncDisposableStack.prototype.defer ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.defer, 'function');
+
+var defer = AsyncDisposableStack.prototype.defer;
+
+assert.throws(TypeError, function() {
+  defer.call({ ['[[AsyncDisposableState]]']: {} });
+}, 'Ordinary object without [[AsyncDisposableState]]');
+
+assert.throws(TypeError, function() {
+  defer.call(AsyncDisposableStack.prototype);
+}, 'AsyncDisposableStack.prototype does not have a [[AsyncDisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  defer.call(AsyncDisposableStack);
+}, 'AsyncDisposableStack does not have a [[AsyncDisposableState]] internal slot');
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  defer.call(stack);
+}, 'DisposableStack instance');

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/this-not-object-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: Throws a TypeError if this is not an Object
+info: |
+  AsyncDisposableStack.prototype.defer ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.defer, 'function');
+
+var defer = AsyncDisposableStack.prototype.defer;
+
+assert.throws(TypeError, function() {
+  defer.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  defer.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  defer.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  defer.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  defer.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  defer.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  defer.call(s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/throws-if-onDisposeAsync-not-callable.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/throws-if-onDisposeAsync-not-callable.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: Adds a callback to the stack
+info: |
+  AsyncDisposableStack.prototype.defer ( onDisposeAsync )
+
+  ...
+  4. If IsCallable(onDisposeAsync) is false, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.defer(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  stack.defer(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  stack.defer(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.defer(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.defer(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.defer('object');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  stack.defer({});
+}, 'object');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.defer(s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/disposes-resources-in-reverse-order.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/disposes-resources-in-reverse-order.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Added resources are disposed in reverse order
+info: |
+
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+  3. If asyncDisposableStack does not have an [[AsyncDisposableState]] internal slot, then
+    a. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
+    b. Return promiseCapability.[[Promise]].
+  4. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, then
+    a. Perform ! Call(promiseCapability.[[Resolve]], undefined, « undefined »).
+    b. Return promiseCapability.[[Promise]].
+  5. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  6. Let result be DisposeResources(asyncDisposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+  7. IfAbruptRejectPromise(result, promiseCapability).
+  8. Perform ! Call(promiseCapability.[[Resolve]], undefined, « result »).
+  9. Return promiseCapability.[[Promise]].
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var disposed = [];
+  var resource1 = { async [Symbol.asyncDispose]() { disposed.push(this); } };
+  var resource2 = { [Symbol.dispose]() { disposed.push(this); } };
+  var resource3 = {};
+  async function dispose3(res) { disposed.push(res); }
+  var resource4 = {};
+  function dispose4(res) { disposed.push(res); }
+  async function dispose5() { disposed.push(dispose5); }
+  function dispose6() { disposed.push(dispose6); }
+  stack.use(resource1);
+  stack.use(resource2);
+  stack.adopt(resource3, dispose3);
+  stack.adopt(resource4, dispose4);
+  stack.defer(dispose5);
+  stack.defer(dispose6);
+  await stack.disposeAsync();
+  assert.sameValue(disposed[0], dispose6);
+  assert.sameValue(disposed[1], dispose5);
+  assert.sameValue(disposed[2], resource4);
+  assert.sameValue(disposed[3], resource3);
+  assert.sameValue(disposed[4], resource2);
+  assert.sameValue(disposed[5], resource1);
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/does-not-reinvoke-disposers-if-already-disposed.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/does-not-reinvoke-disposers-if-already-disposed.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Does not re-invoke disposal on resources after stack has already been disposed.
+info: |
+
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, return undefined.
+  4. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  5. Return DisposeResources(asyncDisposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var useCount = 0;
+  var adoptCount = 0;
+  var deferCount = 0;
+  stack.use({ async [Symbol.asyncDispose]() { useCount++; } });
+  stack.adopt({}, _ => { adoptCount++; });
+  stack.defer(() => { deferCount++; });
+  await stack.disposeAsync();
+  await stack.disposeAsync();
+  assert.sameValue(useCount, 1);
+  assert.sameValue(adoptCount, 1);
+  assert.sameValue(deferCount, 1);
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/does-not-reinvoke-disposers-if-dispose-already-started.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/does-not-reinvoke-disposers-if-dispose-already-started.js
@@ -1,0 +1,60 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Does not re-invoke disposal on resources after stack has already been disposed.
+info: |
+
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, return undefined.
+  4. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  5. Return DisposeResources(asyncDisposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var useCount = 0;
+  var adoptCount = 0;
+  var deferCount = 0;
+  stack.use({ async [Symbol.asyncDispose]() { useCount++; } });
+  stack.adopt({}, _ => { adoptCount++; });
+  stack.defer(() => { deferCount++; });
+  var p1 = stack.disposeAsync();
+  var p2 = stack.disposeAsync();
+  await Promise.all([p1, p2]);
+  assert.sameValue(useCount, 1);
+  assert.sameValue(adoptCount, 1);
+  assert.sameValue(deferCount, 1);
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/does-not-reject-if-already-disposed.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/does-not-reject-if-already-disposed.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Does not throw if already disposed.
+info: |
+
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, return undefined.
+  4. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  5. Return DisposeResources(asyncDisposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var p = stack.disposeAsync();
+  await stack.disposeAsync();
+  await p;
+  await stack.disposeAsync();
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: AsyncDisposableStack.prototype.disposeAsync.length property descriptor
+info: |
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.disposeAsync, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: AsyncDisposableStack.prototype.disposeAsync.name property descriptor
+info: |
+  AsyncDisposableStack.prototype.disposeAsync.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.disposeAsync, 'name', {
+  value: 'disposeAsync',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/not-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: >
+  AsyncDisposableStack.prototype.disposeAsync does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(AsyncDisposableStack.prototype.disposeAsync),
+  false,
+  'isConstructor(AsyncDisposableStack.prototype.disposeAsync) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new AsyncDisposableStack({}); new stack.disposeAsync();
+}, '`let stack = new AsyncDisposableStack({}); new stack.disposeAsync()` throws TypeError');
+

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: >
+  Property descriptor of AsyncDisposableStack.prototype.disposeAsync
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.disposeAsync, 'function');
+
+verifyProperty(AsyncDisposableStack.prototype, 'disposeAsync', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/rejects-with-error-as-is-if-only-one-error-during-disposal.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/rejects-with-error-as-is-if-only-one-error-during-disposal.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Rethrows an error from a disposal as-is if it is the only error.
+info: |
+
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, return undefined.
+  4. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  5. Return DisposeResources(asyncDisposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  class MyError extends Error {}
+  var stack = new AsyncDisposableStack();
+  stack.defer(async function () { throw new MyError(); });
+  stack.defer(function () {});
+  await assert.throwsAsync(MyError, async function () {
+    await stack.disposeAsync();
+  });
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/rejects-with-suppressederror-if-multiple-errors-during-disposal.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/rejects-with-suppressederror-if-multiple-errors-during-disposal.js
@@ -1,0 +1,66 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Throws multiple errors from a disposal nested in one or more SuppressedError instances.
+info: |
+
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, return undefined.
+  4. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  5. Return DisposeResources(asyncDisposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  class MyError extends Error {}
+  var error1 = new MyError();
+  var error2 = new MyError();
+  var error3 = new MyError();
+  var stack = new AsyncDisposableStack();
+  stack.defer(function () { throw error1; });
+  stack.defer(function () { throw error2; });
+  stack.defer(function () { throw error3; });
+  try {
+    await stack.disposeAsync();
+    assert(false, 'Expected await stack.disposeAsync() to have thrown an error.');
+  }
+  catch (e) {
+    assert(e instanceof SuppressedError, "Expected await stack.disposeAsync() to have thrown a SuppressedError");
+    assert.sameValue(e.error, error1, "Expected the outermost suppressing error to have been 'error1'");
+    assert(e.suppressed instanceof SuppressedError, "Expected the outermost suppressed error to have been a SuppressedError");
+    assert.sameValue(e.suppressed.error, error2, "Expected the innermost suppressing error to have been 'error2'");
+    assert.sameValue(e.suppressed.suppressed, error3, "Expected the innermost suppressed error to have been 'error3'");
+  }
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/resolves-to-undefined.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/resolves-to-undefined.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Return value of dispose is undefined
+info: |
+
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, return undefined.
+  4. Set asyncDisposableStack.[[DisposableState]] to disposed.
+  5. Return DisposeResources(asyncDisposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack1 = new AsyncDisposableStack();
+  assert.sameValue(await stack1.disposeAsync(), undefined);
+
+  var stack2 = new AsyncDisposableStack();
+  stack2.defer(async () => 1);
+  stack2.defer(() => 2);
+  assert.sameValue(await stack2.disposeAsync(), undefined);
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/returns-promise.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/returns-promise.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Return value of dispose is undefined
+info: |
+
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, return undefined.
+  4. Set asyncDisposableStack.[[DisposableState]] to disposed.
+  5. Return DisposeResources(asyncDisposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert(stack.disposeAsync() instanceof Promise);

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/sets-state-to-disposed.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/sets-state-to-disposed.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Sets the [[AsyncDisposableState]] internal slot to disposed
+info: |
+
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, return undefined.
+  4. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  5. Return DisposeResources(asyncDisposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var wasDisposed = stack.disposed;
+  var p = stack.disposeAsync();
+  var wasDisposedBeforeAwait = stack.disposed;
+  await p;
+  var isDisposedAfterAwait = stack.disposed;
+  assert.sameValue(wasDisposed, false);
+  assert.sameValue(wasDisposedBeforeAwait, true);
+  assert.sameValue(isDisposedAfterAwait, true);
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/this-does-not-have-internal-asyncdisposablestate-rejects.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/this-does-not-have-internal-asyncdisposablestate-rejects.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Throws a TypeError if this does not have a [[AsyncDisposableState]] internal slot
+info: |
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  assert.sameValue(typeof AsyncDisposableStack.prototype.disposeAsync, 'function');
+  
+  var disposeAsync = AsyncDisposableStack.prototype.disposeAsync;
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call({ ['[[AsyncDisposableState]]']: {} });
+  }, 'Ordinary object without [[AsyncDisposableState]]');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(AsyncDisposableStack.prototype);
+  }, 'AsyncDisposableStack.prototype does not have a [[AsyncDisposableState]] internal slot');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(AsyncDisposableStack);
+  }, 'AsyncDisposableStack does not have a [[AsyncDisposableState]] internal slot');
+  
+  var stack = new DisposableStack();
+  await assert.throwsAsync(TypeError, function () {
+    return disposeAsync.call(stack);
+  }, 'DisposableStack instance');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/this-not-object-rejects.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/this-not-object-rejects.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Throws a TypeError if this is not an Object
+info: |
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.disposeAsync, 'function');
+
+var disposeAsync = AsyncDisposableStack.prototype.disposeAsync;
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(undefined);
+  }, 'undefined');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(null);
+  }, 'null');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(true);
+  }, 'true');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(false);
+  }, 'false');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(1);
+  }, 'number');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call('object');
+  }, 'string');
+  
+  var s = Symbol();
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(s);
+  }, 'symbol');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/does-not-have-asyncdisposablestate-internal-slot.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/does-not-have-asyncdisposablestate-internal-slot.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  Throws a TypeError if `this` object does not have a [[AsyncDisposableState]] internal slot.
+info: |
+  get AsyncDisposableStack.prototype.disposed
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(AsyncDisposableStack.prototype, 'disposed');
+
+var stack = new AsyncDisposableStack();
+
+// Does not throw
+descriptor.get.call(stack);
+
+assert.throws(TypeError, function() {
+  descriptor.get.call([]);
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/getter.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/getter.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  Property type and descriptor.
+info: |
+  get AsyncDisposableStack.prototype.disposed
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(AsyncDisposableStack.prototype, 'disposed');
+
+assert.sameValue(
+  typeof descriptor.get,
+  'function',
+  'typeof descriptor.get is function'
+);
+assert.sameValue(
+  typeof descriptor.set,
+  'undefined',
+  'typeof descriptor.set is undefined'
+);
+
+verifyNotEnumerable(AsyncDisposableStack.prototype, 'disposed');
+verifyConfigurable(AsyncDisposableStack.prototype, 'disposed');

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/length.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  Map.prototype.size.length value and descriptor.
+info: |
+  get Map.prototype.size
+
+  17 ECMAScript Standard Built-in Objects
+includes: [propertyHelper.js]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+
+assert.sameValue(
+  descriptor.get.length, 0,
+  'The value of `Map.prototype.size.length` is `0`'
+);
+
+verifyNotEnumerable(descriptor.get, 'length');
+verifyNotWritable(descriptor.get, 'length');
+verifyConfigurable(descriptor.get, 'length');

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/name.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  AsyncDisposableStack.prototype.disposed.name value and descriptor.
+info: |
+  get AsyncDisposableStack.prototype.size
+
+  17 ECMAScript Standard Built-in Objects
+
+  Functions that are specified as get or set accessor functions of built-in
+  properties have "get " or "set " prepended to the property name string.
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(AsyncDisposableStack.prototype, 'disposed');
+
+assert.sameValue(descriptor.get.name,
+  'get disposed',
+  'The value of `descriptor.get.name` is `get disposed`'
+);
+
+verifyNotEnumerable(descriptor.get, 'name');
+verifyNotWritable(descriptor.get, 'name');
+verifyConfigurable(descriptor.get, 'name');

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/returns-false-when-not-disposed.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/returns-false-when-not-disposed.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  Returns `false` when the AsyncDisposableStack has not yet been disposed.
+info: |
+  get AsyncDisposableStack.prototype.disposed
+
+  ...
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, return true.
+  4. Otherwise, return false.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+
+assert.sameValue(stack.disposed, false);

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/returns-true-when-disposed.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/returns-true-when-disposed.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  Returns `true` after the AsyncDisposableStack has been disposed.
+info: |
+  get AsyncDisposableStack.prototype.disposed
+
+  ...
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, return true.
+  4. Otherwise, return false.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+stack.disposeAsync();
+assert.sameValue(stack.disposed, true);

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/this-not-object-throw.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/this-not-object-throw.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  Throws a TypeError if `this` is not an Object.
+info: |
+  get AsyncDisposableStack.prototype.disposed
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management,Symbol]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(AsyncDisposableStack.prototype, 'disposed');
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(1);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(false);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(1);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call('');
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(undefined);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(null);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(Symbol());
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/move/does-not-dispose-resources.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/does-not-dispose-resources.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: Resources in the stack are not disposed when move is called.
+info: |
+
+  AsyncDisposableStack.prototype.move ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newAsyncDisposableStack be ? OrdinaryCreateFromConstructor(%AsyncDisposableStack%, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  5. Set newAsyncDisposableStack.[[AsyncDisposableState]] to pending.
+  6. Set newAsyncDisposableStack.[[DisposeCapability]] to asyncDisposableStack.[[DisposeCapability]].
+  7. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  9. Return newAsyncDisposableStack.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+var disposed = false;
+stack.defer(() => { disposed = true; });
+stack.move();
+assert.sameValue(disposed, false);

--- a/test/built-ins/AsyncDisposableStack/prototype/move/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: AsyncDisposableStack.prototype.move.length property descriptor
+info: |
+  AsyncDisposableStack.prototype.move ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.move, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/move/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: AsyncDisposableStack.prototype.move.name property descriptor
+info: |
+  AsyncDisposableStack.prototype.move.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.move, 'name', {
+  value: 'move',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/move/not-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: >
+  AsyncDisposableStack.prototype.move does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(AsyncDisposableStack.prototype.move),
+  false,
+  'isConstructor(AsyncDisposableStack.prototype.move) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new AsyncDisposableStack({}); new stack.move();
+}, '`let stack = new AsyncDisposableStack({}); new stack.move()` throws TypeError');
+

--- a/test/built-ins/AsyncDisposableStack/prototype/move/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: >
+  Property descriptor of AsyncDisposableStack.prototype.move
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.move, 'function');
+
+verifyProperty(AsyncDisposableStack.prototype, 'move', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/move/returns-new-asyncdisposablestack-that-contains-moved-resources.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/returns-new-asyncdisposablestack-that-contains-moved-resources.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: Returns a new AsyncDisposableStack that contains the resources originally contained in this stack.
+info: |
+
+  AsyncDisposableStack.prototype.move ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newAsyncDisposableStack be ? OrdinaryCreateFromConstructor(%AsyncDisposableStack%, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  5. Set newAsyncDisposableStack.[[AsyncDisposableState]] to pending.
+  6. Set newAsyncDisposableStack.[[DisposeCapability]] to asyncDisposableStack.[[DisposeCapability]].
+  7. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  9. Return newAsyncDisposableStack.
+
+flags: [async]
+includes: [asyncHelpers.js, deepEqual.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+
+  var stack1 = new AsyncDisposableStack();
+  var disposed = [];
+  stack1.defer(async () => { disposed.push(1); });
+  stack1.defer(() => { disposed.push(2); });
+
+  var stack2 = stack1.move();
+
+  var wasDisposed = disposed.slice();
+  await stack2.disposeAsync();
+  var isDisposed = disposed.slice();
+
+  assert.deepEqual(wasDisposed, []);
+  assert.deepEqual(isDisposed, [2, 1]);
+
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/move/returns-new-asyncdisposablestack-that-is-still-pending.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/returns-new-asyncdisposablestack-that-is-still-pending.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: Returns a new AsyncDisposableStack that is still pending
+info: |
+
+  AsyncDisposableStack.prototype.move ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newAsyncDisposableStack be ? OrdinaryCreateFromConstructor(%AsyncDisposableStack%, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  5. Set newAsyncDisposableStack.[[AsyncDisposableState]] to pending.
+  6. Set newAsyncDisposableStack.[[DisposeCapability]] to asyncDisposableStack.[[DisposeCapability]].
+  7. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  9. Return newAsyncDisposableStack.
+
+features: [explicit-resource-management]
+---*/
+
+var stack1 = new AsyncDisposableStack();
+var stack2 = stack1.move();
+assert.sameValue(stack2.disposed, false);

--- a/test/built-ins/AsyncDisposableStack/prototype/move/returns-new-asyncdisposablestack.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/returns-new-asyncdisposablestack.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: Returns a new AsyncDisposableStack
+info: |
+
+  AsyncDisposableStack.prototype.move ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newAsyncDisposableStack be ? OrdinaryCreateFromConstructor(%AsyncDisposableStack%, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  5. Set newAsyncDisposableStack.[[AsyncDisposableState]] to pending.
+  6. Set newAsyncDisposableStack.[[DisposeCapability]] to asyncDisposableStack.[[DisposeCapability]].
+  7. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  9. Return newAsyncDisposableStack.
+
+features: [explicit-resource-management]
+---*/
+
+var stack1 = new AsyncDisposableStack();
+var stack2 = stack1.move();
+assert(stack2 !== stack1, 'Expected stack2 to not be the same reference as stack1');
+assert(stack2 instanceof AsyncDisposableStack, 'Expected stack2 to be an instance of AsyncDisposableStack');

--- a/test/built-ins/AsyncDisposableStack/prototype/move/sets-state-to-disposed.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/sets-state-to-disposed.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: The stack's [[AsyncDisposableState]] internal slot is set to disposed.
+info: |
+
+  AsyncDisposableStack.prototype.move ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newAsyncDisposableStack be ? OrdinaryCreateFromConstructor(%AsyncDisposableStack%, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  5. Set newAsyncDisposableStack.[[AsyncDisposableState]] to pending.
+  6. Set newAsyncDisposableStack.[[DisposeCapability]] to asyncDisposableStack.[[DisposeCapability]].
+  7. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  9. Return newAsyncDisposableStack.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+var wasDisposed = stack.disposed;
+stack.move();
+var isDisposed = stack.disposed;
+assert.sameValue(wasDisposed, false);
+assert.sameValue(isDisposed, true);

--- a/test/built-ins/AsyncDisposableStack/prototype/move/still-returns-new-asyncdisposablestack-when-subclassed.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/still-returns-new-asyncdisposablestack-when-subclassed.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: Returns a new %AsyncDisposableStack%, even when subclassed
+info: |
+
+  AsyncDisposableStack.prototype.move ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newAsyncDisposableStack be ? OrdinaryCreateFromConstructor(%AsyncDisposableStack%, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  5. Set newAsyncDisposableStack.[[AsyncDisposableState]] to pending.
+  6. Set newAsyncDisposableStack.[[DisposeCapability]] to asyncDisposableStack.[[DisposeCapability]].
+  7. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set asyncDisposableStack.[[AsyncDisposableState]] to disposed.
+  9. Return newAsyncDisposableStack.
+
+features: [explicit-resource-management]
+---*/
+
+class MyAsyncDisposableStack extends AsyncDisposableStack {}
+
+var stack1 = new MyAsyncDisposableStack();
+var stack2 = stack1.move();
+assert(stack2 instanceof AsyncDisposableStack, 'Expected stack2 to be an instance of AsyncDisposableStack');
+assert(!(stack2 instanceof MyAsyncDisposableStack), 'Expected stack2 to not be an instance of MyAsyncDisposableStack');

--- a/test/built-ins/AsyncDisposableStack/prototype/move/this-does-not-have-internal-asyncdisposablestate-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/this-does-not-have-internal-asyncdisposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: Throws a TypeError if this does not have a [[AsyncDisposableState]] internal slot
+info: |
+  AsyncDisposableStack.prototype.move ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.move, 'function');
+
+var move = AsyncDisposableStack.prototype.move;
+
+assert.throws(TypeError, function() {
+  move.call({ ['[[AsyncDisposableState]]']: {} });
+}, 'Ordinary object without [[AsyncDisposableState]]');
+
+assert.throws(TypeError, function() {
+  move.call(AsyncDisposableStack.prototype);
+}, 'AsyncDisposableStack.prototype does not have a [[AsyncDisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  move.call(AsyncDisposableStack);
+}, 'AsyncDisposableStack does not have a [[AsyncDisposableState]] internal slot');
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  move.call(stack);
+}, 'DisposableStack instance');

--- a/test/built-ins/AsyncDisposableStack/prototype/move/this-not-object-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: Throws a TypeError if this is not an Object
+info: |
+  AsyncDisposableStack.prototype.move ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.move, 'function');
+
+var move = AsyncDisposableStack.prototype.move;
+
+assert.throws(TypeError, function() {
+  move.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  move.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  move.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  move.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  move.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  move.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  move.call(s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/move/throws-if-disposed.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/throws-if-disposed.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: Throws a ReferenceError if this is disposed.
+info: |
+  AsyncDisposableStack.prototype.move ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+stack.disposeAsync();
+
+assert.throws(ReferenceError, function() {
+  stack.move();
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The property descriptor AsyncDisposableStack.prototype
+esid: sec-properties-of-the-asyncdisposablestack-constructor
+info: |
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: false }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(AsyncDisposableStack, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/proto.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/proto.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The prototype of AsyncDisposableStack.prototype is Object.prototype
+esid: sec-properties-of-the-asyncdisposablestack-prototype-object
+info: |
+  The value of the [[Prototype]] internal slot of the AsyncDisposableStack prototype object
+  is the intrinsic object %Object.prototype%.
+features: [explicit-resource-management]
+---*/
+
+var proto = Object.getPrototypeOf(AsyncDisposableStack.prototype);
+assert.sameValue(proto, Object.prototype);

--- a/test/built-ins/AsyncDisposableStack/prototype/use/adds-async-disposable-value.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/adds-async-disposable-value.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Adds an asynchronously disposable resource to the stack
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var resource = {
+      disposed: false,
+      async [Symbol.asyncDispose]() {
+          this.disposed = true;
+      }
+  };
+  stack.use(resource);
+  await stack.disposeAsync();
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/adds-sync-disposable-value.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/adds-sync-disposable-value.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Adds a synchronously disposable resource to the stack
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var resource = {
+      disposed: false,
+      [Symbol.dispose]() {
+          this.disposed = true;
+      }
+  };
+  stack.use(resource);
+  await stack.disposeAsync();
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/allows-null-value.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/allows-null-value.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Does not throw when argument is 'null'
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+stack.use(null);

--- a/test/built-ins/AsyncDisposableStack/prototype/use/allows-undefined-value.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/allows-undefined-value.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Does not throw when argument is 'undefined'
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+stack.use(undefined);

--- a/test/built-ins/AsyncDisposableStack/prototype/use/gets-value-Symbol.asyncDispose-property-once.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/gets-value-Symbol.asyncDispose-property-once.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Only reads `[Symbol.asyncDispose]` method once, when added.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var resource = {
+      disposeReadCount: 0,
+      get [Symbol.asyncDispose]() {
+          this.disposeReadCount++;
+          return async function() { };
+      }
+  };
+  stack.use(resource);
+  var countAfterUse = resource.disposeReadCount;
+  await stack.disposeAsync();
+  var countAfterDispose = resource.disposeReadCount;
+  assert.sameValue(countAfterUse, 1, 'Expected [Symbol.asyncDispose] to have been read only once');
+  assert.sameValue(countAfterDispose, 1, 'Expected [Symbol.asyncDispose] to have been read only once');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/gets-value-Symbol.dispose-property-after-trying-Symbol.asyncDispose.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/gets-value-Symbol.dispose-property-after-trying-Symbol.asyncDispose.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Only reads `[Symbol.dispose]` after trying `[Symbol.asyncDispose]` frist
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+includes: [deepEqual.js]
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+var order = [];
+var resource = {
+    get [Symbol.asyncDispose]() {
+        order.push('Symbol.asyncDispose');
+        return undefined;
+    },
+    get [Symbol.dispose]() {
+        order.push('Symbol.dispose');
+        return function() {};
+    },
+};
+stack.use(resource);
+assert.deepEqual(order, ['Symbol.asyncDispose', 'Symbol.dispose']);

--- a/test/built-ins/AsyncDisposableStack/prototype/use/gets-value-Symbol.dispose-property-once.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/gets-value-Symbol.dispose-property-once.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Only reads `[Symbol.dispose]` method once, when added.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var resource = {
+      disposeReadCount: 0,
+      get [Symbol.dispose]() {
+          this.disposeReadCount++;
+          return function() { };
+      }
+  };
+  stack.use(resource);
+  var countAfterUse = resource.disposeReadCount;
+  await stack.disposeAsync();
+  var countAfterDispose = resource.disposeReadCount;
+  assert.sameValue(countAfterUse, 1, 'Expected [Symbol.dispose] to have been read only once');
+  assert.sameValue(countAfterDispose, 1, 'Expected [Symbol.dispose] to have been read only once');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: AsyncDisposableStack.prototype.use.length property descriptor
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.use, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: AsyncDisposableStack.prototype.use.name property descriptor
+info: |
+  AsyncDisposableStack.prototype.use.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.use, 'name', {
+  value: 'use',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/not-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: >
+  AsyncDisposableStack.prototype.use does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(AsyncDisposableStack.prototype.use),
+  false,
+  'isConstructor(AsyncDisposableStack.prototype.use) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new AsyncDisposableStack({}); new stack.use();
+}, '`let stack = new AsyncDisposableStack({}); new stack.use()` throws TypeError');
+

--- a/test/built-ins/AsyncDisposableStack/prototype/use/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: >
+  Property descriptor of AsyncDisposableStack.prototype.use
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.use, 'function');
+
+verifyProperty(AsyncDisposableStack.prototype, 'use', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/puts-value-on-top-of-stack.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/puts-value-on-top-of-stack.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Puts value on the top of the dispose stack
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var stack = new AsyncDisposableStack();
+  var disposed = [];
+  var resource1 = {
+      async [Symbol.asyncDispose]() {
+          disposed.push(this);
+      }
+  };
+  var resource2 = {
+      [Symbol.dispose]() {
+          disposed.push(this);
+      }
+  };
+  stack.use(resource1);
+  stack.use(resource2);
+  await stack.disposeAsync();
+  assert.sameValue(2, disposed.length);
+  assert.sameValue(disposed[0], resource2, 'Expected resource2 to be the first disposed resource');
+  assert.sameValue(disposed[1], resource1, 'Expected resource1 to be the second disposed resource');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/returns-value.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/returns-value.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Returns the argument provided.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  ...
+  5. Return value.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+var resource1 = { async [Symbol.asyncDispose]() { } };
+var resource2 = { [Symbol.dispose]() { } };
+assert.sameValue(stack.use(resource1), resource1);
+assert.sameValue(stack.use(resource2), resource2);
+assert.sameValue(stack.use(null), null);
+assert.sameValue(stack.use(undefined), undefined);

--- a/test/built-ins/AsyncDisposableStack/prototype/use/this-does-not-have-internal-asyncdisposablestate-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/this-does-not-have-internal-asyncdisposablestate-throws.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws a TypeError if this does not have a [[AsyncDisposableState]] internal slot
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, sync-dispose).
+  5. Return value.
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.use, 'function');
+
+var use = AsyncDisposableStack.prototype.use;
+
+assert.throws(TypeError, function() {
+  use.call({ ['[[AsyncDisposableState]]']: {} });
+}, 'Ordinary object without [[AsyncDisposableState]]');
+
+assert.throws(TypeError, function() {
+  use.call(AsyncDisposableStack.prototype);
+}, 'AsyncDisposableStack.prototype does not have a [[AsyncDisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  use.call(AsyncDisposableStack);
+}, 'AsyncDisposableStack does not have a [[AsyncDisposableState]] internal slot');
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  use.call(stack);
+}, 'DisposableStack instance');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/this-not-object-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws a TypeError if this is not an Object
+info: |
+  AsyncDisposableStack.prototype.use ()
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.use, 'function');
+
+var use = AsyncDisposableStack.prototype.use;
+
+assert.throws(TypeError, function() {
+  use.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  use.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  use.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  use.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  use.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  use.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  use.call(s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-disposed.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-disposed.js
@@ -1,0 +1,60 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws a ReferenceError if this is disposed.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+stack.disposeAsync();
+
+assert.throws(ReferenceError, function() {
+  stack.use(undefined);
+}, 'undefined');
+
+assert.throws(ReferenceError, function() {
+  stack.use(null);
+}, 'null');
+
+assert.throws(ReferenceError, function() {
+  stack.use(true);
+}, 'true');
+
+assert.throws(ReferenceError, function() {
+  stack.use(false);
+}, 'false');
+
+assert.throws(ReferenceError, function() {
+  stack.use(1);
+}, 'number');
+
+assert.throws(ReferenceError, function() {
+  stack.use('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(ReferenceError, function() {
+  stack.use(s);
+}, 'symbol');
+
+assert.throws(ReferenceError, function() {
+  stack.use({});
+}, 'non disposable object');
+
+assert.throws(ReferenceError, function() {
+  stack.use({ async [Symbol.asyncDispose]() {} });
+}, 'async disposable object');
+
+assert.throws(ReferenceError, function() {
+  stack.use({ [Symbol.dispose]() {} });
+}, 'disposable object');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.asyncDispose-property-is-null.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.asyncDispose-property-is-null.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws if the argument has a null-valued Symbol.asyncDispose property.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.asyncDispose]: null });
+}, 'true');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.asyncDispose-property-is-undefined.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.asyncDispose-property-is-undefined.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws if the argument has an undefined-valued Symbol.asyncDispose property.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.asyncDispose]: undefined });
+}, 'true');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.asyncDispose-property-not-callable.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.asyncDispose-property-not-callable.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws if the argument has a non-null, non-undefined, non-callable Symbol.asyncDispose property.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  ...
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. If IsCallable(func) is false, throw a TypeError exception.
+    ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.asyncDispose]: true });
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.asyncDispose]: false });
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.asyncDispose]: 1 });
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.asyncDispose]: 'object' });
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.asyncDispose]: s });
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-is-null.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-is-null.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws if the argument has a null-valued Symbol.dispose property.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: null });
+}, 'true');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-is-undefined.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-is-undefined.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws if the argument has an undefined-valued Symbol.dispose property.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: undefined });
+}, 'true');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-not-callable.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-not-callable.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws if the argument has a non-null, non-undefined, non-callable Symbol.asyncDispose property.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  ...
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. If IsCallable(func) is false, throw a TypeError exception.
+    ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: true });
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: false });
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: 1 });
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: 'object' });
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: s });
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-missing-Symbol.asyncDispose-and-Symbol.dispose.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-missing-Symbol.asyncDispose-and-Symbol.dispose.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws if the argument is an object that does not have a Symbol.asyncDispose property.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. If IsCallable(func) is false, throw a TypeError exception.
+    ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ });
+}, 'true');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-not-object.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-not-object.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws if the argument is not an object and is neither null nor undefined.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+    ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.use(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.use(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.use(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.use('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.use(s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/undefined-newtarget-throws.js
+++ b/test/built-ins/AsyncDisposableStack/undefined-newtarget-throws.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: >
+  Throws a TypeError if NewTarget is undefined.
+info: |
+  AsyncDisposableStack ( )
+
+  1. If NewTarget is undefined, throw a TypeError exception.
+  ...
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function() {
+  AsyncDisposableStack();
+});

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/invokes-return.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/invokes-return.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%asynciteratorprototype%-@@asyncDispose
+description: Return value of @@asyncDispose on %AsyncIteratorPrototype%
+info: |
+  %AsyncIteratorPrototype% [ @@asyncDispose ] ( )
+
+  1. Let O be the this value.
+  2. Let return be ? GetMethod(O, "return").
+  3. If return is not undefined, then
+    a. Perform ? Call(return, O, « »).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  async function* generator() {}
+  const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+
+  const iter = Object.create(AsyncIteratorPrototype);
+  var returnCalled = false;
+  iter.return = async function () {
+    returnCalled = true;
+    return { done: true };
+  };
+
+  await iter[Symbol.asyncDispose]();
+  assert.sameValue(returnCalled, true);
+});

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/is-function.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/is-function.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%asynciteratorprototype%-@@asyncDispose
+description: >
+  AsyncIterator.prototype[@@asyncDispose] is a built-in function
+features: [explicit-resource-management]
+---*/
+
+async function* generator() {}
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+
+assert.sameValue(typeof AsyncIteratorPrototype[Symbol.asyncDispose], 'function');

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/length.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%asynciteratorprototype%-@@asyncDispose
+description: Length of %AsyncIteratorPrototype%[ @@asyncDispose ]
+info: |
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+async function* generator() {}
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+
+verifyProperty(AsyncIteratorPrototype[Symbol.asyncDispose], 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/name.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/name.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%asynciteratorprototype%-@@asyncDispose
+description: Descriptor for `name` property
+info: |
+  The value of the name property of this function is "[Symbol.asyncDispose]".
+
+  ES6 Section 17: ECMAScript Standard Built-in Objects
+
+  Every built-in Function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value is a
+  String. Unless otherwise specified, this value is the name that is given to
+  the function in this specification.
+
+  [...]
+
+  Unless otherwise specified, the name property of a built-in Function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+async function* generator() {}
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+
+verifyProperty(AsyncIteratorPrototype[Symbol.asyncDispose], 'name', {
+  value: '[Symbol.asyncDispose]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/prop-desc.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/prop-desc.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%asynciteratorprototype%-@@asyncDispose
+description: Property descriptor
+info: |
+    ES6 Section 17
+
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+async function* generator() {}
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+
+verifyProperty(AsyncIteratorPrototype, Symbol.asyncDispose, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/return-val.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/return-val.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%asynciteratorprototype%-@@asyncDispose
+description: Return value of @@asyncDispose on %AsyncIteratorPrototype%
+info: |
+  %AsyncIteratorPrototype% [ @@asyncDispose ] ( )
+
+  1. Let O be the this value.
+  2. Let return be ? GetMethod(O, "return").
+  3. If return is not undefined, then
+    a. Perform ? Call(return, O, « »).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+async function* generator() {}
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+
+assert(AsyncIteratorPrototype[Symbol.asyncDispose]() instanceof Promise);

--- a/test/built-ins/DisposableStack/constructor.js
+++ b/test/built-ins/DisposableStack/constructor.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack-constructor
+description: >
+  The DisposableStack constructor is the %DisposableStack% intrinsic object and the initial
+  value of the DisposableStack property of the global object.
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(
+  typeof DisposableStack, 'function',
+  'typeof DisposableStack is function'
+);

--- a/test/built-ins/DisposableStack/instance-extensible.js
+++ b/test/built-ins/DisposableStack/instance-extensible.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: Instances of DisposableStack are extensible
+info: |
+  DisposableStack( )
+
+  ...
+  2. Let disposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  3. Set disposableStack.[[DisposableState]] to pending.
+  4. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return disposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  ObjectCreate ( proto [ , internalSlotsList ] )
+
+  4. Set obj.[[Prototype]] to proto.
+  5. Set obj.[[Extensible]] to true.
+  6. Return obj.
+features: [explicit-resource-management, Reflect]
+---*/
+
+var stack = new DisposableStack();
+assert.sameValue(Object.isExtensible(stack), true);

--- a/test/built-ins/DisposableStack/is-a-constructor.js
+++ b/test/built-ins/DisposableStack/is-a-constructor.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The DisposableStack constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [explicit-resource-management, DisposableStack]
+---*/
+
+assert.sameValue(isConstructor(DisposableStack), true, 'isConstructor(DisposableStack) must return true');
+new DisposableStack();
+

--- a/test/built-ins/DisposableStack/length.js
+++ b/test/built-ins/DisposableStack/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: DisposableStack.length property descriptor
+info: |
+  DisposableStack ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/name.js
+++ b/test/built-ins/DisposableStack/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: DisposableStack.name property descriptor
+info: |
+  DisposableStack ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack, 'name', {
+  value: 'DisposableStack',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/newtarget-prototype-is-not-object.js
+++ b/test/built-ins/DisposableStack/newtarget-prototype-is-not-object.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: >
+  [[Prototype]] defaults to %DisposableStack.prototype% if NewTarget.prototype is not an object.
+info: |
+  DisposableStack( target )
+
+  ...
+  2. Let disposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  3. Set disposableStack.[[DisposableState]] to pending.
+  4. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return disposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management, Reflect.construct, Symbol]
+---*/
+
+var stack;
+function newTarget() {}
+
+newTarget.prototype = undefined;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is undefined');
+
+newTarget.prototype = null;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is null');
+
+newTarget.prototype = true;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is a Boolean');
+
+newTarget.prototype = '';
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is a String');
+
+newTarget.prototype = Symbol();
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is a Symbol');
+
+newTarget.prototype = 1;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is a Number');

--- a/test/built-ins/DisposableStack/prop-desc.js
+++ b/test/built-ins/DisposableStack/prop-desc.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack-constructor
+description: >
+  Property descriptor of DisposableStack
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(this, 'DisposableStack', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/proto-from-ctor-realm.js
+++ b/test/built-ins/DisposableStack/proto-from-ctor-realm.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+  DisposableStack( )
+
+  ...
+  2. Let disposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  3. Set disposableStack.[[DisposableState]] to pending.
+  4. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return disposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management, cross-realm, Reflect, Symbol]
+---*/
+
+var other = $262.createRealm().global;
+var newTarget = new other.Function();
+var stack;
+
+newTarget.prototype = undefined;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.DisposableStack.prototype, 'newTarget.prototype is undefined');
+
+newTarget.prototype = null;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.DisposableStack.prototype, 'newTarget.prototype is null');
+
+newTarget.prototype = true;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.DisposableStack.prototype, 'newTarget.prototype is a Boolean');
+
+newTarget.prototype = '';
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.DisposableStack.prototype, 'newTarget.prototype is a String');
+
+newTarget.prototype = Symbol();
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.DisposableStack.prototype, 'newTarget.prototype is a Symbol');
+
+newTarget.prototype = 1;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), other.DisposableStack.prototype, 'newTarget.prototype is a Number');
+

--- a/test/built-ins/DisposableStack/proto.js
+++ b/test/built-ins/DisposableStack/proto.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-disposablestack-constructor
+description: >
+  The prototype of DisposableStack is Function.prototype
+info: |
+  The value of the [[Prototype]] internal slot of the DisposableStack object is the
+  intrinsic object %FunctionPrototype%.
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(
+  Object.getPrototypeOf(DisposableStack),
+  Function.prototype,
+  'Object.getPrototypeOf(DisposableStack) returns the value of `Function.prototype`'
+);

--- a/test/built-ins/DisposableStack/prototype-from-newtarget-abrupt.js
+++ b/test/built-ins/DisposableStack/prototype-from-newtarget-abrupt.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: >
+  Return abrupt from getting the NewTarget prototype
+info: |
+  DisposableStack ( )
+
+  ...
+  2. Let disposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  3. Set disposableStack.[[DisposableState]] to pending.
+  4. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return disposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+features: [explicit-resource-management, Reflect.construct]
+---*/
+
+var calls = 0;
+var newTarget = function() {}.bind(null);
+Object.defineProperty(newTarget, 'prototype', {
+  get: function() {
+    calls += 1;
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.construct(DisposableStack, [], newTarget);
+});
+
+assert.sameValue(calls, 1);

--- a/test/built-ins/DisposableStack/prototype-from-newtarget-custom.js
+++ b/test/built-ins/DisposableStack/prototype-from-newtarget-custom.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: >
+  The [[Prototype]] internal slot is computed from NewTarget.
+info: |
+  DisposableStack ( )
+
+  ...
+  2. Let disposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  3. Set disposableStack.[[DisposableState]] to pending.
+  4. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return disposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management, Reflect.construct]
+---*/
+
+var stack;
+
+stack = Reflect.construct(DisposableStack, [], Object);
+assert.sameValue(Object.getPrototypeOf(stack), Object.prototype, 'NewTarget is built-in Object constructor');
+
+var newTarget = function() {}.bind(null);
+Object.defineProperty(newTarget, 'prototype', {
+  get: function() {
+    return Array.prototype;
+  }
+});
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), Array.prototype, 'NewTarget is BoundFunction with accessor');

--- a/test/built-ins/DisposableStack/prototype-from-newtarget.js
+++ b/test/built-ins/DisposableStack/prototype-from-newtarget.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: >
+  The [[Prototype]] internal slot is computed from NewTarget.
+info: |
+  DisposableStack ( )
+
+  ...
+  2. Let disposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  3. Set disposableStack.[[DisposableState]] to pending.
+  4. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return disposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype);

--- a/test/built-ins/DisposableStack/prototype/Symbol.dispose.js
+++ b/test/built-ins/DisposableStack/prototype/Symbol.dispose.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-disposablestack.prototype-@@dispose
+description: Initial state of the Symbol.dispose property
+info: |
+  The initial value of the @@dispose property is the same function object as
+  the initial value of the dispose property.
+
+  Per ES6 section 17, the method should exist on the Array prototype, and it
+  should be writable and configurable, but not enumerable.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(DisposableStack.prototype[Symbol.dispose], DisposableStack.prototype.dispose);
+verifyNotEnumerable(DisposableStack.prototype, Symbol.dispose);
+verifyWritable(DisposableStack.prototype, Symbol.dispose);
+verifyConfigurable(DisposableStack.prototype, Symbol.dispose);

--- a/test/built-ins/DisposableStack/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/DisposableStack/prototype/Symbol.toStringTag.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype-@@toStringTag
+description: >
+    `Symbol.toStringTag` property descriptor
+info: |
+    The initial value of the @@toStringTag property is the String value
+    'DisposableStack'.
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management, Symbol, Symbol.toStringTag]
+---*/
+
+verifyProperty(DisposableStack.prototype, Symbol.toStringTag, {
+  value: 'DisposableStack',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/adopt/adds-value-onDispose.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/adds-value-onDispose.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: Adds a disposable resource to the stack
+info: |
+  DisposableStack.prototype.adopt ( value, onDispose )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. If IsCallable(onDispose) is false, throw a TypeError exception.
+  5. Let closure be a new Abstract Closure with no parameters that captures value and onDispose and performs the following steps when called:
+    a. Perform ? Call(onDispose, undefined, « value »).
+  6. Let F be CreateBuiltinFunction(closure, 0, "", « »).
+  7. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], undefined, sync-dispose, F).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    ...
+  2. Else,
+    a. Assert: V is undefined.
+    b. Let resource be ? CreateDisposableResource(undefined, hint, method).
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var resource = { disposed: false };
+stack.adopt(resource, r => { r.disposed = true });
+stack.dispose();
+assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');

--- a/test/built-ins/DisposableStack/prototype/adopt/allows-any-value.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/allows-any-value.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: Allows any 'value'
+info: |
+  DisposableStack.prototype.adopt ( value, onDispose )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. If IsCallable(onDispose) is false, throw a TypeError exception.
+  5. Let closure be a new Abstract Closure with no parameters that captures value and onDispose and performs the following steps when called:
+    a. Perform ? Call(onDispose, undefined, « value »).
+  6. Let F be CreateBuiltinFunction(closure, 0, "", « »).
+  7. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], undefined, sync-dispose, F).
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+stack.adopt(null, _ => {});
+stack.adopt(undefined, _ => {});
+stack.adopt({}, _ => {});
+stack.adopt({ [Symbol.dispose]() {} }, _ => {});
+stack.adopt(() => {}, _ => {});
+stack.adopt(true, _ => {});
+stack.adopt(false, _ => {});
+stack.adopt(1, _ => {});
+stack.adopt('object', _ => {});
+stack.adopt(Symbol(), _ => {});

--- a/test/built-ins/DisposableStack/prototype/adopt/length.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: DisposableStack.prototype.adopt.length property descriptor
+info: |
+  DisposableStack.prototype.adopt ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.adopt, 'length', {
+  value: 2,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/adopt/name.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: DisposableStack.prototype.adopt.name property descriptor
+info: |
+  DisposableStack.prototype.adopt.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.adopt, 'name', {
+  value: 'adopt',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/adopt/not-a-constructor.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: >
+  DisposableStack.prototype.adopt does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(DisposableStack.prototype.adopt),
+  false,
+  'isConstructor(DisposableStack.prototype.adopt) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new DisposableStack({}); new stack.adopt();
+}, '`let stack = new DisposableStack({}); new stack.adopt()` throws TypeError');
+

--- a/test/built-ins/DisposableStack/prototype/adopt/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: >
+  Property descriptor of DisposableStack.prototype.adopt
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.adopt, 'function');
+
+verifyProperty(DisposableStack.prototype, 'adopt', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/adopt/puts-value-onDispose-on-top-of-stack.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/puts-value-onDispose-on-top-of-stack.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: Adds a disposable resource to the stack
+info: |
+  DisposableStack.prototype.adopt ( value, onDispose )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. If IsCallable(onDispose) is false, throw a TypeError exception.
+  5. Let closure be a new Abstract Closure with no parameters that captures value and onDispose and performs the following steps when called:
+    a. Perform ? Call(onDispose, undefined, « value »).
+  6. Let F be CreateBuiltinFunction(closure, 0, "", « »).
+  7. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], undefined, sync-dispose, F).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    ...
+  2. Else,
+    a. Assert: V is undefined.
+    b. Let resource be ? CreateDisposableResource(undefined, hint, method).
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var disposed = [];
+var resource1 = {};
+function dispose1(res) { disposed.push([res, dispose1]); }
+var resource2 = {};
+function dispose2(res) { disposed.push([res, dispose2]); }
+stack.adopt(resource1, dispose1);
+stack.adopt(resource2, dispose2);
+stack.dispose();
+assert.sameValue(2, disposed.length);
+assert.sameValue(disposed[0][0], resource2, 'Expected resource2 to be the first disposed resource');
+assert.sameValue(disposed[0][1], dispose2, 'Expected dispose2 to be the first onDispose invoked');
+assert.sameValue(disposed[1][0], resource1, 'Expected resource1 to be the second disposed resource');
+assert.sameValue(disposed[1][1], dispose1, 'Expected dispose1 to be the second onDispose invoked');

--- a/test/built-ins/DisposableStack/prototype/adopt/returns-value.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/returns-value.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: Returns the argument provided.
+info: |
+  DisposableStack.prototype.adopt ( value, onDispose )
+
+  ...
+  8. Return value.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var resource = {};
+assert.sameValue(stack.adopt(resource, _ => {}), resource);
+assert.sameValue(stack.adopt(null, _ => {}), null);
+assert.sameValue(stack.adopt(undefined, _ => {}), undefined);

--- a/test/built-ins/DisposableStack/prototype/adopt/this-does-not-have-internal-disposablestate-throws.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/this-does-not-have-internal-disposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: Throws a TypeError if this does not have a [[DisposableState]] internal slot
+info: |
+  DisposableStack.prototype.adopt ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.adopt, 'function');
+
+var adopt = DisposableStack.prototype.adopt;
+
+assert.throws(TypeError, function() {
+  adopt.call({ ['[[DisposableState]]']: {} });
+}, 'Ordinary object without [[DisposableState]]');
+
+assert.throws(TypeError, function() {
+  adopt.call(DisposableStack.prototype);
+}, 'DisposableStack.prototype does not have a [[DisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  adopt.call(DisposableStack);
+}, 'DisposableStack does not have a [[DisposableState]] internal slot');
+
+var asyncStack = new AsyncDisposableStack(function() {});
+assert.throws(TypeError, function() {
+  adopt.call(asyncStack);
+}, 'AsyncDisposableStack instance');

--- a/test/built-ins/DisposableStack/prototype/adopt/this-not-object-throws.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: Throws a TypeError if this is not an Object
+info: |
+  DisposableStack.prototype.adopt ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.adopt, 'function');
+
+var adopt = DisposableStack.prototype.adopt;
+
+assert.throws(TypeError, function() {
+  adopt.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  adopt.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  adopt.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  adopt.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  adopt.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  adopt.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  adopt.call(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/adopt/throws-if-onDispose-not-callable.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/throws-if-onDispose-not-callable.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: Throws if onDispose argument not callable
+info: |
+  DisposableStack.prototype.adopt ( value, onDispose )
+
+  ...
+  4. If IsCallable(onDispose) is false, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  stack.adopt(null, null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, 1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, 'object');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  stack.adopt(null, {});
+}, 'object');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.adopt(null, s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/constructor.js
+++ b/test/built-ins/DisposableStack/prototype/constructor.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-disposablestack-prototype-object
+description: DisposableStack.prototype.constructor
+info: |
+  DisposableStack.prototype.constructor
+
+  Normative Optional
+
+  The initial value of DisposableStack.prototype.constructor is the intrinsic object %DisposableStack%.
+
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+
+  This section is to be treated identically to the "Annex B" of ECMA-262, but to be written in-line with the main specification.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+var actual = DisposableStack.prototype.hasOwnProperty('constructor');
+
+// If implemented, it should conform to the spec text
+if (actual) {
+  verifyProperty(DisposableStack.prototype, 'constructor', {
+    value: DisposableStack,
+    writable: true,
+    enumerable: false,
+    configurable: true
+  });
+}

--- a/test/built-ins/DisposableStack/prototype/defer/adds-onDispose.js
+++ b/test/built-ins/DisposableStack/prototype/defer/adds-onDispose.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: Adds an onDispose callback to the stack
+info: |
+  DisposableStack.prototype.defer ( onDispose )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. If IsCallable(onDispose) is false, throw a TypeError exception.
+  5. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], undefined, sync-dispose, onDispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    ...
+  2. Else,
+    a. Assert: V is undefined.
+    b. Let resource be ? CreateDisposableResource(undefined, hint, method).
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var disposed = false;
+stack.defer(() => { disposed = true });
+stack.dispose();
+assert.sameValue(disposed, true, 'Expected callback to have been called');

--- a/test/built-ins/DisposableStack/prototype/defer/length.js
+++ b/test/built-ins/DisposableStack/prototype/defer/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: DisposableStack.prototype.defer.length property descriptor
+info: |
+  DisposableStack.prototype.defer ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.defer, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/defer/name.js
+++ b/test/built-ins/DisposableStack/prototype/defer/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: DisposableStack.prototype.defer.name property descriptor
+info: |
+  DisposableStack.prototype.defer.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.defer, 'name', {
+  value: 'defer',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/defer/not-a-constructor.js
+++ b/test/built-ins/DisposableStack/prototype/defer/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: >
+  DisposableStack.prototype.defer does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(DisposableStack.prototype.defer),
+  false,
+  'isConstructor(DisposableStack.prototype.defer) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new DisposableStack({}); new stack.defer();
+}, '`let stack = new DisposableStack({}); new stack.defer()` throws TypeError');
+

--- a/test/built-ins/DisposableStack/prototype/defer/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/defer/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: >
+  Property descriptor of DisposableStack.prototype.defer
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.defer, 'function');
+
+verifyProperty(DisposableStack.prototype, 'defer', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/defer/puts-onDispose-on-top-of-stack.js
+++ b/test/built-ins/DisposableStack/prototype/defer/puts-onDispose-on-top-of-stack.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: Adds a disposable resource to the stack
+info: |
+  DisposableStack.prototype.defer ( onDispose )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. If IsCallable(onDispose) is false, throw a TypeError exception.
+  5. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], undefined, sync-dispose, onDispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    ...
+  2. Else,
+    a. Assert: V is undefined.
+    b. Let resource be ? CreateDisposableResource(undefined, hint, method).
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var disposed = [];
+function dispose1() { disposed.push(dispose1); }
+function dispose2() { disposed.push(dispose2); }
+stack.defer(dispose1);
+stack.defer(dispose2);
+stack.dispose();
+assert.sameValue(2, disposed.length);
+assert.sameValue(disposed[0], dispose2, 'Expected dispose2 to be the first onDispose invoked');
+assert.sameValue(disposed[1], dispose1, 'Expected dispose1 to be the second onDispose invoked');

--- a/test/built-ins/DisposableStack/prototype/defer/returns-undefined.js
+++ b/test/built-ins/DisposableStack/prototype/defer/returns-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: Returns the argument provided.
+info: |
+  DisposableStack.prototype.defer ( onDispose )
+
+  ...
+  6. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.sameValue(stack.defer(_ => {}), undefined);

--- a/test/built-ins/DisposableStack/prototype/defer/this-does-not-have-internal-disposablestate-throws.js
+++ b/test/built-ins/DisposableStack/prototype/defer/this-does-not-have-internal-disposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: Throws a TypeError if this does not have a [[DisposableState]] internal slot
+info: |
+  DisposableStack.prototype.defer ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.defer, 'function');
+
+var defer = DisposableStack.prototype.defer;
+
+assert.throws(TypeError, function() {
+  defer.call({ ['[[DisposableState]]']: {} });
+}, 'Ordinary object without [[DisposableState]]');
+
+assert.throws(TypeError, function() {
+  defer.call(DisposableStack.prototype);
+}, 'DisposableStack.prototype does not have a [[DisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  defer.call(DisposableStack);
+}, 'DisposableStack does not have a [[DisposableState]] internal slot');
+
+var asyncStack = new AsyncDisposableStack(function() {});
+assert.throws(TypeError, function() {
+  defer.call(asyncStack);
+}, 'AsyncDisposableStack instance');

--- a/test/built-ins/DisposableStack/prototype/defer/this-not-object-throws.js
+++ b/test/built-ins/DisposableStack/prototype/defer/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: Throws a TypeError if this is not an Object
+info: |
+  DisposableStack.prototype.defer ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.defer, 'function');
+
+var defer = DisposableStack.prototype.defer;
+
+assert.throws(TypeError, function() {
+  defer.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  defer.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  defer.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  defer.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  defer.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  defer.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  defer.call(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/defer/throws-if-onDispose-not-callable.js
+++ b/test/built-ins/DisposableStack/prototype/defer/throws-if-onDispose-not-callable.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: Adds a callback to the stack
+info: |
+  DisposableStack.prototype.defer ( onDispose )
+
+  ...
+  4. If IsCallable(onDispose) is false, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  stack.defer(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  stack.defer(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  stack.defer(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.defer(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.defer(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.defer('object');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  stack.defer({});
+}, 'object');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.defer(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/dispose/disposes-resources-in-reverse-order.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/disposes-resources-in-reverse-order.js
@@ -1,0 +1,70 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Added resources are disposed in reverse order
+info: |
+
+  UsingDeclaration : using BindingList ;
+
+  1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+  2. Return empty.
+
+  BindingList : BindingList , LexicalBinding
+
+  1. Perform ? BindingEvaluation of BindingList with argument hint.
+  2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+  3. Return unused.
+
+  LexicalBinding : BindingIdentifier Initializer
+
+  1. Let bindingId be StringValue of BindingIdentifier.
+  2. Let lhs be ? ResolveBinding(bindingId).
+  3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+    a. Let value be NamedEvaluation of Initializer with argument bindingId.
+  4. Else,
+    a. Let rhs be the result of evaluating Initializer.
+    b. Let value be ? GetValue(rhs).
+  5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var disposed = [];
+var resource1 = { [Symbol.dispose]() { disposed.push(resource1); } };
+var resource2 = {};
+function dispose2(res) { disposed.push(res); }
+function dispose3() { disposed.push(dispose3); }
+stack.use(resource1);
+stack.adopt(resource2, dispose2);
+stack.defer(dispose3);
+stack.dispose();
+assert.sameValue(disposed[0], dispose3);
+assert.sameValue(disposed[1], resource2);
+assert.sameValue(disposed[2], resource1);

--- a/test/built-ins/DisposableStack/prototype/dispose/does-not-reinvoke-disposers-if-already-disposed.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/does-not-reinvoke-disposers-if-already-disposed.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Does not re-invoke disposal on resources after stack has already been disposed.
+info: |
+
+  DisposableStack.prototype.dispose ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, return undefined.
+  4. Set disposableStack.[[DisposableState]] to disposed.
+  5. Return DisposeResources(disposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var useCount = 0;
+var adoptCount = 0;
+var deferCount = 0;
+stack.use({ [Symbol.dispose]() { useCount++; } });
+stack.adopt({}, _ => { adoptCount++; });
+stack.defer(() => { deferCount++; });
+stack.dispose();
+stack.dispose();
+assert.sameValue(useCount, 1);
+assert.sameValue(adoptCount, 1);
+assert.sameValue(deferCount, 1);

--- a/test/built-ins/DisposableStack/prototype/dispose/does-not-throw-if-already-disposed.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/does-not-throw-if-already-disposed.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Does not throw if already disposed.
+info: |
+
+  DisposableStack.prototype.dispose ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, return undefined.
+  4. Set disposableStack.[[DisposableState]] to disposed.
+  5. Return DisposeResources(disposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+stack.dispose();
+stack.dispose();

--- a/test/built-ins/DisposableStack/prototype/dispose/length.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: DisposableStack.prototype.dispose.length property descriptor
+info: |
+  DisposableStack.prototype.dispose ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.dispose, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/dispose/name.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: DisposableStack.prototype.dispose.name property descriptor
+info: |
+  DisposableStack.prototype.dispose.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.dispose, 'name', {
+  value: 'dispose',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/dispose/not-a-constructor.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: >
+  DisposableStack.prototype.dispose does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(DisposableStack.prototype.dispose),
+  false,
+  'isConstructor(DisposableStack.prototype.dispose) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new DisposableStack({}); new stack.dispose();
+}, '`let stack = new DisposableStack({}); new stack.dispose()` throws TypeError');
+

--- a/test/built-ins/DisposableStack/prototype/dispose/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: >
+  Property descriptor of DisposableStack.prototype.dispose
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.dispose, 'function');
+
+verifyProperty(DisposableStack.prototype, 'dispose', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/dispose/returns-undefined.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/returns-undefined.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Return value of dispose is undefined
+info: |
+
+  DisposableStack.prototype.dispose ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, return undefined.
+  4. Set disposableStack.[[DisposableState]] to disposed.
+  5. Return DisposeResources(disposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.sameValue(stack.dispose(), undefined);

--- a/test/built-ins/DisposableStack/prototype/dispose/sets-state-to-disposed.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/sets-state-to-disposed.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Sets the [[DisposableState]] internal slot to disposed
+info: |
+
+  DisposableStack.prototype.dispose ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, return undefined.
+  4. Set disposableStack.[[DisposableState]] to disposed.
+  5. Return DisposeResources(disposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var wasDisposed = stack.disposed;
+stack.dispose();
+var isDisposed = stack.disposed;
+assert.sameValue(wasDisposed, false);
+assert.sameValue(isDisposed, true);

--- a/test/built-ins/DisposableStack/prototype/dispose/this-does-not-have-internal-disposablestate-throws.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/this-does-not-have-internal-disposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Throws a TypeError if this does not have a [[DisposableState]] internal slot
+info: |
+  DisposableStack.prototype.dispose ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.dispose, 'function');
+
+var dispose = DisposableStack.prototype.dispose;
+
+assert.throws(TypeError, function() {
+  dispose.call({ ['[[DisposableState]]']: {} });
+}, 'Ordinary object without [[DisposableState]]');
+
+assert.throws(TypeError, function() {
+  dispose.call(DisposableStack.prototype);
+}, 'DisposableStack.prototype does not have a [[DisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  dispose.call(DisposableStack);
+}, 'DisposableStack does not have a [[DisposableState]] internal slot');
+
+var asyncStack = new AsyncDisposableStack(function() {});
+assert.throws(TypeError, function() {
+  dispose.call(asyncStack);
+}, 'AsyncDisposableStack instance');

--- a/test/built-ins/DisposableStack/prototype/dispose/this-not-object-throws.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Throws a TypeError if this is not an Object
+info: |
+  DisposableStack.prototype.dispose ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.dispose, 'function');
+
+var dispose = DisposableStack.prototype.dispose;
+
+assert.throws(TypeError, function() {
+  dispose.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  dispose.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  dispose.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  dispose.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  dispose.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  dispose.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  dispose.call(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/dispose/throws-error-as-is-if-only-one-error-during-disposal.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/throws-error-as-is-if-only-one-error-during-disposal.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Rethrows an error from a disposal as-is if it is the only error.
+info: |
+
+  DisposableStack.prototype.dispose ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, return undefined.
+  4. Set disposableStack.[[DisposableState]] to disposed.
+  5. Return DisposeResources(disposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+class MyError extends Error {}
+var stack = new DisposableStack();
+stack.defer(function () { throw new MyError(); });
+stack.defer(function () {});
+assert.throws(MyError, function () {
+  stack.dispose();
+});

--- a/test/built-ins/DisposableStack/prototype/dispose/throws-suppressederror-if-multiple-errors-during-disposal.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/throws-suppressederror-if-multiple-errors-during-disposal.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Throws multiple errors from a disposal nested in one or more SuppressedError instances.
+info: |
+
+  DisposableStack.prototype.dispose ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, return undefined.
+  4. Set disposableStack.[[DisposableState]] to disposed.
+  5. Return DisposeResources(disposableStack.[[DisposeCapability]], NormalCompletion(undefined)).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+class MyError extends Error {}
+var error1 = new MyError();
+var error2 = new MyError();
+var error3 = new MyError();
+var stack = new DisposableStack();
+stack.defer(function () { throw error1; });
+stack.defer(function () { throw error2; });
+stack.defer(function () { throw error3; });
+try {
+  stack.dispose();
+  assert(false, 'Expected stack.dispose() to have thrown an error.');
+}
+catch (e) {
+  assert(e instanceof SuppressedError, "Expected stack.dispose() to have thrown a SuppressedError");
+  assert.sameValue(e.error, error1, "Expected the outermost suppressing error to have been 'error1'");
+  assert(e.suppressed instanceof SuppressedError, "Expected the outermost suppressed error to have been a SuppressedError");
+  assert.sameValue(e.suppressed.error, error2, "Expected the innermost suppressing error to have been 'error2'");
+  assert.sameValue(e.suppressed.suppressed, error3, "Expected the innermost suppressed error to have been 'error3'");
+}

--- a/test/built-ins/DisposableStack/prototype/disposed/does-not-have-disposablestate-internal-slot.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/does-not-have-disposablestate-internal-slot.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  Throws a TypeError if `this` object does not have a [[DisposableState]] internal slot.
+info: |
+  get DisposableStack.prototype.disposed
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');
+
+var stack = new DisposableStack();
+
+// Does not throw
+descriptor.get.call(stack);
+
+assert.throws(TypeError, function() {
+  descriptor.get.call([]);
+});

--- a/test/built-ins/DisposableStack/prototype/disposed/getter.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/getter.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  Property type and descriptor.
+info: |
+  get DisposableStack.prototype.disposed
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');
+
+assert.sameValue(
+  typeof descriptor.get,
+  'function',
+  'typeof descriptor.get is function'
+);
+assert.sameValue(
+  typeof descriptor.set,
+  'undefined',
+  'typeof descriptor.set is undefined'
+);
+
+verifyNotEnumerable(DisposableStack.prototype, 'disposed');
+verifyConfigurable(DisposableStack.prototype, 'disposed');

--- a/test/built-ins/DisposableStack/prototype/disposed/length.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/length.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  Map.prototype.size.length value and descriptor.
+info: |
+  get Map.prototype.size
+
+  17 ECMAScript Standard Built-in Objects
+includes: [propertyHelper.js]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+
+assert.sameValue(
+  descriptor.get.length, 0,
+  'The value of `Map.prototype.size.length` is `0`'
+);
+
+verifyNotEnumerable(descriptor.get, 'length');
+verifyNotWritable(descriptor.get, 'length');
+verifyConfigurable(descriptor.get, 'length');

--- a/test/built-ins/DisposableStack/prototype/disposed/name.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/name.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  DisposableStack.prototype.disposed.name value and descriptor.
+info: |
+  get DisposableStack.prototype.size
+
+  17 ECMAScript Standard Built-in Objects
+
+  Functions that are specified as get or set accessor functions of built-in
+  properties have "get " or "set " prepended to the property name string.
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');
+
+assert.sameValue(descriptor.get.name,
+  'get disposed',
+  'The value of `descriptor.get.name` is `get disposed`'
+);
+
+verifyNotEnumerable(descriptor.get, 'name');
+verifyNotWritable(descriptor.get, 'name');
+verifyConfigurable(descriptor.get, 'name');

--- a/test/built-ins/DisposableStack/prototype/disposed/returns-false-when-not-disposed.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/returns-false-when-not-disposed.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  Returns `false` when the DisposableStack has not yet been disposed.
+info: |
+  get DisposableStack.prototype.disposed
+
+  ...
+  3. If disposableStack.[[DisposableState]] is disposed, return true.
+  4. Otherwise, return false.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+
+assert.sameValue(stack.disposed, false);

--- a/test/built-ins/DisposableStack/prototype/disposed/returns-true-when-disposed.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/returns-true-when-disposed.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  Returns `true` after the DisposableStack has been disposed.
+info: |
+  get DisposableStack.prototype.disposed
+
+  ...
+  3. If disposableStack.[[DisposableState]] is disposed, return true.
+  4. Otherwise, return false.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+stack.dispose();
+assert.sameValue(stack.disposed, true);

--- a/test/built-ins/DisposableStack/prototype/disposed/this-not-object-throw.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/this-not-object-throw.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  Throws a TypeError if `this` is not an Object.
+info: |
+  get DisposableStack.prototype.disposed
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management,Symbol]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(1);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(false);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(1);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call('');
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(undefined);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(null);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(Symbol());
+});

--- a/test/built-ins/DisposableStack/prototype/move/does-not-dispose-resources.js
+++ b/test/built-ins/DisposableStack/prototype/move/does-not-dispose-resources.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: Resources in the stack are not disposed when move is called.
+info: |
+
+  DisposableStack.prototype.move ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newDisposableStack be ? OrdinaryCreateFromConstructor(%DisposableStack%, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  5. Set newDisposableStack.[[DisposableState]] to pending.
+  6. Set newDisposableStack.[[DisposeCapability]] to disposableStack.[[DisposeCapability]].
+  7. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set disposableStack.[[DisposableState]] to disposed.
+  9. Return newDisposableStack.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var disposed = false;
+stack.defer(() => { disposed = true; });
+stack.move();
+assert.sameValue(disposed, false);

--- a/test/built-ins/DisposableStack/prototype/move/length.js
+++ b/test/built-ins/DisposableStack/prototype/move/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: DisposableStack.prototype.move.length property descriptor
+info: |
+  DisposableStack.prototype.move ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.move, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/move/name.js
+++ b/test/built-ins/DisposableStack/prototype/move/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: DisposableStack.prototype.move.name property descriptor
+info: |
+  DisposableStack.prototype.move.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.move, 'name', {
+  value: 'move',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/move/not-a-constructor.js
+++ b/test/built-ins/DisposableStack/prototype/move/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: >
+  DisposableStack.prototype.move does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(DisposableStack.prototype.move),
+  false,
+  'isConstructor(DisposableStack.prototype.move) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new DisposableStack({}); new stack.move();
+}, '`let stack = new DisposableStack({}); new stack.move()` throws TypeError');
+

--- a/test/built-ins/DisposableStack/prototype/move/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/move/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: >
+  Property descriptor of DisposableStack.prototype.move
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.move, 'function');
+
+verifyProperty(DisposableStack.prototype, 'move', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/move/returns-new-disposablestack-that-contains-moved-resources.js
+++ b/test/built-ins/DisposableStack/prototype/move/returns-new-disposablestack-that-contains-moved-resources.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: Returns a new DisposableStack that contains the resources originally contained in this stack.
+info: |
+
+  DisposableStack.prototype.move ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newDisposableStack be ? OrdinaryCreateFromConstructor(%DisposableStack%, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  5. Set newDisposableStack.[[DisposableState]] to pending.
+  6. Set newDisposableStack.[[DisposeCapability]] to disposableStack.[[DisposeCapability]].
+  7. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set disposableStack.[[DisposableState]] to disposed.
+  9. Return newDisposableStack.
+
+includes: [deepEqual.js]
+features: [explicit-resource-management]
+---*/
+
+var stack1 = new DisposableStack();
+var disposed = [];
+stack1.defer(() => { disposed.push(1); });
+stack1.defer(() => { disposed.push(2); });
+
+var stack2 = stack1.move();
+
+var wasDisposed = disposed.slice();
+stack2.dispose();
+var isDisposed = disposed.slice();
+
+assert.deepEqual(wasDisposed, []);
+assert.deepEqual(isDisposed, [2, 1]);

--- a/test/built-ins/DisposableStack/prototype/move/returns-new-disposablestack-that-is-still-pending.js
+++ b/test/built-ins/DisposableStack/prototype/move/returns-new-disposablestack-that-is-still-pending.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: Returns a new DisposableStack that is still pending
+info: |
+
+  DisposableStack.prototype.move ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newDisposableStack be ? OrdinaryCreateFromConstructor(%DisposableStack%, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  5. Set newDisposableStack.[[DisposableState]] to pending.
+  6. Set newDisposableStack.[[DisposeCapability]] to disposableStack.[[DisposeCapability]].
+  7. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set disposableStack.[[DisposableState]] to disposed.
+  9. Return newDisposableStack.
+
+features: [explicit-resource-management]
+---*/
+
+var stack1 = new DisposableStack();
+var stack2 = stack1.move();
+assert.sameValue(stack2.disposed, false);

--- a/test/built-ins/DisposableStack/prototype/move/returns-new-disposablestack.js
+++ b/test/built-ins/DisposableStack/prototype/move/returns-new-disposablestack.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: Returns a new DisposableStack
+info: |
+
+  DisposableStack.prototype.move ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newDisposableStack be ? OrdinaryCreateFromConstructor(%DisposableStack%, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  5. Set newDisposableStack.[[DisposableState]] to pending.
+  6. Set newDisposableStack.[[DisposeCapability]] to disposableStack.[[DisposeCapability]].
+  7. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set disposableStack.[[DisposableState]] to disposed.
+  9. Return newDisposableStack.
+
+features: [explicit-resource-management]
+---*/
+
+var stack1 = new DisposableStack();
+var stack2 = stack1.move();
+assert(stack2 !== stack1, 'Expected stack2 to not be the same reference as stack1');
+assert(stack2 instanceof DisposableStack, 'Expected stack2 to be an instance of DisposableStack');

--- a/test/built-ins/DisposableStack/prototype/move/sets-state-to-disposed.js
+++ b/test/built-ins/DisposableStack/prototype/move/sets-state-to-disposed.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: The stack's [[DisposableState]] internal slot is set to disposed.
+info: |
+
+  DisposableStack.prototype.move ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newDisposableStack be ? OrdinaryCreateFromConstructor(%DisposableStack%, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  5. Set newDisposableStack.[[DisposableState]] to pending.
+  6. Set newDisposableStack.[[DisposeCapability]] to disposableStack.[[DisposeCapability]].
+  7. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set disposableStack.[[DisposableState]] to disposed.
+  9. Return newDisposableStack.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var wasDisposed = stack.disposed;
+stack.move();
+var isDisposed = stack.disposed;
+assert.sameValue(wasDisposed, false);
+assert.sameValue(isDisposed, true);

--- a/test/built-ins/DisposableStack/prototype/move/still-returns-new-disposablestack-when-subclassed.js
+++ b/test/built-ins/DisposableStack/prototype/move/still-returns-new-disposablestack-when-subclassed.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: Returns a new %DisposableStack%, even when subclassed
+info: |
+
+  DisposableStack.prototype.move ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Let newDisposableStack be ? OrdinaryCreateFromConstructor(%DisposableStack%, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  5. Set newDisposableStack.[[DisposableState]] to pending.
+  6. Set newDisposableStack.[[DisposeCapability]] to disposableStack.[[DisposeCapability]].
+  7. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  8. Set disposableStack.[[DisposableState]] to disposed.
+  9. Return newDisposableStack.
+
+features: [explicit-resource-management]
+---*/
+
+class MyDisposableStack extends DisposableStack {}
+
+var stack1 = new MyDisposableStack();
+var stack2 = stack1.move();
+assert(stack2 instanceof DisposableStack, 'Expected stack2 to be an instance of DisposableStack');
+assert(!(stack2 instanceof MyDisposableStack), 'Expected stack2 to not be an instance of MyDisposableStack');

--- a/test/built-ins/DisposableStack/prototype/move/this-does-not-have-internal-disposablestate-throws.js
+++ b/test/built-ins/DisposableStack/prototype/move/this-does-not-have-internal-disposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: Throws a TypeError if this does not have a [[DisposableState]] internal slot
+info: |
+  DisposableStack.prototype.move ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.move, 'function');
+
+var move = DisposableStack.prototype.move;
+
+assert.throws(TypeError, function() {
+  move.call({ ['[[DisposableState]]']: {} });
+}, 'Ordinary object without [[DisposableState]]');
+
+assert.throws(TypeError, function() {
+  move.call(DisposableStack.prototype);
+}, 'DisposableStack.prototype does not have a [[DisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  move.call(DisposableStack);
+}, 'DisposableStack does not have a [[DisposableState]] internal slot');
+
+var asyncStack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  move.call(asyncStack);
+}, 'AsyncDisposableStack instance');

--- a/test/built-ins/DisposableStack/prototype/move/this-not-object-throws.js
+++ b/test/built-ins/DisposableStack/prototype/move/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: Throws a TypeError if this is not an Object
+info: |
+  DisposableStack.prototype.move ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.move, 'function');
+
+var move = DisposableStack.prototype.move;
+
+assert.throws(TypeError, function() {
+  move.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  move.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  move.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  move.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  move.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  move.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  move.call(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/move/throws-if-disposed.js
+++ b/test/built-ins/DisposableStack/prototype/move/throws-if-disposed.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: Throws a ReferenceError if this is disposed.
+info: |
+  DisposableStack.prototype.move ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+stack.dispose();
+
+assert.throws(ReferenceError, function() {
+  stack.move();
+}, 'undefined');

--- a/test/built-ins/DisposableStack/prototype/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The property descriptor DisposableStack.prototype
+esid: sec-properties-of-the-disposablestack-constructor
+info: |
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: false }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(DisposableStack, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false
+});

--- a/test/built-ins/DisposableStack/prototype/proto.js
+++ b/test/built-ins/DisposableStack/prototype/proto.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The prototype of DisposableStack.prototype is Object.prototype
+esid: sec-properties-of-the-disposablestack-prototype-object
+info: |
+  The value of the [[Prototype]] internal slot of the DisposableStack prototype object
+  is the intrinsic object %Object.prototype%.
+features: [explicit-resource-management]
+---*/
+
+var proto = Object.getPrototypeOf(DisposableStack.prototype);
+assert.sameValue(proto, Object.prototype);

--- a/test/built-ins/DisposableStack/prototype/use/adds-value.js
+++ b/test/built-ins/DisposableStack/prototype/use/adds-value.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Adds a disposable resource to the stack
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        this.disposed = true;
+    }
+};
+stack.use(resource);
+stack.dispose();
+assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');

--- a/test/built-ins/DisposableStack/prototype/use/allows-null-value.js
+++ b/test/built-ins/DisposableStack/prototype/use/allows-null-value.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Does not throw when argument is 'null'
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+stack.use(null);

--- a/test/built-ins/DisposableStack/prototype/use/allows-undefined-value.js
+++ b/test/built-ins/DisposableStack/prototype/use/allows-undefined-value.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Does not throw when argument is 'undefined'
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+stack.use(undefined);

--- a/test/built-ins/DisposableStack/prototype/use/gets-value-Symbol.dispose-property-once.js
+++ b/test/built-ins/DisposableStack/prototype/use/gets-value-Symbol.dispose-property-once.js
@@ -1,0 +1,61 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Only reads `[Symbol.dispose]` method once, when added.
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var resource = {
+    disposeReadCount: 0,
+    get [Symbol.dispose]() {
+        this.disposeReadCount++;
+        return function() { };
+    }
+};
+stack.use(resource);
+stack.dispose();
+assert.sameValue(resource.disposeReadCount, 1, 'Expected [Symbol.dispose] to have been read only once');

--- a/test/built-ins/DisposableStack/prototype/use/length.js
+++ b/test/built-ins/DisposableStack/prototype/use/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: DisposableStack.prototype.use.length property descriptor
+info: |
+  DisposableStack.prototype.use ( value )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.use, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/use/name.js
+++ b/test/built-ins/DisposableStack/prototype/use/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: DisposableStack.prototype.use.name property descriptor
+info: |
+  DisposableStack.prototype.use.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.use, 'name', {
+  value: 'use',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/use/not-a-constructor.js
+++ b/test/built-ins/DisposableStack/prototype/use/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: >
+  DisposableStack.prototype.use does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(DisposableStack.prototype.use),
+  false,
+  'isConstructor(DisposableStack.prototype.use) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new DisposableStack({}); new stack.use();
+}, '`let stack = new DisposableStack({}); new stack.use()` throws TypeError');
+

--- a/test/built-ins/DisposableStack/prototype/use/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/use/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: >
+  Property descriptor of DisposableStack.prototype.use
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.use, 'function');
+
+verifyProperty(DisposableStack.prototype, 'use', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/use/puts-value-on-top-of-stack.js
+++ b/test/built-ins/DisposableStack/prototype/use/puts-value-on-top-of-stack.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Puts value on the top of the dispose stack
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var disposed = [];
+var resource1 = {
+    [Symbol.dispose]() {
+        disposed.push(this);
+    }
+};
+var resource2 = {
+    [Symbol.dispose]() {
+        disposed.push(this);
+    }
+};
+stack.use(resource1);
+stack.use(resource2);
+stack.dispose();
+assert.sameValue(2, disposed.length);
+assert.sameValue(disposed[0], resource2, 'Expected resource2 to be the first disposed resource');
+assert.sameValue(disposed[1], resource1, 'Expected resource1 to be the second disposed resource');

--- a/test/built-ins/DisposableStack/prototype/use/returns-value.js
+++ b/test/built-ins/DisposableStack/prototype/use/returns-value.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Returns the argument provided.
+info: |
+  DisposableStack.prototype.use ( value )
+
+  ...
+  5. Return value.
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+var resource = { [Symbol.dispose]() { } };
+assert.sameValue(stack.use(resource), resource);
+assert.sameValue(stack.use(null), null);
+assert.sameValue(stack.use(undefined), undefined);

--- a/test/built-ins/DisposableStack/prototype/use/this-does-not-have-internal-disposablestate-throws.js
+++ b/test/built-ins/DisposableStack/prototype/use/this-does-not-have-internal-disposablestate-throws.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws a TypeError if this does not have a [[DisposableState]] internal slot
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  5. Return value.
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.use, 'function');
+
+var use = DisposableStack.prototype.use;
+
+assert.throws(TypeError, function() {
+  use.call({ ['[[DisposableState]]']: {} });
+}, 'Ordinary object without [[DisposableState]]');
+
+assert.throws(TypeError, function() {
+  use.call(DisposableStack.prototype);
+}, 'DisposableStack.prototype does not have a [[DisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  use.call(DisposableStack);
+}, 'DisposableStack does not have a [[DisposableState]] internal slot');
+
+var asyncStack = new AsyncDisposableStack(function() {});
+assert.throws(TypeError, function() {
+  use.call(asyncStack);
+}, 'AsyncDisposableStack instance');

--- a/test/built-ins/DisposableStack/prototype/use/this-not-object-throws.js
+++ b/test/built-ins/DisposableStack/prototype/use/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws a TypeError if this is not an Object
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.use, 'function');
+
+var use = DisposableStack.prototype.use;
+
+assert.throws(TypeError, function() {
+  use.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  use.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  use.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  use.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  use.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  use.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  use.call(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/use/throws-if-disposed.js
+++ b/test/built-ins/DisposableStack/prototype/use/throws-if-disposed.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws a ReferenceError if this is disposed.
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+stack.dispose();
+
+assert.throws(ReferenceError, function() {
+  stack.use(undefined);
+}, 'undefined');
+
+assert.throws(ReferenceError, function() {
+  stack.use(null);
+}, 'null');
+
+assert.throws(ReferenceError, function() {
+  stack.use(true);
+}, 'true');
+
+assert.throws(ReferenceError, function() {
+  stack.use(false);
+}, 'false');
+
+assert.throws(ReferenceError, function() {
+  stack.use(1);
+}, 'number');
+
+assert.throws(ReferenceError, function() {
+  stack.use('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(ReferenceError, function() {
+  stack.use(s);
+}, 'symbol');
+
+assert.throws(ReferenceError, function() {
+  stack.use({});
+}, 'non disposable object');
+
+assert.throws(ReferenceError, function() {
+  stack.use({ [Symbol.dispose]() {} });
+}, 'disposable object');

--- a/test/built-ins/DisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-is-null.js
+++ b/test/built-ins/DisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-is-null.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws if the argument has a null-valued Symbol.dispose property.
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: null });
+}, 'true');

--- a/test/built-ins/DisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-is-undefined.js
+++ b/test/built-ins/DisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-is-undefined.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws if the argument has an undefined-valued Symbol.dispose property.
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: undefined });
+}, 'true');

--- a/test/built-ins/DisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-not-callable.js
+++ b/test/built-ins/DisposableStack/prototype/use/throws-if-value-Symbol.dispose-property-not-callable.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws if the argument has a non-null, non-undefined, non-callable Symbol.dispose property.
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  ...
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. If IsCallable(func) is false, throw a TypeError exception.
+    ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: true });
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: false });
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: 1 });
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: 'object' });
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.use({ [Symbol.dispose]: s });
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/use/throws-if-value-missing-Symbol.dispose.js
+++ b/test/built-ins/DisposableStack/prototype/use/throws-if-value-missing-Symbol.dispose.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws if the argument is an object that does not have a Symbol.dispose property.
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+    1. Let func be ? GetV(V, P).
+    2. If func is either undefined or null, return undefined.
+    3. If IsCallable(func) is false, throw a TypeError exception.
+    ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  stack.use({ });
+}, 'true');

--- a/test/built-ins/DisposableStack/prototype/use/throws-if-value-not-object.js
+++ b/test/built-ins/DisposableStack/prototype/use/throws-if-value-not-object.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws if the argument is not an object and is neither null nor undefined.
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+    ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  stack.use(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.use(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.use(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.use('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.use(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/undefined-newtarget-throws.js
+++ b/test/built-ins/DisposableStack/undefined-newtarget-throws.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: >
+  Throws a TypeError if NewTarget is undefined.
+info: |
+  DisposableStack ( )
+
+  1. If NewTarget is undefined, throw a TypeError exception.
+  ...
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function() {
+  DisposableStack();
+});

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/invokes-return.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/invokes-return.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%iteratorprototype%-@@dispose
+description: Return value of @@dispose on %IteratorPrototype%
+info: |
+  %IteratorPrototype% [ @@dispose ] ( )
+
+  1. Let O be the this value.
+  2. Let return be ? GetMethod(O, "return").
+  3. If return is not undefined, then
+    a. Perform ? Call(return, O, « »).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+const IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+const iter = Object.create(IteratorPrototype);
+var returnCalled = false;
+iter.return = function () {
+  returnCalled = true;
+  return { done: true };
+};
+
+iter[Symbol.dispose]();
+assert.sameValue(returnCalled, true);

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/is-function.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/is-function.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%iteratorprototype%-@@dispose
+description: >
+  Iterator.prototype[@@dispose] is a built-in function
+features: [explicit-resource-management]
+---*/
+const IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+assert.sameValue(typeof IteratorPrototype[Symbol.dispose], 'function');

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/length.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%iteratorprototype%-@@dispose
+description: Length of %IteratorPrototype%[ @@dispose ]
+info: |
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+const IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+verifyProperty(IteratorPrototype[Symbol.dispose], 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/name.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/name.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%iteratorprototype%-@@dispose
+description: Descriptor for `name` property
+info: |
+  The value of the name property of this function is "[Symbol.dispose]".
+
+  ES6 Section 17: ECMAScript Standard Built-in Objects
+
+  Every built-in Function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value is a
+  String. Unless otherwise specified, this value is the name that is given to
+  the function in this specification.
+
+  [...]
+
+  Unless otherwise specified, the name property of a built-in Function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+const IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+verifyProperty(IteratorPrototype[Symbol.dispose], 'name', {
+  value: '[Symbol.dispose]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/prop-desc.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/prop-desc.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%iteratorprototype%-@@dispose
+description: Property descriptor
+info: |
+    ES6 Section 17
+
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+const IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+verifyProperty(IteratorPrototype, Symbol.dispose, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/return-val.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/return-val.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%iteratorprototype%-@@dispose
+description: Return value of @@dispose on %IteratorPrototype%
+info: |
+  %IteratorPrototype% [ @@dispose ] ( )
+
+  1. Let O be the this value.
+  2. Let return be ? GetMethod(O, "return").
+  3. If return is not undefined, then
+    a. Perform ? Call(return, O, « »).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+const IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+assert.sameValue(IteratorPrototype[Symbol.dispose](), undefined);

--- a/test/built-ins/NativeErrors/SuppressedError/is-a-constructor.js
+++ b/test/built-ins/NativeErrors/SuppressedError/is-a-constructor.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The SuppressedError constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management]
+---*/
+
+assert.sameValue(isConstructor(SuppressedError), true, 'isConstructor(SuppressedError) must return true');
+new SuppressedError();
+  

--- a/test/built-ins/NativeErrors/SuppressedError/length.js
+++ b/test/built-ins/NativeErrors/SuppressedError/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-suppressederror-constructors
+description: SuppressedError.length property descriptor
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError, 'length', {
+  value: 3,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SuppressedError/message-method-prop-cast.js
+++ b/test/built-ins/NativeErrors/SuppressedError/message-method-prop-cast.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Cast ToString values of message in the created method property
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+
+  CreateMethodProperty ( O, P, V )
+
+  ...
+  3. Let newDesc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
+  4. Return ? O.[[DefineOwnProperty]](P, newDesc).
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+var case1 = new SuppressedError(undefined, undefined, 42);
+
+verifyProperty(case1, 'message', {
+  value: '42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case2 = new SuppressedError(undefined, undefined, false);
+
+verifyProperty(case2, 'message', {
+  value: 'false',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case3 = new SuppressedError(undefined, undefined, true);
+
+verifyProperty(case3, 'message', {
+  value: 'true',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case4 = new SuppressedError(undefined, undefined, { toString() { return 'string'; }});
+
+verifyProperty(case4, 'message', {
+  value: 'string',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case5 = new SuppressedError(undefined, undefined, null);
+
+verifyProperty(case5, 'message', {
+  value: 'null',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/SuppressedError/message-method-prop.js
+++ b/test/built-ins/NativeErrors/SuppressedError/message-method-prop.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Creates a method property for message
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+
+  CreateMethodProperty ( O, P, V )
+
+  ...
+  3. Let newDesc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
+  4. Return ? O.[[DefineOwnProperty]](P, newDesc).
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+var obj = new SuppressedError(undefined, undefined, '42');
+
+verifyProperty(obj, 'message', {
+  value: '42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/SuppressedError/message-tostring-abrupt-symbol.js
+++ b/test/built-ins/NativeErrors/SuppressedError/message-tostring-abrupt-symbol.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Abrupt completions of ToString(Symbol message)
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+features: [explicit-resource-management, Symbol, Symbol.toPrimitive]
+---*/
+
+var case1 = Symbol();
+
+assert.throws(TypeError, () => {
+  new SuppressedError(undefined, undefined, case1);
+}, 'toPrimitive');
+
+var case2 = {
+  [Symbol.toPrimitive]() {
+    return Symbol();
+  },
+  toString() {
+    throw new Test262Error();
+  },
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(TypeError, () => {
+  new SuppressedError(undefined, undefined, case2);
+}, 'from ToPrimitive');

--- a/test/built-ins/NativeErrors/SuppressedError/message-tostring-abrupt.js
+++ b/test/built-ins/NativeErrors/SuppressedError/message-tostring-abrupt.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Abrupt completions of ToString(message)
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+features: [explicit-resource-management, Symbol.toPrimitive]
+---*/
+
+var case1 = {
+  [Symbol.toPrimitive]() {
+    throw new Test262Error();
+  },
+  toString() {
+    throw 'toString called';
+  },
+  valueOf() {
+    throw 'valueOf called';
+  }
+};
+
+assert.throws(Test262Error, () => {
+  new SuppressedError(undefined, undefined, case1);
+}, 'toPrimitive');
+
+var case2 = {
+  [Symbol.toPrimitive]: undefined,
+  toString() {
+    throw new Test262Error();
+  },
+  valueOf() {
+    throw 'valueOf called';
+  }
+};
+
+assert.throws(Test262Error, () => {
+  new SuppressedError(undefined, undefined, case2);
+}, 'toString');
+
+var case3 = {
+  [Symbol.toPrimitive]: undefined,
+  toString: undefined,
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, () => {
+  new SuppressedError(undefined, undefined, case3);
+}, 'valueOf');

--- a/test/built-ins/NativeErrors/SuppressedError/message-undefined-no-prop.js
+++ b/test/built-ins/NativeErrors/SuppressedError/message-undefined-no-prop.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  If message is undefined, no property will be set to the new instance
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+features: [explicit-resource-management]
+---*/
+
+var case1 = new SuppressedError(undefined, undefined, undefined);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(case1, 'message'),
+  false,
+  'explicit'
+);
+
+var case2 = new SuppressedError([]);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(case2, 'message'),
+  false,
+  'implicit'
+);

--- a/test/built-ins/NativeErrors/SuppressedError/name.js
+++ b/test/built-ins/NativeErrors/SuppressedError/name.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-suppressederror-constructor
+description: SuppressedError.name property descriptor
+info: |
+  Properties of the SuppressedError Constructor
+
+  - has a name property whose value is the String value "SuppressedError".
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError, 'name', {
+  value: 'SuppressedError',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SuppressedError/newtarget-is-undefined.js
+++ b/test/built-ins/NativeErrors/SuppressedError/newtarget-is-undefined.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  NewTarget is undefined
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
+
+features: [explicit-resource-management]
+---*/
+
+var obj = SuppressedError();
+
+assert.sameValue(Object.getPrototypeOf(obj), SuppressedError.prototype);
+assert(obj instanceof SuppressedError);

--- a/test/built-ins/NativeErrors/SuppressedError/newtarget-proto-custom.js
+++ b/test/built-ins/NativeErrors/SuppressedError/newtarget-proto-custom.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Use a custom NewTarget prototype
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
+  2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%SuppressedError.prototype%", « [[ErrorData]], [[AggregateErrors]] »).
+  ...
+  6. Return O.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  ...
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  Return proto.
+features: [explicit-resource-management, Reflect.construct]
+---*/
+
+var custom = { x: 42 };
+var newt = new Proxy(function() {}, {
+  get(t, p) {
+    if (p === 'prototype') {
+      return custom;
+    }
+
+    return t[p];
+  }
+});
+
+var obj = Reflect.construct(SuppressedError, [], newt);
+
+assert.sameValue(Object.getPrototypeOf(obj), custom);
+assert.sameValue(obj.x, 42);

--- a/test/built-ins/NativeErrors/SuppressedError/newtarget-proto-fallback.js
+++ b/test/built-ins/NativeErrors/SuppressedError/newtarget-proto-fallback.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Fallback to the NewTarget's [[Prototype]] if the prototype property is not an object
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
+  2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%SuppressedError.prototype%", « [[ErrorData]], [[AggregateErrors]] »).
+  ...
+  6. Return O.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  ...
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  Return proto.
+features: [explicit-resource-management, Symbol]
+---*/
+
+const values = [
+  undefined,
+  null,
+  42,
+  false,
+  true,
+  Symbol(),
+  'string',
+  SuppressedError.prototype,
+];
+
+const NewTarget = new Function();
+
+for (const value of values) {
+  const NewTargetProxy = new Proxy(NewTarget, {
+    get(t, p) {
+      if (p === 'prototype') {
+        return value;
+      }
+      return t[p];
+    }
+  });
+
+  const error = Reflect.construct(SuppressedError, [], NewTargetProxy);
+  assert.sameValue(Object.getPrototypeOf(error), SuppressedError.prototype);
+}

--- a/test/built-ins/NativeErrors/SuppressedError/newtarget-proto.js
+++ b/test/built-ins/NativeErrors/SuppressedError/newtarget-proto.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Default prototype is the %SuppressedError.prototype%"
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
+  2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%SuppressedError.prototype%", « [[ErrorData]], [[AggregateErrors]] »).
+  ...
+  6. Return O.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  ...
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  Return proto.
+features: [explicit-resource-management]
+---*/
+
+var obj = new SuppressedError();
+
+assert.sameValue(Object.getPrototypeOf(obj), SuppressedError.prototype);

--- a/test/built-ins/NativeErrors/SuppressedError/order-of-args-evaluation.js
+++ b/test/built-ins/NativeErrors/SuppressedError/order-of-args-evaluation.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Process arguments in superclass-then-subclass order
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  3. If message is not undefined, then
+    a. Let messageString be ? ToString(message).
+    b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", messageString).
+  4. Perform CreateNonEnumerableDataPropertyOrThrow(O, "error", error).
+  5. Perform CreateNonEnumerableDataPropertyOrThrow(O, "suppressed", suppressed).
+
+includes: [deepEqual.js]
+features: [explicit-resource-management, Symbol.iterator]
+---*/
+
+let messageStringified = false;
+const message = {
+  toString() {
+    messageStringified = true;
+    return '';
+  }
+};
+const error = {};
+const suppressed = {};
+
+const e = new SuppressedError(error, suppressed, message);
+
+assert.sameValue(messageStringified, true);
+const keys = Object.getOwnPropertyNames(e);
+assert(keys.indexOf("message") === 0, "Expected 'message' to be defined first");
+assert(keys.indexOf("error") === 1, "Expected 'error' to be defined second");
+assert(keys.indexOf("suppressed") === 2, "Expected 'suppressed' to be defined third");
+

--- a/test/built-ins/NativeErrors/SuppressedError/prop-desc.js
+++ b/test/built-ins/NativeErrors/SuppressedError/prop-desc.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-objects
+description: >
+  Property descriptor of SuppressedError
+info: |
+  SuppressedError Objects
+
+  ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof SuppressedError, 'function');
+
+verifyProperty(this, 'SuppressedError', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SuppressedError/proto-from-ctor-realm.js
+++ b/test/built-ins/NativeErrors/SuppressedError/proto-from-ctor-realm.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: Default [[Prototype]] value derived from realm of the NewTarget.
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
+  2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%SuppressedError.prototype%", « [[ErrorData]] »).
+  ...
+  6. Return O.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  ...
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management, cross-realm, Reflect, Symbol]
+---*/
+
+var other = $262.createRealm().global;
+var newTarget = new other.Function();
+var err;
+
+newTarget.prototype = undefined;
+err = Reflect.construct(SuppressedError, [[]], newTarget);
+assert.sameValue(Object.getPrototypeOf(err), other.SuppressedError.prototype, 'newTarget.prototype is undefined');
+
+newTarget.prototype = null;
+err = Reflect.construct(SuppressedError, [[]], newTarget);
+assert.sameValue(Object.getPrototypeOf(err), other.SuppressedError.prototype, 'newTarget.prototype is null');
+
+newTarget.prototype = true;
+err = Reflect.construct(SuppressedError, [[]], newTarget);
+assert.sameValue(Object.getPrototypeOf(err), other.SuppressedError.prototype, 'newTarget.prototype is a Boolean');
+
+newTarget.prototype = '';
+err = Reflect.construct(SuppressedError, [[]], newTarget);
+assert.sameValue(Object.getPrototypeOf(err), other.SuppressedError.prototype, 'newTarget.prototype is a String');
+
+newTarget.prototype = Symbol();
+err = Reflect.construct(SuppressedError, [[]], newTarget);
+assert.sameValue(Object.getPrototypeOf(err), other.SuppressedError.prototype, 'newTarget.prototype is a Symbol');
+
+newTarget.prototype = -1;
+err = Reflect.construct(SuppressedError, [[]], newTarget);
+assert.sameValue(Object.getPrototypeOf(err), other.SuppressedError.prototype, 'newTarget.prototype is a Number');

--- a/test/built-ins/NativeErrors/SuppressedError/proto.js
+++ b/test/built-ins/NativeErrors/SuppressedError/proto.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The prototype of SuppressedError constructor is Error
+esid: sec-properties-of-the-suppressederror-constructors
+info: |
+  Properties of the SuppressedError Constructor
+
+  - has a [[Prototype]] internal slot whose value is the intrinsic object %Error%.
+features: [explicit-resource-management]
+---*/
+
+var proto = Object.getPrototypeOf(SuppressedError);
+
+assert.sameValue(proto, Error);

--- a/test/built-ins/NativeErrors/SuppressedError/prototype/constructor.js
+++ b/test/built-ins/NativeErrors/SuppressedError/prototype/constructor.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror.prototype.constructor
+description: >
+  The `SuppressedError.prototype.constructor` property descriptor.
+info: |
+  The initial value of SuppressedError.prototype.constructor is the intrinsic
+  object %SuppressedError%.
+
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described (...) has the attributes { [[Writable]]: true,
+    [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError.prototype, 'constructor', {
+  value: SuppressedError,
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SuppressedError/prototype/errors-absent-on-prototype.js
+++ b/test/built-ins/NativeErrors/SuppressedError/prototype/errors-absent-on-prototype.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-suppressederror-prototype-objects
+description: >
+  The SuppressedError prototype object isn't an SuppressedError instance.
+info: |
+  Properties of the SuppressedError Prototype Object
+
+  The SuppressedError prototype object:
+    ...
+    - is not an Error instance or an SuppressedError instance and does not have an
+      [[ErrorData]] internal slot.
+    ...
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(SuppressedError.prototype.hasOwnProperty("error"), false);
+assert.sameValue(SuppressedError.prototype.hasOwnProperty("suppressed"), false);

--- a/test/built-ins/NativeErrors/SuppressedError/prototype/message.js
+++ b/test/built-ins/NativeErrors/SuppressedError/prototype/message.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype.message
+description: >
+  The `SuppressedError.prototype.message` property descriptor.
+info: |
+  The initial value of the message property of the prototype for a given SuppressedError
+  constructor is the empty String.
+
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described (...) has the attributes { [[Writable]]: true,
+    [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError.prototype, 'message', {
+  value: '',
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SuppressedError/prototype/name.js
+++ b/test/built-ins/NativeErrors/SuppressedError/prototype/name.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype.name
+description: >
+  The `SuppressedError.prototype.name` property descriptor.
+info: |
+  The initial value of SuppressedError.prototype.name is "SuppressedError".
+
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described (...) has the attributes { [[Writable]]: true,
+    [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError.prototype, 'name', {
+  value: 'SuppressedError',
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SuppressedError/prototype/prop-desc.js
+++ b/test/built-ins/NativeErrors/SuppressedError/prototype/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype
+description: >
+  Property descriptor of SuppressedError.prototype
+info: |
+  SuppressedError.prototype
+
+  The initial value of SuppressedError.prototype is the intrinsic object %AggregateErrorPrototype%.
+
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof SuppressedError.prototype, 'object');
+
+verifyProperty(SuppressedError, 'prototype', {
+  enumerable: false,
+  writable: false,
+  configurable: false
+});

--- a/test/built-ins/NativeErrors/SuppressedError/prototype/proto.js
+++ b/test/built-ins/NativeErrors/SuppressedError/prototype/proto.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-suppressederror-prototype-objects
+description: The prototype of SuppressedError.prototype constructor is Error.prototype
+info: |
+  Properties of the SuppressedError Prototype Object
+
+  - has a [[Prototype]] internal slot whose value is the intrinsic object %Error.prototype%.
+features: [explicit-resource-management]
+---*/
+
+var proto = Object.getPrototypeOf(SuppressedError.prototype);
+
+assert.sameValue(proto, Error.prototype);

--- a/test/built-ins/Symbol/asyncDispose/cross-realm.js
+++ b/test/built-ins/Symbol/asyncDispose/cross-realm.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: Value shared by all realms
+info: |
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [cross-realm, explicit-resource-management]
+---*/
+
+var OSymbol = $262.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.asyncDispose, OSymbol.asyncDispose);

--- a/test/built-ins/Symbol/asyncDispose/prop-desc.js
+++ b/test/built-ins/Symbol/asyncDispose/prop-desc.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: pending
+description: >
+    `Symbol.asyncDispose` property descriptor
+info: |
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof Symbol.asyncDispose, 'symbol');
+verifyNotEnumerable(Symbol, 'asyncDispose');
+verifyNotWritable(Symbol, 'asyncDispose');
+verifyNotConfigurable(Symbol, 'asyncDispose');

--- a/test/built-ins/Symbol/dispose/cross-realm.js
+++ b/test/built-ins/Symbol/dispose/cross-realm.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: Value shared by all realms
+info: |
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [cross-realm, explicit-resource-management]
+---*/
+
+var OSymbol = $262.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.dispose, OSymbol.dispose);

--- a/test/built-ins/Symbol/dispose/prop-desc.js
+++ b/test/built-ins/Symbol/dispose/prop-desc.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: pending
+description: >
+    `Symbol.dispose` property descriptor
+info: |
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof Symbol.dispose, 'symbol');
+verifyNotEnumerable(Symbol, 'dispose');
+verifyNotWritable(Symbol, 'dispose');
+verifyNotConfigurable(Symbol, 'dispose');

--- a/test/language/statements/await-using/Symbol.asyncDispose-method-called-with-correct-this.js
+++ b/test/language/statements/await-using/Symbol.asyncDispose-method-called-with-correct-this.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-block-runtime-semantics-evaluation
+description: Initialized value is disposed with the correct 'this' value
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  ...
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      async [Symbol.asyncDispose]() {
+          assert.sameValue(this, resource);
+      }
+  };
+
+  {
+    await using _ = resource;
+  }
+});

--- a/test/language/statements/await-using/Symbol.dispose-method-called-with-correct-this.js
+++ b/test/language/statements/await-using/Symbol.dispose-method-called-with-correct-this.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-block-runtime-semantics-evaluation
+description: Initialized value is disposed with the correct 'this' value
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  ...
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        assert.sameValue(this, resource);
+    }
+  };
+
+  {
+    await using _ = resource;
+  }
+});

--- a/test/language/statements/await-using/await-using-Symbol.asyncDispose-allows-non-promise-return-value.js
+++ b/test/language/statements/await-using/await-using-Symbol.asyncDispose-allows-non-promise-return-value.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposeresources
+description: >
+  `await using` allows a non-Promise return value from `[Symbol.asyncDispose]()`
+info: |
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+    [Symbol.asyncDispose]() {
+    }
+  };
+
+  {
+    await using _ = resource;
+  }
+});

--- a/test/language/statements/await-using/await-using-Symbol.asyncDispose-allows-promiselike-return-value.js
+++ b/test/language/statements/await-using/await-using-Symbol.asyncDispose-allows-promiselike-return-value.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposeresources
+description: >
+  `await using` allows non-native `Promise`-like return value from `[Symbol.asyncDispose]()`
+info: |
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+    [Symbol.asyncDispose]() {
+      return {
+        then(resolve) {
+          resolve();
+        }
+      };
+    }
+  };
+
+  {
+    await using _ = resource;
+  }
+});

--- a/test/language/statements/await-using/await-using-allows-null-initializer.js
+++ b/test/language/statements/await-using/await-using-allows-null-initializer.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Allows null in initializer of 'await using'
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    ...
+  ...
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await using x = null;
+});

--- a/test/language/statements/await-using/await-using-allows-undefined-initializer.js
+++ b/test/language/statements/await-using/await-using-allows-undefined-initializer.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Allows undefined in initializer of 'await using'
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    ...
+  ...
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  using x = undefined;
+});

--- a/test/language/statements/await-using/await-using-does-not-imply-await-if-not-evaluated.js
+++ b/test/language/statements/await-using/await-using-does-not-imply-await-if-not-evaluated.js
@@ -1,0 +1,103 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: An 'await using' does not imply an Await occurs if the statement is not evaluated
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined.
+      ii. Set method to undefined.
+    ...
+  ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js, propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+    var BREAK_EARLY = true;
+    var isRunningInSameMicrotask = true;
+    var wasStartedInSameMicrotask = false;
+    var didEvaluatePrecedingBlockStatementsInSameMicrotask = false;
+    var wasRunningInSameMicrotask = false;
+  
+    async function f() {
+      wasStartedInSameMicrotask = isRunningInSameMicrotask;
+      outer: {
+        didEvaluatePrecedingBlockStatementsInSameMicrotask = isRunningInSameMicrotask;
+        if (BREAK_EARLY) break outer;
+        await using _ = null;
+      }
+      wasRunningInSameMicrotask = isRunningInSameMicrotask;
+    }
+  
+    var p = f();
+    isRunningInSameMicrotask = false;
+    await p;
+  
+    assert.sameValue(wasStartedInSameMicrotask, true, 'Expected async function containing `await using` to start in the same microtask');
+    assert.sameValue(didEvaluatePrecedingBlockStatementsInSameMicrotask, true, 'Expected block statements preceding `await using` to be evaluated in the same microtask');
+    assert.sameValue(wasRunningInSameMicrotask, true, 'Expected statements following the block containing unevaluated `await using` to evaluate in the same microtask');
+  });

--- a/test/language/statements/await-using/await-using-implies-await-if-evaluated.js
+++ b/test/language/statements/await-using/await-using-implies-await-if-evaluated.js
@@ -1,0 +1,104 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: An 'await using' implies an Await occurs if the statement is evaluated, even if all initializers are 'null' or 'undefined'
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined.
+      ii. Set method to undefined.
+    ...
+  ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js, propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var isRunningInSameMicrotask = true;
+  var wasStartedInSameMicrotask = false;
+  var didEvaluatePrecedingBlockStatementsInSameMicrotask = false;
+  var didEvaluateFollowingBlockStatementsInSameMicrotask = false;
+  var wasRunningInSameMicrotask = false;
+
+  async function f() {
+    wasStartedInSameMicrotask = isRunningInSameMicrotask;
+    {
+      didEvaluatePrecedingBlockStatementsInSameMicrotask = isRunningInSameMicrotask;
+      await using _ = null;
+      didEvaluateFollowingBlockStatementsInSameMicrotask = isRunningInSameMicrotask;
+    }
+    wasRunningInSameMicrotask = isRunningInSameMicrotask;
+  }
+
+  var p = f();
+  isRunningInSameMicrotask = false;
+  await p;
+
+  assert.sameValue(wasStartedInSameMicrotask, true, 'Expected async function containing `await using` to start in the same microtask');
+  assert.sameValue(didEvaluatePrecedingBlockStatementsInSameMicrotask, true, 'Expected block statements preceding `await using` to be evaluated in the same microtask');
+  assert.sameValue(didEvaluateFollowingBlockStatementsInSameMicrotask, true, 'Expected block statements following `await using` to be evaluated in the same microtask');
+  assert.sameValue(wasRunningInSameMicrotask, false, 'Expected statements following the block containing evaluated `await using` to evaluate in a different microtask');
+});

--- a/test/language/statements/await-using/block-local-closure-get-before-initialization.js
+++ b/test/language/statements/await-using/block-local-closure-get-before-initialization.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    await using: block local closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  function f() { return x + 1; }
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
+  await using x = null;
+});

--- a/test/language/statements/await-using/block-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/statements/await-using/block-local-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    await using: block local use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(ReferenceError, async function() {
+      await using x = x + 1;
+  });
+});

--- a/test/language/statements/await-using/block-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/statements/await-using/block-local-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    await using: block local use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(ReferenceError, async function() {
+    x; await using x = null;
+  });
+});

--- a/test/language/statements/await-using/fn-name-arrow.js
+++ b/test/language/statements/await-using/fn-name-arrow.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Assignment of function `name` attribute (ArrowFunction)
+info: |
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+       a. Let value be NamedEvaluation of Initializer with argument bindingId
+
+flags: [async]
+includes: [propertyHelper.js, asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+// NOTE: only way to verify is to patch `Function.prototype` so as not to trigger a TypeError from AddDisposableResource
+Function.prototype[Symbol.dispose] = function () {}
+asyncTest(async function () {
+  await using arrow = () => {};
+
+  assert.sameValue(arrow.name, 'arrow');
+  verifyNotEnumerable(arrow, 'name');
+  verifyNotWritable(arrow, 'name');
+  verifyConfigurable(arrow, 'name');
+});

--- a/test/language/statements/await-using/fn-name-class.js
+++ b/test/language/statements/await-using/fn-name-class.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Assignment of function `name` attribute (ClassExpression)
+info: |
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+       a. Let value be NamedEvaluation of Initializer with argument bindingId
+
+flags: [async]
+includes: [propertyHelper.js, asyncHelpers.js]
+features: [class, explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+    await using xCls = class x { static async [Symbol.asyncDispose]() {} };
+    await using cls = class { static async [Symbol.asyncDispose]() {} };
+    await using xCls2 = class { static name() {} static async [Symbol.asyncDispose]() {} };
+
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    assert.sameValue(cls.name, 'cls');
+    verifyNotEnumerable(cls, 'name');
+    verifyNotWritable(cls, 'name');
+    verifyConfigurable(cls, 'name');
+});

--- a/test/language/statements/await-using/fn-name-cover.js
+++ b/test/language/statements/await-using/fn-name-cover.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: >
+    Assignment of function `name` attribute (CoverParenthesizedExpression)
+info: |
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+       a. Let value be NamedEvaluation of Initializer with argument bindingId
+
+flags: [async]
+includes: [propertyHelper.js, asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+// NOTE: only way to verify is to patch `Function.prototype` so as not to trigger a TypeError from AddDisposableResource
+Function.prototype[Symbol.dispose] = function () {}
+asyncTest(async function () {
+  await using xCover = (0, function() {});
+  await using cover = (function() {});
+
+  assert(xCover.name !== 'xCover');
+
+  assert.sameValue(cover.name, 'cover');
+  verifyNotEnumerable(cover, 'name');
+  verifyNotWritable(cover, 'name');
+  verifyConfigurable(cover, 'name');
+});

--- a/test/language/statements/await-using/fn-name-fn.js
+++ b/test/language/statements/await-using/fn-name-fn.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Assignment of function `name` attribute (FunctionExpression)
+info: |
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+       a. Let value be NamedEvaluation of Initializer with argument bindingId
+
+flags: [async]
+includes: [propertyHelper.js, asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+// NOTE: only way to verify is to patch `Function.prototype` so as not to trigger a TypeError from AddDisposableResource
+Function.prototype[Symbol.dispose] = function () {}
+asyncTest(async function() {
+    await using xFn = function x() {};
+    await using fn = function() {};
+
+    assert(xFn.name !== 'xFn');
+
+    assert.sameValue(fn.name, 'fn');
+    verifyNotEnumerable(fn, 'name');
+    verifyNotWritable(fn, 'name');
+    verifyConfigurable(fn, 'name');
+});

--- a/test/language/statements/await-using/fn-name-gen.js
+++ b/test/language/statements/await-using/fn-name-gen.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Assignment of function `name` attribute (GeneratorExpression)
+info: |
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+       a. Let value be NamedEvaluation of Initializer with argument bindingId
+
+flags: [async]
+includes: [propertyHelper.js, asyncHelpers.js]
+features: [generators,explicit-resource-management]
+---*/
+
+// NOTE: only way to verify is to patch `Function.prototype` so as not to trigger a TypeError from AddDisposableResource
+Function.prototype[Symbol.dispose] = function () {}
+asyncTest(async function() {
+    await using xGen = function* x() {};
+    await using gen = function*() {};
+
+    assert(xGen.name !== 'xGen');
+
+    assert.sameValue(gen.name, 'gen');
+    verifyNotEnumerable(gen, 'name');
+    verifyNotWritable(gen, 'name');
+    verifyConfigurable(gen, 'name');
+});

--- a/test/language/statements/await-using/function-local-closure-get-before-initialization.js
+++ b/test/language/statements/await-using/function-local-closure-get-before-initialization.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    await using: function local closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  function f() { return x + 1; }
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
+  await using x = null;
+});

--- a/test/language/statements/await-using/function-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/statements/await-using/function-local-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    await using: function local use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+asyncTest(async function () {
+  await assert.throwsAsync(ReferenceError, async function() {
+    await using x = x + 1;
+  });
+});

--- a/test/language/statements/await-using/function-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/statements/await-using/function-local-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    await using: function local use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(ReferenceError, async function() {
+    x; await using x = null;
+  });
+});

--- a/test/language/statements/await-using/gets-initializer-Symbol.asyncDispose-property-once.js
+++ b/test/language/statements/await-using/gets-initializer-Symbol.asyncDispose-property-once.js
@@ -1,0 +1,88 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Only reads `[Symbol.asyncDispose]` method once, when initialized.
+info: |
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    BindingList : BindingList , LexicalBinding
+
+    1. Perform ? BindingEvaluation of BindingList with argument hint.
+    2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+    3. Return unused.
+
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      asyncDisposeReadCount: 0,
+      get [Symbol.asyncDispose]() {
+          this.asyncDisposeReadCount++;
+          return async function() { };
+      }
+  };
+
+  {
+    await using _ = resource;
+  }
+
+  assert.sameValue(resource.asyncDisposeReadCount, 1, 'Expected [Symbol.asyncDispose] to have been read only once');
+});

--- a/test/language/statements/await-using/gets-initializer-Symbol.dispose-after-Symbol.asyncDispose-is-null.js
+++ b/test/language/statements/await-using/gets-initializer-Symbol.dispose-after-Symbol.asyncDispose-is-null.js
@@ -1,0 +1,92 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Reads `[Symbol.dispose]` method if `[Symbol.asyncDispose]` is null
+info: |
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    BindingList : BindingList , LexicalBinding
+
+    1. Perform ? BindingEvaluation of BindingList with argument hint.
+    2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+    3. Return unused.
+
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+flags: [async]
+includes: [asyncHelpers.js, deepEqual.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var order = [];
+  var resource = {
+      get [Symbol.asyncDispose]() {
+        order.push('Symbol.asyncDispose');
+        return null;
+      },
+      get [Symbol.dispose]() {
+          order.push('Symbol.dispose');
+          return function() { };
+      }
+  };
+
+  {
+    await using _ = resource;
+  }
+
+  assert.deepEqual(order, ['Symbol.asyncDispose', 'Symbol.dispose'], 'Expected [Symbol.dispose] to have been read after [Symbol.asyncDispose] returns null');
+});

--- a/test/language/statements/await-using/gets-initializer-Symbol.dispose-after-Symbol.asyncDispose-is-undefined.js
+++ b/test/language/statements/await-using/gets-initializer-Symbol.dispose-after-Symbol.asyncDispose-is-undefined.js
@@ -1,0 +1,92 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Reads `[Symbol.dispose]` method if `[Symbol.asyncDispose]` is undefined.
+info: |
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    BindingList : BindingList , LexicalBinding
+
+    1. Perform ? BindingEvaluation of BindingList with argument hint.
+    2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+    3. Return unused.
+
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+flags: [async]
+includes: [asyncHelpers.js, deepEqual.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var order = [];
+  var resource = {
+      get [Symbol.asyncDispose]() {
+        order.push('Symbol.asyncDispose');
+        return undefined;
+      },
+      get [Symbol.dispose]() {
+          order.push('Symbol.dispose');
+          return function() { };
+      }
+  };
+
+  {
+    await using _ = resource;
+  }
+
+  assert.deepEqual(order, ['Symbol.asyncDispose', 'Symbol.dispose'], 'Expected [Symbol.dispose] to have been read after [Symbol.asyncDispose] returns undefined');
+});

--- a/test/language/statements/await-using/gets-initializer-Symbol.dispose-property-once.js
+++ b/test/language/statements/await-using/gets-initializer-Symbol.dispose-property-once.js
@@ -1,0 +1,88 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Only reads `[Symbol.dispose]` method once, when initialized.
+info: |
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    BindingList : BindingList , LexicalBinding
+
+    1. Perform ? BindingEvaluation of BindingList with argument hint.
+    2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+    3. Return unused.
+
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposeReadCount: 0,
+      get [Symbol.dispose]() {
+          this.disposeReadCount++;
+          return function() { };
+      }
+  };
+
+  {
+    await using _ = resource;
+  }
+
+  assert.sameValue(resource.disposeReadCount, 1, 'Expected [Symbol.dispose] to have been read only once');
+});

--- a/test/language/statements/await-using/gets-initializer-does-not-read-Symbol.dispose-if-Symbol.asyncDispose-exists.js
+++ b/test/language/statements/await-using/gets-initializer-does-not-read-Symbol.dispose-if-Symbol.asyncDispose-exists.js
@@ -1,0 +1,92 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Does not read `[Symbol.dispose]` if `[Symbol.asyncDispose]` is neither null or undefined.
+info: |
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    BindingList : BindingList , LexicalBinding
+
+    1. Perform ? BindingEvaluation of BindingList with argument hint.
+    2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+    3. Return unused.
+
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+flags: [async]
+includes: [asyncHelpers.js, deepEqual.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var order = [];
+  var resource = {
+      get [Symbol.asyncDispose]() {
+        order.push('Symbol.asyncDispose');
+        return async function() {};
+      },
+      get [Symbol.dispose]() {
+          order.push('Symbol.dispose');
+          return function() { };
+      }
+  };
+
+  {
+    await using _ = resource;
+  }
+
+  assert.deepEqual(order, ['Symbol.asyncDispose'], 'Expected [Symbol.dispose] to not have been read');
+});

--- a/test/language/statements/await-using/global-closure-get-before-initialization.js
+++ b/test/language/statements/await-using/global-closure-get-before-initialization.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    await using: global closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  function f() { return x + 1; }
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
+  await using x = null;
+});

--- a/test/language/statements/await-using/global-use-before-initialization-in-declaration-statement.js
+++ b/test/language/statements/await-using/global-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    await using: global use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+negative:
+  phase: runtime
+  type: ReferenceError
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await using x = x + 1;
+});

--- a/test/language/statements/await-using/global-use-before-initialization-in-prior-statement.js
+++ b/test/language/statements/await-using/global-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    await using: global use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+negative:
+  phase: runtime
+  type: ReferenceError
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  x; await using x = null;
+});

--- a/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-asyncfunctionbody.js
+++ b/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-asyncfunctionbody.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncblockstart
+description: Initialized value is disposed at end of AsyncFunctionBody
+info: |
+
+  AsyncBlockStart ( promiseCapability, asyncBody, asyncContext )
+
+  1. Assert: promiseCapability is a PromiseCapability Record.
+  2. Let runningContext be the running execution context.
+  3. Let closure be a new Abstract Closure with no parameters that captures promiseCapability and asyncBody and performs the following steps when called:
+    a. Let acAsyncContext be the running execution context.
+    b. Let result be Completion(Evaluation of asyncBody).
+    c. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
+    d. Remove acAsyncContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+    e. Let env be acAsyncContext's LexicalEnvironment.
+    f. Set result to DisposeResources(env.[[DisposeCapability]], result).
+    g. If result.[[Type]] is normal, then
+      i. Perform ! Call(promiseCapability.[[Resolve]], undefined, « undefined »).
+    h. Else if result.[[Type]] is return, then
+      i. Perform ! Call(promiseCapability.[[Resolve]], undefined, « result.[[Value]] »).
+    i. Else,
+      i. Assert: result.[[Type]] is throw.
+      ii. Perform ! Call(promiseCapability.[[Reject]], undefined, « result.[[Value]] »).
+    j. Return unused.
+  4. Set the code evaluation state of asyncContext such that when evaluation is resumed for that execution context, closure will be called with no arguments.
+  5. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
+  6. Resume the suspended evaluation of asyncContext. Let result be the value returned by the resumed computation.
+  7. Assert: When we return here, asyncContext has already been removed from the execution context stack and runningContext is the currently running execution context.
+  8. Assert: result is a normal completion with a value of unused. The possible sources of this value are Await or, if the async function doesn't await anything, step 3.h above.
+  9. Return unused.
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+
+  var resource = {
+      disposed: false,
+      async [Symbol.asyncDispose]() {
+          this.disposed = true;
+      }
+  };
+
+  var releaseF1;
+  var suspendFPromise1 = new Promise(function (resolve) { releaseF1 = resolve; });
+
+  var releaseBody;
+  var suspendBodyPromise = new Promise(function (resolve) { releaseBody = resolve; });
+
+  var releaseF2;
+  var suspendFPromise2 = new Promise(function (resolve) { releaseF2 = resolve; });
+
+  async function f() {
+      await using _ = resource;
+      await suspendFPromise1;
+      releaseBody();
+      await suspendFPromise2;
+  }
+
+  var resultPromise = f();
+
+  var wasDisposedWhileSuspended1 = resource.disposed;
+
+  releaseF1();
+  await suspendBodyPromise;
+
+  var wasDisposedWhileSuspended2 = resource.disposed;
+
+  releaseF2();
+  await resultPromise;
+
+  var isDisposedAfterCompleted = resource.disposed;
+
+  assert.sameValue(wasDisposedWhileSuspended1, false, 'Expected resource to not have been disposed while async function is suspended during await');
+  assert.sameValue(wasDisposedWhileSuspended2, false, 'Expected resource to not have been disposed while async function is suspended during await');
+  assert.sameValue(isDisposedAfterCompleted, true, 'Expected resource to have been disposed after async function completed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-asyncgeneratorbody.js
+++ b/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-asyncgeneratorbody.js
@@ -1,0 +1,108 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncgeneratorstart
+description: Initialized value is disposed at end of AsyncGeneratorBody
+info: |
+
+  AsyncGeneratorStart ( generator, generatorBody )
+
+  1. Assert: generator.[[AsyncGeneratorState]] is undefined.
+  2. Let genContext be the running execution context.
+  3. Set the Generator component of genContext to generator.
+  4. Let closure be a new Abstract Closure with no parameters that captures generatorBody and performs the following steps when called:
+    a. Let acGenContext be the running execution context.
+    b. Let acGenerator be the Generator component of acGenContext.
+    c. If generatorBody is a Parse Node, then
+      i. Let result be Completion(Evaluation of generatorBody).
+    d. Else,
+      i. Assert: generatorBody is an Abstract Closure with no parameters.
+      ii. Let result be Completion(generatorBody()).
+    e. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
+    f. Remove acGenContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+    g. Set acGenerator.[[AsyncGeneratorState]] to completed.
+    h. Let env be genContext's LexicalEnvironment.
+    i. If env is not undefined, then
+      i. Assert: env is a Declarative Environment Record
+      ii. Set result to DisposeResources(env.[[DisposeCapability]], result).
+    h. If result.[[Type]] is normal, set result to NormalCompletion(undefined).
+    i. If result.[[Type]] is return, set result to NormalCompletion(result.[[Value]]).
+    j. Perform AsyncGeneratorCompleteStep(acGenerator, result, true).
+    k. Perform AsyncGeneratorDrainQueue(acGenerator).
+    l. Return undefined.
+  5. Set the code evaluation state of genContext such that when evaluation is resumed for that execution context, closure will be called with no arguments.
+  6. Set generator.[[AsyncGeneratorContext]] to genContext.
+  7. Set generator.[[AsyncGeneratorState]] to suspendedStart.
+  8. Set generator.[[AsyncGeneratorQueue]] to a new empty List.
+  9. Return unused.
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+
+  var resource = {
+      disposed: false,
+      async [Symbol.asyncDispose]() {
+          this.disposed = true;
+      }
+  };
+
+  var releaseF;
+  var suspendFPromise = new Promise(function (resolve) { releaseF = resolve; });
+
+  async function * f() {
+      await using _ = resource;
+      yield;
+      await suspendFPromise;
+  }
+
+  var g = f();
+
+  var wasDisposedBeforeAsyncGeneratorStarted = resource.disposed;
+
+  await g.next();
+
+  var wasDisposedWhileSuspendedForYield = resource.disposed;
+
+  var nextPromise = g.next();
+
+  var wasDisposedWhileSuspendedForAwait = resource.disposed;
+
+  releaseF();
+  await nextPromise;
+
+  var isDisposedAfterCompleted = resource.disposed;
+
+  assert.sameValue(wasDisposedBeforeAsyncGeneratorStarted, false, 'Expected resource to not have been disposed prior to async generator start');
+  assert.sameValue(wasDisposedWhileSuspendedForYield, false, 'Expected resource to not have been disposed while async generator function is suspended for yield');
+  assert.sameValue(wasDisposedWhileSuspendedForAwait, false, 'Expected resource to not have been disposed while async generator function is suspended during await');
+  assert.sameValue(isDisposedAfterCompleted, true, 'Expected resource to have been disposed after async generator function completed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-block.js
+++ b/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-block.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-block-runtime-semantics-evaluation
+description: Initialized value is disposed at end of Block
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      async [Symbol.asyncDispose]() {
+          this.disposed = true;
+      }
+  };
+
+  {
+    await using _ = resource;
+  }
+
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-each-iteration-of-forofstatement.js
+++ b/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-each-iteration-of-forofstatement.js
@@ -1,0 +1,85 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset
+description: Initialized value is disposed at end of each iteration of ForOfStatement
+info: |
+
+  ForIn/OfBodyEvaluation ( lhs, stmt, iteratorRecord, iterationKind, lhsKind, labelSet [ , iteratorKind ] )
+
+  1. If iteratorKind is not present, set iteratorKind to sync.
+  2. Let oldEnv be the running execution context's LexicalEnvironment.
+  3. Let V be undefined.
+  4. If IsAwaitUsingDeclaration of lhs is true, then
+    a. Let hint be async-dispose.
+  5. Else, if IsUsingDeclaration of lhs is true, then
+    a. Let hint be sync-dispose.
+  6. Else,
+    a. Let hint be normal.
+  7. Let destructuring be IsDestructuring of lhs.
+  8. If destructuring is true and if lhsKind is assignment, then
+    a. Assert: lhs is a LeftHandSideExpression.
+    b. Let assignmentPattern be the AssignmentPattern that is covered by lhs.
+  9. Repeat,
+    ...
+    j. Let result be Completion(Evaluation of stmt).
+    k. If iterationEnv is not undefined, then
+      i. Set result to Completion(DisposeResources(iterationEnv.[[DisposeCapability]], result)).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      async [Symbol.asyncDispose]() {
+          this.disposed = true;
+      }
+  };
+
+  var wasDisposedBeforeBody = false;
+  var wasDisposedBeforeIteration = false;
+  var wasDisposedAfterIteration = false;
+
+  function * g() {
+    wasDisposedBeforeIteration = resource.disposed;
+    yield resource;
+    wasDisposedAfterIteration = resource.disposed;
+  }
+
+  for (await using _ of g()) {
+    wasDisposedBeforeBody = resource.disposed;
+  }
+
+  assert.sameValue(wasDisposedBeforeIteration, false, 'Expected resource to not been disposed before the for-of loop has received a value');
+  assert.sameValue(wasDisposedBeforeBody, false, 'Expected resource to not been disposed while for-of loop is still iterating');
+  assert.sameValue(wasDisposedAfterIteration, true, 'Expected resource to have been disposed after the for-of loop advanced to the next value');
+});

--- a/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-forstatement.js
+++ b/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-forstatement.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-forloopevaluation
+description: Initialized value is disposed at end of ForStatement
+info: |
+
+  RS: ForLoopEvaluation
+    ForStatement : for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    ...
+    12. Let bodyResult be Completion(ForBodyEvaluation(test, increment, Statement, perIterationLets, labelSet)).
+    13. Set bodyResult to Completion(DisposeResources(loopEnv.[[DisposeCapability]], bodyResult)).
+    14. Assert: If bodyResult.[[Type]] is normal, then bodyResult.[[Value]] is not empty.
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      async [Symbol.asyncDispose]() {
+          this.disposed = true;
+      }
+  };
+
+  var i = 0;
+  var wasDisposedInForStatement;
+  for (await using _ = resource; i < 1; i++) {
+    wasDisposedInForStatement = resource.disposed;
+  }
+
+  assert.sameValue(wasDisposedInForStatement, false, 'Expected resource to not been disposed while for loop is still iterating');
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-switchstatement.js
+++ b/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-switchstatement.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-switch-statement-runtime-semantics-evaluation
+description: Initialized value is disposed at end of a SwitchStatement
+info: |
+
+  RS: Evaluation
+    SwitchStatement : switch ( Expression ) CaseBlock
+
+    ...
+    7. Let R be Completion(CaseBlockEvaluation of CaseBlock with argument switchValue).
+    8. Set R to Completion(DisposeResources(blockEnv.[[DisposeCapability]], R)).
+    9. Assert: If R.[[Type]] is normal, then R.[[Value]] is not empty.
+    ..
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      async [Symbol.asyncDispose]() {
+          this.disposed = true;
+      }
+  };
+
+  switch (0) {
+    default:
+      await using _ = resource;
+      break;
+  }
+
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-if-subsequent-initializer-throws-in-forstatement-head.js
+++ b/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-if-subsequent-initializer-throws-in-forstatement-head.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-forloopevaluation
+description: Initialized value is disposed at end of FunctionBody
+info: |
+
+  RS: ForLoopEvaluation
+    ForStatement : for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    ...
+    7. Let forDcl be Completion(Evaluation of LexicalDeclaration).
+    8. If forDcl is an abrupt completion, then
+      a. Set forDcl to Completion(DisposeResources(loopEnv.[[DisposeCapability]], forDcl)).
+      b. Assert: forDcl is an abrupt completion.
+      c. Set the running execution context's LexicalEnvironment to oldEnv.
+      d. Return ? forDcl.
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      async [Symbol.asyncDispose]() {
+          this.disposed = true;
+      }
+  };
+
+  function getResource() {
+    throw new Error();
+  }
+
+  await assert.throwsAsync(Error, async function () {
+    var i = 0;
+    for (await using _1 = resource, _2 = getResource(); i < 1; i++) {
+    }
+  }, 'for');
+
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-if-subsequent-initializer-throws.js
+++ b/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-if-subsequent-initializer-throws.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-block-runtime-semantics-evaluation
+description: Initialized value is disposed even if subsequent initializer throws
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+    disposed: false,
+    async [Symbol.asyncDispose]() {
+        this.disposed = true;
+    }
+  };
+
+  function getResource() {
+    throw new Error();
+  }
+
+  await assert.throwsAsync(Error, async function () {
+    await using _1 = resource, _2 = getResource();
+  });
+
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-asyncfunctionbody.js
+++ b/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-asyncfunctionbody.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncblockstart
+description: Initialized value is disposed at end of AsyncFunctionBody
+info: |
+
+  AsyncBlockStart ( promiseCapability, asyncBody, asyncContext )
+
+  1. Assert: promiseCapability is a PromiseCapability Record.
+  2. Let runningContext be the running execution context.
+  3. Let closure be a new Abstract Closure with no parameters that captures promiseCapability and asyncBody and performs the following steps when called:
+    a. Let acAsyncContext be the running execution context.
+    b. Let result be Completion(Evaluation of asyncBody).
+    c. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
+    d. Remove acAsyncContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+    e. Let env be acAsyncContext's LexicalEnvironment.
+    f. Set result to DisposeResources(env.[[DisposeCapability]], result).
+    g. If result.[[Type]] is normal, then
+      i. Perform ! Call(promiseCapability.[[Resolve]], undefined, « undefined »).
+    h. Else if result.[[Type]] is return, then
+      i. Perform ! Call(promiseCapability.[[Resolve]], undefined, « result.[[Value]] »).
+    i. Else,
+      i. Assert: result.[[Type]] is throw.
+      ii. Perform ! Call(promiseCapability.[[Reject]], undefined, « result.[[Value]] »).
+    j. Return unused.
+  4. Set the code evaluation state of asyncContext such that when evaluation is resumed for that execution context, closure will be called with no arguments.
+  5. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
+  6. Resume the suspended evaluation of asyncContext. Let result be the value returned by the resumed computation.
+  7. Assert: When we return here, asyncContext has already been removed from the execution context stack and runningContext is the currently running execution context.
+  8. Assert: result is a normal completion with a value of unused. The possible sources of this value are Await or, if the async function doesn't await anything, step 3.h above.
+  9. Return unused.
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+
+  var resource = {
+      disposed: false,
+      [Symbol.dispose]() {
+          this.disposed = true;
+      }
+  };
+
+  var releaseF1;
+  var suspendFPromise1 = new Promise(function (resolve) { releaseF1 = resolve; });
+
+  var releaseBody;
+  var suspendBodyPromise = new Promise(function (resolve) { releaseBody = resolve; });
+
+  var releaseF2;
+  var suspendFPromise2 = new Promise(function (resolve) { releaseF2 = resolve; });
+
+  async function f() {
+      await using _ = resource;
+      await suspendFPromise1;
+      releaseBody();
+      await suspendFPromise2;
+  }
+
+  var resultPromise = f();
+
+  var wasDisposedWhileSuspended1 = resource.disposed;
+
+  releaseF1();
+  await suspendBodyPromise;
+
+  var wasDisposedWhileSuspended2 = resource.disposed;
+
+  releaseF2();
+  await resultPromise;
+
+  var isDisposedAfterCompleted = resource.disposed;
+
+  assert.sameValue(wasDisposedWhileSuspended1, false, 'Expected resource to not have been disposed while async function is suspended during await');
+  assert.sameValue(wasDisposedWhileSuspended2, false, 'Expected resource to not have been disposed while async function is suspended during await');
+  assert.sameValue(isDisposedAfterCompleted, true, 'Expected resource to have been disposed after async function completed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-asyncgeneratorbody.js
+++ b/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-asyncgeneratorbody.js
@@ -1,0 +1,108 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncgeneratorstart
+description: Initialized value is disposed at end of AsyncGeneratorBody
+info: |
+
+  AsyncGeneratorStart ( generator, generatorBody )
+
+  1. Assert: generator.[[AsyncGeneratorState]] is undefined.
+  2. Let genContext be the running execution context.
+  3. Set the Generator component of genContext to generator.
+  4. Let closure be a new Abstract Closure with no parameters that captures generatorBody and performs the following steps when called:
+    a. Let acGenContext be the running execution context.
+    b. Let acGenerator be the Generator component of acGenContext.
+    c. If generatorBody is a Parse Node, then
+      i. Let result be Completion(Evaluation of generatorBody).
+    d. Else,
+      i. Assert: generatorBody is an Abstract Closure with no parameters.
+      ii. Let result be Completion(generatorBody()).
+    e. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
+    f. Remove acGenContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+    g. Set acGenerator.[[AsyncGeneratorState]] to completed.
+    h. Let env be genContext's LexicalEnvironment.
+    i. If env is not undefined, then
+      i. Assert: env is a Declarative Environment Record
+      ii. Set result to DisposeResources(env.[[DisposeCapability]], result).
+    h. If result.[[Type]] is normal, set result to NormalCompletion(undefined).
+    i. If result.[[Type]] is return, set result to NormalCompletion(result.[[Value]]).
+    j. Perform AsyncGeneratorCompleteStep(acGenerator, result, true).
+    k. Perform AsyncGeneratorDrainQueue(acGenerator).
+    l. Return undefined.
+  5. Set the code evaluation state of genContext such that when evaluation is resumed for that execution context, closure will be called with no arguments.
+  6. Set generator.[[AsyncGeneratorContext]] to genContext.
+  7. Set generator.[[AsyncGeneratorState]] to suspendedStart.
+  8. Set generator.[[AsyncGeneratorQueue]] to a new empty List.
+  9. Return unused.
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+
+  var resource = {
+      disposed: false,
+      [Symbol.dispose]() {
+          this.disposed = true;
+      }
+  };
+
+  var releaseF;
+  var suspendFPromise = new Promise(function (resolve) { releaseF = resolve; });
+
+  async function * f() {
+      await using _ = resource;
+      yield;
+      await suspendFPromise;
+  }
+
+  var g = f();
+
+  var wasDisposedBeforeAsyncGeneratorStarted = resource.disposed;
+
+  await g.next();
+
+  var wasDisposedWhileSuspendedForYield = resource.disposed;
+
+  var nextPromise = g.next();
+
+  var wasDisposedWhileSuspendedForAwait = resource.disposed;
+
+  releaseF();
+  await nextPromise;
+
+  var isDisposedAfterCompleted = resource.disposed;
+
+  assert.sameValue(wasDisposedBeforeAsyncGeneratorStarted, false, 'Expected resource to not have been disposed prior to async generator start');
+  assert.sameValue(wasDisposedWhileSuspendedForYield, false, 'Expected resource to not have been disposed while async generator function is suspended for yield');
+  assert.sameValue(wasDisposedWhileSuspendedForAwait, false, 'Expected resource to not have been disposed while async generator function is suspended during await');
+  assert.sameValue(isDisposedAfterCompleted, true, 'Expected resource to have been disposed after async generator function completed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-block.js
+++ b/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-block.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-block-runtime-semantics-evaluation
+description: Initialized value is disposed at end of Block
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      [Symbol.dispose]() {
+          this.disposed = true;
+      }
+  };
+
+  {
+    await using _ = resource;
+  }
+
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-each-iteration-of-forofstatement.js
+++ b/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-each-iteration-of-forofstatement.js
@@ -1,0 +1,85 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset
+description: Initialized value is disposed at end of each iteration of ForOfStatement
+info: |
+
+  ForIn/OfBodyEvaluation ( lhs, stmt, iteratorRecord, iterationKind, lhsKind, labelSet [ , iteratorKind ] )
+
+  1. If iteratorKind is not present, set iteratorKind to sync.
+  2. Let oldEnv be the running execution context's LexicalEnvironment.
+  3. Let V be undefined.
+  4. If IsAwaitUsingDeclaration of lhs is true, then
+    a. Let hint be async-dispose.
+  5. Else, if IsUsingDeclaration of lhs is true, then
+    a. Let hint be sync-dispose.
+  6. Else,
+    a. Let hint be normal.
+  7. Let destructuring be IsDestructuring of lhs.
+  8. If destructuring is true and if lhsKind is assignment, then
+    a. Assert: lhs is a LeftHandSideExpression.
+    b. Let assignmentPattern be the AssignmentPattern that is covered by lhs.
+  9. Repeat,
+    ...
+    j. Let result be Completion(Evaluation of stmt).
+    k. If iterationEnv is not undefined, then
+      i. Set result to Completion(DisposeResources(iterationEnv.[[DisposeCapability]], result)).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      [Symbol.dispose]() {
+          this.disposed = true;
+      }
+  };
+
+  var wasDisposedBeforeBody = false;
+  var wasDisposedBeforeIteration = false;
+  var wasDisposedAfterIteration = false;
+
+  function * g() {
+    wasDisposedBeforeIteration = resource.disposed;
+    yield resource;
+    wasDisposedAfterIteration = resource.disposed;
+  }
+
+  for (await using _ of g()) {
+    wasDisposedBeforeBody = resource.disposed;
+  }
+
+  assert.sameValue(wasDisposedBeforeIteration, false, 'Expected resource to not been disposed before the for-of loop has received a value');
+  assert.sameValue(wasDisposedBeforeBody, false, 'Expected resource to not been disposed while for-of loop is still iterating');
+  assert.sameValue(wasDisposedAfterIteration, true, 'Expected resource to have been disposed after the for-of loop advanced to the next value');
+});

--- a/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-forstatement.js
+++ b/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-forstatement.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-forloopevaluation
+description: Initialized value is disposed at end of ForStatement
+info: |
+
+  RS: ForLoopEvaluation
+    ForStatement : for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    ...
+    12. Let bodyResult be Completion(ForBodyEvaluation(test, increment, Statement, perIterationLets, labelSet)).
+    13. Set bodyResult to Completion(DisposeResources(loopEnv.[[DisposeCapability]], bodyResult)).
+    14. Assert: If bodyResult.[[Type]] is normal, then bodyResult.[[Value]] is not empty.
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      async [Symbol.asyncDispose]() {
+          this.disposed = true;
+      }
+  };
+
+  var i = 0;
+  var wasDisposedInForStatement;
+  for (await using _ = resource; i < 1; i++) {
+    wasDisposedInForStatement = resource.disposed;
+  }
+
+  assert.sameValue(wasDisposedInForStatement, false, 'Expected resource to not been disposed while for loop is still iterating');
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-switchstatement.js
+++ b/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-switchstatement.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-switch-statement-runtime-semantics-evaluation
+description: Initialized value is disposed at end of a SwitchStatement
+info: |
+
+  RS: Evaluation
+    SwitchStatement : switch ( Expression ) CaseBlock
+
+    ...
+    7. Let R be Completion(CaseBlockEvaluation of CaseBlock with argument switchValue).
+    8. Set R to Completion(DisposeResources(blockEnv.[[DisposeCapability]], R)).
+    9. Assert: If R.[[Type]] is normal, then R.[[Value]] is not empty.
+    ..
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      [Symbol.dispose]() {
+          this.disposed = true;
+      }
+  };
+
+  switch (0) {
+    default:
+      await using _ = resource;
+      break;
+  }
+
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.dispose-called-if-subsequent-initializer-throws-in-forstatement-head.js
+++ b/test/language/statements/await-using/initializer-Symbol.dispose-called-if-subsequent-initializer-throws-in-forstatement-head.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-forloopevaluation
+description: Initialized value is disposed at end of FunctionBody
+info: |
+
+  RS: ForLoopEvaluation
+    ForStatement : for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    ...
+    7. Let forDcl be Completion(Evaluation of LexicalDeclaration).
+    8. If forDcl is an abrupt completion, then
+      a. Set forDcl to Completion(DisposeResources(loopEnv.[[DisposeCapability]], forDcl)).
+      b. Assert: forDcl is an abrupt completion.
+      c. Set the running execution context's LexicalEnvironment to oldEnv.
+      d. Return ? forDcl.
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+      disposed: false,
+      [Symbol.dispose]() {
+          this.disposed = true;
+      }
+  };
+
+  function getResource() {
+    throw new Error();
+  }
+
+  await assert.throwsAsync(Error, async function () {
+    var i = 0;
+    for (await using _1 = resource, _2 = getResource(); i < 1; i++) {
+    }
+  }, 'for');
+
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/language/statements/await-using/initializer-Symbol.dispose-called-if-subsequent-initializer-throws.js
+++ b/test/language/statements/await-using/initializer-Symbol.dispose-called-if-subsequent-initializer-throws.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-block-runtime-semantics-evaluation
+description: Initialized value is disposed even if subsequent initializer throws
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        this.disposed = true;
+    }
+  };
+
+  function getResource() {
+    throw new Error();
+  }
+
+  await assert.throwsAsync(Error, async function () {
+    await using _1 = resource, _2 = getResource();
+  });
+
+  assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');
+});

--- a/test/language/statements/await-using/multiple-resources-disposed-in-reverse-order.js
+++ b/test/language/statements/await-using/multiple-resources-disposed-in-reverse-order.js
@@ -1,0 +1,60 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposeresources
+description: Multiple resources are disposed in the reverse of the order in which they were added
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  var disposed = [];
+  var resource1 = { async [Symbol.asyncDispose]() { disposed.push(this); } };
+  var resource2 = { [Symbol.dispose]() { disposed.push(this); } };
+  var resource3 = { async [Symbol.asyncDispose]() { disposed.push(this); } };
+
+  {
+    await using _1 = resource1, _2 = resource2;
+    await using _3 = resource3;
+  }
+
+  assert.sameValue(disposed[0], resource3);
+  assert.sameValue(disposed[1], resource2);
+  assert.sameValue(disposed[2], resource1);
+});

--- a/test/language/statements/await-using/puts-initializer-on-top-of-disposableresourcestack-multiple-bindings.js
+++ b/test/language/statements/await-using/puts-initializer-on-top-of-disposableresourcestack-multiple-bindings.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: >
+  Puts initialized value on the top of the environment's [[DisposableResourceStack]] with multiple lexical bindings
+  in a single 'await using' declaration
+info: |
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    BindingList : BindingList , LexicalBinding
+
+    1. Perform ? BindingEvaluation of BindingList with argument hint.
+    2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+    3. Return unused.
+
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  3. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  var disposed = [];
+  var resource1 = {
+      async [Symbol.asyncDispose]() {
+          disposed.push(this);
+      }
+  };
+  var resource2 = {
+      [Symbol.dispose]() {
+          disposed.push(this);
+      }
+  };
+  {
+    await using r1 = resource1, r2 = resource2;
+  }
+  assert.sameValue(2, disposed.length);
+  assert.sameValue(disposed[0], resource2, 'Expected resource2 to be the first disposed resource');
+  assert.sameValue(disposed[1], resource1, 'Expected resource1 to be the second disposed resource');
+});

--- a/test/language/statements/await-using/puts-initializer-on-top-of-disposableresourcestack-subsequent-usings.js
+++ b/test/language/statements/await-using/puts-initializer-on-top-of-disposableresourcestack-subsequent-usings.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: >
+  Puts initialized value on the top of the environment's [[DisposableResourceStack]] with multiple subsequent 'await using'
+  declarations in the same block scope
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  3. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  var disposed = [];
+  var resource1 = {
+      async [Symbol.asyncDispose]() {
+          disposed.push(this);
+      }
+  };
+  var resource2 = {
+      [Symbol.dispose]() {
+          disposed.push(this);
+      }
+  };
+  {
+    await using r1 = resource1;
+    await using r2 = resource2;
+  }
+  assert.sameValue(2, disposed.length);
+  assert.sameValue(disposed[0], resource2, 'Expected resource2 to be the first disposed resource');
+  assert.sameValue(disposed[1], resource1, 'Expected resource1 to be the second disposed resource');
+});

--- a/test/language/statements/await-using/redeclaration-error-from-within-strict-mode-function-await-using.js
+++ b/test/language/statements/await-using/redeclaration-error-from-within-strict-mode-function-await-using.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-initializebinding-n-v
+description: >
+    Redeclaration error within strict mode function inside non-strict code.
+negative:
+  phase: parse
+  type: SyntaxError
+flags: [noStrict, explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+(async function() { 'use strict'; { await using f = null; var f; } })
+

--- a/test/language/statements/await-using/syntax/await-using-allowed-at-top-level-of-module.js
+++ b/test/language/statements/await-using/syntax/await-using-allowed-at-top-level-of-module.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations allowed at the top level of a module
+info: |
+  AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+flags: [module]
+features: [explicit-resource-management]
+---*/
+
+await using x = null;

--- a/test/language/statements/await-using/syntax/await-using-allows-bindingidentifier.js
+++ b/test/language/statements/await-using/syntax/await-using-allows-bindingidentifier.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' allows BindingIdentifier in lexical bindings
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+asyncTest(async function () {
+  await using x = null;
+});

--- a/test/language/statements/await-using/syntax/await-using-allows-multiple-bindings.js
+++ b/test/language/statements/await-using/syntax/await-using-allows-multiple-bindings.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' allows multiple lexical bindings
+features: [explicit-resource-management]
+---*/
+
+async function f() {
+  await using x = null, y = null;
+}

--- a/test/language/statements/await-using/syntax/await-using-declaring-let-split-across-two-lines.js
+++ b/test/language/statements/await-using/syntax/await-using-declaring-let-split-across-two-lines.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using: |await using let| split across two lines is treated as two statements.
+info: |
+  Lexical declarations may not declare a binding named "let".
+flags: [noStrict, async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await using
+  let = "irrelevant initializer";
+
+  assert(typeof let === "string");
+  var using, let;
+});

--- a/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern-after-bindingidentifier.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern-after-bindingidentifier.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' does not allow ArrayBindingPattern in lexical bindings, even after a valid lexical binding
+negative:
+  phase: parse
+  type: SyntaxError
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  await using x = null, [] = null;
+});

--- a/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern-does-not-break-element-access.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern-does-not-break-element-access.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' does not break existing element access
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+var using = [], x = 0;
+
+asyncTest(async function () {
+  await using[x];
+});

--- a/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' does not allow ArrayBindingPattern in lexical bindings
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function() {
+  await using [] = null;
+}

--- a/test/language/statements/await-using/syntax/await-using-invalid-assignment-next-expression-for.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-assignment-next-expression-for.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using: invalid assignment in next expression
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function() {
+    for (await using i = 0; i < 1; i++) {}
+  });
+});

--- a/test/language/statements/await-using/syntax/await-using-invalid-assignment-statement-body-for-of.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-assignment-statement-body-for-of.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using: invalid assignment in Statement body
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function () {
+    for (await using x of [1, 2, 3]) { x++ }
+  });
+});

--- a/test/language/statements/await-using/syntax/await-using-invalid-for-in.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-for-in.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    await using: not allowed in for..in
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  for (await using x in [1, 2, 3]) { }
+}

--- a/test/language/statements/await-using/syntax/await-using-invalid-objectbindingpattern-after-bindingidentifier.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-objectbindingpattern-after-bindingidentifier.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' does not allow ObjectBindingPattern in lexical bindings, even after a valid lexical binding
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  await using x = null, {} = null;
+}

--- a/test/language/statements/await-using/syntax/await-using-invalid-objectbindingpattern.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-objectbindingpattern.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' does not allow ObjectBindingPattern in lexical bindings
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  await using {} = null;
+}

--- a/test/language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-eval.js
+++ b/test/language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-eval.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations not allowed at the top level of eval
+info: |
+  AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(SyntaxError, async function () {
+    eval('await using x = null;')
+  });
+});

--- a/test/language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-script.js
+++ b/test/language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-script.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations not allowed at the top level of a Script
+info: |
+  AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+await using x = null;

--- a/test/language/statements/await-using/syntax/await-using-outer-inner-using-bindings.js
+++ b/test/language/statements/await-using/syntax/await-using-outer-inner-using-bindings.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    outer await using binding unchanged by for-loop await using binding
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  const outer_x = { [Symbol.dispose]() {} };
+  const outer_y = { [Symbol.dispose]() {} };
+  const inner_x = { [Symbol.dispose]() {} };
+  const inner_y = { [Symbol.dispose]() {} };
+
+  {
+    await using x = outer_x;
+    await using y = outer_y;
+    var i = 0;
+
+    for (await using x = inner_x; i < 1; i++) {
+      await using y = inner_y;
+
+      assert.sameValue(x, inner_x);
+      assert.sameValue(y, inner_y);
+    }
+    assert.sameValue(x, outer_x);
+    assert.sameValue(y, outer_y);
+  }
+});

--- a/test/language/statements/await-using/syntax/await-using.js
+++ b/test/language/statements/await-using/syntax/await-using.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    module and block scope await using
+flags: [module]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+await using z = null;
+
+// Block local
+{
+  await using z = undefined;
+}
+
+assert.sameValue(z, null);
+
+if (true) {
+  const obj = { [Symbol.dispose]() { } };
+  await using z = obj;
+  assert.sameValue(z, obj);
+}
+

--- a/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-mixed-with-without-initializer.js
+++ b/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-mixed-with-without-initializer.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations mixed: with, without initializer
+negative:
+  phase: parse
+  type: SyntaxError
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  await using x = null, y;
+}

--- a/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-mixed-without-with-initializer.js
+++ b/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-mixed-without-with-initializer.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations mixed: without, with initializer
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  await using x, y = null;
+}

--- a/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-without-initializer.js
+++ b/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-without-initializer.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initializer
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  await using x;
+}

--- a/test/language/statements/await-using/syntax/with-initializer-case-expression-statement-list.js
+++ b/test/language/statements/await-using/syntax/with-initializer-case-expression-statement-list.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    case Expression : StatementList
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+asyncTest(async function () {
+    switch (true) { case true: await using x = null; }
+});

--- a/test/language/statements/await-using/syntax/with-initializer-default-statement-list.js
+++ b/test/language/statements/await-using/syntax/with-initializer-default-statement-list.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    default : StatementList
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+asyncTest(async function () {
+    switch (true) { default: await using x = null; }
+});

--- a/test/language/statements/await-using/syntax/with-initializer-do-statement-while-expression.js
+++ b/test/language/statements/await-using/syntax/with-initializer-do-statement-while-expression.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    do Statement while ( Expression )
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  do await using x = 1; while (false)
+}

--- a/test/language/statements/await-using/syntax/with-initializer-for-statement.js
+++ b/test/language/statements/await-using/syntax/with-initializer-for-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    for (;;) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  for (;false;) await using x = null;
+}

--- a/test/language/statements/await-using/syntax/with-initializer-if-expression-statement-else-statement.js
+++ b/test/language/statements/await-using/syntax/with-initializer-if-expression-statement-else-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    if ( Expression ) Statement else Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  if (true) {} else await using x = null;
+}

--- a/test/language/statements/await-using/syntax/with-initializer-if-expression-statement.js
+++ b/test/language/statements/await-using/syntax/with-initializer-if-expression-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    if ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  if (true) await using x = null;
+}

--- a/test/language/statements/await-using/syntax/with-initializer-label-statement.js
+++ b/test/language/statements/await-using/syntax/with-initializer-label-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    label: Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  label: await using x = null;
+}

--- a/test/language/statements/await-using/syntax/with-initializer-while-expression-statement.js
+++ b/test/language/statements/await-using/syntax/with-initializer-while-expression-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    while ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  while (false) await using x = null;
+}

--- a/test/language/statements/await-using/syntax/without-initializer-case-expression-statement-list.js
+++ b/test/language/statements/await-using/syntax/without-initializer-case-expression-statement-list.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    case Expression : StatementList
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  switch (true) { case true: await using x; }
+}

--- a/test/language/statements/await-using/syntax/without-initializer-default-statement-list.js
+++ b/test/language/statements/await-using/syntax/without-initializer-default-statement-list.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    default : StatementList
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  switch (true) { default: await using x; }
+}

--- a/test/language/statements/await-using/syntax/without-initializer-do-statement-while-expression.js
+++ b/test/language/statements/await-using/syntax/without-initializer-do-statement-while-expression.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    do Statement while ( Expression )
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  do await using x; while (false)
+}

--- a/test/language/statements/await-using/syntax/without-initializer-for-statement.js
+++ b/test/language/statements/await-using/syntax/without-initializer-for-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    for ( ;;) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  for (;false;) await using x;
+}

--- a/test/language/statements/await-using/syntax/without-initializer-if-expression-statement-else-statement.js
+++ b/test/language/statements/await-using/syntax/without-initializer-if-expression-statement-else-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    if ( Expression ) Statement else Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  if (true) {} else await using x;
+}

--- a/test/language/statements/await-using/syntax/without-initializer-if-expression-statement.js
+++ b/test/language/statements/await-using/syntax/without-initializer-if-expression-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    if ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  if (true) await using x;
+}

--- a/test/language/statements/await-using/syntax/without-initializer-label-statement.js
+++ b/test/language/statements/await-using/syntax/without-initializer-label-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    label: Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  label: await using x;
+}

--- a/test/language/statements/await-using/syntax/without-initializer-while-expression-statement.js
+++ b/test/language/statements/await-using/syntax/without-initializer-while-expression-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    while ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  while (false) await using x;
+}

--- a/test/language/statements/await-using/throws-error-as-is-if-only-one-error-during-disposal.js
+++ b/test/language/statements/await-using/throws-error-as-is-if-only-one-error-during-disposal.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposeresources
+description: >
+  Rethrows an error as-is if it is the only error thrown during evaluation of subsequent statements following 'await using'
+  or from disposal.
+info: |
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  class MyError extends Error {}
+  await assert.throwsAsync(MyError, async function () {
+    await using _1 = { async [Symbol.asyncDispose]() { throw new MyError(); } };
+    await using _2 = { [Symbol.dispose]() { } };
+  });
+
+  await assert.throwsAsync(MyError, async function () {
+    await using _1 = { async [Symbol.asyncDispose]() { } };
+    await using _2 = { [Symbol.dispose]() { throw new MyError(); } };
+  });
+
+  await assert.throwsAsync(MyError, async function () {
+    await using _1 = { async [Symbol.asyncDispose]() { } };
+    await using _2 = { [Symbol.dispose]() { } };
+    throw new MyError();
+  });
+});

--- a/test/language/statements/await-using/throws-if-initializer-Symbol.asyncDispose-property-is-null.js
+++ b/test/language/statements/await-using/throws-if-initializer-Symbol.asyncDispose-property-is-null.js
@@ -1,0 +1,79 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value's Symbol.asyncDispose property is null and Symbol.dispose is not present
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+  1. Let func be ? GetV(V, P).
+  2. If func is either undefined or null, return undefined.
+  3. ...
+
+flags: [async]
+includes: [propertyHelper.js, asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function () {
+      await using x = { [Symbol.asyncDispose]: null };
+  });
+});

--- a/test/language/statements/await-using/throws-if-initializer-Symbol.asyncDispose-property-is-undefined.js
+++ b/test/language/statements/await-using/throws-if-initializer-Symbol.asyncDispose-property-is-undefined.js
@@ -1,0 +1,79 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value's Symbol.asyncDispose property is undefined and Symbol.dispose is not present
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+  1. Let func be ? GetV(V, P).
+  2. If func is either undefined or null, return undefined.
+  3. ...
+
+flags: [async]
+includes: [propertyHelper.js, asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function () {
+      await using x = { [Symbol.asyncDispose]: undefined };
+  });
+});

--- a/test/language/statements/await-using/throws-if-initializer-Symbol.asyncDispose-property-not-callable.js
+++ b/test/language/statements/await-using/throws-if-initializer-Symbol.asyncDispose-property-not-callable.js
@@ -1,0 +1,100 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value's Symbol.asyncDispose property is not callable
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined.
+      ii. Set method to undefined.
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+    ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+  1. Let func be ? GetV(V, P).
+  2. If func is either undefined or null, return undefined.
+  3. If IsCallable(func) is false, throw a TypeError exception.
+  4. Return func.
+
+flags: [async]
+includes: [asyncHelpers.js, propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = { [Symbol.asyncDispose]: true };
+  }, 'true');
+
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = { [Symbol.asyncDispose]: false };
+  }, 'false');
+
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = { [Symbol.asyncDispose]: 1 };
+  }, 'number');
+
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = { [Symbol.asyncDispose]: 'object' };
+  }, 'string');
+
+  var s = Symbol();
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = { [Symbol.asyncDispose]: s };
+  }, 'symbol');
+});

--- a/test/language/statements/await-using/throws-if-initializer-Symbol.dispose-property-is-null.js
+++ b/test/language/statements/await-using/throws-if-initializer-Symbol.dispose-property-is-null.js
@@ -1,0 +1,79 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value's Symbol.dispose property is null
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+  1. Let func be ? GetV(V, P).
+  2. If func is either undefined or null, return undefined.
+  3. ...
+
+flags: [async]
+includes: [asyncHelpers.js, propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function () {
+      await using x = { [Symbol.dispose]: null };
+  });
+});

--- a/test/language/statements/await-using/throws-if-initializer-Symbol.dispose-property-is-undefined.js
+++ b/test/language/statements/await-using/throws-if-initializer-Symbol.dispose-property-is-undefined.js
@@ -1,0 +1,79 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value's Symbol.dispose property is undefined
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+  1. Let func be ? GetV(V, P).
+  2. If func is either undefined or null, return undefined.
+  3. ...
+
+flags: [async]
+includes: [asyncHelpers.js, propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function () {
+      await using x = { [Symbol.dispose]: undefined };
+  });
+});

--- a/test/language/statements/await-using/throws-if-initializer-Symbol.dispose-property-not-callable.js
+++ b/test/language/statements/await-using/throws-if-initializer-Symbol.dispose-property-not-callable.js
@@ -1,0 +1,100 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value's Symbol.dispose property is not callable
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined.
+      ii. Set method to undefined.
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+    ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+  1. Let func be ? GetV(V, P).
+  2. If func is either undefined or null, return undefined.
+  3. If IsCallable(func) is false, throw a TypeError exception.
+  4. Return func.
+
+flags: [async]
+includes: [asyncHelpers.js, propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function () {
+    await using x = { [Symbol.dispose]: true };
+  }, 'true');
+
+  await assert.throwsAsync(TypeError, async function () {
+    await using x = { [Symbol.dispose]: false };
+  }, 'false');
+
+  await assert.throwsAsync(TypeError, async function () {
+    await using x = { [Symbol.dispose]: 1 };
+  }, 'number');
+
+  await assert.throwsAsync(TypeError, async function () {
+    await using x = { [Symbol.dispose]: 'object' };
+  }, 'string');
+
+  var s = Symbol();
+  await assert.throwsAsync(TypeError, async function () {
+    await using x = { [Symbol.dispose]: s };
+  }, 'symbol');
+});

--- a/test/language/statements/await-using/throws-if-initializer-missing-both-Symbol.asyncDispose-and-Symbol.dispose.js
+++ b/test/language/statements/await-using/throws-if-initializer-missing-both-Symbol.asyncDispose-and-Symbol.dispose.js
@@ -1,0 +1,80 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value is missing both the Symbol.asyncDispose and Symbol.dispose properties
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    BindingList : BindingList , LexicalBinding
+
+    1. Perform ? BindingEvaluation of BindingList with argument hint.
+    2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+    3. Return unused.
+
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  3. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+
+flags: [async]
+includes: [asyncHelpers.js, propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function () {
+      await using x = {};
+  });
+});

--- a/test/language/statements/await-using/throws-if-initializer-not-object.js
+++ b/test/language/statements/await-using/throws-if-initializer-not-object.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value is not an Object
+info: |
+
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ...
+  ...
+
+flags: [async]
+includes: [asyncHelpers.js, propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = true;
+  }, 'true');
+
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = false;
+  }, 'false');
+
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = 1;
+  }, 'number');
+
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = 'object';
+  }, 'string');
+
+  var s = Symbol();
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = s;
+  }, 'symbol');
+});

--- a/test/language/statements/await-using/throws-suppressederror-if-multiple-errors-during-disposal.js
+++ b/test/language/statements/await-using/throws-suppressederror-if-multiple-errors-during-disposal.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposeresources
+description: >
+  Throws a nested hierarchy of SuppressedErrors if multiple errors were thrown during evaluation of subsequent statements following 'await using'
+  and/or from disposal.
+info: |
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  class MyError extends Error {}
+  const error1 = new MyError();
+  const error2 = new MyError();
+  const error3 = new MyError();
+
+  try {
+    await using _1 = { async [Symbol.asyncDispose]() { throw error1; } };
+    await using _2 = { [Symbol.dispose]() { throw error2; } };
+    throw error3;
+  }
+  catch (e) {
+    assert(e instanceof SuppressedError, "Expected an SuppressedError to have been thrown");
+    assert.sameValue(e.error, error1, "Expected the outermost suppressing error to have been 'error1'");
+    assert(e.suppressed instanceof SuppressedError, "Expected the outermost suppressed error to have been a SuppressedError");
+    assert.sameValue(e.suppressed.error, error2, "Expected the innermost suppressing error to have been 'error2'");
+    assert.sameValue(e.suppressed.suppressed, error3, "Expected the innermost suppressed error to have been 'error3'");
+  }
+});

--- a/test/language/statements/using/Symbol.dispose-method-called-with-correct-this.js
+++ b/test/language/statements/using/Symbol.dispose-method-called-with-correct-this.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-block-runtime-semantics-evaluation
+description: Initialized value is disposed with the correct 'this' value
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        assert.sameValue(this, resource);
+    }
+};
+
+{
+  using _ = resource;
+}

--- a/test/language/statements/using/block-local-closure-get-before-initialization.js
+++ b/test/language/statements/using/block-local-closure-get-before-initialization.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    using: block local closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+features: [explicit-resource-management]
+---*/
+{
+  function f() { return x + 1; }
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
+  using x = null;
+}
+

--- a/test/language/statements/using/block-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/statements/using/block-local-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    using: block local use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+features: [explicit-resource-management]
+---*/
+
+assert.throws(ReferenceError, function() {
+  {
+    using x = x + 1;
+  }
+});

--- a/test/language/statements/using/block-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/statements/using/block-local-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    using: block local use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+features: [explicit-resource-management]
+---*/
+
+assert.throws(ReferenceError, function() {
+  {
+    x; using x = null;
+  }
+});

--- a/test/language/statements/using/cptn-value.js
+++ b/test/language/statements/using/cptn-value.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Returns an empty completion
+info: |
+  UsingDeclaration : using BindingList ;
+
+  1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+  2. Return empty.
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(
+  eval('{using test262id1 = null;}'), undefined, 'Single declaration'
+);
+assert.sameValue(
+  eval('{using test262id2 = null, test262id3 = null;}'),
+  undefined,
+  'Multiple declarations'
+);
+
+assert.sameValue(eval('4; {using test262id5 = null;}'), 4);
+assert.sameValue(eval('6; {using test262id7 = null, test262id8 = null;}'), 6);

--- a/test/language/statements/using/fn-name-arrow.js
+++ b/test/language/statements/using/fn-name-arrow.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Assignment of function `name` attribute (ArrowFunction)
+info: |
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+       a. Let value be NamedEvaluation of Initializer with argument bindingId
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+// NOTE: only way to verify is to patch `Function.prototype` so as not to trigger a TypeError from AddDisposableResource
+Function.prototype[Symbol.dispose] = function () {}
+{
+    using arrow = () => {};
+
+    assert.sameValue(arrow.name, 'arrow');
+    verifyNotEnumerable(arrow, 'name');
+    verifyNotWritable(arrow, 'name');
+    verifyConfigurable(arrow, 'name');
+}

--- a/test/language/statements/using/fn-name-class.js
+++ b/test/language/statements/using/fn-name-class.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Assignment of function `name` attribute (ClassExpression)
+info: |
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+       a. Let value be NamedEvaluation of Initializer with argument bindingId
+includes: [propertyHelper.js]
+features: [class, explicit-resource-management]
+---*/
+{
+    using xCls = class x { static [Symbol.dispose]() {} };
+    using cls = class { static [Symbol.dispose]() {} };
+    using xCls2 = class { static name() {} static [Symbol.dispose]() {} };
+
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    assert.sameValue(cls.name, 'cls');
+    verifyNotEnumerable(cls, 'name');
+    verifyNotWritable(cls, 'name');
+    verifyConfigurable(cls, 'name');
+}

--- a/test/language/statements/using/fn-name-cover.js
+++ b/test/language/statements/using/fn-name-cover.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: >
+    Assignment of function `name` attribute (CoverParenthesizedExpression)
+info: |
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+       a. Let value be NamedEvaluation of Initializer with argument bindingId
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+// NOTE: only way to verify is to patch `Function.prototype` so as not to trigger a TypeError from AddDisposableResource
+Function.prototype[Symbol.dispose] = function () {}
+{
+    using xCover = (0, function() {});
+    using cover = (function() {});
+
+    assert(xCover.name !== 'xCover');
+
+    assert.sameValue(cover.name, 'cover');
+    verifyNotEnumerable(cover, 'name');
+    verifyNotWritable(cover, 'name');
+    verifyConfigurable(cover, 'name');
+}

--- a/test/language/statements/using/fn-name-fn.js
+++ b/test/language/statements/using/fn-name-fn.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Assignment of function `name` attribute (FunctionExpression)
+info: |
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+       a. Let value be NamedEvaluation of Initializer with argument bindingId
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+// NOTE: only way to verify is to patch `Function.prototype` so as not to trigger a TypeError from AddDisposableResource
+Function.prototype[Symbol.dispose] = function () {}
+{
+    using xFn = function x() {};
+    using fn = function() {};
+
+    assert(xFn.name !== 'xFn');
+
+    assert.sameValue(fn.name, 'fn');
+    verifyNotEnumerable(fn, 'name');
+    verifyNotWritable(fn, 'name');
+    verifyConfigurable(fn, 'name');
+}

--- a/test/language/statements/using/fn-name-gen.js
+++ b/test/language/statements/using/fn-name-gen.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Assignment of function `name` attribute (GeneratorExpression)
+info: |
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+       a. Let value be NamedEvaluation of Initializer with argument bindingId
+includes: [propertyHelper.js]
+features: [generators,explicit-resource-management]
+---*/
+
+// NOTE: only way to verify is to patch `Function.prototype` so as not to trigger a TypeError from AddDisposableResource
+Function.prototype[Symbol.dispose] = function () {}
+{
+    using xGen = function* x() {};
+    using gen = function*() {};
+
+    assert(xGen.name !== 'xGen');
+
+    assert.sameValue(gen.name, 'gen');
+    verifyNotEnumerable(gen, 'name');
+    verifyNotWritable(gen, 'name');
+    verifyConfigurable(gen, 'name');
+}

--- a/test/language/statements/using/function-local-closure-get-before-initialization.js
+++ b/test/language/statements/using/function-local-closure-get-before-initialization.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    using: function local closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+features: [explicit-resource-management]
+---*/
+
+(function() {
+  function f() { return x + 1; }
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
+  using x = null;
+}());

--- a/test/language/statements/using/function-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/statements/using/function-local-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    using: function local use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+features: [explicit-resource-management]
+---*/
+
+assert.throws(ReferenceError, function() {
+  (function() {
+    using x = x + 1;
+  }());
+});

--- a/test/language/statements/using/function-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/statements/using/function-local-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    using: function local use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+features: [explicit-resource-management]
+---*/
+
+assert.throws(ReferenceError, function() {
+  (function() {
+    x; using x = null;
+  }());
+});

--- a/test/language/statements/using/gets-initializer-Symbol.dispose-property-once.js
+++ b/test/language/statements/using/gets-initializer-Symbol.dispose-property-once.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Only reads `[Symbol.dispose]` method once, when initialized.
+info: |
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    BindingList : BindingList , LexicalBinding
+
+    1. Perform ? BindingEvaluation of BindingList with argument hint.
+    2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+    3. Return unused.
+
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined
+      ii. Set method to undefined
+    b. Else,
+      i. If Type(V) is not Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+      a. ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    a. Let method be ? GetMethod(V, @@asyncDispose).
+    b. If method is undefined, then
+      i. Set method to ? GetMethod(V, @@dispose).
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+features: [explicit-resource-management]
+---*/
+
+var resource = {
+    disposeReadCount: 0,
+    get [Symbol.dispose]() {
+        this.disposeReadCount++;
+        return function() { };
+    }
+};
+
+{
+  using _ = resource;
+}
+
+assert.sameValue(resource.disposeReadCount, 1, 'Expected [Symbol.dispose] to have been read only once');

--- a/test/language/statements/using/global-closure-get-before-initialization.js
+++ b/test/language/statements/using/global-closure-get-before-initialization.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    using: global closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+features: [explicit-resource-management]
+---*/
+
+{
+  function f() { return x + 1; }
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
+  using x = null;
+}

--- a/test/language/statements/using/global-use-before-initialization-in-declaration-statement.js
+++ b/test/language/statements/using/global-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    using: global use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+negative:
+  phase: runtime
+  type: ReferenceError
+features: [explicit-resource-management]
+---*/
+
+{
+  using x = x + 1;
+}

--- a/test/language/statements/using/global-use-before-initialization-in-prior-statement.js
+++ b/test/language/statements/using/global-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-getbindingvalue-n-s
+description: >
+    using: global use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+negative:
+  phase: runtime
+  type: ReferenceError
+features: [explicit-resource-management]
+---*/
+
+{
+  x; using x = null;
+}

--- a/test/language/statements/using/initializer-disposed-at-end-of-asyncfunctionbody.js
+++ b/test/language/statements/using/initializer-disposed-at-end-of-asyncfunctionbody.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncblockstart
+description: Initialized value is disposed at end of AsyncFunctionBody
+info: |
+
+  AsyncBlockStart ( promiseCapability, asyncBody, asyncContext )
+
+  1. Assert: promiseCapability is a PromiseCapability Record.
+  2. Let runningContext be the running execution context.
+  3. Let closure be a new Abstract Closure with no parameters that captures promiseCapability and asyncBody and performs the following steps when called:
+    a. Let acAsyncContext be the running execution context.
+    b. Let result be Completion(Evaluation of asyncBody).
+    c. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
+    d. Remove acAsyncContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+    e. Let env be acAsyncContext's LexicalEnvironment.
+    f. Set result to DisposeResources(env.[[DisposeCapability]], result).
+    g. If result.[[Type]] is normal, then
+      i. Perform ! Call(promiseCapability.[[Resolve]], undefined, « undefined »).
+    h. Else if result.[[Type]] is return, then
+      i. Perform ! Call(promiseCapability.[[Resolve]], undefined, « result.[[Value]] »).
+    i. Else,
+      i. Assert: result.[[Type]] is throw.
+      ii. Perform ! Call(promiseCapability.[[Reject]], undefined, « result.[[Value]] »).
+    j. Return unused.
+  4. Set the code evaluation state of asyncContext such that when evaluation is resumed for that execution context, closure will be called with no arguments.
+  5. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
+  6. Resume the suspended evaluation of asyncContext. Let result be the value returned by the resumed computation.
+  7. Assert: When we return here, asyncContext has already been removed from the execution context stack and runningContext is the currently running execution context.
+  8. Assert: result is a normal completion with a value of unused. The possible sources of this value are Await or, if the async function doesn't await anything, step 3.h above.
+  9. Return unused.
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+
+  var resource = {
+      disposed: false,
+      [Symbol.dispose]() {
+          this.disposed = true;
+      }
+  };
+
+  var releaseF1;
+  var suspendFPromise1 = new Promise(function (resolve) { releaseF1 = resolve; });
+
+  var releaseBody;
+  var suspendBodyPromise = new Promise(function (resolve) { releaseBody = resolve; });
+
+  var releaseF2;
+  var suspendFPromise2 = new Promise(function (resolve) { releaseF2 = resolve; });
+
+  async function f() {
+      using _ = resource;
+      await suspendFPromise1;
+      releaseBody();
+      await suspendFPromise2;
+  }
+
+  var resultPromise = f();
+
+  var wasDisposedWhileSuspended1 = resource.disposed;
+
+  releaseF1();
+  await suspendBodyPromise;
+
+  var wasDisposedWhileSuspended2 = resource.disposed;
+
+  releaseF2();
+  await resultPromise;
+
+  var isDisposedAfterCompleted = resource.disposed;
+
+  assert.sameValue(wasDisposedWhileSuspended1, false, 'Expected resource to not have been disposed while async function is suspended during await');
+  assert.sameValue(wasDisposedWhileSuspended2, false, 'Expected resource to not have been disposed while async function is suspended during await');
+  assert.sameValue(isDisposedAfterCompleted, true, 'Expected resource to have been disposed after async function completed');
+});

--- a/test/language/statements/using/initializer-disposed-at-end-of-asyncgeneratorbody.js
+++ b/test/language/statements/using/initializer-disposed-at-end-of-asyncgeneratorbody.js
@@ -1,0 +1,108 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncgeneratorstart
+description: Initialized value is disposed at end of AsyncGeneratorBody
+info: |
+
+  AsyncGeneratorStart ( generator, generatorBody )
+
+  1. Assert: generator.[[AsyncGeneratorState]] is undefined.
+  2. Let genContext be the running execution context.
+  3. Set the Generator component of genContext to generator.
+  4. Let closure be a new Abstract Closure with no parameters that captures generatorBody and performs the following steps when called:
+    a. Let acGenContext be the running execution context.
+    b. Let acGenerator be the Generator component of acGenContext.
+    c. If generatorBody is a Parse Node, then
+      i. Let result be Completion(Evaluation of generatorBody).
+    d. Else,
+      i. Assert: generatorBody is an Abstract Closure with no parameters.
+      ii. Let result be Completion(generatorBody()).
+    e. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
+    f. Remove acGenContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+    g. Set acGenerator.[[AsyncGeneratorState]] to completed.
+    h. Let env be genContext's LexicalEnvironment.
+    i. If env is not undefined, then
+      i. Assert: env is a Declarative Environment Record
+      ii. Set result to DisposeResources(env.[[DisposeCapability]], result).
+    h. If result.[[Type]] is normal, set result to NormalCompletion(undefined).
+    i. If result.[[Type]] is return, set result to NormalCompletion(result.[[Value]]).
+    j. Perform AsyncGeneratorCompleteStep(acGenerator, result, true).
+    k. Perform AsyncGeneratorDrainQueue(acGenerator).
+    l. Return undefined.
+  5. Set the code evaluation state of genContext such that when evaluation is resumed for that execution context, closure will be called with no arguments.
+  6. Set generator.[[AsyncGeneratorContext]] to genContext.
+  7. Set generator.[[AsyncGeneratorState]] to suspendedStart.
+  8. Set generator.[[AsyncGeneratorQueue]] to a new empty List.
+  9. Return unused.
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+
+  var resource = {
+      disposed: false,
+      [Symbol.dispose]() {
+          this.disposed = true;
+      }
+  };
+
+  var releaseF;
+  var suspendFPromise = new Promise(function (resolve) { releaseF = resolve; });
+
+  async function * f() {
+      using _ = resource;
+      yield;
+      await suspendFPromise;
+  }
+
+  var g = f();
+
+  var wasDisposedBeforeAsyncGeneratorStarted = resource.disposed;
+
+  await g.next();
+
+  var wasDisposedWhileSuspendedForYield = resource.disposed;
+
+  var nextPromise = g.next();
+
+  var wasDisposedWhileSuspendedForAwait = resource.disposed;
+
+  releaseF();
+  await nextPromise;
+
+  var isDisposedAfterCompleted = resource.disposed;
+
+  assert.sameValue(wasDisposedBeforeAsyncGeneratorStarted, false, 'Expected resource to not have been disposed prior to async generator start');
+  assert.sameValue(wasDisposedWhileSuspendedForYield, false, 'Expected resource to not have been disposed while async generator function is suspended for yield');
+  assert.sameValue(wasDisposedWhileSuspendedForAwait, false, 'Expected resource to not have been disposed while async generator function is suspended during await');
+  assert.sameValue(isDisposedAfterCompleted, true, 'Expected resource to have been disposed after async generator function completed');
+});

--- a/test/language/statements/using/initializer-disposed-at-end-of-block.js
+++ b/test/language/statements/using/initializer-disposed-at-end-of-block.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-block-runtime-semantics-evaluation
+description: Initialized value is disposed at end of Block
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        this.disposed = true;
+    }
+};
+
+{
+  using _ = resource;
+}
+
+assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');

--- a/test/language/statements/using/initializer-disposed-at-end-of-each-iteration-of-forofstatementjs
+++ b/test/language/statements/using/initializer-disposed-at-end-of-each-iteration-of-forofstatementjs
@@ -1,0 +1,81 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset
+description: Initialized value is disposed at end of each iteration of ForOfStatement
+info: |
+
+  ForIn/OfBodyEvaluation ( lhs, stmt, iteratorRecord, iterationKind, lhsKind, labelSet [ , iteratorKind ] )
+
+  1. If iteratorKind is not present, set iteratorKind to sync.
+  2. Let oldEnv be the running execution context's LexicalEnvironment.
+  3. Let V be undefined.
+  4. If IsAwaitUsingDeclaration of lhs is true, then
+    a. Let hint be async-dispose.
+  5. Else, if IsUsingDeclaration of lhs is true, then
+    a. Let hint be sync-dispose.
+  6. Else,
+    a. Let hint be normal.
+  7. Let destructuring be IsDestructuring of lhs.
+  8. If destructuring is true and if lhsKind is assignment, then
+    a. Assert: lhs is a LeftHandSideExpression.
+    b. Let assignmentPattern be the AssignmentPattern that is covered by lhs.
+  9. Repeat,
+    ...
+    j. Let result be Completion(Evaluation of stmt).
+    k. If iterationEnv is not undefined, then
+      i. Set result to Completion(DisposeResources(iterationEnv.[[DisposeCapability]], result)).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        this.disposed = true;
+    }
+};
+
+var wasDisposedBeforeBody = false;
+var wasDisposedBeforeIteration = false;
+var wasDisposedAfterIteration = false;
+
+function * g() {
+  wasDisposedBeforeIteration = resource.disposed;
+  yield resource;
+  wasDisposedAfterIteration = resource.disposed;
+}
+
+for (using _ of g()) {
+  wasDisposedBeforeBody = resource.disposed;
+}
+
+assert.sameValue(wasDisposedBeforeIteration, false, 'Expected resource to not been disposed before the for-of loop has received a value');
+assert.sameValue(wasDisposedBeforeBody, false, 'Expected resource to not been disposed while for-of loop is still iterating');
+assert.sameValue(wasDisposedAfterIteration, true, 'Expected resource to have been disposed after the for-of loop advanced to the next value');

--- a/test/language/statements/using/initializer-disposed-at-end-of-forstatement.js
+++ b/test/language/statements/using/initializer-disposed-at-end-of-forstatement.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-forloopevaluation
+description: Initialized value is disposed at end of ForStatement
+info: |
+
+  RS: ForLoopEvaluation
+    ForStatement : for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    ...
+    12. Let bodyResult be Completion(ForBodyEvaluation(test, increment, Statement, perIterationLets, labelSet)).
+    13. Set bodyResult to Completion(DisposeResources(loopEnv.[[DisposeCapability]], bodyResult)).
+    14. Assert: If bodyResult.[[Type]] is normal, then bodyResult.[[Value]] is not empty.
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        this.disposed = true;
+    }
+};
+
+var i = 0;
+var wasDisposedInForStatement;
+for (using _ = resource; i < 1; i++) {
+  wasDisposedInForStatement = resource.disposed;
+}
+
+assert.sameValue(wasDisposedInForStatement, false, 'Expected resource to not been disposed while for loop is still iterating');
+assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');

--- a/test/language/statements/using/initializer-disposed-at-end-of-functionbody.js
+++ b/test/language/statements/using/initializer-disposed-at-end-of-functionbody.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-evaluatefunctionbody
+description: Initialized value is disposed at end of FunctionBody
+info: |
+
+  FunctionBody : FunctionStatementList
+
+  ...
+  3. Let result be Completion(Evaluation of FunctionStatementList).
+  4. Let env be the running execution context's LexicalEnvironment.
+  5. Return ? DisposeResources(env.[[DisposeCapability]], result).
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        this.disposed = true;
+    }
+};
+
+function f() {
+    using _ = resource;
+}
+
+f();
+
+assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');

--- a/test/language/statements/using/initializer-disposed-at-end-of-generatorbody.js
+++ b/test/language/statements/using/initializer-disposed-at-end-of-generatorbody.js
@@ -1,0 +1,91 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-generatorstart
+description: Initialized value is disposed at end of GeneratorBody
+info: |
+
+  GeneratorStart ( generator, generatorBody )
+  
+  1. Assert: The value of generator.[[GeneratorState]] is undefined.
+  2. Let genContext be the running execution context.
+  3. Set the Generator component of genContext to generator.
+  4. Let closure be a new Abstract Closure with no parameters that captures generatorBody and performs the following steps when called:
+    a. Let acGenContext be the running execution context.
+    b. Let acGenerator be the Generator component of acGenContext.
+    c. If generatorBody is a Parse Node, then
+      i. Let result be Completion(Evaluation of generatorBody).
+    d. Else,
+      i. Assert: generatorBody is an Abstract Closure with no parameters.
+      ii. Let result be generatorBody().
+    e. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
+    f. Remove acGenContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+    g. Set acGenerator.[[GeneratorState]] to completed.
+    h. NOTE: Once a generator enters the completed state it never leaves it and its associated execution context is never resumed. Any execution state associated with acGenerator can be discarded at this point.
+    i. Let env be genContext's LexicalEnvironment.
+    j. If env is not undefined, then
+      i. Assert: env is a Declarative Environment Record.
+      i. Set result to DisposeResources(env.[[DisposeCapability]], result).
+    k. If result.[[Type]] is normal, then
+      i. Let resultValue be undefined.
+    l. Else if result.[[Type]] is return, then
+      i. Let resultValue be result.[[Value]].
+    m. Else,
+      i. Assert: result.[[Type]] is throw.
+      ii. Return ? result.
+    n. Return CreateIterResultObject(resultValue, true).
+  5. Set the code evaluation state of genContext such that when evaluation is resumed for that execution context, closure will be called with no arguments.
+  6. Set generator.[[GeneratorContext]] to genContext.
+  7. Set generator.[[GeneratorState]] to suspendedStart.
+  8. Return unused.
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        this.disposed = true;
+    }
+};
+
+function * f() {
+    using _ = resource;
+    yield;
+}
+
+var g = f();
+var wasDisposedBeforeGeneratorStarted = resource.disposed;
+g.next();
+var wasDisposedWhileSuspended = resource.disposed;
+assert.sameValue(g.next().done, true);
+var isDisposedAfterGeneratorCompleted = resource.disposed;
+
+assert.sameValue(wasDisposedBeforeGeneratorStarted, false, 'Expected resource to not have been disposed prior to generator start');
+assert.sameValue(wasDisposedWhileSuspended, false, 'Expected resource to not have been disposed while generator is suspended');
+assert.sameValue(isDisposedAfterGeneratorCompleted, true, 'Expected resource to have been disposed after generator completed');

--- a/test/language/statements/using/initializer-disposed-at-end-of-switchstatement.js
+++ b/test/language/statements/using/initializer-disposed-at-end-of-switchstatement.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-switch-statement-runtime-semantics-evaluation
+description: Initialized value is disposed at end of a SwitchStatement
+info: |
+
+  RS: Evaluation
+    SwitchStatement : switch ( Expression ) CaseBlock
+
+    ...
+    7. Let R be Completion(CaseBlockEvaluation of CaseBlock with argument switchValue).
+    8. Set R to Completion(DisposeResources(blockEnv.[[DisposeCapability]], R)).
+    9. Assert: If R.[[Type]] is normal, then R.[[Value]] is not empty.
+    ..
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        this.disposed = true;
+    }
+};
+
+switch (0) {
+  default:
+    using _ = resource;
+    break;
+}
+
+assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');

--- a/test/language/statements/using/initializer-disposed-if-subsequent-initializer-throws-in-forstatement-head.js
+++ b/test/language/statements/using/initializer-disposed-if-subsequent-initializer-throws-in-forstatement-head.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-forloopevaluation
+description: Initialized value is disposed at end of FunctionBody
+info: |
+
+  RS: ForLoopEvaluation
+    ForStatement : for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    ...
+    7. Let forDcl be Completion(Evaluation of LexicalDeclaration).
+    8. If forDcl is an abrupt completion, then
+      a. Set forDcl to Completion(DisposeResources(loopEnv.[[DisposeCapability]], forDcl)).
+      b. Assert: forDcl is an abrupt completion.
+      c. Set the running execution context's LexicalEnvironment to oldEnv.
+      d. Return ? forDcl.
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        this.disposed = true;
+    }
+};
+
+function getResource() {
+  throw new Error();
+}
+
+assert.throws(Error, function () {
+  var i = 0;
+  for (using _1 = resource, _2 = getResource(); i < 1; i++) {
+  }
+}, 'for');
+
+assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');

--- a/test/language/statements/using/initializer-disposed-if-subsequent-initializer-throws.js
+++ b/test/language/statements/using/initializer-disposed-if-subsequent-initializer-throws.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-block-runtime-semantics-evaluation
+description: Initialized value is disposed even if subsequent initializer throws
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var resource = {
+    disposed: false,
+    [Symbol.dispose]() {
+        this.disposed = true;
+    }
+};
+
+function getResource() {
+  throw new Error();
+}
+
+assert.throws(Error, function () {
+  using _1 = resource, _2 = getResource();
+});
+
+assert.sameValue(resource.disposed, true, 'Expected resource to have been disposed');

--- a/test/language/statements/using/multiple-resources-disposed-in-reverse-order.js
+++ b/test/language/statements/using/multiple-resources-disposed-in-reverse-order.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposeresources
+description: Multiple resources are disposed in the reverse of the order in which they were added
+info: |
+
+  RS: Evaluation
+    Block : { StatementList }
+
+    ...
+    5. Let blockValue be the result of evaluating StatementList.
+    6. Set blockValue to DisposeResources(blockEnv.[[DisposeCapability]], blockValue).
+    ...
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. ...
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+var disposed = [];
+var resource1 = { [Symbol.dispose]() { disposed.push(this); } };
+var resource2 = { [Symbol.dispose]() { disposed.push(this); } };
+var resource3 = { [Symbol.dispose]() { disposed.push(this); } };
+
+{
+  using _1 = resource1, _2 = resource2;
+  using _3 = resource3;
+}
+
+assert.sameValue(disposed[0], resource3);
+assert.sameValue(disposed[1], resource2);
+assert.sameValue(disposed[2], resource1);

--- a/test/language/statements/using/puts-initializer-on-top-of-disposableresourcestack-multiple-bindings.js
+++ b/test/language/statements/using/puts-initializer-on-top-of-disposableresourcestack-multiple-bindings.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: >
+  Puts initialized value on the top of the environment's [[DisposableResourceStack]] with multiple lexical bindings
+  in a single 'using' declaration
+info: |
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    BindingList : BindingList , LexicalBinding
+
+    1. Perform ? BindingEvaluation of BindingList with argument hint.
+    2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+    3. Return unused.
+
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  3. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+features: [explicit-resource-management]
+---*/
+
+var disposed = [];
+var resource1 = {
+    [Symbol.dispose]() {
+        disposed.push(this);
+    }
+};
+var resource2 = {
+    [Symbol.dispose]() {
+        disposed.push(this);
+    }
+};
+{
+  using r1 = resource1, r2 = resource2;
+}
+assert.sameValue(2, disposed.length);
+assert.sameValue(disposed[0], resource2, 'Expected resource2 to be the first disposed resource');
+assert.sameValue(disposed[1], resource1, 'Expected resource1 to be the second disposed resource');

--- a/test/language/statements/using/puts-initializer-on-top-of-disposableresourcestack-subsequent-usings.js
+++ b/test/language/statements/using/puts-initializer-on-top-of-disposableresourcestack-subsequent-usings.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: >
+  Puts initialized value on the top of the environment's [[DisposableResourceStack]] with multiple subsequent 'using'
+  declarations in the same block scope
+info: |
+
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  3. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+features: [explicit-resource-management]
+---*/
+
+var disposed = [];
+var resource1 = {
+    [Symbol.dispose]() {
+        disposed.push(this);
+    }
+};
+var resource2 = {
+    [Symbol.dispose]() {
+        disposed.push(this);
+    }
+};
+{
+  using r1 = resource1;
+  using r2 = resource2;
+}
+assert.sameValue(2, disposed.length);
+assert.sameValue(disposed[0], resource2, 'Expected resource2 to be the first disposed resource');
+assert.sameValue(disposed[1], resource1, 'Expected resource1 to be the second disposed resource');

--- a/test/language/statements/using/redeclaration-error-from-within-strict-mode-function-using.js
+++ b/test/language/statements/using/redeclaration-error-from-within-strict-mode-function-using.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-declarative-environment-records-initializebinding-n-v
+description: >
+    Redeclaration error within strict mode function inside non-strict code.
+negative:
+  phase: parse
+  type: SyntaxError
+flags: [noStrict, explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+(function() { 'use strict'; { using f = null; var f; } })
+

--- a/test/language/statements/using/static-init-await-binding-invalid.js
+++ b/test/language/statements/using/static-init-await-binding-invalid.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-class-definitions-static-semantics-early-errors
+description: BindingIdentifier may not be `await` within class static blocks
+info: |
+  BindingIdentifier : Identifier
+
+  [...]
+  - It is a Syntax Error if the code matched by this production is nested,
+    directly or indirectly (but not crossing function or static initialization
+    block boundaries), within a ClassStaticBlock and the StringValue of
+    Identifier is "await".
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-static-block, explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  static {
+    using await = null;
+  }
+}

--- a/test/language/statements/using/static-init-await-binding-valid.js
+++ b/test/language/statements/using/static-init-await-binding-valid.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-class-definitions-static-semantics-early-errors
+description: The `await` keyword is interpreted as an identifier within arrow function bodies
+info: |
+  ClassStaticBlockBody : ClassStaticBlockStatementList
+
+  [...]
+  - It is a Syntax Error if ContainsAwait of ClassStaticBlockStatementList is true.
+features: [class-static-block, explicit-resource-management]
+---*/
+
+class C {
+  static {
+    (() => { using await = null; });
+  }
+}

--- a/test/language/statements/using/syntax/block-scope-syntax-using-declarations-mixed-with-without-initializer.js
+++ b/test/language/statements/using/syntax/block-scope-syntax-using-declarations-mixed-with-without-initializer.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations mixed: with, without initializer
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+{
+  using x = null, y;
+}

--- a/test/language/statements/using/syntax/block-scope-syntax-using-declarations-mixed-without-with-initializer.js
+++ b/test/language/statements/using/syntax/block-scope-syntax-using-declarations-mixed-without-with-initializer.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations mixed: without, with initializer
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+{
+  using x, y = null;
+}

--- a/test/language/statements/using/syntax/block-scope-syntax-using-declarations-without-initializer.js
+++ b/test/language/statements/using/syntax/block-scope-syntax-using-declarations-without-initializer.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initializer
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+{
+  using x;
+}

--- a/test/language/statements/using/syntax/using-allowed-at-top-level-of-module.js
+++ b/test/language/statements/using/syntax/using-allowed-at-top-level-of-module.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations allowed at the top level of a module
+info: |
+  UsingDeclaration : using BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+flags: [module]
+features: [explicit-resource-management]
+---*/
+
+using x = null;

--- a/test/language/statements/using/syntax/using-allows-bindingidentifier.js
+++ b/test/language/statements/using/syntax/using-allows-bindingidentifier.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' allows BindingIdentifier in lexical bindings
+features: [explicit-resource-management]
+---*/
+{
+  using x = null;
+}

--- a/test/language/statements/using/syntax/using-allows-multiple-bindings.js
+++ b/test/language/statements/using/syntax/using-allows-multiple-bindings.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' allows multiple lexical bindings
+features: [explicit-resource-management]
+---*/
+
+{
+  using x = null, y = null;
+}

--- a/test/language/statements/using/syntax/using-declaring-let-split-across-two-lines.js
+++ b/test/language/statements/using/syntax/using-declaring-let-split-across-two-lines.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using: |using let| split across two lines is treated as two statements.
+info: |
+  Lexical declarations may not declare a binding named "let".
+flags: [noStrict]
+features: [explicit-resource-management]
+---*/
+
+{
+  using
+  let = "irrelevant initializer";
+
+  assert(typeof let === "string");
+  var using, let;
+}

--- a/test/language/statements/using/syntax/using-invalid-arraybindingpattern-after-bindingidentifier.js
+++ b/test/language/statements/using/syntax/using-invalid-arraybindingpattern-after-bindingidentifier.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' does not allow ArrayBindingPattern in lexical bindings, even after a valid lexical binding
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+{
+  using x = null, [] = null;
+}

--- a/test/language/statements/using/syntax/using-invalid-arraybindingpattern-does-not-break-element-access.js
+++ b/test/language/statements/using/syntax/using-invalid-arraybindingpattern-does-not-break-element-access.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' does not break existing element access
+features: [explicit-resource-management]
+---*/
+
+var using = [], x = 0;
+
+{
+  using[x] = null;
+}

--- a/test/language/statements/using/syntax/using-invalid-arraybindingpattern.js
+++ b/test/language/statements/using/syntax/using-invalid-arraybindingpattern.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' does not allow ArrayBindingPattern in lexical bindings
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+{
+  using [] = null;
+}

--- a/test/language/statements/using/syntax/using-invalid-assignment-next-expression-for.js
+++ b/test/language/statements/using/syntax/using-invalid-assignment-next-expression-for.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using: invalid assignment in next expression
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function() {
+  for (using i = 0; i < 1; i++) {}
+});

--- a/test/language/statements/using/syntax/using-invalid-assignment-statement-body-for-of.js
+++ b/test/language/statements/using/syntax/using-invalid-assignment-statement-body-for-of.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using: invalid assignment in Statement body
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function() {
+  for (using x of [1, 2, 3]) { x++ }
+});

--- a/test/language/statements/using/syntax/using-invalid-for-in.js
+++ b/test/language/statements/using/syntax/using-invalid-for-in.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    using: not allowed in for..in
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+for (using x in [1, 2, 3]) { }

--- a/test/language/statements/using/syntax/using-invalid-objectbindingpattern-after-bindingidentifier.js
+++ b/test/language/statements/using/syntax/using-invalid-objectbindingpattern-after-bindingidentifier.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' does not allow ObjectBindingPattern in lexical bindings, even after a valid lexical binding
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+{
+  using x = null, {} = null;
+}

--- a/test/language/statements/using/syntax/using-invalid-objectbindingpattern.js
+++ b/test/language/statements/using/syntax/using-invalid-objectbindingpattern.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' does not allow ObjectBindingPattern in lexical bindings
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+{
+  using {} = null;
+}

--- a/test/language/statements/using/syntax/using-not-allowed-at-top-level-of-eval.js
+++ b/test/language/statements/using/syntax/using-not-allowed-at-top-level-of-eval.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations not allowed at the top level of eval
+info: |
+  UsingDeclaration : using BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+features: [explicit-resource-management]
+---*/
+
+assert.throws(SyntaxError, function() {
+  eval('using x = null;')
+});

--- a/test/language/statements/using/syntax/using-not-allowed-at-top-level-of-script.js
+++ b/test/language/statements/using/syntax/using-not-allowed-at-top-level-of-script.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations not allowed at the top level of a Script
+info: |
+  UsingDeclaration : using BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+using x = null;

--- a/test/language/statements/using/syntax/using-outer-inner-using-bindings.js
+++ b/test/language/statements/using/syntax/using-outer-inner-using-bindings.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    outer using binding unchanged by for-loop using binding
+features: [explicit-resource-management]
+---*/
+
+const outer_x = { [Symbol.dispose]() {} };
+const outer_y = { [Symbol.dispose]() {} };
+const inner_x = { [Symbol.dispose]() {} };
+const inner_y = { [Symbol.dispose]() {} };
+
+{
+  using x = outer_x;
+  using y = outer_y;
+  var i = 0;
+
+  for (using x = inner_x; i < 1; i++) {
+    using y = inner_y;
+
+    assert.sameValue(x, inner_x);
+    assert.sameValue(y, inner_y);
+  }
+  assert.sameValue(x, outer_x);
+  assert.sameValue(y, outer_y);
+}

--- a/test/language/statements/using/syntax/using.js
+++ b/test/language/statements/using/syntax/using.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    module and block scope using
+flags: [module]
+features: [explicit-resource-management]
+---*/
+
+using z = null;
+
+// Block local
+{
+  using z = undefined;
+}
+
+assert.sameValue(z, null);
+
+if (true) {
+  const obj = { [Symbol.dispose]() { } };
+  using z = obj;
+  assert.sameValue(z, obj);
+}
+

--- a/test/language/statements/using/syntax/with-initializer-case-expression-statement-list.js
+++ b/test/language/statements/using/syntax/with-initializer-case-expression-statement-list.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    case Expression : StatementList
+features: [explicit-resource-management]
+---*/
+switch (true) { case true: using x = null; }

--- a/test/language/statements/using/syntax/with-initializer-default-statement-list.js
+++ b/test/language/statements/using/syntax/with-initializer-default-statement-list.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    default : StatementList
+features: [explicit-resource-management]
+---*/
+switch (true) { default: using x = null; }

--- a/test/language/statements/using/syntax/with-initializer-do-statement-while-expression.js
+++ b/test/language/statements/using/syntax/with-initializer-do-statement-while-expression.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    do Statement while ( Expression )
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+do using x = 1; while (false)

--- a/test/language/statements/using/syntax/with-initializer-for-statement.js
+++ b/test/language/statements/using/syntax/with-initializer-for-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    for (;;) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+for (;false;) using x = null;

--- a/test/language/statements/using/syntax/with-initializer-if-expression-statement-else-statement.js
+++ b/test/language/statements/using/syntax/with-initializer-if-expression-statement-else-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    if ( Expression ) Statement else Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+if (true) {} else using x = null;

--- a/test/language/statements/using/syntax/with-initializer-if-expression-statement.js
+++ b/test/language/statements/using/syntax/with-initializer-if-expression-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    if ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+if (true) using x = null;

--- a/test/language/statements/using/syntax/with-initializer-label-statement.js
+++ b/test/language/statements/using/syntax/with-initializer-label-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    label: Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+label: using x = null;

--- a/test/language/statements/using/syntax/with-initializer-while-expression-statement.js
+++ b/test/language/statements/using/syntax/with-initializer-while-expression-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    while ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+while (false) using x = null;

--- a/test/language/statements/using/syntax/without-initializer-case-expression-statement-list.js
+++ b/test/language/statements/using/syntax/without-initializer-case-expression-statement-list.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    case Expression : StatementList
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+switch (true) { case true: using x; }

--- a/test/language/statements/using/syntax/without-initializer-default-statement-list.js
+++ b/test/language/statements/using/syntax/without-initializer-default-statement-list.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    default : StatementList
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+switch (true) { default: using x; }

--- a/test/language/statements/using/syntax/without-initializer-do-statement-while-expression.js
+++ b/test/language/statements/using/syntax/without-initializer-do-statement-while-expression.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    do Statement while ( Expression )
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+do using x; while (false)

--- a/test/language/statements/using/syntax/without-initializer-for-statement.js
+++ b/test/language/statements/using/syntax/without-initializer-for-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    for ( ;;) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+for (;false;) using x;

--- a/test/language/statements/using/syntax/without-initializer-if-expression-statement-else-statement.js
+++ b/test/language/statements/using/syntax/without-initializer-if-expression-statement-else-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    if ( Expression ) Statement else Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+if (true) {} else using x;

--- a/test/language/statements/using/syntax/without-initializer-if-expression-statement.js
+++ b/test/language/statements/using/syntax/without-initializer-if-expression-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    if ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+if (true) using x;

--- a/test/language/statements/using/syntax/without-initializer-label-statement.js
+++ b/test/language/statements/using/syntax/without-initializer-label-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    label: Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+label: using x;

--- a/test/language/statements/using/syntax/without-initializer-while-expression-statement.js
+++ b/test/language/statements/using/syntax/without-initializer-while-expression-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    while ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+while (false) using x;

--- a/test/language/statements/using/throws-error-as-is-if-only-one-error-during-disposal.js
+++ b/test/language/statements/using/throws-error-as-is-if-only-one-error-during-disposal.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposeresources
+description: >
+  Rethrows an error as-is if it is the only error thrown during evaluation of subsequent statements following 'using'
+  or from disposal.
+info: |
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+class MyError extends Error {}
+assert.throws(MyError, function () {
+  using _1 = { [Symbol.dispose]() { throw new MyError(); } };
+  using _2 = { [Symbol.dispose]() { } };
+});
+
+assert.throws(MyError, function () {
+  using _1 = { [Symbol.dispose]() { } };
+  using _2 = { [Symbol.dispose]() { throw new MyError(); } };
+});
+
+assert.throws(MyError, function () {
+  using _1 = { [Symbol.dispose]() { } };
+  using _2 = { [Symbol.dispose]() { } };
+  throw new MyError();
+});

--- a/test/language/statements/using/throws-if-initializer-Symbol.dispose-property-is-null.js
+++ b/test/language/statements/using/throws-if-initializer-Symbol.dispose-property-is-null.js
@@ -1,0 +1,74 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value's Symbol.dispose property is null
+info: |
+
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    ...
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+  1. Let func be ? GetV(V, P).
+  2. If func is either undefined or null, return undefined.
+  3. ...
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function () {
+    using x = { [Symbol.dispose]: null };
+});

--- a/test/language/statements/using/throws-if-initializer-Symbol.dispose-property-is-undefined.js
+++ b/test/language/statements/using/throws-if-initializer-Symbol.dispose-property-is-undefined.js
@@ -1,0 +1,74 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value's Symbol.dispose property is undefined
+info: |
+
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    ...
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+  1. Let func be ? GetV(V, P).
+  2. If func is either undefined or null, return undefined.
+  3. ...
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function () {
+    using x = { [Symbol.dispose]: undefined };
+});

--- a/test/language/statements/using/throws-if-initializer-Symbol.dispose-property-not-callable.js
+++ b/test/language/statements/using/throws-if-initializer-Symbol.dispose-property-not-callable.js
@@ -1,0 +1,95 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value's Symbol.dispose property is not callable
+info: |
+
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  2. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      i. Set V to undefined.
+      ii. Set method to undefined.
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  2. Else,
+    ...
+  3. Return the DisposableResource Record { [[ResourceValue]]: V, [[Hint]]: hint, [[DisposeMethod]]: method }.
+
+  GetDisposeMethod ( V, hint )
+
+  1. If hint is async-dispose, then
+    ...
+  2. Else,
+    a. Let method be ? GetMethod(V, @@dispose).
+  3. Return method.
+
+  GetMethod ( V, P )
+
+  1. Let func be ? GetV(V, P).
+  2. If func is either undefined or null, return undefined.
+  3. If IsCallable(func) is false, throw a TypeError exception.
+  4. Return func.
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function() {
+  using x = { [Symbol.dispose]: true };
+}, 'true');
+
+assert.throws(TypeError, function() {
+  using x = { [Symbol.dispose]: false };
+}, 'false');
+
+assert.throws(TypeError, function() {
+  using x = { [Symbol.dispose]: 1 };
+}, 'number');
+
+assert.throws(TypeError, function() {
+  using x = { [Symbol.dispose]: 'object' };
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  using x = { [Symbol.dispose]: s };
+}, 'symbol');

--- a/test/language/statements/using/throws-if-initializer-missing-Symbol.dispose.js
+++ b/test/language/statements/using/throws-if-initializer-missing-Symbol.dispose.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value is missing Symbol.dispose property
+info: |
+
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    BindingList : BindingList , LexicalBinding
+
+    1. Perform ? BindingEvaluation of BindingList with argument hint.
+    2. Perform ? BindingEvaluation of LexicalBinding with argument hint.
+    3. Return unused.
+
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  3. Else,
+    ...
+  3. Append resource to disposeCapability.[[DisposableResourceStack]].
+  4. Return unused.
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ii. Set method to ? GetDisposeMethod(V, hint).
+      iii. If method is undefined, throw a TypeError exception.
+  ...
+
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function () {
+    using x = {};
+});

--- a/test/language/statements/using/throws-if-initializer-not-object.js
+++ b/test/language/statements/using/throws-if-initializer-not-object.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value is not an Object
+info: |
+
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ...
+  ...
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function() {
+  using x = true;
+}, 'true');
+
+assert.throws(TypeError, function() {
+  using x = false;
+}, 'false');
+
+assert.throws(TypeError, function() {
+  using x = 1;
+}, 'number');
+
+assert.throws(TypeError, function() {
+  using x = 'object';
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  using x = s;
+}, 'symbol');

--- a/test/language/statements/using/throws-suppressederror-if-multiple-errors-during-disposal.js
+++ b/test/language/statements/using/throws-suppressederror-if-multiple-errors-during-disposal.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposeresources
+description: >
+  Throws a nested hierarchy of SuppressedErrors if multiple errors were thrown during evaluation of subsequent statements following 'using'
+  and/or from disposal.
+info: |
+
+  DisposeResources ( disposeCapability, completion )
+
+  1. For each resource of disposeCapability.[[DisposableResourceStack]], in reverse list order, do
+    a. Let result be Dispose(resource.[[ResourceValue]], resource.[[Hint]], resource.[[DisposeMethod]]).
+    b. If result.[[Type]] is throw, then
+      i. If completion.[[Type]] is throw, then
+        1. Set result to result.[[Value]].
+        2. Let suppressed be completion.[[Value]].
+        3. Let error be a newly created SuppressedError object.
+        4. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "error", result).
+        5. Perform ! CreateNonEnumerableDataPropertyOrThrow(error, "suppressed", suppressed).
+        6. Set completion to ThrowCompletion(error).
+      ii. Else,
+        1. Set completion to result.
+  2. Return completion.
+
+  Dispose ( V, hint, method )
+
+  1. If method is undefined, let result be undefined.
+  2. Else, let result be ? Call(method, V).
+  3. If hint is async-dispose, then
+    a. Perform ? Await(result).
+  4. Return undefined.
+
+features: [explicit-resource-management]
+---*/
+
+class MyError extends Error {}
+const error1 = new MyError();
+const error2 = new MyError();
+const error3 = new MyError();
+
+try {
+  using _1 = { [Symbol.dispose]() { throw error1; } };
+  using _2 = { [Symbol.dispose]() { throw error2; } };
+  throw error3;
+}
+catch (e) {
+  assert(e instanceof SuppressedError, "Expected an SuppressedError to have been thrown");
+  assert.sameValue(e.error, error1, "Expected the outermost suppressing error to have been 'error1'");
+  assert(e.suppressed instanceof SuppressedError, "Expected the outermost suppressed error to have been a SuppressedError");
+  assert.sameValue(e.suppressed.error, error2, "Expected the innermost suppressing error to have been 'error2'");
+  assert.sameValue(e.suppressed.suppressed, error3, "Expected the innermost suppressed error to have been 'error3'");
+}

--- a/test/language/statements/using/using-allows-null-initializer.js
+++ b/test/language/statements/using/using-allows-null-initializer.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Allows null in initializer of 'using'
+info: |
+
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+{
+  using x = null;
+}

--- a/test/language/statements/using/using-allows-undefined-initializer.js
+++ b/test/language/statements/using/using-allows-undefined-initializer.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Allows undefined in initializer of 'using'
+info: |
+
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+{
+  using x = undefined;
+}


### PR DESCRIPTION
This adds tests for the [Explicit Resource Management proposal](https://github.com/tc39/proposal-explicit-resource-management) based on the spec text at https://tc39.es/proposal-explicit-resource-management as well as several pending pull requests in the proposal repo.