### PR TITLE
Add tests for DurationFormat PR 172 and 167

### DIFF
--- a/test/intl402/DurationFormat/constructor-option-read-order.js
+++ b/test/intl402/DurationFormat/constructor-option-read-order.js
@@ -1,0 +1,47 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat
+description: Checks the order of option read.
+features: [Intl.DurationFormat]
+includes: [compareArray.js]
+---*/
+
+let optionKeys =  Object.keys((new Intl.DurationFormat()).resolvedOptions());
+let opt = {};
+let readKeys = new Array();
+// For each item returned by resolvedOptions of default, add a getter
+// to track the reading order.
+optionKeys.forEach((property) =>
+    Object.defineProperty(opt, property, {
+        get() {
+            readKeys[readKeys.length] = property;
+            return undefined;
+        },
+    }));
+let p = new Intl.DurationFormat(undefined, opt);
+assert.compareArray(
+    readKeys,
+    ['numberingSystem',
+    'style',
+    'years',
+    'yearsDisplay',
+    'months',
+    'monthsDisplay',
+    'weeks',
+    'weeksDisplay',
+    'days',
+    'daysDisplay',
+    'hours',
+    'hoursDisplay',
+    'minutes',
+    'minutesDisplay',
+    'seconds',
+    'secondsDisplay',
+    'milliseconds',
+    'millisecondsDisplay',
+    'microseconds',
+    'microsecondsDisplay',
+    'nanoseconds',
+    'nanosecondsDisplay']);

--- a/test/intl402/DurationFormat/prototype/resolvedOptions/return-keys-order-default.js
+++ b/test/intl402/DurationFormat/prototype/resolvedOptions/return-keys-order-default.js
@@ -1,0 +1,34 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.durationformat.prototype.resolvedoptions
+description: order of property keys for the object returned by resolvedOptions()
+features: [Intl.DurationFormat]
+includes: [compareArray.js]
+---*/
+
+assert.compareArray(
+    Object.keys((new Intl.DurationFormat()).resolvedOptions()),
+    ['locale',
+    'numberingSystem',
+    'style',
+    'years',
+    'yearsDisplay',
+    'months',
+    'monthsDisplay',
+    'weeks',
+    'weeksDisplay',
+    'days',
+    'daysDisplay',
+    'hours',
+    'hoursDisplay',
+    'minutes',
+    'minutesDisplay',
+    'seconds',
+    'secondsDisplay',
+    'milliseconds',
+    'millisecondsDisplay',
+    'microseconds',
+    'microsecondsDisplay',
+    'nanoseconds',
+    'nanosecondsDisplay']);


### PR DESCRIPTION
Test the order of resolvedOptions in default setting Also add test to check the reading order of options based on the property returned in the default setting resolvedOptions.

https://github.com/tc39/proposal-intl-duration-format/pull/167 

https://github.com/tc39/proposal-intl-duration-format/pull/172 

https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.resolvedOptions

These two PRs are presenting to TC39 2023-09 meeting