### PR TITLE
Add Collator test for ignorePunctuation

### DIFF
--- a/test/intl402/Collator/prototype/compare/ignorePunctuation.js
+++ b/test/intl402/Collator/prototype/compare/ignorePunctuation.js
@@ -1,0 +1,16 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-collator-comparestrings
+description: test CompareStrings sync with resolvedOptions().ignorePunctuation.
+---*/
+// test on three locales, 'th' has different default.
+['en','th','ja'].forEach((locale) => {
+  [undefined, true, false].forEach((ignorePunctuation) => {
+    let col = new Intl.Collator(locale, {ignorePunctuation});
+    // if ignorePunctuation is true, the comparison will be 0
+    let expected = col.resolvedOptions().ignorePunctuation ? 0 : -1;
+    assert.sameValue(expected, col.compare("", " "));
+    assert.sameValue(expected, col.compare("", "*"));
+  });
+});

--- a/test/intl402/Collator/prototype/compare/ignorePunctuation.js
+++ b/test/intl402/Collator/prototype/compare/ignorePunctuation.js
@@ -3,14 +3,15 @@
 /*---
 esid: sec-collator-comparestrings
 description: test CompareStrings sync with resolvedOptions().ignorePunctuation.
+locale: [en, th, ja]
 ---*/
 // test on three locales, 'th' has different default.
-['en','th','ja'].forEach((locale) => {
+['en', 'th', 'ja'].forEach((locale) => {
   [undefined, true, false].forEach((ignorePunctuation) => {
     let col = new Intl.Collator(locale, {ignorePunctuation});
     // if ignorePunctuation is true, the comparison will be 0
     let expected = col.resolvedOptions().ignorePunctuation ? 0 : -1;
-    assert.sameValue(expected, col.compare("", " "));
-    assert.sameValue(expected, col.compare("", "*"));
+    assert.sameValue(col.compare("", " "), expected, "Compare to space");
+    assert.sameValue(col.compare("", "*"), expected, "Compare to star");
   });
 });

--- a/test/intl402/Collator/prototype/resolvedOptions/ignorePunctuation-not-default.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/ignorePunctuation-not-default.js
@@ -1,0 +1,14 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializecollator
+description: resolved ignorePunctuation is the same as the one specified in option bag.
+---*/
+['en','th','ja'].forEach((locale) => {
+  [true, false].forEach((ignorePunctuation) => {
+    assert.sameValue(
+    ignorePunctuation,
+    (new Intl.Collator(locale, {ignorePunctuation}))
+        .resolvedOptions().ignorePunctuation);
+  });
+});

--- a/test/intl402/Collator/prototype/resolvedOptions/ignorePunctuation-not-default.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/ignorePunctuation-not-default.js
@@ -3,12 +3,13 @@
 /*---
 esid: sec-initializecollator
 description: resolved ignorePunctuation is the same as the one specified in option bag.
+locale: [en, th, ja]
 ---*/
-['en','th','ja'].forEach((locale) => {
+['en', 'th', 'ja'].forEach((locale) => {
   [true, false].forEach((ignorePunctuation) => {
     assert.sameValue(
-    ignorePunctuation,
-    (new Intl.Collator(locale, {ignorePunctuation}))
-        .resolvedOptions().ignorePunctuation);
+      (new Intl.Collator(locale, {ignorePunctuation}))
+          .resolvedOptions().ignorePunctuation,
+      ignorePunctuation);
   });
 });


### PR DESCRIPTION
Test the explicit setting of ignorePunctuation in the option bag reflect to the value in resolvedOptions() under Thai and other locales. (Thai is a special case)

Test the behavior of the compare sync with the value of resolvedOptions().ignorePunctuation

Spec text
https://tc39.es/ecma402/#sec-initializecollator
https://tc39.es/ecma402/#sec-intl.collator.prototype.resolvedoptions
https://tc39.es/ecma402/#sec-collator-comparestrings
