### PR TITLE
Fixup class names in class decorator private identifier tests.

### DIFF
--- a/src/decorator/syntax/class-valid/cls-decl-decorators-valid-syntax.template
+++ b/src/decorator/syntax/class-valid/cls-decl-decorators-valid-syntax.template
@@ -25,6 +25,6 @@ features: [class, decorators]
 class C {
   /*{ elements }*/
   static {
-    /*{ decorators }*/ class C {}
+    /*{ decorators }*/ class D {}
   }
 }

--- a/src/decorator/syntax/class-valid/cls-expr-decorators-valid-syntax.template
+++ b/src/decorator/syntax/class-valid/cls-expr-decorators-valid-syntax.template
@@ -21,9 +21,9 @@ info: |
 features: [class, decorators]
 ---*/
 
-var C = class {
+class C {
   /*{ elements }*/
   static {
-    var C = /*{ decorators }*/ class {}
+    var D = /*{ decorators }*/ class {}
   }
 };

--- a/test/language/expressions/class/decorator/syntax/class-valid/decorator-member-expr-private-identifier.js
+++ b/test/language/expressions/class/decorator/syntax/class-valid/decorator-member-expr-private-identifier.js
@@ -32,7 +32,7 @@ info: |
 ---*/
 
 
-var C = class {
+class C {
   static #$() {}
   static #_() {}
   static #\u{6F}() {}
@@ -43,7 +43,7 @@ var C = class {
   static #await() {}
 
   static {
-    var C = @C.#$
+    var D = @C.#$
     @C.#_
     @C.#\u{6F}
     @C.#\u2118

--- a/test/language/expressions/class/decorator/syntax/class-valid/decorator-member-expr-private-identifier.js
+++ b/test/language/expressions/class/decorator/syntax/class-valid/decorator-member-expr-private-identifier.js
@@ -32,7 +32,7 @@ info: |
 ---*/
 
 
-class C {
+var C = class {
   static #$() {}
   static #_() {}
   static #\u{6F}() {}
@@ -43,7 +43,7 @@ class C {
   static #await() {}
 
   static {
-    var D = @C.#$
+    var C = @C.#$
     @C.#_
     @C.#\u{6F}
     @C.#\u2118

--- a/test/language/statements/class/decorator/syntax/class-valid/decorator-member-expr-private-identifier.js
+++ b/test/language/statements/class/decorator/syntax/class-valid/decorator-member-expr-private-identifier.js
@@ -51,6 +51,6 @@ class C {
     @C.#ZW_\u200C_NJ
     @C.#ZW_\u200D_J
     @C.#yield
-    @C.#await class C {}
+    @C.#await class D {}
   }
 }

--- a/test/language/statements/class/decorator/syntax/class-valid/decorator-member-expr-private-identifier.js
+++ b/test/language/statements/class/decorator/syntax/class-valid/decorator-member-expr-private-identifier.js
@@ -51,6 +51,6 @@ class C {
     @C.#ZW_\u200C_NJ
     @C.#ZW_\u200D_J
     @C.#yield
-    @C.#await class D {}
+    @C.#await class C {}
   }
 }


### PR DESCRIPTION
For the statement level test, the inner class name is not initialized at the time the decorators evaluate, resulting in a ReferenceError that the declaration can not be accessed prior to initialization.

Similar, non-decorator code, like:
    class C {
        static dec() {}
        static {
            this.x = C.dec();
            class C {}
        }
    }
also results in a ReferenceError.

For the expression level test, the var C is undefined at the time the decorators are evaluated, resulting in TypeError while trying to access a member of undefined.

Similar, non-decorator code, like:
    var C = class {
        static f() {};
        static {
            this.x = C.f();
        }
    }
also results in a TypeError.