### PR TITLE
Remove unnecessary dup GetOption in DateTimeFormat to sync ECMA402PR709

### DIFF
--- a/test/intl402/DateTimeFormat/constructor-options-order-dayPeriod.js
+++ b/test/intl402/DateTimeFormat/constructor-options-order-dayPeriod.js
@@ -4,12 +4,6 @@
 /*---
 esid: sec-initializedatetimeformat
 description: Checks the order of getting options of 'dayPeriod' for the DateTimeFormat constructor.
-info: |
-    ToDateTimeOptions ( options, required, defaults )
-    4. If required is "date" or "any", then
-      a. For each of the property names "weekday", "year", "month", "day", "dayPeriod" do
-    5. If required is "time" or "any", then
-      a. For each of the property names "hour", "minute", "second", do
 includes: [compareArray.js]
 features: [Intl.DateTimeFormat-dayPeriod]
 
@@ -17,10 +11,6 @@ features: [Intl.DateTimeFormat-dayPeriod]
 
 // Just need to ensure dayPeriod are get between day and hour.
 const expected = [
-  // ToDateTimeOptions step 4.
-  "day", "dayPeriod",
-  // ToDateTimeOptions step 5.
-  "hour",
   // InitializeDateTimeFormat step 22.
   "day",
   "dayPeriod",

--- a/test/intl402/DateTimeFormat/constructor-options-order-fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/constructor-options-order-fractionalSecondDigits.js
@@ -6,12 +6,7 @@
 esid: sec-initializedatetimeformat
 description: Checks the order of getting options of 'fractionalSecondDigits' for the DateTimeFormat constructor.
 info: |
-  ToDateTimeOptions ( options, required, defaults )
-  5. If required is "time" or "any", then
-    a. For each of the property names "hour", "minute", "second", "fractionalSecondDigits", do
-
   InitializeDateTimeFormat ( dateTimeFormat, locales, options )
-  2. Let options be ? ToDateTimeOptions(options, "any", "date").
   4. Let matcher be ? GetOption(options, "localeMatcher", "string", «  "lookup", "best fit" », "best fit").
   22. For each row of Table 5, except the header row, do
     a. Let value be ? GetOption(options, prop, "string", « the strings given in the Values column of the row », undefined).
@@ -25,9 +20,6 @@ features: [Intl.DateTimeFormat-fractionalSecondDigits]
 // between second and localeMatcher the first time and
 // between timeZoneName and formatMatcher the second time.
 const expected = [
-  // InitializeDateTimeFormat step 2.
-  //  ToDateTimeOptions step 5.
-  "second", "fractionalSecondDigits",
   // InitializeDateTimeFormat step 4.
   "localeMatcher",
   // InitializeDateTimeFormat step 22.

--- a/test/intl402/DateTimeFormat/constructor-options-order-timedate-style.js
+++ b/test/intl402/DateTimeFormat/constructor-options-order-timedate-style.js
@@ -11,15 +11,6 @@ features: [Intl.DateTimeFormat-datetimestyle]
 // To be merged into constructor-options-order.js when the feature is removed.
 
 const expected = [
-  // ToDateTimeOptions step 4.
-  "weekday", "year", "month", "day",
-  // ToDateTimeOptions step 5.
-  "hour", "minute", "second",
-  // ToDateTimeOptions step 6.
-  "dateStyle",
-  // ToDateTimeOptions step 7.
-  "timeStyle",
-
   // InitializeDateTimeFormat step 4.
   "localeMatcher",
   // InitializeDateTimeFormat step 6.

--- a/test/intl402/DateTimeFormat/constructor-options-order.js
+++ b/test/intl402/DateTimeFormat/constructor-options-order.js
@@ -8,11 +8,6 @@ includes: [compareArray.js]
 ---*/
 
 const expected = [
-  // ToDateTimeOptions step 4.
-  "weekday", "year", "month", "day",
-  // ToDateTimeOptions step 5.
-  "hour", "minute", "second",
-
   // InitializeDateTimeFormat step 4.
   "localeMatcher",
   // InitializeDateTimeFormat step 6.


### PR DESCRIPTION
ECMA402 PR709 remove unnecessary duplicated GetOption calls This PR sync the test to PR709
PR709 recach TC39 consensus in July 2023 meeting.

https://github.com/tc39/ecma402/pull/709