### PR TITLE
use proper isConstructor check for recently added ArrayBuffer/SharedArrayBuffer tests

### DIFF
--- a/test/built-ins/ArrayBuffer/prototype/resize/nonconstructor.js
+++ b/test/built-ins/ArrayBuffer/prototype/resize/nonconstructor.js
@@ -11,13 +11,11 @@ info: |
     Built-in function objects that are not identified as constructors do not
     implement the [[Construct]] internal method unless otherwise specified
     in the description of a particular function.
-features: [resizable-arraybuffer]
+includes: [isConstructor.js]
+features: [resizable-arraybuffer, Reflect.construct]
 ---*/
 
-assert.sameValue(
-  Object.prototype.hasOwnProperty.call(ArrayBuffer.prototype.resize, 'prototype'),
-  false
-);
+assert(!isConstructor(ArrayBuffer.prototype.resize), "ArrayBuffer.prototype.resize is not a constructor");
 
 var arrayBuffer = new ArrayBuffer(8);
 assert.throws(TypeError, function() {

--- a/test/built-ins/ArrayBuffer/prototype/slice/nonconstructor.js
+++ b/test/built-ins/ArrayBuffer/prototype/slice/nonconstructor.js
@@ -12,9 +12,11 @@ info: |
     Built-in function objects that are not identified as constructors do not
     implement the [[Construct]] internal method unless otherwise specified
     in the description of a particular function.
+includes: [isConstructor.js]
+features: [Reflect.construct]
 ---*/
 
-assert.sameValue(Object.prototype.hasOwnProperty.call(ArrayBuffer.prototype.slice, "prototype"), false);
+assert(!isConstructor(ArrayBuffer.prototype.slice), "ArrayBuffer.prototype.slice is not a constructor");
 
 var arrayBuffer = new ArrayBuffer(8);
 assert.throws(TypeError, function() {

--- a/test/built-ins/ArrayBuffer/prototype/transfer/nonconstructor.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/nonconstructor.js
@@ -11,13 +11,11 @@ info: |
     Built-in function objects that are not identified as constructors do not
     implement the [[Construct]] internal method unless otherwise specified
     in the description of a particular function.
-features: [arraybuffer-transfer]
+includes: [isConstructor.js]
+features: [arraybuffer-transfer, Reflect.construct]
 ---*/
 
-assert.sameValue(
-  Object.prototype.hasOwnProperty.call(ArrayBuffer.prototype.transfer, 'prototype'),
-  false
-);
+assert(!isConstructor(ArrayBuffer.prototype.transfer), "ArrayBuffer.prototype.transfer is not a constructor");
 
 var arrayBuffer = new ArrayBuffer(8);
 assert.throws(TypeError, function() {

--- a/test/built-ins/ArrayBuffer/prototype/transferToFixedLength/nonconstructor.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToFixedLength/nonconstructor.js
@@ -11,13 +11,11 @@ info: |
     Built-in function objects that are not identified as constructors do not
     implement the [[Construct]] internal method unless otherwise specified
     in the description of a particular function.
-features: [arraybuffer-transfer]
+includes: [isConstructor.js]
+features: [arraybuffer-transfer, Reflect.construct]
 ---*/
 
-assert.sameValue(
-  Object.prototype.hasOwnProperty.call(ArrayBuffer.prototype.transferToFixedLength, 'prototype'),
-  false
-);
+assert(!isConstructor(ArrayBuffer.prototype.transferToFixedLength), "ArrayBuffer.prototype.transferToFixedLength is not a constructor");
 
 var arrayBuffer = new ArrayBuffer(8);
 assert.throws(TypeError, function() {

--- a/test/built-ins/SharedArrayBuffer/prototype/grow/nonconstructor.js
+++ b/test/built-ins/SharedArrayBuffer/prototype/grow/nonconstructor.js
@@ -11,13 +11,11 @@ info: |
     Built-in function objects that are not identified as constructors do not
     implement the [[Construct]] internal method unless otherwise specified
     in the description of a particular function.
-features: [SharedArrayBuffer, resizable-arraybuffer]
+includes: [isConstructor.js]
+features: [SharedArrayBuffer, resizable-arraybuffer, Reflect.construct]
 ---*/
 
-assert.sameValue(
-  Object.prototype.hasOwnProperty.call(SharedArrayBuffer.prototype.grow, 'prototype'),
-  false
-);
+assert(!isConstructor(SharedArrayBuffer.prototype.grow), "SharedArrayBuffer.prototype.grow is not a constructor");
 
 var arrayBuffer = new SharedArrayBuffer(8);
 assert.throws(TypeError, function() {

--- a/test/built-ins/SharedArrayBuffer/prototype/slice/nonconstructor.js
+++ b/test/built-ins/SharedArrayBuffer/prototype/slice/nonconstructor.js
@@ -12,10 +12,11 @@ info: |
     Built-in function objects that are not identified as constructors do not
     implement the [[Construct]] internal method unless otherwise specified
     in the description of a particular function.
-features: [SharedArrayBuffer]
+includes: [isConstructor.js]
+features: [SharedArrayBuffer, Reflect.construct]
 ---*/
 
-assert.sameValue(Object.prototype.hasOwnProperty.call(SharedArrayBuffer.prototype.slice, "prototype"), false);
+assert(!isConstructor(SharedArrayBuffer.prototype.slice), "SharedArrayBuffer.prototype.slice is not a constructor");
 
 var arrayBuffer = new SharedArrayBuffer(8);
 assert.throws(TypeError, function() {


### PR DESCRIPTION
This also allows these tests to be filtered out by "features".