### PR TITLE
Temporal: Test rejecting ISO strings with subminute offsets

### DIFF
--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.Duration(1);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.Duration(1);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.Duration(1);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.Duration(1);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.Instant(0n);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.toString({ timeZone }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.toString({ timeZone }), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = instance.toString({ timeZone });
 assert.sameValue(result1.substr(-6), "+00:00", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.Instant(0n);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.toZonedDateTime({ timeZone, calendar: "iso8601" }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.toZonedDateTime({ timeZone, calendar: "iso8601" }), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = instance.toZonedDateTime({ timeZone, calendar: "iso8601" });
 assert.sameValue(result1.timeZoneId, "UTC", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.Instant(0n);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.toZonedDateTimeISO(timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.toZonedDateTimeISO(timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = instance.toZonedDateTimeISO(timeZone);
 assert.sameValue(result1.timeZoneId, "UTC", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/Now/plainDate/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDate/timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.Now.plainDate("iso8601", timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.Now.plainDate("iso8601", timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/Now/plainDateISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDateISO/timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.Now.plainDateISO(timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.Now.plainDateISO(timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/Now/plainDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.Now.plainDateTime("iso8601", timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.Now.plainDateTime("iso8601", timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO(timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO(timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/Now/plainTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainTimeISO/timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.Now.plainTimeISO(timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.Now.plainTimeISO(timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/Now/zonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.Now.zonedDateTime("iso8601", timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.Now.zonedDateTime("iso8601", timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = Temporal.Now.zonedDateTime("iso8601", timeZone);
 assert.sameValue(result1.timeZoneId, "UTC", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.Now.zonedDateTimeISO(timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.Now.zonedDateTimeISO(timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = Temporal.Now.zonedDateTimeISO(timeZone);
 assert.sameValue(result1.timeZoneId, "UTC", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.PlainDate(2000, 5, 2);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.toZonedDateTime(timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.toZonedDateTime(timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = instance.toZonedDateTime(timeZone);
 assert.sameValue(result1.timeZoneId, "UTC", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.PlainDateTime(2000, 5, 2);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.toZonedDateTime(timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.toZonedDateTime(timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = instance.toZonedDateTime(timeZone);
 assert.sameValue(result1.timeZoneId, "UTC", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.PlainTime();
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone }), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone });
 assert.sameValue(result1.timeZoneId, "UTC", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/TimeZone/from/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/TimeZone/from/timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.TimeZone.from(timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.TimeZone.from(timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = Temporal.TimeZone.from(timeZone);
 assert.sameValue(result1.id, "UTC", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-timezone-string-datetime.js
@@ -13,6 +13,10 @@ let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.ZonedDateTime.compare({ year: 2000, month: 5, day: 2, timeZone }, instance), "bare date-time string is not a time zone (arg 1)");
 assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(instance, { year: 2000, month: 5, day: 2, timeZone }), "bare date-time string is not a time zone (arg 2)");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.ZonedDateTime.compare({ year: 2000, month: 5, day: 2, timeZone }, instance), "ISO string sub-minute offset is not OK as time zone (arg 1)");
+assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(instance, { year: 2000, month: 5, day: 2, timeZone }), "ISO string sub-minute offset is not OK as time zone (arg 2)");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone }), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone });
 assert.sameValue(result1.timeZoneId, "UTC", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-string-datetime.js
@@ -13,6 +13,9 @@ const instance1 = new Temporal.ZonedDateTime(0n, expectedTimeZone);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance1.since({ year: 2020, month: 5, day: 2, timeZone }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance1.since({ year: 2020, month: 5, day: 2, timeZone }), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw. They should produce
 // expectedTimeZone, so additionally the operation will not throw due to the
 // time zones being different on the receiver and the argument.

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-string-datetime.js
@@ -13,6 +13,9 @@ const instance1 = new Temporal.ZonedDateTime(0n, expectedTimeZone);
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance1.until({ year: 2020, month: 5, day: 2, timeZone }), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance1.until({ year: 2020, month: 5, day: 2, timeZone }), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw. They should produce
 // expectedTimeZone, so additionally the operation will not throw due to the
 // time zones being different on the receiver and the argument.

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone/timezone-string-datetime.js
@@ -12,6 +12,9 @@ const instance = new Temporal.ZonedDateTime(0n, "UTC");
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => instance.withTimeZone(timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => instance.withTimeZone(timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = instance.withTimeZone(timeZone);
 assert.sameValue(result1.timeZoneId, "UTC", "date-time + Z is UTC time zone");

--- a/test/built-ins/Temporal/ZonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/timezone-string-datetime.js
@@ -10,6 +10,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => new Temporal.ZonedDateTime(0n, timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => new Temporal.ZonedDateTime(0n, timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 timeZone = "2021-08-19T17:30Z";
 const result1 = new Temporal.ZonedDateTime(0n, timeZone);
 assert.sameValue(result1.timeZoneId, "UTC", "date-time + Z is UTC time zone");

--- a/test/intl402/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
@@ -9,6 +9,9 @@ features: [Temporal]
 let timeZone = "2021-08-19T17:30";
 assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO(timeZone), "bare date-time string is not a time zone");
 
+timeZone = "2021-08-19T17:30-07:00:01";
+assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO(timeZone), "ISO string sub-minute offset is not OK as time zone");
+
 // The following are all valid strings so should not throw:
 
 [

--- a/test/staging/Temporal/Regex/old/timezone.js
+++ b/test/staging/Temporal/Regex/old/timezone.js
@@ -43,7 +43,6 @@ function generateTest(dateTimeString, zoneString, expectedName) {
 });
 generateTest("1976-11-18T15:23", "z", "UTC");
 test("1976-11-18T15:23:30,1234Z", "UTC");
-test("1976-11-18T15:23-04:00:00,000000000", "-04:00");
 test("1976-11-18T15:23+000000,0[UTC]", "UTC");
 [
   "\u221204:00",


### PR DESCRIPTION
This PR verifies that ISO strings with sub-minute offsets cannot be parsed into time zone identifiers. This was a change introduced in the recently-merged tc39/proposal-temporal#2607, but tests for this case were missing from #3862 (the tests for that PR).

I noticed in codecov results on an unrelated PR that this case wasn't being tested, so fixing that mistake now.