### PR TITLE
update iterator helpers tests that passed even in noncompliant impls

### DIFF
--- a/test/built-ins/Iterator/prototype/reduce/iterator-already-exhausted-no-initial-value.js
+++ b/test/built-ins/Iterator/prototype/reduce/iterator-already-exhausted-no-initial-value.js
@@ -19,3 +19,5 @@ assert.sameValue(done, true);
 assert.throws(TypeError, function() {
   iterator.reduce(() => {});
 });
+
+iterator.reduce(() => {}, 0);

--- a/test/built-ins/Iterator/prototype/reduce/non-callable-reducer.js
+++ b/test/built-ins/Iterator/prototype/reduce/non-callable-reducer.js
@@ -18,3 +18,5 @@ let iterator = (function* () {
 assert.throws(TypeError, function () {
   iterator.reduce(nonCallable);
 });
+
+iterator.reduce(() => {});


### PR DESCRIPTION
These were the only 2 iterator helper tests that were passing even in implementations that had not yet added support for iterator helpers.