### PR TITLE
verify that non-integral values throw

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/throws-on-nan.js
+++ b/test/intl402/DurationFormat/prototype/format/throws-on-nan.js
@@ -1,0 +1,23 @@
+// Copyright 2023 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.format
+description: Check that format throws on non-integral values
+info: |
+    1.1.2 ToIntegerWithoutRounding ( argument )
+      1. Let number be ? ToNumber(argument).
+      2. If IsIntegralNumber(number) is false, throw a RangeError exception.
+      3. Return ℝ(number).
+features: [Intl.DurationFormat]
+---*/
+
+var invalidValues = [NaN, Infinity, -Infinity];
+
+var format = new Intl.DateTimeFormat();
+
+invalidValues.forEach(function (value) {
+    assert.throws(RangeError, function() {
+        var result = format.format(value);
+    }, "Invalid value " + value + " was not rejected.");
+});

--- a/test/intl402/DurationFormat/prototype/format/throws-value-non-integral.js
+++ b/test/intl402/DurationFormat/prototype/format/throws-value-non-integral.js
@@ -1,0 +1,23 @@
+// Copyright 2023 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.format
+description: Check that format throws on non-integral values
+info: |
+    1.1.2 ToIntegerWithoutRounding ( argument )
+      1. Let number be ? ToNumber(argument).
+      2. If IsIntegralNumber(number) is false, throw a RangeError exception.
+      3. Return ℝ(number).
+features: [Intl.DurationFormat]
+---*/
+
+var invalidValues = [NaN, Infinity, -Infinity, 0.137, 1.37, -398.2];
+
+var format = new Intl.DateTimeFormat();
+
+invalidValues.forEach(function (value) {
+    assert.throws(RangeError, function() {
+        var result = format.format(value);
+    }, "Invalid value " + value + " was not rejected.");
+});


### PR DESCRIPTION
Update to reflect recent normative change https://github.com/tc39/proposal-intl-duration-format/pull/158 making ToIntegerWithoutRounding throw on NaN instead of treating it as 0.