### PR TITLE
Add different formatting for test/intl402/DurationFormat/prototype/format/style-digital-en.js

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/style-digital-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-en.js
@@ -1,4 +1,5 @@
 // Copyright 2022 Igalia, S.L. All rights reserved.
+// Copyright 2023 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -9,7 +10,7 @@ features: [Intl.DurationFormat]
 ---*/
 
 const style = "digital";
-const expected = "1 yr 2 mths 3 wks 3 days 4:05:06";
+const expected = "1 yr, 2 mths, 3 wks, 3 days, 4:05:06";
 
 const duration = {
   years: 1,


### PR DESCRIPTION
ECMA-402 does not require specific CLDR format, and each platform has some customization for their platform consistency.
macOS system ICU is shipping new CLDR, but it has many overrides on the top of it to make the formatted output suitable for the system.
This change modifies the test to accept that alternative output from AppleICU.