### PR TITLE
Correct DurationFormat test

### DIFF
--- a/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-default-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-default-en.js
@@ -52,15 +52,15 @@ const expected = [
     { type: "literal", value: ", " },
     { type: "integer", value: "123", unit: "millisecond" },
     { type: "literal", value: " ", unit: "millisecond" },
-    { type: "unit", value: "msec", unit: "millisecond" },
+    { type: "unit", value: "ms", unit: "millisecond" },
     { type: "literal", value: ", " },
     { type: "integer", value: "456", unit: "microsecond" },
     { type: "literal", value: " ", unit: "microsecond" },
-    { type: "unit", value: "μsec", unit: "microsecond" },
-    { type: "literal", value: " and " },
+    { type: "unit", value: "μs", unit: "microsecond" },
+    { type: "literal", value: ", " },
     { type: "integer", value: "789", unit: "nanosecond" },
     { type: "literal", value: " ", unit: "nanosecond" },
-    { type: "unit", value: "nsec", unit: "nanosecond" },
+    { type: "unit", value: "ns", unit: "nanosecond" },
   ];
 
 let df = new Intl.DurationFormat('en');

--- a/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-long-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-long-en.js
@@ -58,7 +58,7 @@ const expected = [
     { type: "integer", value: "456", unit: "microsecond" },
     { type: "literal", value: " ", unit: "microsecond" },
     { type: "unit", value: "microseconds", unit: "microsecond" },
-    { type: "literal", value: " and " },
+    { type: "literal", value: ", " },
     { type: "integer", value: "789", unit: "nanosecond" },
     { type: "literal", value: " ", unit: "nanosecond" },
     { type: "unit", value: "nanoseconds", unit: "nanosecond" },

--- a/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-short-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-short-en.js
@@ -53,15 +53,15 @@ const expected = [
     { type: "literal", value: ", " },
     { type: "integer", value: "123", unit: "millisecond" },
     { type: "literal", value: " ", unit: "millisecond" },
-    { type: "unit", value: "msec", unit: "millisecond" },
+    { type: "unit", value: "ms", unit: "millisecond" },
     { type: "literal", value: ", " },
     { type: "integer", value: "456", unit: "microsecond" },
     { type: "literal", value: " ", unit: "microsecond" },
-    { type: "unit", value: "μsec", unit: "microsecond" },
-    { type: "literal", value: " and " },
+    { type: "unit", value: "μs", unit: "microsecond" },
+    { type: "literal", value: ", " },
     { type: "integer", value: "789", unit: "nanosecond" },
     { type: "literal", value: " ", unit: "nanosecond" },
-    { type: "unit", value: "nsec", unit: "nanosecond" },
+    { type: "unit", value: "ns", unit: "nanosecond" },
   ];
 
 let df = new Intl.DurationFormat('en', { style });


### PR DESCRIPTION
The expectation values for the formatToParts are incorrect.

A. The listFormat is consturcted with
  6. Perform ! CreateDataPropertyOrThrow(lfOpts, "type", "unit"). so it should not have " and " in the string. Comparing with (new Intl.ListFormat("en", {type: "unit"})).formatToParts(["a", "b", "c"]) and value in the format d and the expected values in the DurationFormat/prototype/format directory B. The localized unit values for "short" (and therefore default)
   are incorrect. Comparing with the expected values in the
  DurationFormat/prototype/format directory