### PR TITLE
Update to reflect normative change in formatting when Intl.DurationFormat's fractionalDigits option is undefined

### DIFF
--- a/test/intl402/DurationFormat/constructor-options-fractionalDigits-valid.js
+++ b/test/intl402/DurationFormat/constructor-options-fractionalDigits-valid.js
@@ -15,7 +15,8 @@ const validOptions = [
   0,
   1,
   5,
-  9
+  9,
+  undefined
 ];
 
 for (const fractionalDigits of validOptions) {

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-partitiondurationformatpattern
+description: >
+  Test to ensure that correct number of fractional digits is displayed (i.e. however many are necessary to represent the data fully) if the fractionalDigits option is left *undefined*
+
+info: |
+  4. If durationFormat.[[FractionalDigits]] is undefined, then
+    a. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", 9).
+    b. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", 0).
+  5. Else,
+    a. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", durationFormat.[[FractionalDigits]]).
+    b. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", durationFormat.[[FractionalDigits]]).
+    
+---*/
+
+
+const durationNano = {
+  hours: 1,
+  minutes: 22,
+  seconds: 33,
+  milliseconds: 111,
+  microseconds: 222,
+  nanoseconds: 333
+};
+
+const durationMicro = {
+  hours: 1,
+  minutes: 22,
+  seconds: 33,
+  milliseconds: 111,
+  microseconds: 222
+};
+
+const durationMill = {
+  hours: 1,
+  minutes: 22,
+  seconds: 33,
+  milliseconds: 111
+}
+
+const durationNoSubsecond = {
+  hours: 1,
+  minutes: 22,
+  seconds: 33
+}
+
+const style = "digital";
+const df = new Intl.DurationFormat(undefined, {style, fractionalDigits: undefined});
+
+assert.sameValue(df.format(durationNano), "1:22:33.111222333", `format output with nanosecond digits and fractionalDigits: undefined using ${style} style option`);
+assert.sameValue(df.format(durationMicro), "1:22:33.111222", `format output with microsecond digits and fractionalDigits: undefined using ${style} style option`);
+assert.sameValue(df.format(durationMilli), "1:22:33.111", `format output with millisecond digits and fractionalDigits: undefined using ${style} style option`);
+assert.sameValue(df.format(durationNoSubsecond), "1:22:33", `format output with no subsecond digits and fractionalDigits: undefined using ${style} style option`);

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined.js
@@ -39,13 +39,22 @@ const durationMill = {
   minutes: 22,
   seconds: 33,
   milliseconds: 111
-}
+};
 
 const durationNoSubsecond = {
   hours: 1,
   minutes: 22,
   seconds: 33
-}
+};
+
+const durationSevenFractional = {
+  hours: 2,
+  minutes: 30,
+  seconds: 10,
+  milliseconds: 111,
+  microseconds: 220,
+  nanoseconds: 300
+};
 
 const style = "digital";
 const df = new Intl.DurationFormat(undefined, {style, fractionalDigits: undefined});
@@ -54,3 +63,6 @@ assert.sameValue(df.format(durationNano), "1:22:33.111222333", `format output wi
 assert.sameValue(df.format(durationMicro), "1:22:33.111222", `format output with microsecond digits and fractionalDigits: undefined using ${style} style option`);
 assert.sameValue(df.format(durationMilli), "1:22:33.111", `format output with millisecond digits and fractionalDigits: undefined using ${style} style option`);
 assert.sameValue(df.format(durationNoSubsecond), "1:22:33", `format output with no subsecond digits and fractionalDigits: undefined using ${style} style option`);
+
+assert.sameValue(df.format(durationFiveFractional), "2:30:11122", `format output with five subsecond digits and fractionalDigits: undefined using ${style} style option`);
+assert.sameValue(df.format(durationSevenFractional), "2:30:1112203", `format output with seven subsecond digits and fractionalDigits: undefined using ${style} style option`);

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-partitiondurationformatpattern
+description: >
+  Test to ensure that correct number of fractional digits is displayed if fractionalDigits is explicitly specified.
+
+info: |
+  4. If durationFormat.[[FractionalDigits]] is undefined, then
+    a. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", 9).
+    b. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", 0).
+  5. Else,
+    a. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", durationFormat.[[FractionalDigits]]).
+    b. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", durationFormat.[[FractionalDigits]]).
+---*/
+
+const duration = {
+  hours: 1,
+  minutes: 22,
+  seconds: 33,
+  milliseconds: 111,
+  microseconds: 222,
+  nanoseconds: 333,
+};
+
+
+const style = "digital";
+const df = new Intl.DurationFormat(undefined, {style, fractionalDigits: 0});
+const dfMilli = new Intl.DurationFormat(undefined, {style, fractionalDigits: 3});
+const dfMicro = new Intl.DurationFormat(undefined, {style, fractionalDigits: 6});
+const dfNano = new Intl.DurationFormat(undefined, {style, fractionalDigits: 9});
+
+assert.sameValue(df.format(duration), "1:22:33", `format output without sub-second digits using ${style} style option`);
+
+assert.sameValue(dfMilli.format(duration), "1:22:33.111", `format output with sub-second digits and fractionalDigits: 3 using ${style} style option`);
+
+assert.sameValue(dfMicro.format(duration), "1:22:33.111222", `format output with sub-second digits and fractionalDigits: 6 using ${style} style option`);
+
+assert.sameValue(dfNano.format(duration), "1:22:33.111222333", `format output with sub-second digits and fractionalDigits: 9 using ${style} style option`);

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits.js
@@ -28,13 +28,19 @@ const duration = {
 const style = "digital";
 const df = new Intl.DurationFormat(undefined, {style, fractionalDigits: 0});
 const dfMilli = new Intl.DurationFormat(undefined, {style, fractionalDigits: 3});
+const dfFourDigits = new Intl.DurationFormat(undefined, {style, fractionalDigits: 4});
 const dfMicro = new Intl.DurationFormat(undefined, {style, fractionalDigits: 6});
+const dfEightDigits = new Intl.DurationFormat(undefined, {style, fractionalDigits: 8});
 const dfNano = new Intl.DurationFormat(undefined, {style, fractionalDigits: 9});
 
 assert.sameValue(df.format(duration), "1:22:33", `format output without sub-second digits using ${style} style option`);
 
 assert.sameValue(dfMilli.format(duration), "1:22:33.111", `format output with sub-second digits and fractionalDigits: 3 using ${style} style option`);
 
+assert.sameValue(dfFourDigits.format(duration), "1:22:33.1112", `format output with sub-second digits and fractionalDigits: 4 using ${style} style option`);
+
 assert.sameValue(dfMicro.format(duration), "1:22:33.111222", `format output with sub-second digits and fractionalDigits: 6 using ${style} style option`);
+
+assert.sameValue(dfEightDigits.format(duration), "1:22:33.11122233", `format output with sub-second digits and fractionalDigits: 8 using ${style} style option`);
 
 assert.sameValue(dfNano.format(duration), "1:22:33.111222333", `format output with sub-second digits and fractionalDigits: 9 using ${style} style option`);


### PR DESCRIPTION
https://github.com/tc39/proposal-intl-duration-format/issues/144 recently changed the behaviour of Intl.DurationFormat when the number of fractional digits (i.e. sub-second values) is left undefined.  prototype/format/style-digital-fractionalDigits-undefined.js tests for this case, prototype/format/style-digital-fractionalDigits.js provides additional test coverage for fractional digits in general.