### PR TITLE
Accept "mo" narrow style for month

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/style-narrow-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-narrow-en.js
@@ -9,7 +9,7 @@ features: [Intl.DurationFormat]
 ---*/
 
 const style = "narrow";
-const expected = "1y 2m 3w 3d 4h 5m 6s 7ms 8μs 9ns";
+const expected = /^1y 2mo? 3w 3d 4h 5m 6s 7ms 8μs 9ns$/;
 
 const duration = {
   years: 1,
@@ -25,4 +25,5 @@ const duration = {
 };
 
 const df = new Intl.DurationFormat("en", {style});
-assert.sameValue(df.format(duration), expected, `Assert DurationFormat format output using ${style} style option`);
+const actual = df.format(duration);
+assert(expected.test(actual), `Assert DurationFormat format output using ${style} style option, actual: ${actual}`);


### PR DESCRIPTION
macOS system ICU is shipping new CLDR, but it has many overrides on the top of it to make the formatted output suitable for the system. For narrow "month" representation, CLDR uses "m", but AppleICU uses "mo" to distinguish between "month" and "minute". This patch accepts this since it is done based on different readability decision, and ECMA-402 allows it.