### PR TITLE
change metadata in Intl.DateTimeFormat tests to reflect recent editorial change

### DIFF
--- a/test/intl402/DateTimeFormat/casing-numbering-system-calendar-options.js
+++ b/test/intl402/DateTimeFormat/casing-numbering-system-calendar-options.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Tests that the options numberingSystem and calendar are mapped
     to lower case properly.

--- a/test/intl402/DateTimeFormat/constructor-calendar-numberingSystem-order.js
+++ b/test/intl402/DateTimeFormat/constructor-calendar-numberingSystem-order.js
@@ -2,18 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
   Checks the order of getting "calendar" and "numberingSystem" options in the
   DateTimeFormat is between "localeMatcher" and "hour12" options.
 info: |
-  4. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
+  5. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, ~string~, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
   ...
-  6. Let _calendar_ be ? GetOption(_options_, `"calendar"`, `"string"`, *undefined*, *undefined*).
+  7. Let _calendar_ be ? GetOption(_options_, `"calendar"`, ~string~ , ~empty~, *undefined*).
   ...
-  9. Let _numberingSystem_ be ? GetOption(_options_, `"numberingSystem"`, `"string"`, *undefined*, *undefined*).
+  10. Let _numberingSystem_ be ? GetOption(_options_, `"numberingSystem"`, ~string~, ~empty~, *undefined*).
   ...
-  12. Let _hour12_ be ? GetOption(_options_, `"hour12"`, `"boolean"`, *undefined*, *undefined*).
+  13. Let _hour12_ be ? GetOption(_options_, `"hour12"`, ~boolean~, ~empty~, *undefined*).
 includes: [compareArray.js]
 ---*/
 

--- a/test/intl402/DateTimeFormat/constructor-default-value.js
+++ b/test/intl402/DateTimeFormat/constructor-default-value.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
   Tests that the constructor for Intl.DateTimeFormat uses appropriate default
   values for its arguments (locales and options).

--- a/test/intl402/DateTimeFormat/constructor-options-calendar-invalid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-calendar-invalid.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Checks error cases for the options argument to the DateTimeFormat constructor.
 info: |
-    InitializeDateTimeFormat ( dateTimeFormat, locales, options )
+    CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
 
     ...
-    7. If calendar is not undefined, then
+    8. If calendar is not undefined, then
         a. If calendar does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
 ---*/
 

--- a/test/intl402/DateTimeFormat/constructor-options-dateStyle-invalid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-dateStyle-invalid.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Checks error cases for the options argument to the DateTimeFormat constructor.
 info: |
-    InitializeDateTimeFormat ( dateTimeFormat, locales, options )
+    CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
 
     ...
-    28. Let dateStyle be ? GetOption(options, "dateStyle", "string", « "full", "long", "medium", "short" », undefined).
+    39. Let dateStyle be ? GetOption(options, "dateStyle", "string", « "full", "long", "medium", "short" », undefined).
 features: [Intl.DateTimeFormat-datetimestyle]
 ---*/
 

--- a/test/intl402/DateTimeFormat/constructor-options-dateStyle-valid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-dateStyle-valid.js
@@ -2,15 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Checks handling of the options argument to the DateTimeFormat constructor.
 info: |
-    InitializeDateTimeFormat ( dateTimeFormat, locales, options )
+    CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
 
     ...
-    28. Let dateStyle be ? GetOption(options, "dateStyle", "string", « "full", "long", "medium", "short" », undefined).
-    29. If dateStyle is not undefined, set dateTimeFormat.[[DateStyle]] to dateStyle.
+    39. Let dateStyle be ? GetOption(options, "dateStyle", "string", « "full", "long", "medium", "short" », undefined).
+    40. If dateStyle is not undefined, set dateTimeFormat.[[DateStyle]] to dateStyle.
 features: [Intl.DateTimeFormat-datetimestyle]
 ---*/
 

--- a/test/intl402/DateTimeFormat/constructor-options-dayPeriod-invalid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-dayPeriod-invalid.js
@@ -2,12 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
   Checks error cases for the options argument to the DateTimeFormat constructor.
 info: |
   [[DayPeriod]]    `"dayPeriod"`    `"narrow"`, `"short"`, `"long"`
-  InitializeDateTimeFormat ( dateTimeFormat, locales, options )
+  CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
 
   ...
 features: [Intl.DateTimeFormat-dayPeriod]

--- a/test/intl402/DateTimeFormat/constructor-options-dayPeriod-valid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-dayPeriod-valid.js
@@ -2,12 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
   Checks handling of the options argument to the DateTimeFormat constructor.
 info: |
   [[DayPeriod]]    `"dayPeriod"`    `"narrow"`, `"short"`, `"long"`
-  InitializeDateTimeFormat ( dateTimeFormat, locales, options )
+  CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
 
   ...
 features: [Intl.DateTimeFormat-dayPeriod]

--- a/test/intl402/DateTimeFormat/constructor-options-fractionalSecondDigits-invalid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-fractionalSecondDigits-invalid.js
@@ -2,14 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Checks error cases for the options argument to the DateTimeFormat constructor.
 info: |
-    InitializeDateTimeFormat ( dateTimeFormat, locales, options )
-    23. Let _opt_.[[FractionalSecondDigits]] be ? GetNumberOption(_options_, `"fractionalSecondDigits"`, 0, 3, 0).
-
+    CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
     ...
+    37. For each row of Table 7, except the header row, in table order, do
+      a. Let prop be the name given in the Property column of the row.
+      b. If prop is "fractionalSecondDigits", then
+          i. Let value be ? GetNumberOption(options, "fractionalSecondDigits", 1, 3, undefined).
 features: [Intl.DateTimeFormat-fractionalSecondDigits]
 ---*/
 

--- a/test/intl402/DateTimeFormat/constructor-options-fractionalSecondDigits-valid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-fractionalSecondDigits-valid.js
@@ -2,12 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Checks handling of the options argument to the DateTimeFormat constructor.
 info: |
-    InitializeDateTimeFormat ( dateTimeFormat, locales, options )
-    23. Let _opt_.[[FractionalSecondDigits]] be ? GetNumberOption(_options_, `"fractionalSecondDigits"`, 0, 3, 0).
+    CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
+    ...
+    37. For each row of Table 7, except the header row, in table order, do
+      a. Let prop be the name given in the Property column of the row.
+      b. If prop is "fractionalSecondDigits", then
+        i. Let value be ? GetNumberOption(options, "fractionalSecondDigits", 1, 3, undefined).
 features: [Intl.DateTimeFormat-fractionalSecondDigits]
 ---*/
 

--- a/test/intl402/DateTimeFormat/constructor-options-numberingSystem-invalid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-numberingSystem-invalid.js
@@ -2,14 +2,13 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Checks error cases for the options argument to the DateTimeFormat constructor.
 info: |
-    InitializeDateTimeFormat ( dateTimeFormat, locales, options )
-
+    CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
     ...
-    10. If numberingSystem is not undefined, then
+    27. If numberingSystem is not undefined, then
         a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
 ---*/
 

--- a/test/intl402/DateTimeFormat/constructor-options-style-conflict.js
+++ b/test/intl402/DateTimeFormat/constructor-options-style-conflict.js
@@ -2,19 +2,20 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Conflicting properties of dateStyle/timeStyle must be rejected with a TypeError for the options argument to the DateTimeFormat constructor.
 info: |
     InitializeDateTimeFormat ( dateTimeFormat, locales, options )
 
     ...
-    36. If dateStyle is not undefined or timeStyle is not undefined, then
-      a. For each row in Table 4, except the header row, do
-        i. Let prop be the name given in the Property column of the row.
-        ii. Let p be opt.[[<prop>]].
-        iii. If p is not undefined, then
-          1. Throw a TypeError exception.
+    43. If dateStyle is not undefined or timeStyle is not undefined, then
+      a. If hasExplicitFormatComponents is true, then
+        i. Throw a TypeError exception.
+      b. If required is date and timeStyle is not undefined, then
+        i. Throw a TypeError exception.
+      c. If required is time and dateStyle is not undefined, then
+        i. Throw a TypeError exception.
 ---*/
 
 

--- a/test/intl402/DateTimeFormat/constructor-options-throwing-getters-dayPeriod.js
+++ b/test/intl402/DateTimeFormat/constructor-options-throwing-getters-dayPeriod.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks the propagation of exceptions from the options for the DateTimeFormat constructor.
 features: [Intl.DateTimeFormat-dayPeriod]
 ---*/

--- a/test/intl402/DateTimeFormat/constructor-options-throwing-getters-fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/constructor-options-throwing-getters-fractionalSecondDigits.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks the propagation of exceptions from the options for the DateTimeFormat constructor.
 features: [Intl.DateTimeFormat-fractionalSecondDigits]
 ---*/

--- a/test/intl402/DateTimeFormat/constructor-options-throwing-getters-timedate-style.js
+++ b/test/intl402/DateTimeFormat/constructor-options-throwing-getters-timedate-style.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks the propagation of exceptions from the options for the DateTimeFormat constructor.
 features: [Intl.DateTimeFormat-datetimestyle]
 ---*/
@@ -12,9 +12,9 @@ features: [Intl.DateTimeFormat-datetimestyle]
 function CustomError() {}
 
 const options = [
-  // InitializeDateTimeFormat step 28
+  // CreateDateTimeFormat step 39 
   "dateStyle",
-  // InitializeDateTimeFormat step 30
+  // CreateDateTimeFormat step 41 
   "timeStyle",
 ];
 

--- a/test/intl402/DateTimeFormat/constructor-options-throwing-getters.js
+++ b/test/intl402/DateTimeFormat/constructor-options-throwing-getters.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks the propagation of exceptions from the options for the DateTimeFormat constructor.
 ---*/
 

--- a/test/intl402/DateTimeFormat/constructor-options-timeStyle-invalid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-timeStyle-invalid.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Checks error cases for the options argument to the DateTimeFormat constructor.
 info: |
-    InitializeDateTimeFormat ( dateTimeFormat, locales, options )
+    CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
 
     ...
-    30. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full", "long", "medium", "short" », undefined).
+    41. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full", "long", "medium", "short" », undefined).
 features: [Intl.DateTimeFormat-datetimestyle]
 ---*/
 

--- a/test/intl402/DateTimeFormat/constructor-options-timeStyle-valid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-timeStyle-valid.js
@@ -2,15 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Checks handling of the options argument to the DateTimeFormat constructor.
 info: |
-    InitializeDateTimeFormat ( dateTimeFormat, locales, options )
+    CreateDateTimeFormat ( dateTimeFormat, locales, options, required, default )
 
     ...
-    30. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full", "long", "medium", "short" », undefined).
-    31. If timeStyle is not undefined, set dateTimeFormat.[[TimeStyle]] to timeStyle.
+    41. Let timeStyle be ? GetOption(options, "timeStyle", string, « "full", "long", "medium", "short" », undefined).
+    42. Set dateTimeFormat.[[TimeStyle]] to timeStyle.
 features: [Intl.DateTimeFormat-datetimestyle]
 ---*/
 

--- a/test/intl402/DateTimeFormat/constructor-options-timeZoneName-invalid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-timeZoneName-invalid.js
@@ -1,7 +1,7 @@
 // Copyright 2021 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
   Invalid values for the `timeZoneName` option of the DateTimeFormat constructor
 features: [Intl.DateTimeFormat-extend-timezonename]

--- a/test/intl402/DateTimeFormat/constructor-options-timeZoneName-valid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-timeZoneName-valid.js
@@ -1,7 +1,7 @@
 // Copyright 2021 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
   Valid values for the `timeZoneName` option of the DateTimeFormat constructor
 features: [Intl.DateTimeFormat-extend-timezonename]

--- a/test/intl402/DateTimeFormat/constructor-options-toobject.js
+++ b/test/intl402/DateTimeFormat/constructor-options-toobject.js
@@ -2,15 +2,11 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
   Tests that Intl.DateTimeFormat contructor converts the options argument
   to an object using `ToObject` (7.1.13).
-info: |
-  12.1.2 ToDateTimeOptions
 
-  1. If options is undefined, let options be null; otherwise let options be ?
-  ToObject(options).
 ---*/
 
 const toObjectResults = [

--- a/test/intl402/DateTimeFormat/numbering-system-calendar-options.js
+++ b/test/intl402/DateTimeFormat/numbering-system-calendar-options.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Tests that the options numberingSystem and calendar can be  set through
     either the locale or the options.

--- a/test/intl402/DateTimeFormat/prototype/format/dayPeriod-long-en.js
+++ b/test/intl402/DateTimeFormat/prototype/format/dayPeriod-long-en.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, long format.
 features: [Intl.DateTimeFormat-dayPeriod]
 locale: [en-US]

--- a/test/intl402/DateTimeFormat/prototype/format/dayPeriod-narrow-en.js
+++ b/test/intl402/DateTimeFormat/prototype/format/dayPeriod-narrow-en.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, narrow format.
 features: [Intl.DateTimeFormat-dayPeriod]
 locale: [en-US]

--- a/test/intl402/DateTimeFormat/prototype/format/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/format/fractionalSecondDigits.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks basic handling of fractionalSecondDigits.
 features: [Intl.DateTimeFormat-fractionalSecondDigits]
 locale: [en-US]

--- a/test/intl402/DateTimeFormat/prototype/formatRange/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRange/fractionalSecondDigits.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks basic handling of fractionalSecondDigits.
 features: [Intl.DateTimeFormat-fractionalSecondDigits, Intl.DateTimeFormat-formatRange]
 locale: [en-US]

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/fractionalSecondDigits.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks basic handling of fractionalSecondDigits.
 features: [Intl.DateTimeFormat-fractionalSecondDigits, Intl.DateTimeFormat-formatRange]
 locale: [en-US]

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/pattern-on-calendar.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/pattern-on-calendar.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
   Checks the DateTimeFormat choose different patterns based
   on calendar.

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-long-en.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-long-en.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, long format.
 features: [Intl.DateTimeFormat-dayPeriod]
 ---*/

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-narrow-en.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-narrow-en.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, narrow format.
 features: [Intl.DateTimeFormat-dayPeriod]
 ---*/

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-short-en.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-short-en.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, short format.
 features: [Intl.DateTimeFormat-dayPeriod]
 ---*/

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/fractionalSecondDigits.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: Checks basic handling of fractionalSecondDigits.
 features: [Intl.DateTimeFormat-fractionalSecondDigits]
 locale: [en-US]

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/pattern-on-calendar.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/pattern-on-calendar.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
   Checks the DateTimeFormat choose different patterns based
   on calendar.

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js
@@ -9,7 +9,7 @@ description: >
 info: |
   12.4.5 Intl.DateTimeFormat.prototype.resolvedOptions()
 
-  12.1.1 InitializeDateTimeFormat ( dateTimeFormat, locales, options )
+  11.1.2 CreateDateTimeFormat ( dateTimeFormat, locales, options, required, defaults )
    29. If dateTimeFormat.[[Hour]] is not undefined, then
      a. Let hcDefault be dataLocaleData.[[hourCycle]].
      b. Let hc be dateTimeFormat.[[HourCycle]].

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-locale-with-hc-unicode.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-locale-with-hc-unicode.js
@@ -7,13 +7,12 @@ description: >
   The resolved locale doesn't include a hc Unicode extension value if the
   hour12 or hourCycle option is also present.
 info: |
-  12.1.1 InitializeDateTimeFormat(dateTimeFormat, locales, options)
+  11.1.2 CreateDateTimeFormat( dateTimeFormat, locales, options, required, defaults )
     ...
-    6. Let hour12 be ? GetOption(options, "hour12", "boolean", undefined, undefined).
-    7. Let hourCycle be ? GetOption(options, "hourCycle", "string", « "h11", "h12", "h23", "h24" », undefined).
-    8. If hour12 is not undefined, then
-      a. Let hourCycle be null.
-    9. Set opt.[[hc]] to hourCycle.
+    13. Let hour12 be ? GetOption(options, "hour12", boolean, empty, undefined).
+    14. Let hourCycle be ? GetOption(options, "hourCycle", string, « "h11", "h12", "h23", "h24" », undefined).
+    15. If hour12 is not undefined, then
+      a. Set hourCycle to null.
     ...
 
   9.2.6 ResolveLocale(availableLocales, requestedLocales, options, relevantExtensionKeys, localeData)

--- a/test/intl402/DateTimeFormat/taint-Object-prototype-dayPeriod.js
+++ b/test/intl402/DateTimeFormat/taint-Object-prototype-dayPeriod.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Tests that the behavior of a Record is not affected by
     adversarial changes to Object.prototype.

--- a/test/intl402/DateTimeFormat/taint-Object-prototype-fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/taint-Object-prototype-fractionalSecondDigits.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-initializedatetimeformat
+esid: sec-createdatetimeformat
 description: >
     Tests that the behavior of a Record is not affected by
     adversarial  changes to Object.prototype.


### PR DESCRIPTION
 https://github.com/tc39/ecma402/commit/6e3b70dcae3fed2472a1af7a99de7e6c842b6406  renames the InitializeDateTimeFormat AO to CreateDateTimeFormat. This PR updates the metadata on Intl.DateTimeFormat tests to refer to this new AO and sec-createdatetimeformat rather than sec-initializedatetimeformat.