### PR TITLE
Test Temporal.PlainTime parsing without full ISO strings

### DIFF
--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-with-utc-designator.js
@@ -10,6 +10,8 @@ features: [Temporal, arrow-function]
 const invalidStrings = [
   "2019-10-01T09:00:00Z",
   "2019-10-01T09:00:00Z[UTC]",
+  "09:00:00Z[UTC]",
+  "09:00:00Z",
 ];
 const instance = new Temporal.PlainDate(2000, 5, 2);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-with-utc-designator.js
@@ -10,6 +10,8 @@ features: [Temporal, arrow-function]
 const invalidStrings = [
   "2019-10-01T09:00:00Z",
   "2019-10-01T09:00:00Z[UTC]",
+  "09:00:00Z[UTC]",
+  "09:00:00Z",
 ];
 const instance = new Temporal.PlainDate(2000, 5, 2);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-with-utc-designator.js
@@ -10,6 +10,8 @@ features: [Temporal, arrow-function]
 const invalidStrings = [
   "2019-10-01T09:00:00Z",
   "2019-10-01T09:00:00Z[UTC]",
+  "09:00:00Z[UTC]",
+  "09:00:00Z",
 ];
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainTime/compare/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-string-with-utc-designator.js
@@ -10,6 +10,8 @@ features: [Temporal, arrow-function]
 const invalidStrings = [
   "2019-10-01T09:00:00Z",
   "2019-10-01T09:00:00Z[UTC]",
+  "09:00:00Z[UTC]",
+  "09:00:00Z",
 ];
 const plainTime = new Temporal.PlainTime();
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainTime/from/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-string-with-utc-designator.js
@@ -10,6 +10,8 @@ features: [Temporal, arrow-function]
 const invalidStrings = [
   "2019-10-01T09:00:00Z",
   "2019-10-01T09:00:00Z[UTC]",
+  "09:00:00Z[UTC]",
+  "09:00:00Z",
 ];
 invalidStrings.forEach((arg) => {
   assert.throws(

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-with-utc-designator.js
@@ -10,6 +10,8 @@ features: [Temporal, arrow-function]
 const invalidStrings = [
   "2019-10-01T09:00:00Z",
   "2019-10-01T09:00:00Z[UTC]",
+  "09:00:00Z[UTC]",
+  "09:00:00Z",
 ];
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-with-utc-designator.js
@@ -10,6 +10,8 @@ features: [Temporal, arrow-function]
 const invalidStrings = [
   "2019-10-01T09:00:00Z",
   "2019-10-01T09:00:00Z[UTC]",
+  "09:00:00Z[UTC]",
+  "09:00:00Z",
 ];
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-with-utc-designator.js
@@ -10,6 +10,8 @@ features: [Temporal, arrow-function]
 const invalidStrings = [
   "2019-10-01T09:00:00Z",
   "2019-10-01T09:00:00Z[UTC]",
+  "09:00:00Z[UTC]",
+  "09:00:00Z",
 ];
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-with-utc-designator.js
@@ -10,6 +10,8 @@ features: [Temporal, arrow-function]
 const invalidStrings = [
   "2019-10-01T09:00:00Z",
   "2019-10-01T09:00:00Z[UTC]",
+  "09:00:00Z[UTC]",
+  "09:00:00Z",
 ];
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 invalidStrings.forEach((arg) => {


### PR DESCRIPTION
Codecov showed that PlainTime strings like "09:00:00Z[UTC]" or "09:00:00Z" were not being tested. This commit fills that gap.

It'd probably be good to make similar changes for other Plain* types, but Codecov didn't complain about them so they may be covered via other tests so it was less urgent.