### PR TITLE
Remove pointless 'string check' from isEnumerable() property helper

### DIFF
--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -113,23 +113,10 @@ function isConfigurable(obj, name) {
 }
 
 function isEnumerable(obj, name) {
-  var stringCheck = false;
-
-  if (typeof name === "string") {
-    for (var x in obj) {
-      if (x === name) {
-        stringCheck = true;
-        break;
-      }
-    }
-  } else {
-    // skip it if name is not string, works for Symbol names.
-    stringCheck = true;
-  }
-
-  return stringCheck &&
+  return (
     Object.prototype.hasOwnProperty.call(obj, name) &&
-    Object.prototype.propertyIsEnumerable.call(obj, name);
+    Object.prototype.propertyIsEnumerable.call(obj, name)
+  );
 }
 
 function isSameValue(a, b) {


### PR DESCRIPTION
As far as I can tell this does nothing that `hasOwnProperty()` doesn't already take care of. This is essentially a revert of 866d7f8d8e4601618d4a94fb8fa7b4219c69bcf6, the purpose of which I don't understand.