### PR TITLE
Tests for audit of Temporal user code calls, part 2

### DIFF
--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -1948,6 +1948,30 @@ var TemporalHelpers = {
   },
 
   /*
+   * A custom time zone that does not allow any of its methods to be called, for
+   * the purpose of asserting that a particular operation does not call into
+   * user code.
+   */
+  timeZoneThrowEverything() {
+    class TimeZoneThrowEverything extends Temporal.TimeZone {
+      constructor() {
+        super("UTC");
+      }
+      getOffsetNanosecondsFor() {
+        TemporalHelpers.assertUnreachable("getOffsetNanosecondsFor should not be called");
+      }
+      getPossibleInstantsFor() {
+        TemporalHelpers.assertUnreachable("getPossibleInstantsFor should not be called");
+      }
+      toString() {
+        TemporalHelpers.assertUnreachable("toString should not be called");
+      }
+    }
+
+    return new TimeZoneThrowEverything();
+  },
+
+  /*
    * Returns an object that will append logs of any Gets or Calls of its valueOf
    * or toString properties to the array calls. Both valueOf and toString will
    * return the actual primitiveValue. propertyName is used in the log.

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.dateAdd(arg, new Temporal.Duration());
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19));
+instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.day
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.day(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofweek
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.dayOfWeek(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofyear
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.dayOfYear(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinmonth
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.daysInMonth(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinweek
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.daysInWeek(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinyear
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.daysInYear(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.inleapyear
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.inLeapYear(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.month
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.month(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthcode
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.monthCode(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthsinyear
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.monthsInYear(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.weekOfYear(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.year
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.year(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.yearofweek
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.yearOfWeek(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Duration/compare/calendar-dateadd-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Duration/compare/calendar-dateadd-called-with-options-undefined.js
@@ -15,7 +15,7 @@ const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600
 const relativeTo = new Temporal.ZonedDateTime(0n, timeZone, calendar);
 
 const duration1 = new Temporal.Duration(0, 0, 1);
-const duration2 = new Temporal.Duration(0, 0, 1);
+const duration2 = new Temporal.Duration(0, 0, 1, 1);
 Temporal.Duration.compare(duration1, duration2, { relativeTo });
 assert.sameValue(calendar.dateAddCallCount, 4);
 // one call in CalculateOffsetShift for each duration argument, plus one in

--- a/test/built-ins/Temporal/Duration/compare/calendar-dateadd-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Duration/compare/calendar-dateadd-called-with-options-undefined.js
@@ -17,6 +17,5 @@ const relativeTo = new Temporal.ZonedDateTime(0n, timeZone, calendar);
 const duration1 = new Temporal.Duration(0, 0, 1);
 const duration2 = new Temporal.Duration(0, 0, 1, 1);
 Temporal.Duration.compare(duration1, duration2, { relativeTo });
-assert.sameValue(calendar.dateAddCallCount, 4);
-// one call in CalculateOffsetShift for each duration argument, plus one in
-// UnbalanceDurationRelative for each duration argument
+assert.sameValue(calendar.dateAddCallCount, 2);
+// one call for each duration argument to add it to relativeTo

--- a/test/built-ins/Temporal/Duration/compare/calendar-possibly-required.js
+++ b/test/built-ins/Temporal/Duration/compare/calendar-possibly-required.js
@@ -6,43 +6,47 @@ esid: sec-temporal.duration.compare
 description: relativeTo argument needed if days = 0 but years/months/weeks non-zero
 features: [Temporal]
 ---*/
-const duration1 = new Temporal.Duration(1);
-const duration2 = new Temporal.Duration(0, 12);
-const duration3 = new Temporal.Duration(0, 0, 5);
-const duration4 = new Temporal.Duration(0, 0, 0, 42);
+const duration1a = new Temporal.Duration(1);
+const duration1b = new Temporal.Duration(1, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+const duration2a = new Temporal.Duration(0, 12);
+const duration2b = new Temporal.Duration(0, 12, 0, 0, 0, 0, 0, 0, 0, 1);
+const duration3a = new Temporal.Duration(0, 0, 5);
+const duration3b = new Temporal.Duration(0, 0, 5, 0, 0, 0, 0, 0, 0, 1);
+const duration4a = new Temporal.Duration(0, 0, 0, 42);
+const duration4b = new Temporal.Duration(0, 0, 0, 42, 0, 0, 0, 0, 0, 1);
 const relativeTo = new Temporal.PlainDate(2021, 12, 15);
 assert.throws(
   RangeError,
-  () => { Temporal.Duration.compare(duration1, duration1); },
+  () => { Temporal.Duration.compare(duration1a, duration1b); },
   "cannot compare Duration values without relativeTo if year is non-zero"
 );
-assert.sameValue(0,
-  Temporal.Duration.compare(duration1, duration1, { relativeTo }),
+assert.sameValue(-1,
+  Temporal.Duration.compare(duration1a, duration1b, { relativeTo }),
   "compare succeeds for year-only Duration provided relativeTo is supplied");
 assert.throws(
   RangeError,
-  () => { Temporal.Duration.compare(duration2, duration2); },
+  () => { Temporal.Duration.compare(duration2a, duration2b); },
   "cannot compare Duration values without relativeTo if month is non-zero"
 );
-assert.sameValue(0,
-  Temporal.Duration.compare(duration2, duration2, { relativeTo }),
+assert.sameValue(-1,
+  Temporal.Duration.compare(duration2a, duration2b, { relativeTo }),
   "compare succeeds for year-and-month Duration provided relativeTo is supplied");
 assert.throws(
   RangeError,
-  () => { Temporal.Duration.compare(duration3, duration3); },
+  () => { Temporal.Duration.compare(duration3a, duration3b); },
   "cannot compare Duration values without relativeTo if week is non-zero"
 );
-assert.sameValue(0,
-  Temporal.Duration.compare(duration3, duration3, { relativeTo }),
+assert.sameValue(-1,
+  Temporal.Duration.compare(duration3a, duration3b, { relativeTo }),
   "compare succeeds for year-and-month-and-week Duration provided relativeTo is supplied"
 );
 
-assert.sameValue(0,
-  Temporal.Duration.compare(duration4, duration4),
+assert.sameValue(-1,
+  Temporal.Duration.compare(duration4a, duration4b),
   "compare succeeds for zero year-month-week non-zero day Duration even without relativeTo");
 
 // Double-check that the comparison also works with a relative-to argument
-assert.sameValue(0,
-  Temporal.Duration.compare(duration4, duration4, { relativeTo }),
+assert.sameValue(-1,
+  Temporal.Duration.compare(duration4a, duration4b, { relativeTo }),
   "compare succeeds for zero year-month-week non-zero day Duration with relativeTo"
 );

--- a/test/built-ins/Temporal/Duration/compare/instances-identical.js
+++ b/test/built-ins/Temporal/Duration/compare/instances-identical.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: >
+  Shortcut return with no observable user code calls when two Temporal.Duration
+  have identical internal slots
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const duration1 = new Temporal.Duration(0, 0, 0, 5, 5, 5, 5, 5, 5, 5);
+const duration2 = new Temporal.Duration(0, 0, 0, 5, 5, 5, 5, 5, 5, 5);
+assert.sameValue(Temporal.Duration.compare(duration1, duration2), 0, "identical Duration instances should be equal");
+
+const dateDuration1 = new Temporal.Duration(5, 5, 5, 5, 5, 5, 5, 5, 5, 5);
+const dateDuration2 = new Temporal.Duration(5, 5, 5, 5, 5, 5, 5, 5, 5, 5);
+assert.sameValue(
+  Temporal.Duration.compare(dateDuration1, dateDuration2),
+  0,
+  "relativeTo is not required if two distinct Duration instances are identical"
+);
+
+const calendar = TemporalHelpers.calendarThrowEverything();
+const relativeTo = new Temporal.PlainDate(2000, 1, 1, calendar);
+assert.sameValue(
+  Temporal.Duration.compare(dateDuration1, dateDuration2, { relativeTo }),
+  0,
+  "no calendar methods are called if two distinct Duration instances are identical"
+);
+
+const dateDuration3 = new Temporal.Duration(5, 5, 5, 5, 4, 65, 5, 5, 5, 5);
+assert.throws(
+  RangeError,
+  () => Temporal.Duration.compare(dateDuration1, dateDuration3),
+  "relativeTo is required if two Duration instances are the same length but not identical"
+);
+
+assert.throws(
+  Test262Error,
+  () => Temporal.Duration.compare(dateDuration1, dateDuration3, { relativeTo }),
+  "calendar methods are called if two Duration instances are the same length but not identical"
+);

--- a/test/built-ins/Temporal/Duration/compare/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/compare/order-of-operations.js
@@ -353,16 +353,15 @@ actual.splice(0); // clear
 const expectedOpsForDayBalancing = expectedOpsForZonedRelativeTo.concat(
   expectedOpsForCalculateOffsetShift,
   [
-    // UnbalanceDurationRelative
-    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 7.a ToTemporalDate
+    // ToTemporalDate
+    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
     "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+    // UnbalanceDurationRelative
     "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
     "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
     "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
     "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
     // UnbalanceDurationRelative again for the second argument:
-    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 7.a ToTemporalDate
-    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
     "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
     "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
     "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate

--- a/test/built-ins/Temporal/Duration/compare/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/compare/order-of-operations.js
@@ -266,31 +266,19 @@ const expectedOpsForZonedRelativeTo = expected.concat([
   "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
 ]);
 
-const expectedOpsForCalculateOffsetShift = [
-  // CalculateOffsetShift on first argument
+const expectedOpsForZonedCalendarCompare = [
   "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  // ...in AddZonedDateTime
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  // AddZonedDateTime on first argument
   "get options.relativeTo.calendar.dateAdd",
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",
   "call options.relativeTo.timeZone.getPossibleInstantsFor",
-  // ...done with AddZonedDateTime
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  // CalculateOffsetShift on second argument
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  // AddZonedDateTime on second argument
   "get options.relativeTo.calendar.dateAdd",
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",
   "call options.relativeTo.timeZone.getPossibleInstantsFor",
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
 ];
 
 const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
@@ -317,7 +305,7 @@ Temporal.Duration.compare(
 );
 assert.compareArray(
   actual,
-  expectedOpsForZonedRelativeTo.concat(expectedOpsForCalculateOffsetShift),
+  expectedOpsForZonedRelativeTo.concat(expectedOpsForZonedCalendarCompare),
   "order of operations with ZonedDateTime relativeTo and no calendar units except days"
 );
 actual.splice(0); // clear
@@ -330,47 +318,20 @@ Temporal.Duration.compare(
 );
 assert.compareArray(
   actual,
-  expectedOpsForZonedRelativeTo.concat([
-    // CalculateOffsetShift on first arg
-    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-    // AddZonedDateTime
-    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-    // CalculateOffsetShift on second arg
-    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-    // AddZonedDateTime
-    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  ]),
+  expectedOpsForZonedRelativeTo,
   "order of operations with ZonedDateTime relativeTo and only time units"
 );
 actual.splice(0); // clear
 
-// code path through UnbalanceDurationRelative that balances higher units down
-// to days:
-const expectedOpsForDayBalancing = expectedOpsForZonedRelativeTo.concat(
-  expectedOpsForCalculateOffsetShift,
-  [
-    // ToTemporalDate
-    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-    // UnbalanceDurationRelative
-    "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
-    "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
-    "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
-    "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
-    // UnbalanceDurationRelative again for the second argument:
-    "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
-    "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
-    "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
-    "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
-  ]
-);
+// order of observable operations with zoned relativeTo and calendar units
 Temporal.Duration.compare(
   createDurationPropertyBagObserver("one", 1, 1, 1),
   createDurationPropertyBagObserver("two", 1, 1, 1, 1),
   createOptionsObserver(zonedRelativeTo)
 );
-assert.compareArray(actual, expectedOpsForDayBalancing, "order of operations with calendar units");
+assert.compareArray(
+  actual,
+  expectedOpsForZonedRelativeTo.concat(expectedOpsForZonedCalendarCompare),
+  "order of operations with ZonedDateTime relativeTo and calendar units"
+);
+actual.splice(0); // clear

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: >
+  Calling the method with a relativeTo property bag with a builtin calendar
+  causes no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const timeZone = "UTC";
+const relativeTo = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, timeZone, calendar: "iso8601" };
+const duration1 = new Temporal.Duration(0, 0, 1);
+const duration2 = new Temporal.Duration(0, 0, 0, 7);
+Temporal.Duration.compare(duration1, duration2, { relativeTo });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string-datetime.js
@@ -8,7 +8,7 @@ features: [Temporal]
 ---*/
 
 let timeZone = "2021-08-19T17:30";
-assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "bare date-time string is not a time zone");
+assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(1), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "bare date-time string is not a time zone");
 
 [
   "2021-08-19T17:30-07:00:01",
@@ -34,7 +34,7 @@ assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(
 ].forEach((timeZone) => {
   assert.throws(
     RangeError,
-    () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
+    () => Temporal.Duration.compare(new Temporal.Duration(1), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
     `ISO string ${timeZone} with a sub-minute offset is not a valid time zone`
   );
 });
@@ -57,5 +57,5 @@ assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(
   "2021-08-19T17:30-0700[UTC]",
   "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
-  Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
+  Temporal.Duration.compare(new Temporal.Duration(1), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
 });

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string-leap-second.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string-leap-second.js
@@ -12,7 +12,7 @@ let timeZone = "2016-12-31T23:59:60+00:00[UTC]";
 // A string with a leap second is a valid ISO string, so the following
 // operation should not throw
 
-Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
+Temporal.Duration.compare(new Temporal.Duration(1), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
 
 timeZone = "2021-08-19T17:30:45.123456789+23:59[+23:59:60]";
-assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "leap second in time zone name not valid");
+assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(1), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), "leap second in time zone name not valid");

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string-year-zero.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string-year-zero.js
@@ -14,7 +14,7 @@ const invalidStrings = [
 invalidStrings.forEach((timeZone) => {
   assert.throws(
     RangeError,
-    () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
+    () => Temporal.Duration.compare(new Temporal.Duration(1), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
     "reject minus zero as extended year"
   );
 });

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string.js
@@ -28,7 +28,7 @@ Object.defineProperty(Temporal.TimeZone.prototype, "getOffsetNanosecondsFor", {
 // The following are all valid strings so should not throw:
 
 ["UTC", "+01:00"].forEach((timeZone) => {
-  Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
+  Temporal.Duration.compare(new Temporal.Duration(1), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
 });
 
 Object.defineProperty(Temporal.TimeZone.prototype, "getPossibleInstantsFor", getPossibleInstantsForOriginal);

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-wrong-type.js
@@ -21,7 +21,7 @@ const primitiveTests = [
 for (const [timeZone, description] of primitiveTests) {
   assert.throws(
     typeof timeZone === 'string' ? RangeError : TypeError,
-    () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
+    () => Temporal.Duration.compare(new Temporal.Duration(1), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }),
     `${description} does not convert to a valid ISO string`
   );
 }
@@ -33,5 +33,5 @@ const typeErrorTests = [
 ];
 
 for (const [timeZone, description] of typeErrorTests) {
-  assert.throws(TypeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Duration.compare(new Temporal.Duration(1), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Duration/compare/relativeto-undefined-throw-on-calendar-units.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-undefined-throw-on-calendar-units.js
@@ -13,8 +13,9 @@ const oneYear = new Temporal.Duration(1);
 const oneMonth = new Temporal.Duration(0, 1);
 const oneWeek = new Temporal.Duration(0, 0, 1);
 const oneDay = new Temporal.Duration(0, 0, 0, 1);
+const twoDays = new Temporal.Duration(0, 0, 0, 2);
 
-assert.sameValue(Temporal.Duration.compare(oneDay, oneDay), 0, "days do not require relativeTo");
+assert.sameValue(Temporal.Duration.compare(oneDay, twoDays), -1, "days do not require relativeTo");
 
 assert.throws(RangeError, () => Temporal.Duration.compare(oneWeek, oneDay), "weeks in left operand require relativeTo");
 assert.throws(RangeError, () => Temporal.Duration.compare(oneDay, oneWeek), "weeks in right operand require relativeTo");

--- a/test/built-ins/Temporal/Duration/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/order-of-operations.js
@@ -249,8 +249,6 @@ const expectedOpsForZonedRelativeTo = expected.concat([
   "get options.relativeTo.calendar.dateUntil",
   "call options.relativeTo.calendar.dateUntil",
   // AddDuration → DifferenceZonedDateTime → AddZonedDateTime
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "get options.relativeTo.calendar.dateAdd",
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",
@@ -264,8 +262,6 @@ const expectedOpsForZonedRelativeTo = expected.concat([
   "get options.relativeTo.calendar.dateUntil",
   "call options.relativeTo.calendar.dateUntil",
   // AddDuration → DifferenceZonedDateTime → NanosecondsToDays → AddZonedDateTime 1
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "get options.relativeTo.calendar.dateAdd",
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: >
+  Calling the method with a relativeTo property bag with a builtin calendar
+  causes no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const timeZone = "UTC";
+const instance = new Temporal.Duration(1, 0, 0, 1);
+const relativeTo = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, timeZone, calendar: "iso8601" };
+instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
@@ -363,8 +363,6 @@ const expectedOpsForYearRoundingZoned = expectedOpsForZonedRelativeTo.concat([
   "get options.relativeTo.calendar.dateUntil",                // 12. DifferenceISODateTime
   "call options.relativeTo.calendar.dateUntil",
   // NanosecondsToDays → AddZonedDateTime
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 5. GetPlainDateTimeFor
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "get options.relativeTo.calendar.dateAdd",                  // 8.
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",   // 10. GetInstantFor

--- a/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
@@ -327,9 +327,6 @@ const expectedOpsForZonedRelativeTo = [
   "get options.smallestUnit",
   "get options.smallestUnit.toString",
   "call options.smallestUnit.toString",
-  // RoundDuration → ToTemporalDate
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
 ];
 
 const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
@@ -376,6 +373,9 @@ const expectedOpsForYearRoundingZoned = expectedOpsForZonedRelativeTo.concat([
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",   // 10. GetInstantFor
   "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // ToTemporalDate
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "get options.relativeTo.calendar.dateAdd",     // 9.b
   "call options.relativeTo.calendar.dateAdd",    // 9.c
   "call options.relativeTo.calendar.dateAdd",    // 9.e

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Calling the method with a relativeTo property bag with a builtin calendar
+  causes no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const timeZone = "UTC";
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+const relativeTo = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, timeZone, calendar: "iso8601" };
+instance.round({ largestUnit: "years", relativeTo });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-zoneddatetime-nanoseconds-to-days-range-errors.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-zoneddatetime-nanoseconds-to-days-range-errors.js
@@ -43,7 +43,6 @@ let zdt = new Temporal.ZonedDateTime(
   timeZoneSubstituteValues(
     [[epochInstant]], // Returned for NanosecondsToDays step 14, setting _intermediateNs_
     [
-      0, // Returned for RoundDuration step 6.c.i, setting _intermediate_ - making _startNs_ 0 in NanosecondsToDays
       dayNs - 1, // Returned for NanosecondsToDays step 7, setting _startDateTime_
       -dayNs + 1, // Returned for NanosecondsToDays step 11, setting _endDateTime_
     ]
@@ -64,7 +63,6 @@ zdt = new Temporal.ZonedDateTime(
   timeZoneSubstituteValues(
     [[epochInstant]], // Returned for NanosecondsToDays step 14, setting _intermediateNs_
     [
-      0, // Returned for RoundDuration step 6.c.i, setting _intermediate_ - making _startNs_ 0 in NanosecondsToDays
       -dayNs + 1, // Returned for NanosecondsToDays step 7, setting _startDateTime_
       dayNs - 1, // Returned for NanosecondsToDays step 11, setting _endDateTime_
     ]
@@ -88,7 +86,6 @@ zdt = new Temporal.ZonedDateTime(
       [new Temporal.Instant(-4n)], // Returned for NanosecondsToDays step 18.a, setting _oneDayFartherNs_
     ],
     [
-      0, // Returned for RoundDuration step 6.c.i, setting _intermediate_ - making _startNs_ 0 in NanosecondsToDays
       dayNs - 1, // Returned for NanosecondsToDays step 7, setting _startDateTime_
       -dayNs + 1, // Returned for NanosecondsToDays step 11, setting _endDateTime_
     ]

--- a/test/built-ins/Temporal/Duration/prototype/round/rounding-is-noop.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/rounding-is-noop.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  No calendar or time zone methods are called under circumstances where rounding
+  is a no-op
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarThrowEverything();
+const timeZone = TemporalHelpers.timeZoneThrowEverything();
+const plainRelativeTo = new Temporal.PlainDate(2000, 1, 1, calendar);
+const zonedRelativeTo = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+const d = new Temporal.Duration(0, 0, 0, 0, 23, 59, 59, 999, 999, 997);
+
+const noopRoundingOperations = [
+  [d, { smallestUnit: "nanoseconds" }, "smallestUnit ns"],
+  [d, { smallestUnit: "nanoseconds", relativeTo: plainRelativeTo }, "smallestUnit ns and plain relativeTo"],
+  [d, { smallestUnit: "nanoseconds", relativeTo: zonedRelativeTo }, "smallestUnit ns and zoned relativeTo"],
+  [d, { smallestUnit: "nanoseconds", roundingIncrement: 1 }, "round to 1 ns"],
+  // No balancing because largestUnit is already the largest unit and no time units overflow:
+  [d, { largestUnit: "hours" }, "largestUnit hours"],
+  // Unless relativeTo is ZonedDateTime, no-op is still possible with days>0:
+  [new Temporal.Duration(0, 0, 0, 1), { smallestUnit: "nanoseconds" }, "days>0 and smallestUnit ns"],
+  [new Temporal.Duration(0, 0, 0, 1), { smallestUnit: "nanoseconds", relativeTo: plainRelativeTo }, "days>0, smallestUnit ns, and plain relativeTo"],
+];
+for (const [duration, options, descr] of noopRoundingOperations) {
+  const result = duration.round(options);
+  assert.notSameValue(result, duration, "rounding result should be a new object");
+  TemporalHelpers.assertDurationsEqual(result, duration, `rounding should be a no-op with ${descr}`);
+}
+
+// These operations are not no-op rounding operations, but still should not call
+// any calendar methods:
+const roundingOperationsNotCallingCalendarMethods = [
+  [d, { smallestUnit: "microseconds" }, "round to 1 µs"],
+  [d, { smallestUnit: "nanoseconds", roundingIncrement: 2 }, "round to 2 ns"],
+  [new Temporal.Duration(0, 0, 0, 0, 24), { largestUnit: "days" }, "upwards balancing requested"],
+  [d, { largestUnit: "minutes" }, "downwards balancing requested"],
+  [new Temporal.Duration(0, 0, 0, 0, 1, 120), { smallestUnit: "nanoseconds" }, "time units could overflow"],
+  [new Temporal.Duration(0, 0, 0, 1, 24), { smallestUnit: "nanoseconds" }, "hours-to-days conversion could occur"],
+];
+for (const [duration, options, descr] of roundingOperationsNotCallingCalendarMethods) {
+  const result = duration.round(options);
+  let equal = true;
+  for (const prop of ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds']) {
+    if (result[prop] !== duration[prop]) {
+      equal = false;
+      break;
+    }
+  }
+  assert(!equal, `round result ${result} should be different from ${duration} with ${descr}`);
+}
+
+// These operations should not be short-circuited because they have to call
+// calendar methods:
+const roundingOperationsCallingCalendarMethods = [
+  [new Temporal.Duration(0, 0, 1), { smallestUnit: "nanoseconds", relativeTo: plainRelativeTo }, "calendar units present"],
+  [d, { largestUnit: "days", relativeTo: zonedRelativeTo }, "largestUnit days with zoned relativeTo"],
+  [new Temporal.Duration(0, 0, 0, 1), { smallestUnit: "nanoseconds", relativeTo: zonedRelativeTo }, "hours-to-days conversion could occur with zoned relativeTo"],
+];
+
+for (const [duration, options, descr] of roundingOperationsCallingCalendarMethods) {
+  assert.throws(Test262Error, () => duration.round(options), `rounding should not be a no-op with ${descr}`);
+}

--- a/test/built-ins/Temporal/Duration/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/order-of-operations.js
@@ -249,8 +249,6 @@ const expectedOpsForZonedRelativeTo = expected.concat([
   "get options.relativeTo.calendar.dateUntil",
   "call options.relativeTo.calendar.dateUntil",
   // AddDuration → DifferenceZonedDateTime → AddZonedDateTime
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "get options.relativeTo.calendar.dateAdd",
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",
@@ -264,8 +262,6 @@ const expectedOpsForZonedRelativeTo = expected.concat([
   "get options.relativeTo.calendar.dateUntil",
   "call options.relativeTo.calendar.dateUntil",
   // AddDuration → DifferenceZonedDateTime → NanosecondsToDays → AddZonedDateTime 1
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "get options.relativeTo.calendar.dateAdd",
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: >
+  Calling the method with a relativeTo property bag with a builtin calendar
+  causes no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const timeZone = "UTC";
+const instance = new Temporal.Duration(1, 0, 0, 1);
+const relativeTo = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, timeZone, calendar: "iso8601" };
+instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
@@ -259,6 +259,9 @@ assert.compareArray(actual, expectedOpsForZonedRelativeTo, "order of operations 
 actual.splice(0); // clear
 
 const expectedOpsForYearRoundingZoned = expectedOpsForZonedRelativeTo.concat([
+  // ToTemporalDate
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   // BalancePossiblyInfiniteDuration → NanosecondsToDays
   "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 7. GetPlainDateTimeFor
   "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
@@ -289,9 +292,6 @@ const expectedOpsForYearRoundingZoned = expectedOpsForZonedRelativeTo.concat([
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",   // 10. GetInstantFor
   "call options.relativeTo.timeZone.getPossibleInstantsFor",
-  // ToTemporalDate
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "get options.relativeTo.calendar.dateAdd",     // 9.b
   "call options.relativeTo.calendar.dateAdd",    // 9.c
   "call options.relativeTo.calendar.dateAdd",    // 9.e
@@ -306,5 +306,39 @@ assert.compareArray(
   actual,
   expectedOpsForYearRoundingZoned,
   "order of operations with unit = years and ZonedDateTime relativeTo"
+);
+actual.splice(0); // clear
+
+// code path that hits UnbalanceDateDurationRelative and RoundDuration
+const expectedOpsForUnbalanceRound = expectedOpsForZonedRelativeTo.concat([
+  // ToTemporalDate
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  // No user code calls in UnbalanceDateDurationRelative
+  // MoveRelativeZonedDateTime → AddZonedDateTime
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 5. GetPlainDateTimeFor
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",                  // 8.
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",   // 10. GetInstantFor
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // RoundDuration → MoveRelativeZonedDateTime → AddZonedDateTime
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 5. GetPlainDateTimeFor
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",                  // 8.
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",   // 10. GetInstantFor
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // RoundDuration
+  "get options.relativeTo.calendar.dateAdd",   // 7.d.i
+  "call options.relativeTo.calendar.dateAdd",  // 7.f
+  "call options.relativeTo.calendar.dateAdd",  // 7.h
+  "call options.relativeTo.calendar.dateAdd",  // 7.n MoveRelativeDate
+]);
+new Temporal.Duration(0, 1, 1).total(createOptionsObserver({ unit: "months", relativeTo: zonedRelativeTo }));
+assert.compareArray(
+  actual,
+  expectedOpsForUnbalanceRound,
+  "order of operations with unit = months and ZonedDateTime relativeTo"
 );
 actual.splice(0); // clear

--- a/test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
@@ -270,8 +270,6 @@ const expectedOpsForYearRoundingZoned = expectedOpsForZonedRelativeTo.concat([
   "get options.relativeTo.calendar.dateUntil",                // 12. DifferenceISODateTime
   "call options.relativeTo.calendar.dateUntil",
   // BalancePossiblyInfiniteDuration → NanosecondsToDays → AddZonedDateTime
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 5. GetPlainDateTimeFor
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "get options.relativeTo.calendar.dateAdd",                  // 8.
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",   // 10. GetInstantFor

--- a/test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
@@ -255,14 +255,7 @@ const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
 
 // basic order of observable operations, without rounding:
 instance.total(createOptionsObserver({ unit: "nanoseconds", relativeTo: zonedRelativeTo }));
-assert.compareArray(
-  actual,
-  expectedOpsForZonedRelativeTo.concat([
-    // RoundDuration → ToTemporalDate
-    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  ]),
-  "order of operations for ZonedDateTime relativeTo");
+assert.compareArray(actual, expectedOpsForZonedRelativeTo, "order of operations for ZonedDateTime relativeTo");
 actual.splice(0); // clear
 
 const expectedOpsForYearRoundingZoned = expectedOpsForZonedRelativeTo.concat([
@@ -288,9 +281,6 @@ const expectedOpsForYearRoundingZoned = expectedOpsForZonedRelativeTo.concat([
   "get options.relativeTo.timeZone.getPossibleInstantsFor",   // 10. GetInstantFor
   "call options.relativeTo.timeZone.getPossibleInstantsFor",
 ], [
-  // ToTemporalDate
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   // code path through RoundDuration that rounds to the nearest year:
   // MoveRelativeZonedDateTime → AddZonedDateTime
   "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 5. GetPlainDateTimeFor
@@ -299,6 +289,9 @@ const expectedOpsForYearRoundingZoned = expectedOpsForZonedRelativeTo.concat([
   "call options.relativeTo.calendar.dateAdd",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",   // 10. GetInstantFor
   "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // ToTemporalDate
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "get options.relativeTo.calendar.dateAdd",     // 9.b
   "call options.relativeTo.calendar.dateAdd",    // 9.c
   "call options.relativeTo.calendar.dateAdd",    // 9.e

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  Calling the method with a relativeTo property bag with a builtin calendar
+  causes no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const timeZone = "UTC";
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+const relativeTo = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, timeZone, calendar: "iso8601" };
+instance.total({ unit: "days", relativeTo });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDate/compare/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18));
+Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDate/from/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+Temporal.PlainDate.from(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.equals(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.since(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplainmonthday
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDate(2023, 5, 2, "iso8601");
+instance.toPlainMonthDay();
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplainyearmonth
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDate(2023, 5, 2, "iso8601");
+instance.toPlainYearMonth();
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.until(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDate/prototype/with/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/with/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.with
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDate(2023, 5, 2, "iso8601");
+instance.with({ day: 5 });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, calendar: "iso8601" };
+Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18));
+Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, calendar: "iso8601" };
+Temporal.PlainDateTime.from(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, calendar: "iso8601" };
+instance.equals(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, calendar: "iso8601" };
+instance.since(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toPlainMonthDay/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toPlainMonthDay/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.toplainmonthday
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDateTime(2023, 5, 2, 12, 34, 56, 987, 654, 321, "iso8601");
+instance.toPlainMonthDay();
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toPlainYearMonth/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toPlainYearMonth/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.toplainyearmonth
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDateTime(2023, 5, 2, 12, 34, 56, 987, 654, 321, "iso8601");
+instance.toPlainYearMonth();
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, calendar: "iso8601" };
+instance.until(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/with/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/with/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.with
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDateTime(2023, 5, 2, 12, 34, 56, 987, 654, 321, "iso8601");
+instance.with({ day: 5 });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaindate
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.withPlainDate(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const arg = { monthCode: "M11", day: 23, calendar: "iso8601" };
+Temporal.PlainMonthDay.from(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainMonthDay(5, 2);
+const arg = { monthCode: "M11", day: 23, calendar: "iso8601" };
+instance.equals(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.toplaindate
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainMonthDay(5, 1, "iso8601");
+instance.toPlainDate({ year: 2005 });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/with/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/with/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.with
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainMonthDay(5, 1, "iso8601");
+instance.with({ monthCode: "M04" });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.toplaindatetime
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.toPlainDateTime(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const arg = { year: 2000, month: 5, calendar: "iso8601" };
+Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6));
+Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const arg = { year: 2000, month: 5, calendar: "iso8601" };
+Temporal.PlainYearMonth.from(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainYearMonth(2023, 5, "iso8601");
+instance.add({ years: 5, months: 2 });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainYearMonth(2000, 5);
+const arg = { year: 2000, month: 5, calendar: "iso8601" };
+instance.equals(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainYearMonth(2000, 5);
+const arg = { year: 2000, month: 5, calendar: "iso8601" };
+instance.since(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainYearMonth(2023, 5, "iso8601");
+instance.since({ year: 2005, month: 3 });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
@@ -117,6 +117,11 @@ function createOptionsObserver({ smallestUnit = "months", largestUnit = "auto", 
 // clear any observable things that happened while constructing the objects
 actual.splice(0);
 
+// code path that skips RoundDuration:
+instance.since(otherYearMonthPropertyBag, createOptionsObserver({ smallestUnit: "months", roundingIncrement: 1 }));
+assert.compareArray(actual, expected, "order of operations with no rounding");
+actual.splice(0); // clear
+
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat([
   "get this.calendar.dateAdd",     // 9.b

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainYearMonth(2023, 5, "iso8601");
+instance.subtract({ years: 5, months: 2 });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.toplaindate
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainYearMonth(2023, 5, "iso8601");
+instance.toPlainDate({ day: 5 });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainYearMonth(2000, 5);
+const arg = { year: 2000, month: 5, calendar: "iso8601" };
+instance.until(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainYearMonth(2023, 5, "iso8601");
+instance.until({ year: 2070, month: 7 });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
@@ -117,6 +117,11 @@ function createOptionsObserver({ smallestUnit = "months", largestUnit = "auto", 
 // clear any observable things that happened while constructing the objects
 actual.splice(0);
 
+// code path that skips RoundDuration:
+instance.since(otherYearMonthPropertyBag, createOptionsObserver({ smallestUnit: "months", roundingIncrement: 1 }));
+assert.compareArray(actual, expected, "order of operations with no rounding");
+actual.splice(0); // clear
+
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat([
   "get this.calendar.dateAdd",     // 9.b

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/with/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/with/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.with
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.PlainYearMonth(2023, 5, "iso8601");
+instance.with({ month: 4 });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.TimeZone("UTC");
+// Patch getPossibleInstantsFor to allow the spec-mandated observable array
+// iteration in the GetPossibleInstantsFor AO.
+instance.getPossibleInstantsFor = function (...args) {
+  const instants = Temporal.TimeZone.prototype.getPossibleInstantsFor.apply(this, args);
+  instants[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;
+  return instants;
+}
+
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, calendar: "iso8601" };
+instance.getInstantFor(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.TimeZone("UTC");
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, calendar: "iso8601" };
+instance.getPossibleInstantsFor(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const timeZone = "UTC";
+const datetime = new Temporal.ZonedDateTime(0n, timeZone);
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, timeZone, calendar: "iso8601" };
+Temporal.ZonedDateTime.compare(arg, datetime);
+Temporal.ZonedDateTime.compare(datetime, arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const timeZone = "UTC";
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, timeZone, calendar: "iso8601" };
+Temporal.ZonedDateTime.from(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const timeZone = "UTC";
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, timeZone, calendar: "iso8601" };
+instance.equals(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/div-zero.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/div-zero.js
@@ -18,7 +18,7 @@ class Calendar extends Temporal.Calendar {
 
 const zdt = new Temporal.ZonedDateTime(0n, "UTC", new Calendar());
 
-const units = ["day", "hour", "minute", "second", "millisecond", "microsecond", "nanosecond"];
+const units = ["hour", "minute", "second", "millisecond", "microsecond", "nanosecond"];
 for (const smallestUnit of units) {
-  assert.throws(RangeError, () => zdt.round({ smallestUnit }));
+  assert.throws(RangeError, () => zdt.round({ smallestUnit, roundingIncrement: 2 }));
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/order-of-operations.js
@@ -25,8 +25,6 @@ const expected = [
   "get this.timeZone.getPossibleInstantsFor",
   "call this.timeZone.getPossibleInstantsFor",
   // AddZonedDateTime
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
   "get this.calendar.dateAdd",
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/order-of-operations.js
@@ -42,7 +42,7 @@ const actual = [];
 const options = TemporalHelpers.propertyBagObserver(actual, {
   smallestUnit: "nanoseconds",
   roundingMode: "halfExpand",
-  roundingIncrement: 1,
+  roundingIncrement: 2,
 }, "options");
 
 const instance = new Temporal.ZonedDateTime(

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/rounding-is-noop.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/rounding-is-noop.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.round
+description: >
+  No calendar or time zone methods are called under circumstances where rounding
+  is a no-op
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarThrowEverything();
+const timeZone = TemporalHelpers.timeZoneThrowEverything();
+const instance = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+const noopRoundingOperations = [
+  [{ smallestUnit: "nanoseconds" }, "smallestUnit ns"],
+  [{ smallestUnit: "nanoseconds", roundingIncrement: 1 }, "round to 1 ns"],
+];
+for (const [options, descr] of noopRoundingOperations) {
+  const result = instance.round(options);
+  assert.notSameValue(result, instance, "rounding result should be a new object");
+  assert.sameValue(result.epochNanoseconds, instance.epochNanoseconds, "instant should be unchanged");
+  assert.sameValue(result.getCalendar(), instance.getCalendar(), "calendar should be preserved");
+  assert.sameValue(result.getTimeZone(), instance.getTimeZone(), "time zone should be preserved");
+}
+
+const notNoopRoundingOperations = [
+  [{ smallestUnit: "microseconds" }, "round to 1 µs"],
+  [{ smallestUnit: "nanoseconds", roundingIncrement: 2 }, "round to 2 ns"],
+];
+for (const [options, descr] of notNoopRoundingOperations) {
+  assert.throws(Test262Error, () => instance.round(options), `rounding should not be a no-op with ${descr}`);
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const timeZone = "UTC";
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, timeZone, calendar: "iso8601" };
+instance.since(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
@@ -189,9 +189,6 @@ const expectedOpsForCalendarDifference = [
 ];
 
 const expectedOpsForCalendarRounding = [
-  // RoundDuration → ToTemporalDate
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
   // RoundDuration → MoveRelativeZonedDateTime → AddZonedDateTime
   "get this.timeZone.getOffsetNanosecondsFor",
   "call this.timeZone.getOffsetNanosecondsFor",
@@ -214,6 +211,9 @@ const expectedOpsForCalendarRounding = [
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",
   "call this.timeZone.getPossibleInstantsFor",
+  // RoundDuration → ToTemporalDate
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
 ];
 
 // code path that skips RoundDuration:

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
@@ -158,8 +158,6 @@ const expectedOpsForCalendarDifference = [
   "get this.calendar.dateUntil",
   "call this.calendar.dateUntil",
   // AddZonedDateTime
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
   "get this.calendar.dateAdd",
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",
@@ -173,8 +171,6 @@ const expectedOpsForCalendarDifference = [
   "get this.calendar.dateUntil",
   "call this.calendar.dateUntil",
   // NanosecondsToDays → AddZonedDateTime
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
   "get this.calendar.dateAdd",
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
@@ -189,6 +189,9 @@ const expectedOpsForCalendarDifference = [
 ];
 
 const expectedOpsForCalendarRounding = [
+  // ToTemporalDate
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
   // RoundDuration → MoveRelativeZonedDateTime → AddZonedDateTime
   "get this.timeZone.getOffsetNanosecondsFor",
   "call this.timeZone.getOffsetNanosecondsFor",
@@ -211,9 +214,6 @@ const expectedOpsForCalendarRounding = [
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",
   "call this.timeZone.getPossibleInstantsFor",
-  // RoundDuration → ToTemporalDate
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
 ];
 
 // code path that skips RoundDuration:

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
@@ -186,6 +186,9 @@ const expectedOpsForCalendarDifference = [
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",
   "call this.timeZone.getPossibleInstantsFor",
+];
+
+const expectedOpsForCalendarRounding = [
   // RoundDuration → ToTemporalDate
   "get this.timeZone.getOffsetNanosecondsFor",
   "call this.timeZone.getOffsetNanosecondsFor",
@@ -213,8 +216,13 @@ const expectedOpsForCalendarDifference = [
   "call this.timeZone.getPossibleInstantsFor",
 ];
 
+// code path that skips RoundDuration:
+instance.since(otherDateTimePropertyBag, createOptionsObserver({ largestUnit: "years", smallestUnit: "nanoseconds", roundingIncrement: 1 }));
+assert.compareArray(actual, expected.concat(expectedOpsForCalendarDifference), "order of operations with largestUnit years and no rounding");
+actual.splice(0); // clear
+
 // code path through RoundDuration that rounds to the nearest year:
-const expectedOpsForYearRounding = expected.concat(expectedOpsForCalendarDifference, [
+const expectedOpsForYearRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
   "get this.calendar.dateAdd",     // 9.b
   "call this.calendar.dateAdd",    // 9.c
   "call this.calendar.dateAdd",    // 9.e
@@ -229,7 +237,7 @@ assert.compareArray(actual, expectedOpsForYearRounding, "order of operations wit
 actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
-const expectedOpsForMonthRounding = expected.concat(expectedOpsForCalendarDifference, [
+const expectedOpsForMonthRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
   "get this.calendar.dateAdd",     // 10.b
   "call this.calendar.dateAdd",    // 10.c
   "call this.calendar.dateAdd",    // 10.e
@@ -240,7 +248,7 @@ assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations wi
 actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest week:
-const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDifference, [
+const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
   "get this.calendar.dateAdd",   // 11.c
   "call this.calendar.dateAdd",  // 11.d MoveRelativeDate
 ]);  // (11.g.iii MoveRelativeDate not called because days already balanced)

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainMonthDay/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainMonthDay/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.toplainmonthday
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", "iso8601");
+instance.toPlainMonthDay();
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainYearMonth/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainYearMonth/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.toplainyearmonth
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", "iso8601");
+instance.toPlainYearMonth();
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const timeZone = "UTC";
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+const arg = { year: 2000, month: 5, day: 2, hour: 21, minute: 43, second: 5, timeZone, calendar: "iso8601" };
+instance.until(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
@@ -186,6 +186,9 @@ const expectedOpsForCalendarDifference = [
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",
   "call this.timeZone.getPossibleInstantsFor",
+];
+
+const expectedOpsForCalendarRounding = [
   // RoundDuration → ToTemporalDate
   "get this.timeZone.getOffsetNanosecondsFor",
   "call this.timeZone.getOffsetNanosecondsFor",
@@ -213,8 +216,13 @@ const expectedOpsForCalendarDifference = [
   "call this.timeZone.getPossibleInstantsFor",
 ];
 
+// code path that skips RoundDuration:
+instance.until(otherDateTimePropertyBag, createOptionsObserver({ largestUnit: "years", smallestUnit: "nanoseconds", roundingIncrement: 1 }));
+assert.compareArray(actual, expected.concat(expectedOpsForCalendarDifference), "order of operations with largestUnit years and no rounding");
+actual.splice(0); // clear
+
 // code path through RoundDuration that rounds to the nearest year:
-const expectedOpsForYearRounding = expected.concat(expectedOpsForCalendarDifference, [
+const expectedOpsForYearRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
   "get this.calendar.dateAdd",     // 9.b
   "call this.calendar.dateAdd",    // 9.c
   "call this.calendar.dateAdd",    // 9.e
@@ -229,7 +237,7 @@ assert.compareArray(actual, expectedOpsForYearRounding, "order of operations wit
 actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
-const expectedOpsForMonthRounding = expected.concat(expectedOpsForCalendarDifference, [
+const expectedOpsForMonthRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
   "get this.calendar.dateAdd",     // 10.b
   "call this.calendar.dateAdd",    // 10.c
   "call this.calendar.dateAdd",    // 10.e
@@ -240,7 +248,7 @@ assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations wi
 actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest week:
-const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDifference, [
+const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
   "get this.calendar.dateAdd",   // 11.c
   "call this.calendar.dateAdd",  // 11.d MoveRelativeDate
 ]);  // (11.g.iii MoveRelativeDate not called because days already balanced)

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
@@ -189,9 +189,6 @@ const expectedOpsForCalendarDifference = [
 ];
 
 const expectedOpsForCalendarRounding = [
-  // RoundDuration → ToTemporalDate
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
   // RoundDuration → MoveRelativeZonedDateTime → AddZonedDateTime
   "get this.timeZone.getOffsetNanosecondsFor",
   "call this.timeZone.getOffsetNanosecondsFor",
@@ -214,6 +211,9 @@ const expectedOpsForCalendarRounding = [
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",
   "call this.timeZone.getPossibleInstantsFor",
+  // RoundDuration → ToTemporalDate
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
 ];
 
 // code path that skips RoundDuration:

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
@@ -158,8 +158,6 @@ const expectedOpsForCalendarDifference = [
   "get this.calendar.dateUntil",
   "call this.calendar.dateUntil",
   // AddZonedDateTime
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
   "get this.calendar.dateAdd",
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",
@@ -173,8 +171,6 @@ const expectedOpsForCalendarDifference = [
   "get this.calendar.dateUntil",
   "call this.calendar.dateUntil",
   // NanosecondsToDays → AddZonedDateTime
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
   "get this.calendar.dateAdd",
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
@@ -189,6 +189,9 @@ const expectedOpsForCalendarDifference = [
 ];
 
 const expectedOpsForCalendarRounding = [
+  // ToTemporalDate
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
   // RoundDuration → MoveRelativeZonedDateTime → AddZonedDateTime
   "get this.timeZone.getOffsetNanosecondsFor",
   "call this.timeZone.getOffsetNanosecondsFor",
@@ -211,9 +214,6 @@ const expectedOpsForCalendarRounding = [
   "call this.calendar.dateAdd",
   "get this.timeZone.getPossibleInstantsFor",
   "call this.timeZone.getPossibleInstantsFor",
-  // RoundDuration → ToTemporalDate
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
 ];
 
 // code path that skips RoundDuration:

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/builtin-calendar-no-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.with
+description: >
+  Calling the method on an instance constructed with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", "iso8601");
+instance.with({ day: 5 });
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-builtin-calendar-no-array-iteration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.withPlainDate(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-builtin-calendar-no-array-iteration.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.era(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-builtin-calendar-no-array-iteration.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-builtin-calendar-no-array-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: >
+  Calling the method with a property bag argument with a builtin calendar causes
+  no observable array iteration when getting the calendar fields.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+const instance = new Temporal.Calendar("iso8601");
+const arg = { year: 2000, month: 5, day: 2, calendar: "iso8601" };
+instance.eraYear(arg);
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;


### PR DESCRIPTION
Continuing on from #3894, https://github.com/tc39/proposal-temporal/pull/2519 is a very large pull request and I'm planning to land it in parts. This PR contains tests for the second part. Each commit here corresponds to the same-named commit in the proposal-temporal normative PR.

Recommend reviewing commit-by-commit. Note, in the commit titled "Temporal: Don't observably iterate array in built-in calendar's fields()" there are a large number of tests that are basically copy-pasted except for one, as noted in the commit message, so double-check that one when reviewing.