### PR TITLE
updated Intl.DateTimeFormat.prototype.resolvedOptions() tests to reflect recent normative change

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-dateStyle.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-dateStyle.js
@@ -6,6 +6,30 @@ esid: sec-Intl.DateTimeFormat.prototype.resolvedOptions
 description: >
   Intl.DateTimeFormat.prototype.resolvedOptions properly
   reflect hourCycle settings when using dateStyle.
+  Note: "properly reflect hourCycle settings when using dateStyle", in this context, means "if dateStyle but not timeStyle is set, both hourCycle and hour12 will be *undefined*". This is because the CreateDateTimeFormat AO resets [[HourCycle]] to *undefined* if [[Hour]] is *undefined*, and if dateStyle but not timeStyle is set, [[HourCycle]] is set to *undefined*. 
+info: |
+  11.3.7 Intl.DateTimeFormat.prototype.resolvedOptions()
+  ...
+  5. For each row of Table 6, except the header row, in table order, do
+    a. Let p be the Property value of the current row.
+    b. If p is "hour12", then
+        i. Let hc be dtf.[[HourCycle]].
+        ii. If hc is "h11" or "h12", let v be true.
+        iii. Else if, hc is "h23" or "h24", let v be false.
+        iv. Else, let v be undefined.
+    c. Else,
+        i. Let v be the value of dtf's internal slot whose name is the Internal Slot value of the current row.
+    d. If the Internal Slot value of the current row is an Internal Slot value in Table 7, then
+        i. If dtf.[[DateStyle]] is not undefined or dtf.[[TimeStyle]] is not undefined, then
+            1. Let v be undefined.
+    e. If v is not undefined, then
+        i. Perform ! CreateDataPropertyOrThrow(options, p, v).
+
+  11.1.2 CreateDateTimeFormat( newTarget, locales, options, required, defaults)
+  ...
+  45. If dateTimeFormat.[[Hour]] is undefined, then
+
+    a. Set dateTimeFormat.[[HourCycle]] to undefined.
 features: [Intl.DateTimeFormat-datetimestyle]
 ---*/
 
@@ -17,7 +41,7 @@ for (const dateStyle of ["full", "long", "medium", "short"]) {
                    dateStyle,
                    `Should support dateStyle=${dateStyle}`);
 
-  /* Values passed via unicode extension key work */
+  /* Values passed via unicode extension key set to *undefined* */
 
   for (const hcValue of hcValues) {
     const resolvedOptions = new Intl.DateTimeFormat(`de-u-hc-${hcValue}`, {
@@ -28,7 +52,7 @@ for (const dateStyle of ["full", "long", "medium", "short"]) {
     assert.sameValue(resolvedOptions.hour12, undefined);
   }
 
-  /* Values passed via options work */
+  /* Values passed via options set to *undefined**/
 
   for (const hcValue of hcValues) {
     const resolvedOptions = new Intl.DateTimeFormat("en-US", {

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc. All rights reserved.
+// Copyright 2019 Google Inc., 2023 Igalia S.L. All rights reserved.
 // This code is governed by the license found in the LICENSE file.
 
 /*---
@@ -7,50 +7,37 @@ description: >
   Intl.DateTimeFormat.prototype.resolvedOptions properly
   reflect hourCycle settings.
 info: |
-  12.4.5 Intl.DateTimeFormat.prototype.resolvedOptions()
+  11.3.7 Intl.DateTimeFormat.prototype.resolvedOptions()
 
   11.1.2 CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
-   29. If dateTimeFormat.[[Hour]] is not undefined, then
-     a. Let hcDefault be dataLocaleData.[[hourCycle]].
-     b. Let hc be dateTimeFormat.[[HourCycle]].
-     c. If hc is null, then
-        i. Set hc to hcDefault.
-     d. If hour12 is not undefined, then
-        i. If hour12 is true, then
-           1. If hcDefault is "h11" or "h23", then
-              a. Set hc to "h11".
-           2. Else,
-              a. Set hc to "h12".
-        ii. Else,
-           1. Assert: hour12 is false.
-           2. If hcDefault is "h11" or "h23", then
-              a. Set hc to "h23".
-           3. Else,
-              a. Set hc to "h24".
-     e. Set dateTimeFormat.[[HourCycle]] to hc.
-     
-locale: [en, fr, it, ja, zh, ko, ar, hi]
+   23. Let dataLocaleData be localeData.[[<dataLocale>]].
+   24. If hour12 is true, then
+       a. Let hc be dataLocaleData.[[hourCycle12]].
+   25. Else if hour12 is false, then
+       a. Let hc be dataLocaleData.[[hourCycle24]].
+   26. Else,
+        a. Assert: hour12 is undefined.
+        b. Let hc be r.[[hc]].
+        c. If hc is null, set hc to dataLocaleData.[[hourCycle]].
+  27. Set dateTimeFormat.[[HourCycle]] to hc.
+
+locale: [en, fr, it, ja, zh, ko, ar, hi, en-u-hc-h24]
 ---*/
 
 let locales = ["en", "fr", "it", "ja", "zh", "ko", "ar", "hi"];
 
 locales.forEach(function(locale) {
-  let hcDefault = (new Intl.DateTimeFormat(locale, {hour: "numeric"}))
-      .resolvedOptions().hourCycle;
-  if (hcDefault == "h11" || hcDefault == "h23") {
-    assert.sameValue("h11",
-        (new Intl.DateTimeFormat(locale, {hour: "numeric", hour12: true}))
-        .resolvedOptions().hourCycle);
-    assert.sameValue("h23",
-        (new Intl.DateTimeFormat(locale, {hour: "numeric", hour12: false}))
-        .resolvedOptions().hourCycle);
-  } else {
-    assert.sameValue(true, hcDefault == "h12" || hcDefault == "h24")
-    assert.sameValue("h12",
-        (new Intl.DateTimeFormat(locale, {hour: "numeric", hour12: true}))
-        .resolvedOptions().hourCycle);
-    assert.sameValue("h24",
-        (new Intl.DateTimeFormat(locale, {hour: "numeric", hour12: false}))
-        .resolvedOptions().hourCycle);
+  let hcDefault = new Intl.DateTimeFormat(locale, { hour: "numeric" }).resolvedOptions().hourCycle;
+  if (hcDefault === "h11" || hcDefault === "h12") {
+    assert.sameValue(new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: true }).resolvedOptions().hourCycle, hcDefault);
+
+    // no locale has "h24" as a default. see https://github.com/tc39/ecma402/pull/758#issue-1622377292
+    assert.sameValue(new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: false }).resolvedOptions().hourCycle, "h23");
+  }
+  if (hcDefault === "h23" || hcDefault === "h24") {
+    assert.sameValue(new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: false }).resolvedOptions().hourCycle, hcDefault);
+
+    let hcHour12 = new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: true }).resolvedOptions().hourCycle;
+    assert((hcHour12 === "h11" || hcHour12 === "h12"), "Expected `hourCycle` to be in ['h11', 'h12']");
   }
 });

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js
@@ -24,7 +24,7 @@ info: |
 locale: [en, fr, it, ja, zh, ko, ar, hi, en-u-hc-h24]
 ---*/
 
-let locales = ["en", "fr", "it", "ja", "zh", "ko", "ar", "hi"];
+let locales = ["en", "fr", "it", "ja", "ja-u-hc-h11", "zh", "ko", "ar", "hi", "en-u-hc-h24"];
 
 locales.forEach(function(locale) {
   let hcDefault = new Intl.DateTimeFormat(locale, { hour: "numeric" }).resolvedOptions().hourCycle;
@@ -34,10 +34,12 @@ locales.forEach(function(locale) {
     // no locale has "h24" as a default. see https://github.com/tc39/ecma402/pull/758#issue-1622377292
     assert.sameValue(new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: false }).resolvedOptions().hourCycle, "h23");
   }
+
+  // however, "h24" can be set via locale extension.
   if (hcDefault === "h23" || hcDefault === "h24") {
     assert.sameValue(new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: false }).resolvedOptions().hourCycle, hcDefault);
-
-    let hcHour12 = new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: true }).resolvedOptions().hourCycle;
-    assert((hcHour12 === "h11" || hcHour12 === "h12"), "Expected `hourCycle` to be in ['h11', 'h12']");
   }
+
+  let hcHour12 = new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: true }).resolvedOptions().hourCycle;
+  assert(hcHour12 === "h11" || hcHour12 === "h12", "Expected `hourCycle`: " + hcHour12 + " to be in [\"h11\", \"h12\"]");
 });


### PR DESCRIPTION
Address https://github.com/tc39/test262/issues/3812 
Fix #3876 

https://github.com/tc39/ecma402/pull/758 changes the `hourCycle` logic in Intl.DateTimeFormat.InitializeDateAndTime() to no longer erroneously assume that `h24` is the 24 hour clock expected in locales using `h11` or `h12` as defaults.

73537444cb14a80f0276453f235951068f41b1b9 and 15792dab3be7758f0be7105f67902698e0865078 update hourCycle-default.js to reflect the new behaviour.

note: I don't believe any engine currently passes all of the tests in the new `hourCycle-default.js`. v8 and node fail because they associate `h12` with `h24`, as was required by the old algorithm, while jsc and spidermonkey fail because they ignore the -u-hc-h24 extension when `hour12` is set to `false`, as below:

```js

// sm and jsc
new Intl.DateTimeFormat('en-u-hc-h24', {hour: "numeric", hour12: false}).resolvedOptions().hourCycle;
=> "h23"
```

commit 26481445717e1f66baa32bbac063d3fa7c306d66 updates hourCycle-dateStyle.js with explanatory comments. Essentially, all this test does is verify that `hour12` and `hourCycle` are set to `undefined` when `dateStyle` but not `timeStyle` is set, but the comments and metadata in the previous version appear to say something different.