### PR TITLE
Update test/intl402 and test/language to use verifyProperty function

### DIFF
--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -45,6 +45,19 @@ function verifyProperty(obj, name, desc, options) {
     return true;
   }
 
+  var names = Object.getOwnPropertyNames(desc);
+  for (var i = 0; i < names.length; i++) {
+    assert(
+      names[i] === "value" ||
+        names[i] === "writable" ||
+        names[i] === "enumerable" ||
+        names[i] === "configurable" ||
+        names[i] === "get" ||
+        names[i] === "set",
+      "Invalid descriptor field: " + names[i],
+    );
+  }
+
   assert(
     Object.prototype.hasOwnProperty.call(obj, name),
     "obj should have an own property " + nameStr

--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -68,6 +68,9 @@ function verifyProperty(obj, name, desc, options) {
     if (!isSameValue(desc.value, originalDesc.value)) {
       failures.push("descriptor value should be " + desc.value);
     }
+    if (!isSameValue(desc.value, obj[name])) {
+      failures.push(failures, "object value should be " + desc.value);
+    }
   }
 
   if (Object.prototype.hasOwnProperty.call(desc, 'enumerable')) {

--- a/test/built-ins/ArrayBuffer/prototype/transfer/name.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/name.js
@@ -22,6 +22,6 @@ includes: [propertyHelper.js]
 verifyProperty(ArrayBuffer.prototype.transfer, 'name', {
   value: 'transfer',
   enumerable: false,
-  wrtiable: false,
+  writable: false,
   configurable: true
 });

--- a/test/built-ins/ArrayBuffer/prototype/transferToFixedLength/name.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToFixedLength/name.js
@@ -22,6 +22,6 @@ includes: [propertyHelper.js]
 verifyProperty(ArrayBuffer.prototype.transferToFixedLength, 'name', {
   value: 'transferToFixedLength',
   enumerable: false,
-  wrtiable: false,
+  writable: false,
   configurable: true
 });

--- a/test/built-ins/Error/cause_property.js
+++ b/test/built-ins/Error/cause_property.js
@@ -29,7 +29,7 @@ var error = new Error(message, { cause });
 verifyProperty(error, "cause", {
   configurable: true,
   enumerable: false,
-  writeable: true,
+  writable: true,
   value: cause,
 });
 

--- a/test/built-ins/NativeErrors/AggregateError/cause-property.js
+++ b/test/built-ins/NativeErrors/AggregateError/cause-property.js
@@ -31,7 +31,7 @@ var error = new AggregateError(errors, message, { cause });
 verifyProperty(error, "cause", {
   configurable: true,
   enumerable: false,
-  writeable: true,
+  writable: true,
   value: cause,
 });
 

--- a/test/built-ins/NativeErrors/cause_property_native_error.js
+++ b/test/built-ins/NativeErrors/cause_property_native_error.js
@@ -36,7 +36,7 @@ for (var i = 0; i < nativeErrors.length; ++i) {
   verifyProperty(error, "cause", {
     configurable: true,
     enumerable: false,
-    writeable: true,
+    writable: true,
     value: cause,
   });
 

--- a/test/intl402/Collator/length.js
+++ b/test/intl402/Collator/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.Collator.length, 0);
-
-verifyNotEnumerable(Intl.Collator, "length");
-verifyNotWritable(Intl.Collator, "length");
-verifyConfigurable(Intl.Collator, "length");
+verifyProperty(Intl.Collator, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/name.js
+++ b/test/intl402/Collator/name.js
@@ -19,8 +19,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.Collator.name, "Collator");
-
-verifyNotEnumerable(Intl.Collator, "name");
-verifyNotWritable(Intl.Collator, "name");
-verifyConfigurable(Intl.Collator, "name");
+verifyProperty(Intl.Collator, "name", {
+  value: "Collator",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/prop-desc.js
+++ b/test/intl402/Collator/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl, "Collator");
-verifyWritable(Intl, "Collator");
-verifyConfigurable(Intl, "Collator");
+verifyProperty(Intl, "Collator", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/prototype/compare/compare-function-length.js
+++ b/test/intl402/Collator/prototype/compare/compare-function-length.js
@@ -21,8 +21,9 @@ includes: [propertyHelper.js]
 
 var compareFn = new Intl.Collator().compare;
 
-assert.sameValue(compareFn.length, 2);
-
-verifyNotEnumerable(compareFn, "length");
-verifyNotWritable(compareFn, "length");
-verifyConfigurable(compareFn, "length");
+verifyProperty(compareFn, "length", {
+  value: 2,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/prototype/compare/length.js
+++ b/test/intl402/Collator/prototype/compare/length.js
@@ -26,8 +26,9 @@ includes: [propertyHelper.js]
 
 var desc = Object.getOwnPropertyDescriptor(Intl.Collator.prototype, "compare");
 
-assert.sameValue(desc.get.length, 0);
-
-verifyNotEnumerable(desc.get, "length");
-verifyNotWritable(desc.get, "length");
-verifyConfigurable(desc.get, "length");
+verifyProperty(desc.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/prototype/compare/name.js
+++ b/test/intl402/Collator/prototype/compare/name.js
@@ -21,8 +21,9 @@ includes: [propertyHelper.js]
 
 var desc = Object.getOwnPropertyDescriptor(Intl.Collator.prototype, "compare");
 
-assert.sameValue(desc.get.name, "get compare");
-
-verifyNotEnumerable(desc.get, "name");
-verifyNotWritable(desc.get, "name");
-verifyConfigurable(desc.get, "name");
+verifyProperty(desc.get, "name", {
+  value: "get compare",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/prototype/compare/prop-desc.js
+++ b/test/intl402/Collator/prototype/compare/prop-desc.js
@@ -31,5 +31,7 @@ var desc = Object.getOwnPropertyDescriptor(Intl.Collator.prototype, "compare");
 assert.sameValue(desc.set, undefined);
 assert.sameValue(typeof desc.get, "function");
 
-verifyNotEnumerable(Intl.Collator.prototype, "compare");
-verifyConfigurable(Intl.Collator.prototype, "compare");
+verifyProperty(Intl.Collator.prototype, "compare", {
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/prototype/constructor/prop-desc.js
+++ b/test/intl402/Collator/prototype/constructor/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.Collator.prototype, "constructor");
-verifyWritable(Intl.Collator.prototype, "constructor");
-verifyConfigurable(Intl.Collator.prototype, "constructor");
+verifyProperty(Intl.Collator.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/prototype/resolvedOptions/length.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.Collator.prototype.resolvedOptions.length, 0);
-
-verifyNotEnumerable(Intl.Collator.prototype.resolvedOptions, "length");
-verifyNotWritable(Intl.Collator.prototype.resolvedOptions, "length");
-verifyConfigurable(Intl.Collator.prototype.resolvedOptions, "length");
+verifyProperty(Intl.Collator.prototype.resolvedOptions, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/prototype/resolvedOptions/name.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/name.js
@@ -19,8 +19,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.Collator.prototype.resolvedOptions.name, "resolvedOptions");
-
-verifyNotEnumerable(Intl.Collator.prototype.resolvedOptions, "name");
-verifyNotWritable(Intl.Collator.prototype.resolvedOptions, "name");
-verifyConfigurable(Intl.Collator.prototype.resolvedOptions, "name");
+verifyProperty(Intl.Collator.prototype.resolvedOptions, "name", {
+  value: "resolvedOptions",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/prototype/resolvedOptions/prop-desc.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.Collator.prototype, "resolvedOptions");
-verifyWritable(Intl.Collator.prototype, "resolvedOptions");
-verifyConfigurable(Intl.Collator.prototype, "resolvedOptions");
+verifyProperty(Intl.Collator.prototype, "resolvedOptions", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/supportedLocalesOf/length.js
+++ b/test/intl402/Collator/supportedLocalesOf/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.Collator.supportedLocalesOf.length, 1);
-
-verifyNotEnumerable(Intl.Collator.supportedLocalesOf, "length");
-verifyNotWritable(Intl.Collator.supportedLocalesOf, "length");
-verifyConfigurable(Intl.Collator.supportedLocalesOf, "length");
+verifyProperty(Intl.Collator.supportedLocalesOf, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/supportedLocalesOf/name.js
+++ b/test/intl402/Collator/supportedLocalesOf/name.js
@@ -19,8 +19,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.Collator.supportedLocalesOf.name, "supportedLocalesOf");
-
-verifyNotEnumerable(Intl.Collator.supportedLocalesOf, "name");
-verifyNotWritable(Intl.Collator.supportedLocalesOf, "name");
-verifyConfigurable(Intl.Collator.supportedLocalesOf, "name");
+verifyProperty(Intl.Collator.supportedLocalesOf, "name", {
+  value: "supportedLocalesOf",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Collator/supportedLocalesOf/prop-desc.js
+++ b/test/intl402/Collator/supportedLocalesOf/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.Collator, "supportedLocalesOf");
-verifyWritable(Intl.Collator, "supportedLocalesOf");
-verifyConfigurable(Intl.Collator, "supportedLocalesOf");
+verifyProperty(Intl.Collator, "supportedLocalesOf", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Date/prototype/toLocaleDateString/length.js
+++ b/test/intl402/Date/prototype/toLocaleDateString/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Date.prototype.toLocaleDateString.length, 0);
-
-verifyNotEnumerable(Date.prototype.toLocaleDateString, "length");
-verifyNotWritable(Date.prototype.toLocaleDateString, "length");
-verifyConfigurable(Date.prototype.toLocaleDateString, "length");
+verifyProperty(Date.prototype.toLocaleDateString, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Date/prototype/toLocaleString/length.js
+++ b/test/intl402/Date/prototype/toLocaleString/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Date.prototype.toLocaleString.length, 0);
-
-verifyNotEnumerable(Date.prototype.toLocaleString, "length");
-verifyNotWritable(Date.prototype.toLocaleString, "length");
-verifyConfigurable(Date.prototype.toLocaleString, "length");
+verifyProperty(Date.prototype.toLocaleString, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Date/prototype/toLocaleTimeString/length.js
+++ b/test/intl402/Date/prototype/toLocaleTimeString/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Date.prototype.toLocaleTimeString.length, 0);
-
-verifyNotEnumerable(Date.prototype.toLocaleTimeString, "length");
-verifyNotWritable(Date.prototype.toLocaleTimeString, "length");
-verifyConfigurable(Date.prototype.toLocaleTimeString, "length");
+verifyProperty(Date.prototype.toLocaleTimeString, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/length.js
+++ b/test/intl402/DateTimeFormat/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.DateTimeFormat.length, 0);
-
-verifyNotEnumerable(Intl.DateTimeFormat, "length");
-verifyNotWritable(Intl.DateTimeFormat, "length");
-verifyConfigurable(Intl.DateTimeFormat, "length");
+verifyProperty(Intl.DateTimeFormat, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/name.js
+++ b/test/intl402/DateTimeFormat/name.js
@@ -19,8 +19,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.DateTimeFormat.name, "DateTimeFormat");
-
-verifyNotEnumerable(Intl.DateTimeFormat, "name");
-verifyNotWritable(Intl.DateTimeFormat, "name");
-verifyConfigurable(Intl.DateTimeFormat, "name");
+verifyProperty(Intl.DateTimeFormat, "name", {
+  value: "DateTimeFormat",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/prop-desc.js
+++ b/test/intl402/DateTimeFormat/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl, "DateTimeFormat");
-verifyWritable(Intl, "DateTimeFormat");
-verifyConfigurable(Intl, "DateTimeFormat");
+verifyProperty(Intl, "DateTimeFormat", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/prototype/constructor/prop-desc.js
+++ b/test/intl402/DateTimeFormat/prototype/constructor/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.DateTimeFormat.prototype, "constructor");
-verifyWritable(Intl.DateTimeFormat.prototype, "constructor");
-verifyConfigurable(Intl.DateTimeFormat.prototype, "constructor");
+verifyProperty(Intl.DateTimeFormat.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/prototype/format/format-function-length.js
+++ b/test/intl402/DateTimeFormat/prototype/format/format-function-length.js
@@ -21,8 +21,9 @@ includes: [propertyHelper.js]
 
 var formatFn = new Intl.DateTimeFormat().format;
 
-assert.sameValue(formatFn.length, 1);
-
-verifyNotEnumerable(formatFn, "length");
-verifyNotWritable(formatFn, "length");
-verifyConfigurable(formatFn, "length");
+verifyProperty(formatFn, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/prototype/format/length.js
+++ b/test/intl402/DateTimeFormat/prototype/format/length.js
@@ -26,8 +26,9 @@ includes: [propertyHelper.js]
 
 var desc = Object.getOwnPropertyDescriptor(Intl.DateTimeFormat.prototype, "format");
 
-assert.sameValue(desc.get.length, 0);
-
-verifyNotEnumerable(desc.get, "length");
-verifyNotWritable(desc.get, "length");
-verifyConfigurable(desc.get, "length");
+verifyProperty(desc.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/prototype/format/name.js
+++ b/test/intl402/DateTimeFormat/prototype/format/name.js
@@ -21,8 +21,9 @@ includes: [propertyHelper.js]
 
 var desc = Object.getOwnPropertyDescriptor(Intl.DateTimeFormat.prototype, "format");
 
-assert.sameValue(desc.get.name, "get format");
-
-verifyNotEnumerable(desc.get, "name");
-verifyNotWritable(desc.get, "name");
-verifyConfigurable(desc.get, "name");
+verifyProperty(desc.get, "name", {
+  value: "get format",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/prototype/format/prop-desc.js
+++ b/test/intl402/DateTimeFormat/prototype/format/prop-desc.js
@@ -31,5 +31,7 @@ var desc = Object.getOwnPropertyDescriptor(Intl.DateTimeFormat.prototype, "forma
 assert.sameValue(desc.set, undefined);
 assert.sameValue(typeof desc.get, "function");
 
-verifyNotEnumerable(Intl.DateTimeFormat.prototype, "format");
-verifyConfigurable(Intl.DateTimeFormat.prototype, "format");
+verifyProperty(Intl.DateTimeFormat.prototype, "format", {
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/formatToParts.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/formatToParts.js
@@ -12,6 +12,8 @@ assert.sameValue(
   '`typeof Intl.DateTimeFormat.prototype.formatToParts` is `function`'
 );
 
-verifyNotEnumerable(Intl.DateTimeFormat.prototype, 'formatToParts');
-verifyWritable(Intl.DateTimeFormat.prototype, 'formatToParts');
-verifyConfigurable(Intl.DateTimeFormat.prototype, 'formatToParts');
+verifyProperty(Intl.DateTimeFormat.prototype, "formatToParts", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/length.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.DateTimeFormat.prototype.resolvedOptions.length, 0);
-
-verifyNotEnumerable(Intl.DateTimeFormat.prototype.resolvedOptions, "length");
-verifyNotWritable(Intl.DateTimeFormat.prototype.resolvedOptions, "length");
-verifyConfigurable(Intl.DateTimeFormat.prototype.resolvedOptions, "length");
+verifyProperty(Intl.DateTimeFormat.prototype.resolvedOptions, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/name.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/name.js
@@ -19,8 +19,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.DateTimeFormat.prototype.resolvedOptions.name, "resolvedOptions");
-
-verifyNotEnumerable(Intl.DateTimeFormat.prototype.resolvedOptions, "name");
-verifyNotWritable(Intl.DateTimeFormat.prototype.resolvedOptions, "name");
-verifyConfigurable(Intl.DateTimeFormat.prototype.resolvedOptions, "name");
+verifyProperty(Intl.DateTimeFormat.prototype.resolvedOptions, "name", {
+  value: "resolvedOptions",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/prop-desc.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.DateTimeFormat.prototype, "resolvedOptions");
-verifyWritable(Intl.DateTimeFormat.prototype, "resolvedOptions");
-verifyConfigurable(Intl.DateTimeFormat.prototype, "resolvedOptions");
+verifyProperty(Intl.DateTimeFormat.prototype, "resolvedOptions", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/supportedLocalesOf/length.js
+++ b/test/intl402/DateTimeFormat/supportedLocalesOf/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.DateTimeFormat.supportedLocalesOf.length, 1);
-
-verifyNotEnumerable(Intl.DateTimeFormat.supportedLocalesOf, "length");
-verifyNotWritable(Intl.DateTimeFormat.supportedLocalesOf, "length");
-verifyConfigurable(Intl.DateTimeFormat.supportedLocalesOf, "length");
+verifyProperty(Intl.DateTimeFormat.supportedLocalesOf, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/supportedLocalesOf/name.js
+++ b/test/intl402/DateTimeFormat/supportedLocalesOf/name.js
@@ -19,8 +19,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.DateTimeFormat.supportedLocalesOf.name, "supportedLocalesOf");
-
-verifyNotEnumerable(Intl.DateTimeFormat.supportedLocalesOf, "name");
-verifyNotWritable(Intl.DateTimeFormat.supportedLocalesOf, "name");
-verifyConfigurable(Intl.DateTimeFormat.supportedLocalesOf, "name");
+verifyProperty(Intl.DateTimeFormat.supportedLocalesOf, "name", {
+  value: "supportedLocalesOf",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DateTimeFormat/supportedLocalesOf/prop-desc.js
+++ b/test/intl402/DateTimeFormat/supportedLocalesOf/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.DateTimeFormat, "supportedLocalesOf");
-verifyWritable(Intl.DateTimeFormat, "supportedLocalesOf");
-verifyConfigurable(Intl.DateTimeFormat, "supportedLocalesOf");
+verifyProperty(Intl.DateTimeFormat, "supportedLocalesOf", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DurationFormat/prototype/constructor/prop-desc.js
+++ b/test/intl402/DurationFormat/prototype/constructor/prop-desc.js
@@ -25,6 +25,8 @@ features: [Intl.DurationFormat]
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.DurationFormat.prototype, "constructor");
-verifyWritable(Intl.DurationFormat.prototype, "constructor");
-verifyConfigurable(Intl.DurationFormat.prototype, "constructor");
+verifyProperty(Intl.DurationFormat.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/DurationFormat/prototype/prototype_attributes.js
+++ b/test/intl402/DurationFormat/prototype/prototype_attributes.js
@@ -10,6 +10,9 @@ features: [Intl.DurationFormat]
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.DurationFormat, "prototype");
-verifyNotWritable(Intl.DurationFormat, "prototype");
-verifyNotConfigurable(Intl.DurationFormat, "prototype");
+verifyProperty(Intl.DurationFormat, "prototype", {
+  value: Intl.DurationFormat.prototype,
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/intl402/Intl/getCanonicalLocales/getCanonicalLocales.js
+++ b/test/intl402/Intl/getCanonicalLocales/getCanonicalLocales.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof Intl.getCanonicalLocales` is `function`'
 );
 
-verifyNotEnumerable(Intl, 'getCanonicalLocales');
-verifyWritable(Intl, 'getCanonicalLocales');
-verifyConfigurable(Intl, 'getCanonicalLocales');
+verifyProperty(Intl, "getCanonicalLocales", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Intl/getCanonicalLocales/length.js
+++ b/test/intl402/Intl/getCanonicalLocales/length.js
@@ -11,8 +11,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.getCanonicalLocales.length, 1);
-
-verifyNotEnumerable(Intl.getCanonicalLocales, "length");
-verifyNotWritable(Intl.getCanonicalLocales, "length");
-verifyConfigurable(Intl.getCanonicalLocales, "length");
+verifyProperty(Intl.getCanonicalLocales, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Intl/getCanonicalLocales/name.js
+++ b/test/intl402/Intl/getCanonicalLocales/name.js
@@ -11,10 +11,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.getCanonicalLocales.name, 'getCanonicalLocales',
-  'The value of `Intl.getCanonicalLocales.name` is `"getCanonicalLocales"`'
-);
-
-verifyNotEnumerable(Intl.getCanonicalLocales, 'name');
-verifyNotWritable(Intl.getCanonicalLocales, 'name');
-verifyConfigurable(Intl.getCanonicalLocales, 'name');
+verifyProperty(Intl.getCanonicalLocales, "name", {
+  value: "getCanonicalLocales",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Intl/getCanonicalLocales/returned-object-is-mutable.js
+++ b/test/intl402/Intl/getCanonicalLocales/returned-object-is-mutable.js
@@ -14,22 +14,34 @@ includes: [propertyHelper.js]
 var locales = ['en-US', 'fr'];
 var result = Intl.getCanonicalLocales(locales);
 
-verifyEnumerable(result, 0);
-verifyWritable(result, 0);
-verifyConfigurable(result, 0);
+verifyProperty(result, 0, {
+  value: 'en-US',
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
 
 result = Intl.getCanonicalLocales(locales);
-verifyEnumerable(result, 1);
-verifyWritable(result, 1);
-verifyConfigurable(result, 1);
+
+verifyProperty(result, 1, {
+  value: 'fr',
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
 
 result = Intl.getCanonicalLocales(locales);
-verifyNotEnumerable(result, 'length');
-verifyNotConfigurable(result, 'length');
 
-assert.sameValue(result.length, 2);
+verifyProperty(result, "length", {
+  value: 2,
+  writable: true,
+  enumerable: false,
+  configurable: false,
+});
+
 result.length = 42;
 assert.sameValue(result.length, 42);
+
 assert.throws(RangeError, function() {
   result.length = "Leo";
 }, "a non-numeric value can't be set to result.length");

--- a/test/intl402/NumberFormat/prototype/constructor/prop-desc.js
+++ b/test/intl402/NumberFormat/prototype/constructor/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.NumberFormat.prototype, "constructor");
-verifyWritable(Intl.NumberFormat.prototype, "constructor");
-verifyConfigurable(Intl.NumberFormat.prototype, "constructor");
+verifyProperty(Intl.NumberFormat.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/prototype/format/format-function-length.js
+++ b/test/intl402/NumberFormat/prototype/format/format-function-length.js
@@ -21,8 +21,9 @@ includes: [propertyHelper.js]
 
 var formatFn = new Intl.NumberFormat().format;
 
-assert.sameValue(formatFn.length, 1);
-
-verifyNotEnumerable(formatFn, "length");
-verifyNotWritable(formatFn, "length");
-verifyConfigurable(formatFn, "length");
+verifyProperty(formatFn, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/prototype/format/length.js
+++ b/test/intl402/NumberFormat/prototype/format/length.js
@@ -26,8 +26,9 @@ includes: [propertyHelper.js]
 
 var desc = Object.getOwnPropertyDescriptor(Intl.NumberFormat.prototype, "format");
 
-assert.sameValue(desc.get.length, 0);
-
-verifyNotEnumerable(desc.get, "length");
-verifyNotWritable(desc.get, "length");
-verifyConfigurable(desc.get, "length");
+verifyProperty(desc.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/prototype/format/name.js
+++ b/test/intl402/NumberFormat/prototype/format/name.js
@@ -21,8 +21,9 @@ includes: [propertyHelper.js]
 
 var desc = Object.getOwnPropertyDescriptor(Intl.NumberFormat.prototype, "format");
 
-assert.sameValue(desc.get.name, "get format");
-
-verifyNotEnumerable(desc.get, "name");
-verifyNotWritable(desc.get, "name");
-verifyConfigurable(desc.get, "name");
+verifyProperty(desc.get, "name", {
+  value: "get format",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/prototype/format/prop-desc.js
+++ b/test/intl402/NumberFormat/prototype/format/prop-desc.js
@@ -31,5 +31,7 @@ var desc = Object.getOwnPropertyDescriptor(Intl.NumberFormat.prototype, "format"
 assert.sameValue(desc.set, undefined);
 assert.sameValue(typeof desc.get, "function");
 
-verifyNotEnumerable(Intl.NumberFormat.prototype, "format");
-verifyConfigurable(Intl.NumberFormat.prototype, "format");
+verifyProperty(Intl.NumberFormat.prototype, "format", {
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/prototype/formatToParts/length.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/length.js
@@ -6,8 +6,9 @@ description: Intl.NumberFormat.prototype.formatToParts.length.
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.NumberFormat.prototype.formatToParts.length, 1);
-
-verifyNotEnumerable(Intl.NumberFormat.prototype.formatToParts, "length");
-verifyNotWritable(Intl.NumberFormat.prototype.formatToParts, "length");
-verifyConfigurable(Intl.NumberFormat.prototype.formatToParts, "length");
+verifyProperty(Intl.NumberFormat.prototype.formatToParts, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/prototype/formatToParts/name.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/name.js
@@ -6,10 +6,9 @@ description: Intl.NumberFormat.prototype.formatToParts.name value and descriptor
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.NumberFormat.prototype.formatToParts.name, 'formatToParts',
-  'The value of `Intl.NumberFormat.prototype.formatToParts.name` is `"formatToParts"`'
-);
-
-verifyNotEnumerable(Intl.NumberFormat.prototype.formatToParts, 'name');
-verifyNotWritable(Intl.NumberFormat.prototype.formatToParts, 'name');
-verifyConfigurable(Intl.NumberFormat.prototype.formatToParts, 'name');
+verifyProperty(Intl.NumberFormat.prototype.formatToParts, "name", {
+  value: "formatToParts",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/prototype/formatToParts/prop-desc.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/prop-desc.js
@@ -32,6 +32,8 @@ assert.sameValue(
   '`typeof Intl.NumberFormat.prototype.formatToParts` is `function`'
 );
 
-verifyNotEnumerable(Intl.NumberFormat.prototype, 'formatToParts');
-verifyWritable(Intl.NumberFormat.prototype, 'formatToParts');
-verifyConfigurable(Intl.NumberFormat.prototype, 'formatToParts');
+verifyProperty(Intl.NumberFormat.prototype, "formatToParts", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/prototype/resolvedOptions/length.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.NumberFormat.prototype.resolvedOptions.length, 0);
-
-verifyNotEnumerable(Intl.NumberFormat.prototype.resolvedOptions, "length");
-verifyNotWritable(Intl.NumberFormat.prototype.resolvedOptions, "length");
-verifyConfigurable(Intl.NumberFormat.prototype.resolvedOptions, "length");
+verifyProperty(Intl.NumberFormat.prototype.resolvedOptions, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/prototype/resolvedOptions/name.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/name.js
@@ -19,8 +19,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.NumberFormat.prototype.resolvedOptions.name, "resolvedOptions");
-
-verifyNotEnumerable(Intl.NumberFormat.prototype.resolvedOptions, "name");
-verifyNotWritable(Intl.NumberFormat.prototype.resolvedOptions, "name");
-verifyConfigurable(Intl.NumberFormat.prototype.resolvedOptions, "name");
+verifyProperty(Intl.NumberFormat.prototype.resolvedOptions, "name", {
+  value: "resolvedOptions",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/prototype/resolvedOptions/prop-desc.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.NumberFormat.prototype, "resolvedOptions");
-verifyWritable(Intl.NumberFormat.prototype, "resolvedOptions");
-verifyConfigurable(Intl.NumberFormat.prototype, "resolvedOptions");
+verifyProperty(Intl.NumberFormat.prototype, "resolvedOptions", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/supportedLocalesOf/length.js
+++ b/test/intl402/NumberFormat/supportedLocalesOf/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.NumberFormat.supportedLocalesOf.length, 1);
-
-verifyNotEnumerable(Intl.NumberFormat.supportedLocalesOf, "length");
-verifyNotWritable(Intl.NumberFormat.supportedLocalesOf, "length");
-verifyConfigurable(Intl.NumberFormat.supportedLocalesOf, "length");
+verifyProperty(Intl.NumberFormat.supportedLocalesOf, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/supportedLocalesOf/name.js
+++ b/test/intl402/NumberFormat/supportedLocalesOf/name.js
@@ -19,8 +19,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.NumberFormat.supportedLocalesOf.name, "supportedLocalesOf");
-
-verifyNotEnumerable(Intl.NumberFormat.supportedLocalesOf, "name");
-verifyNotWritable(Intl.NumberFormat.supportedLocalesOf, "name");
-verifyConfigurable(Intl.NumberFormat.supportedLocalesOf, "name");
+verifyProperty(Intl.NumberFormat.supportedLocalesOf, "name", {
+  value: "supportedLocalesOf",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/NumberFormat/supportedLocalesOf/prop-desc.js
+++ b/test/intl402/NumberFormat/supportedLocalesOf/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.NumberFormat, "supportedLocalesOf");
-verifyWritable(Intl.NumberFormat, "supportedLocalesOf");
-verifyConfigurable(Intl.NumberFormat, "supportedLocalesOf");
+verifyProperty(Intl.NumberFormat, "supportedLocalesOf", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/PluralRules/prototype/constructor/prop-desc.js
+++ b/test/intl402/PluralRules/prototype/constructor/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.PluralRules.prototype, "constructor");
-verifyWritable(Intl.PluralRules.prototype, "constructor");
-verifyConfigurable(Intl.PluralRules.prototype, "constructor");
+verifyProperty(Intl.PluralRules.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/PluralRules/prototype/resolvedOptions/length.js
+++ b/test/intl402/PluralRules/prototype/resolvedOptions/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.PluralRules.prototype.resolvedOptions.length, 0);
-
-verifyNotEnumerable(Intl.PluralRules.prototype.resolvedOptions, "length");
-verifyNotWritable(Intl.PluralRules.prototype.resolvedOptions, "length");
-verifyConfigurable(Intl.PluralRules.prototype.resolvedOptions, "length");
+verifyProperty(Intl.PluralRules.prototype.resolvedOptions, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/PluralRules/prototype/resolvedOptions/name.js
+++ b/test/intl402/PluralRules/prototype/resolvedOptions/name.js
@@ -8,8 +8,9 @@ author: Zibi Braniecki
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.PluralRules.prototype.resolvedOptions.name, "resolvedOptions");
-
-verifyNotEnumerable(Intl.PluralRules.prototype.resolvedOptions, "name");
-verifyNotWritable(Intl.PluralRules.prototype.resolvedOptions, "name");
-verifyConfigurable(Intl.PluralRules.prototype.resolvedOptions, "name");
+verifyProperty(Intl.PluralRules.prototype.resolvedOptions, "name", {
+  value: "resolvedOptions",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/PluralRules/prototype/resolvedOptions/prop-desc.js
+++ b/test/intl402/PluralRules/prototype/resolvedOptions/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.PluralRules.prototype, "resolvedOptions");
-verifyWritable(Intl.PluralRules.prototype, "resolvedOptions");
-verifyConfigurable(Intl.PluralRules.prototype, "resolvedOptions");
+verifyProperty(Intl.PluralRules.prototype, "resolvedOptions", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/PluralRules/prototype/select/length.js
+++ b/test/intl402/PluralRules/prototype/select/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.PluralRules.prototype.select.length, 1);
-
-verifyNotEnumerable(Intl.PluralRules.prototype.select, "length");
-verifyNotWritable(Intl.PluralRules.prototype.select, "length");
-verifyConfigurable(Intl.PluralRules.prototype.select, "length");
+verifyProperty(Intl.PluralRules.prototype.select, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/PluralRules/prototype/select/name.js
+++ b/test/intl402/PluralRules/prototype/select/name.js
@@ -8,10 +8,9 @@ author: Zibi Braniecki
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.PluralRules.prototype.select.name, 'select',
-  'The value of `Intl.PluralRules.prototype.select.name` is `"select"`'
-);
-
-verifyNotEnumerable(Intl.PluralRules.prototype.select, 'name');
-verifyNotWritable(Intl.PluralRules.prototype.select, 'name');
-verifyConfigurable(Intl.PluralRules.prototype.select, 'name');
+verifyProperty(Intl.PluralRules.prototype.select, "name", {
+  value: "select",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/PluralRules/prototype/select/prop-desc.js
+++ b/test/intl402/PluralRules/prototype/select/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.PluralRules.prototype, "select");
-verifyWritable(Intl.PluralRules.prototype, "select");
-verifyConfigurable(Intl.PluralRules.prototype, "select");
+verifyProperty(Intl.PluralRules.prototype, "select", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/PluralRules/supportedLocalesOf/length.js
+++ b/test/intl402/PluralRules/supportedLocalesOf/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.PluralRules.supportedLocalesOf.length, 1);
-
-verifyNotEnumerable(Intl.PluralRules.supportedLocalesOf, "length");
-verifyNotWritable(Intl.PluralRules.supportedLocalesOf, "length");
-verifyConfigurable(Intl.PluralRules.supportedLocalesOf, "length");
+verifyProperty(Intl.PluralRules.supportedLocalesOf, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/PluralRules/supportedLocalesOf/name.js
+++ b/test/intl402/PluralRules/supportedLocalesOf/name.js
@@ -7,8 +7,10 @@ description: Tests that Intl.PluralRules.supportedLocalesOf.name is "supportedLo
 author: Zibi Braniecki
 includes: [propertyHelper.js]
 ---*/
-assert.sameValue(Intl.PluralRules.supportedLocalesOf.name, "supportedLocalesOf");
 
-verifyNotEnumerable(Intl.PluralRules.supportedLocalesOf, "name");
-verifyNotWritable(Intl.PluralRules.supportedLocalesOf, "name");
-verifyConfigurable(Intl.PluralRules.supportedLocalesOf, "name");
+verifyProperty(Intl.PluralRules.supportedLocalesOf, "name", {
+  value: "supportedLocalesOf",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/PluralRules/supportedLocalesOf/prop-desc.js
+++ b/test/intl402/PluralRules/supportedLocalesOf/prop-desc.js
@@ -24,6 +24,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl.PluralRules, "supportedLocalesOf");
-verifyWritable(Intl.PluralRules, "supportedLocalesOf");
-verifyConfigurable(Intl.PluralRules, "supportedLocalesOf");
+verifyProperty(Intl.PluralRules, "supportedLocalesOf", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/String/prototype/localeCompare/length.js
+++ b/test/intl402/String/prototype/localeCompare/length.js
@@ -24,8 +24,9 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(String.prototype.localeCompare.length, 1);
-
-verifyNotEnumerable(String.prototype.localeCompare, "length");
-verifyNotWritable(String.prototype.localeCompare, "length");
-verifyConfigurable(String.prototype.localeCompare, "length");
+verifyProperty(String.prototype.localeCompare, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/arguments-object/10.5-1-s.js
+++ b/test/language/arguments-object/10.5-1-s.js
@@ -7,9 +7,8 @@ description: Strict Mode - arguments object is immutable
 flags: [onlyStrict]
 ---*/
 
-
 assert.throws(SyntaxError, function() {
-            (function fun() {
-                eval("arguments = 10");
-            })(30);
+    (function fun() {
+        eval("arguments = 10");
+    })(30);
 });

--- a/test/language/arguments-object/10.5-7-b-1-s.js
+++ b/test/language/arguments-object/10.5-7-b-1-s.js
@@ -7,7 +7,6 @@ description: Strict Mode - arguments object is immutable in eval'ed functions
 flags: [onlyStrict]
 ---*/
 
-
 assert.throws(SyntaxError, function() {
-            eval("(function _10_5_7_b_1_fun() { arguments = 10;} ());");
+    eval("(function _10_5_7_b_1_fun() { arguments = 10;} ());");
 });

--- a/test/language/arguments-object/10.5-7-b-2-s.js
+++ b/test/language/arguments-object/10.5-7-b-2-s.js
@@ -6,9 +6,9 @@ es5id: 10.5-7-b-2-s
 description: Arguments object index assignment is allowed
 ---*/
 
-        function _10_5_7_b_2_fun() {
-            arguments[7] = 12;
-            return arguments[7] === 12;
-        };
+function _10_5_7_b_2_fun() {
+    arguments[7] = 12;
+    return arguments[7] === 12;
+};
 
 assert(_10_5_7_b_2_fun(30), '_10_5_7_b_2_fun(30) !== true');

--- a/test/language/arguments-object/10.5-7-b-3-s.js
+++ b/test/language/arguments-object/10.5-7-b-3-s.js
@@ -7,9 +7,9 @@ description: >
     Adding property to the arguments object successful under strict mode
 ---*/
 
-        function _10_5_7_b_3_fun() {
-            arguments[1] = 12;
-            return arguments[0] === 30 && arguments[1] === 12;
-        };
+function _10_5_7_b_3_fun() {
+    arguments[1] = 12;
+    return arguments[0] === 30 && arguments[1] === 12;
+};
 
 assert(_10_5_7_b_3_fun(30), '_10_5_7_b_3_fun(30) !== true');

--- a/test/language/arguments-object/10.5-7-b-4-s.js
+++ b/test/language/arguments-object/10.5-7-b-4-s.js
@@ -7,11 +7,11 @@ description: >
     Deleting property of the arguments object successful under strict mode
 ---*/
 
-        function _10_5_7_b_4_fun() {
-            var _10_5_7_b_4_1 = arguments[0] === 30 && arguments[1] === 12;
-            delete arguments[1];
-            var _10_5_7_b_4_2 = arguments[0] === 30 && typeof arguments[1] === "undefined";
-            return _10_5_7_b_4_1 && _10_5_7_b_4_2;
-        };
+function _10_5_7_b_4_fun() {
+    var _10_5_7_b_4_1 = arguments[0] === 30 && arguments[1] === 12;
+    delete arguments[1];
+    var _10_5_7_b_4_2 = arguments[0] === 30 && typeof arguments[1] === "undefined";
+    return _10_5_7_b_4_1 && _10_5_7_b_4_2;
+};
 
 assert(_10_5_7_b_4_fun(30, 12), '_10_5_7_b_4_fun(30, 12) !== true');

--- a/test/language/arguments-object/10.6-10-c-ii-1-s.js
+++ b/test/language/arguments-object/10.6-10-c-ii-1-s.js
@@ -9,10 +9,10 @@ description: >
 flags: [onlyStrict]
 ---*/
 
-  function foo(a,b,c)
-  {
-    a = 1; b = 'str'; c = 2.1;
-    return (arguments[0] === 10 && arguments[1] === 'sss' && arguments[2] === 1);
-  }
+function foo(a,b,c)
+{
+  a = 1; b = 'str'; c = 2.1;
+  return (arguments[0] === 10 && arguments[1] === 'sss' && arguments[2] === 1);
+}
 
 assert(foo(10, 'sss', 1), 'foo(10, "sss", 1) !== true');

--- a/test/language/arguments-object/10.6-10-c-ii-1.js
+++ b/test/language/arguments-object/10.6-10-c-ii-1.js
@@ -7,11 +7,11 @@ description: arguments[i] change with actual parameters
 flags: [noStrict]
 ---*/
 
-  function foo(a,b,c)
-  {
-    a = 1; b = 'str'; c = 2.1;
-    if(arguments[0] === 1 && arguments[1] === 'str' && arguments[2] === 2.1)
-      return true;   
-  }
+function foo(a,b,c)
+{
+  a = 1; b = 'str'; c = 2.1;
+  if(arguments[0] === 1 && arguments[1] === 'str' && arguments[2] === 2.1)
+    return true;
+}
 
 assert(foo(10,'sss',1), 'foo(10,"sss",1) !== true');

--- a/test/language/arguments-object/10.6-10-c-ii-2.js
+++ b/test/language/arguments-object/10.6-10-c-ii-2.js
@@ -7,11 +7,11 @@ description: arguments[i] map to actual parameter
 flags: [noStrict]
 ---*/
 
-  function foo(a,b,c)
-  {
-    arguments[0] = 1; arguments[1] = 'str'; arguments[2] = 2.1;
-    if(1 === a && 'str' === b && 2.1 === c)
-      return true;   
-  }
+function foo(a,b,c)
+{
+  arguments[0] = 1; arguments[1] = 'str'; arguments[2] = 2.1;
+  if(1 === a && 'str' === b && 2.1 === c)
+    return true;
+}
 
 assert(foo(10,'sss',1), 'foo(10,"sss",1) !== true');

--- a/test/language/arguments-object/10.6-11-b-1.js
+++ b/test/language/arguments-object/10.6-11-b-1.js
@@ -7,6 +7,7 @@ description: >
     Arguments Object has index property '0' as its own property, it
     shoulde be writable, enumerable, configurable and does not invoke
     the setter defined on Object.prototype[0] (Step 11.b)
+includes: [propertyHelper.js]
 ---*/
 
             var data = "data";
@@ -26,26 +27,11 @@ description: >
 
             var argObj = (function () { return arguments })(1);
 
-            var verifyValue = false;
-            verifyValue = (argObj[0] === 1);
+verifyProperty(argObj, "0", {
+    value: 1,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+});
 
-            var verifyEnumerable = false;
-            for (var p in argObj) {
-                if (p === "0" && argObj.hasOwnProperty("0")) {
-                    verifyEnumerable = true;
-                }
-            }
-
-            var verifyWritable = false;
-            argObj[0] = 1001;
-            verifyWritable = (argObj[0] === 1001);
-
-            var verifyConfigurable = false;
-            delete argObj[0];
-            verifyConfigurable = argObj.hasOwnProperty("0");
-
-assert(verifyValue, 'verifyValue !== true');
-assert(verifyWritable, 'verifyWritable !== true');
-assert(verifyEnumerable, 'verifyEnumerable !== true');
-assert.sameValue(verifyConfigurable, false, 'verifyConfigurable');
 assert.sameValue(data, "data", 'data');

--- a/test/language/arguments-object/10.6-11-b-1.js
+++ b/test/language/arguments-object/10.6-11-b-1.js
@@ -10,22 +10,22 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-            var data = "data";
-            var getFunc = function () {
-                return data;
-            };
+var data = "data";
+var getFunc = function () {
+    return data;
+};
 
-            var setFunc = function (value) {
-                data = value;
-            };
+var setFunc = function (value) {
+    data = value;
+};
 
-            Object.defineProperty(Object.prototype, "0", {
-                get: getFunc,
-                set: setFunc,
-                configurable: true
-            });
+Object.defineProperty(Object.prototype, "0", {
+    get: getFunc,
+    set: setFunc,
+    configurable: true
+});
 
-            var argObj = (function () { return arguments })(1);
+var argObj = (function () { return arguments })(1);
 
 verifyProperty(argObj, "0", {
     value: 1,

--- a/test/language/arguments-object/10.6-12-1.js
+++ b/test/language/arguments-object/10.6-12-1.js
@@ -9,5 +9,5 @@ flags: [noStrict]
 
 function testcase() {
     arguments.callee;
- }
+}
 testcase();

--- a/test/language/arguments-object/10.6-12-2.js
+++ b/test/language/arguments-object/10.6-12-2.js
@@ -15,5 +15,5 @@ function testcase() {
   assert.sameValue(desc.writable, true, 'desc.writable');
   assert.sameValue(desc.hasOwnProperty('get'), false, 'desc.hasOwnProperty("get")');
   assert.sameValue(desc.hasOwnProperty('set'), false, 'desc.hasOwnProperty("set")');
- }
+}
 testcase();

--- a/test/language/arguments-object/10.6-13-a-1.js
+++ b/test/language/arguments-object/10.6-13-a-1.js
@@ -10,13 +10,13 @@ includes: [propertyHelper.js]
 flags: [noStrict]
 ---*/
 
-            Object.defineProperty(Object.prototype, "callee", {
-                value: 1,
-                writable: false,
-                configurable: true
-            });
+Object.defineProperty(Object.prototype, "callee", {
+    value: 1,
+    writable: false,
+    configurable: true
+});
 
-            var argObj = (function () { return arguments })();
+var argObj = (function () { return arguments })();
 
 assert.sameValue(typeof argObj.callee, "function");
 

--- a/test/language/arguments-object/10.6-13-a-1.js
+++ b/test/language/arguments-object/10.6-13-a-1.js
@@ -6,6 +6,7 @@ es5id: 10.6-13-a-1
 description: >
     In non-strict mode, arguments object should have its own 'callee'
     property defined (Step 13.a)
+includes: [propertyHelper.js]
 flags: [noStrict]
 ---*/
 
@@ -17,25 +18,10 @@ flags: [noStrict]
 
             var argObj = (function () { return arguments })();
 
-            var verifyValue = false;
-            verifyValue = typeof argObj.callee === "function";
-            
-            var verifyWritable = false;
-            argObj.callee = 1001;
-            verifyWritable = (argObj.callee === 1001);
+assert.sameValue(typeof argObj.callee, "function");
 
-            var verifyEnumerable = false;
-            for (var p in argObj) {
-                if (p === "callee" && argObj.hasOwnProperty("callee")) {
-                    verifyEnumerable = true;
-                }
-            }
-
-            var verifyConfigurable = false;
-            delete argObj.callee;
-            verifyConfigurable = argObj.hasOwnProperty("callee");
-
-assert(verifyValue, 'verifyValue !== true');
-assert(verifyWritable, 'verifyWritable !== true');
-assert.sameValue(verifyEnumerable, false, 'verifyEnumerable');
-assert.sameValue(verifyConfigurable, false, 'verifyConfigurable');
+verifyProperty(argObj, "callee", {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/arguments-object/10.6-13-a-2.js
+++ b/test/language/arguments-object/10.6-13-a-2.js
@@ -8,24 +8,24 @@ flags: [noStrict]
 features: [caller]
 ---*/
 
-    var called = false;
-    
-    function test1(flag) {
-        if (flag!==true) {
-            test2();
-        } else {
-            called = true;
-        }
-    }
+var called = false;
 
-    function test2() {
-        if(arguments.callee.caller===undefined) {
-          called=true; // Extension not supported - fake it
-        } else {
-          arguments.callee.caller(true);
-        }
+function test1(flag) {
+    if (flag!==true) {
+        test2();
+    } else {
+        called = true;
     }
-    
-    test1();
+}
+
+function test2() {
+    if(arguments.callee.caller===undefined) {
+      called=true; // Extension not supported - fake it
+    } else {
+      arguments.callee.caller(true);
+    }
+}
+
+test1();
 
 assert(called, 'called !== true');

--- a/test/language/arguments-object/10.6-13-a-3.js
+++ b/test/language/arguments-object/10.6-13-a-3.js
@@ -8,25 +8,25 @@ flags: [noStrict]
 features: [caller]
 ---*/
 
-    var called = false;
-    
-    function test1(flag) {
-        if (flag!==true) {
-            test2();
-        } else {
-            called = true;
-        }
-    }
+var called = false;
 
-    function test2() {  
-       if (arguments.callee.caller===undefined) {
-         called = true;  //Extension not supported - fake it
-       } else {     
-         var explicit = arguments.callee.caller;
-         explicit(true);
-       }
+function test1(flag) {
+    if (flag!==true) {
+        test2();
+    } else {
+        called = true;
     }
-    
-    test1();
+}
+
+function test2() {
+   if (arguments.callee.caller===undefined) {
+     called = true;  //Extension not supported - fake it
+   } else {
+     var explicit = arguments.callee.caller;
+     explicit(true);
+   }
+}
+
+test1();
 
 assert(called, 'called !== true');

--- a/test/language/arguments-object/10.6-13-c-2-s.js
+++ b/test/language/arguments-object/10.6-13-c-2-s.js
@@ -9,5 +9,5 @@ description: arguments.callee is exists
 function testcase() {
   var desc = Object.getOwnPropertyDescriptor(arguments,"callee");
   assert.notSameValue(desc, undefined);
- }
+}
 testcase();

--- a/test/language/arguments-object/10.6-13-c-3-s.js
+++ b/test/language/arguments-object/10.6-13-c-3-s.js
@@ -16,5 +16,5 @@ function testcase() {
   assert.sameValue(desc.hasOwnProperty('writable'), false, 'desc.hasOwnProperty("writable")');
   assert.sameValue(desc.hasOwnProperty('get'), true, 'desc.hasOwnProperty("get")');
   assert.sameValue(desc.hasOwnProperty('set'), true, 'desc.hasOwnProperty("set")');
- }
+}
 testcase();

--- a/test/language/arguments-object/10.6-14-c-1-s.js
+++ b/test/language/arguments-object/10.6-14-c-1-s.js
@@ -5,18 +5,13 @@
 es5id: 10.6-14-c-1-s
 description: >
     [[Enumerable]] attribute value in 'callee' is false
+includes: [propertyHelper.js]
 ---*/
 
         var argObj = function () {
             return arguments;
         } ();
 
-        var verifyEnumerable = false;
-        for (var _10_6_14_c_1 in argObj) {
-            if (argObj.hasOwnProperty(_10_6_14_c_1) && _10_6_14_c_1 === "callee") {
-                verifyEnumerable = true;
-            }
-        }
-
-assert.sameValue(verifyEnumerable, false, 'verifyEnumerable');
-assert(argObj.hasOwnProperty("callee"), 'argObj.hasOwnProperty("callee") !== true');
+verifyProperty(argObj, "callee", {
+    enumerable: false,
+});

--- a/test/language/arguments-object/10.6-14-c-1-s.js
+++ b/test/language/arguments-object/10.6-14-c-1-s.js
@@ -8,9 +8,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var argObj = function () {
-            return arguments;
-        } ();
+var argObj = function () {
+    return arguments;
+} ();
 
 verifyProperty(argObj, "callee", {
     enumerable: false,

--- a/test/language/arguments-object/10.6-14-c-4-s.js
+++ b/test/language/arguments-object/10.6-14-c-4-s.js
@@ -9,9 +9,10 @@ description: >
 flags: [onlyStrict]
 ---*/
 
-        var argObj = function () {
-            return arguments;
-        } ();
+var argObj = function () {
+    return arguments;
+} ();
+
 assert.throws(TypeError, function() {
-            argObj.callee = {};
+    argObj.callee = {};
 });

--- a/test/language/arguments-object/10.6-5-1.js
+++ b/test/language/arguments-object/10.6-5-1.js
@@ -10,5 +10,5 @@ description: >
 
 function testcase() {
   assert.sameValue(Object.getPrototypeOf(arguments), Object.getPrototypeOf({}));
- }
+}
 testcase();

--- a/test/language/arguments-object/10.6-6-1.js
+++ b/test/language/arguments-object/10.6-6-1.js
@@ -7,8 +7,7 @@ description: "'length property of arguments object exists"
 ---*/
 
 function testcase() {
-  
   var desc = Object.getOwnPropertyDescriptor(arguments,"length");
   assert.notSameValue(desc, undefined);
- }
+}
 testcase();

--- a/test/language/arguments-object/10.6-6-2.js
+++ b/test/language/arguments-object/10.6-6-2.js
@@ -13,5 +13,5 @@ function testcase() {
     enumerable: false,
     configurable: true,
   });
- }
+}
 testcase();

--- a/test/language/arguments-object/10.6-6-2.js
+++ b/test/language/arguments-object/10.6-6-2.js
@@ -4,13 +4,14 @@
 /*---
 es5id: 10.6-6-2
 description: "'length' property of arguments object has correct attributes"
+includes: [propertyHelper.js]
 ---*/
 
 function testcase() {
-  var desc = Object.getOwnPropertyDescriptor(arguments,"length");
-
-  assert.sameValue(desc.configurable, true, 'desc.configurable');
-  assert.sameValue(desc.enumerable, false, 'desc.enumerable');
-  assert.sameValue(desc.writable, true, 'desc.writable');
+  verifyProperty(arguments, "length", {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
  }
 testcase();

--- a/test/language/arguments-object/10.6-6-3-s.js
+++ b/test/language/arguments-object/10.6-6-3-s.js
@@ -10,5 +10,5 @@ description: >
 
 function testcase() {
   assert.sameValue(arguments.length, 0);
- }
+}
 testcase();

--- a/test/language/arguments-object/10.6-6-3.js
+++ b/test/language/arguments-object/10.6-6-3.js
@@ -10,7 +10,7 @@ flags: [noStrict]
 ---*/
 
 function testcase() {
-      var arguments= undefined;
-	(function () { assert.sameValue(arguments.length, 0); })();
- }
+    var arguments= undefined;
+    (function () { assert.sameValue(arguments.length, 0); })();
+}
 testcase();

--- a/test/language/arguments-object/10.6-6-4-s.js
+++ b/test/language/arguments-object/10.6-6-4-s.js
@@ -9,6 +9,6 @@ description: >
 ---*/
 
 function testcase(a,b,c) {
-	assert.sameValue(arguments.length, 0);
- }
+    assert.sameValue(arguments.length, 0);
+}
 testcase();

--- a/test/language/arguments-object/10.6-6-4.js
+++ b/test/language/arguments-object/10.6-6-4.js
@@ -10,7 +10,7 @@ flags: [noStrict]
 ---*/
 
 function testcase() {
-      var arguments= undefined;
-	(function (a,b,c) { assert.sameValue(arguments.length, 0); })();
- }
+    var arguments= undefined;
+    (function (a,b,c) { assert.sameValue(arguments.length, 0); })();
+}
 testcase();

--- a/test/language/arguments-object/10.6-7-1.js
+++ b/test/language/arguments-object/10.6-7-1.js
@@ -9,22 +9,22 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-            var data = "data";
-            var getFunc = function () {
-                return 12;
-            };
+var data = "data";
+var getFunc = function () {
+    return 12;
+};
 
-            var setFunc = function (value) {
-                data = value;
-            };
+var setFunc = function (value) {
+    data = value;
+};
 
-            Object.defineProperty(Object.prototype, "length", {
-                get: getFunc,
-                set: setFunc,
-                configurable: true
-            });
+Object.defineProperty(Object.prototype, "length", {
+    get: getFunc,
+    set: setFunc,
+    configurable: true
+});
 
-            var argObj = (function () { return arguments })();
+var argObj = (function () { return arguments })();
 
 verifyProperty(argObj, "length", {
     value: 0,

--- a/test/language/arguments-object/10.6-7-1.js
+++ b/test/language/arguments-object/10.6-7-1.js
@@ -6,6 +6,7 @@ es5id: 10.6-7-1
 description: >
     Arguments Object has length as its own property and does not
     invoke the setter defined on Object.prototype.length (Step 7)
+includes: [propertyHelper.js]
 ---*/
 
             var data = "data";
@@ -23,27 +24,13 @@ description: >
                 configurable: true
             });
 
-            var verifyValue = false;
             var argObj = (function () { return arguments })();
-            verifyValue = (argObj.length === 0);
 
-            var verifyWritable = false;
-            argObj.length = 1001;
-            verifyWritable = (argObj.length === 1001);
+verifyProperty(argObj, "length", {
+    value: 0,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});
 
-            var verifyEnumerable = false;
-            for (var p in argObj) {
-                if (p === "length") {
-                    verifyEnumerable = true;
-                }
-            }
-
-            var verifyConfigurable = false;
-            delete argObj.length;
-            verifyConfigurable = argObj.hasOwnProperty("length");
-
-assert(verifyValue, 'verifyValue !== true');
-assert(verifyWritable, 'verifyWritable !== true');
-assert.sameValue(verifyEnumerable, false, 'verifyEnumerable');
-assert.sameValue(verifyConfigurable, false, 'verifyConfigurable');
 assert.sameValue(data, "data", 'data');

--- a/test/language/arguments-object/mapped/Symbol.iterator.js
+++ b/test/language/arguments-object/mapped/Symbol.iterator.js
@@ -11,11 +11,10 @@ features: [Symbol.iterator]
 ---*/
 
 (function() {
-  var descriptor = Object.getOwnPropertyDescriptor(arguments, Symbol.iterator);
-
-  assert.sameValue(arguments[Symbol.iterator], [][Symbol.iterator]);
-
-  verifyNotEnumerable(Array.prototype, Symbol.iterator);
-  verifyWritable(Array.prototype, Symbol.iterator);
-  verifyConfigurable(Array.prototype, Symbol.iterator);
+  verifyProperty(arguments, Symbol.iterator, {
+    value: [][Symbol.iterator],
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
 }());

--- a/test/language/arguments-object/mapped/nonconfigurable-descriptors-basic.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-descriptors-basic.js
@@ -13,10 +13,11 @@ includes: [propertyHelper.js]
 function argumentsNonConfigurable(a) {
   Object.defineProperty(arguments, "0", {configurable: false});
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyEnumerable(arguments, "0");
-  verifyWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: true,
+    enumerable: true,
+    configurable: false,
+  });
 }
 argumentsNonConfigurable(1);

--- a/test/language/arguments-object/mapped/nonconfigurable-descriptors-set-value-by-arguments.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-descriptors-set-value-by-arguments.js
@@ -16,12 +16,14 @@ function argumentsAndSetByIndex(a) {
 
   arguments[0] = 2;
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
   assert.sameValue(a, 2);
-  verifyEnumerable(arguments, "0");
-  verifyWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: true,
+    enumerable: true,
+    configurable: false,
+  });
 }
 argumentsAndSetByIndex(1);
 

--- a/test/language/arguments-object/mapped/nonconfigurable-descriptors-set-value-with-define-property.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-descriptors-set-value-with-define-property.js
@@ -16,12 +16,14 @@ function setArgumentValueWithDefineOwnProperty(a) {
 
   Object.defineProperty(arguments, "0", {value: 2});
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
   assert.sameValue(a, 2);
-  verifyEnumerable(arguments, "0");
-  verifyWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: true,
+    enumerable: true,
+    configurable: false,
+  });
 }
 setArgumentValueWithDefineOwnProperty(1);
 

--- a/test/language/arguments-object/mapped/nonconfigurable-descriptors-with-param-assign.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-descriptors-with-param-assign.js
@@ -15,11 +15,13 @@ function argumentsAndSetMutableBinding(a) {
   Object.defineProperty(arguments, "0", {configurable: false});
 
   a = 2;
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
-  verifyEnumerable(arguments, "0");
-  verifyWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: true,
+    enumerable: true,
+    configurable: false,
+  });
 }
 argumentsAndSetMutableBinding(1);
 

--- a/test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js
@@ -17,11 +17,12 @@ function fn(a) {
   // Postcondition: Arguments mapping is removed.
   a = 2;
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 }
 fn(1);
 

--- a/test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js
@@ -17,20 +17,24 @@ function fn(a) {
   arguments[0] = 2;
   Object.defineProperty(arguments, "0", {writable: false});
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
   assert.sameValue(a, 2);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 
   // Postcondition: Arguments mapping is removed.
   a = 3;
-  propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 }
 fn(1);
 

--- a/test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js
@@ -18,19 +18,22 @@ function fn(a) {
   a = 2;
   Object.defineProperty(arguments, "0", {writable: false});
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 
   // Postcondition: Arguments mapping is removed.
   a = 3;
-  propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 }
 fn(1);
 

--- a/test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-basic.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-basic.js
@@ -18,11 +18,12 @@ function fn(a) {
   // Postcondition: Arguments mapping is removed.
   a = 2;
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 }
 fn(1);
 

--- a/test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js
@@ -16,19 +16,22 @@ function fn(a) {
   Object.defineProperty(arguments, "0", {configurable: false});
   Object.defineProperty(arguments, "0", {writable: false});
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 
   // Postcondition: Arguments mapping is removed.
   a = 2;
-  propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 }
 fn(1);
 

--- a/test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js
@@ -18,20 +18,25 @@ function fn(a) {
   Object.defineProperty(arguments, "0", {configurable: false});
   arguments[0] = 2;
   Object.defineProperty(arguments, "0", {writable: false});
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
+
   assert.sameValue(a, 2)
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 
   // Postcondition: Arguments mapping is removed.
   a = 3;
-  propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 }
 fn(1);
 

--- a/test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js
+++ b/test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js
@@ -18,19 +18,22 @@ function fn(a) {
   a = 2;
   Object.defineProperty(arguments, "0", {writable: false});
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 
   // Postcondition: Arguments mapping is removed.
   a = 3;
-  propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 }
 fn(1);
 

--- a/test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-basic.js
+++ b/test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-basic.js
@@ -17,20 +17,24 @@ includes: [propertyHelper.js]
 function fn(a) {
   Object.defineProperty(arguments, "0", {writable: false});
   Object.defineProperty(arguments, "0", {configurable: false});
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 
   // Postcondition: Arguments mapping is removed. Descriptors need to be the same
   // as above.
   a = 2;
-  propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 }
 fn(1);
 

--- a/test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js
+++ b/test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js
@@ -18,20 +18,25 @@ function fn(a) {
   Object.defineProperty(arguments, "0", {writable: false});
   arguments[0] = 2;
   Object.defineProperty(arguments, "0", {configurable: false});
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
+
   assert.sameValue(a, 1);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 
   // Postcondition: Arguments mapping is removed.
   a = 3;
-  propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 }
 fn(1);
 

--- a/test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js
+++ b/test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js
@@ -18,11 +18,13 @@ function fn(a) {
   Object.defineProperty(arguments, "0", {writable: false});
   a = 2;
   Object.defineProperty(arguments, "0", {configurable: false});
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
 }
 fn(1);
 

--- a/test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js
+++ b/test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js
@@ -18,18 +18,21 @@ function fn(a) {
   Object.defineProperty(arguments, "0", {writable: false, enumerable: false});
   Object.defineProperty(arguments, "0", {configurable: false});
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 
   // Postcondition: Arguments mapping is removed.
   a = 2;
-  propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 }
 fn(1);

--- a/test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js
+++ b/test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js
@@ -17,18 +17,21 @@ function fn(a) {
   arguments[0] = 2;
   Object.defineProperty(arguments, "0", {configurable: false});
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 
   // Postcondition: Arguments mapping is removed.
   a = 3;
-  propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 }
 fn(1);

--- a/test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-define-property.js
+++ b/test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-define-property.js
@@ -17,11 +17,11 @@ includes: [propertyHelper.js]
 function fn(a) {
   Object.defineProperty(arguments, "0", {writable: false, enumerable: false, value: 2, configurable: false});
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 2);
-  assert.sameValue(arguments[0], 2);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+  verifyProperty(arguments, "0", {
+    value: 2,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 }
 fn(1);

--- a/test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js
+++ b/test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js
@@ -18,18 +18,21 @@ function fn(a) {
   a = 2;
   Object.defineProperty(arguments, "0", {configurable: false});
 
-  let propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 
   // Postcondition: Arguments mapping is removed.
   a = 3;
-  propertyDescriptor = Object.getOwnPropertyDescriptor(arguments, "0");
-  assert.sameValue(propertyDescriptor.value, 1);
-  verifyNotEnumerable(arguments, "0");
-  verifyNotWritable(arguments, "0");
-  verifyNotConfigurable(arguments, "0");
+
+  verifyProperty(arguments, "0", {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
 }
 fn(1);

--- a/test/language/arguments-object/unmapped/Symbol.iterator.js
+++ b/test/language/arguments-object/unmapped/Symbol.iterator.js
@@ -12,11 +12,11 @@ features: [Symbol.iterator]
 
 (function() {
   'use strict';
-  var descriptor = Object.getOwnPropertyDescriptor(arguments, Symbol.iterator);
 
-  assert.sameValue(arguments[Symbol.iterator], [][Symbol.iterator]);
-
-  verifyNotEnumerable(Array.prototype, Symbol.iterator);
-  verifyWritable(Array.prototype, Symbol.iterator);
-  verifyConfigurable(Array.prototype, Symbol.iterator);
+  verifyProperty(arguments, Symbol.iterator, {
+    value: [][Symbol.iterator],
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
 }());

--- a/test/language/eval-code/direct/var-env-func-init-global-new.js
+++ b/test/language/eval-code/direct/var-env-func-init-global-new.js
@@ -32,8 +32,11 @@ var initial;
 
 eval('initial = f; function f() { return 234; }');
 
-verifyEnumerable(this, 'f');
-verifyWritable(this, 'f');
-verifyConfigurable(this, 'f');
+verifyProperty(this, 'f', {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+
 assert.sameValue(typeof initial, 'function');
 assert.sameValue(initial(), 234);

--- a/test/language/eval-code/direct/var-env-func-init-global-update-configurable.js
+++ b/test/language/eval-code/direct/var-env-func-init-global-update-configurable.js
@@ -38,8 +38,11 @@ Object.defineProperty(this, 'f', {
 
 eval('initial = f; function f() { return 345; }');
 
-verifyEnumerable(this, 'f');
-verifyWritable(this, 'f');
-verifyConfigurable(this, 'f');
+verifyProperty(this, 'f', {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+
 assert.sameValue(typeof initial, 'function');
 assert.sameValue(initial(), 345);

--- a/test/language/eval-code/direct/var-env-func-init-global-update-non-configurable.js
+++ b/test/language/eval-code/direct/var-env-func-init-global-update-non-configurable.js
@@ -38,8 +38,11 @@ Object.defineProperty(this, 'f', {
 
 eval('initial = f; function f() { return 2222; }');
 
-verifyEnumerable(this, 'f');
-verifyWritable(this, 'f');
-verifyNotConfigurable(this, 'f');
+verifyProperty(this, 'f', {
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
+
 assert.sameValue(typeof initial, 'function');
 assert.sameValue(initial(), 2222);

--- a/test/language/eval-code/direct/var-env-var-init-global-exstng.js
+++ b/test/language/eval-code/direct/var-env-var-init-global-exstng.js
@@ -26,8 +26,11 @@ var x = 23;
 
 eval('initial = x; var x = 45;');
 
-verifyEnumerable(this, 'x');
-verifyWritable(this, 'x');
-verifyNotConfigurable(this, 'x');
+verifyProperty(this, 'x', {
+  value: 45,
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
 
 assert.sameValue(initial, 23);

--- a/test/language/eval-code/direct/var-env-var-init-global-new.js
+++ b/test/language/eval-code/direct/var-env-var-init-global-new.js
@@ -26,8 +26,11 @@ var initial = null;
 
 eval('initial = x; var x;');
 
-verifyEnumerable(this, 'x');
-verifyWritable(this, 'x');
-verifyConfigurable(this, 'x');
+verifyProperty(this, 'x', {
+  value: undefined,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
 
 assert.sameValue(initial, undefined);

--- a/test/language/eval-code/indirect/var-env-func-init-global-new.js
+++ b/test/language/eval-code/indirect/var-env-func-init-global-new.js
@@ -31,8 +31,11 @@ var initial;
 
 (0, eval)('initial = f; function f() { return 234; }');
 
-verifyEnumerable(this, 'f');
-verifyWritable(this, 'f');
-verifyConfigurable(this, 'f');
+verifyProperty(this, 'f', {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+
 assert.sameValue(typeof initial, 'function');
 assert.sameValue(initial(), 234);

--- a/test/language/eval-code/indirect/var-env-func-init-global-update-configurable.js
+++ b/test/language/eval-code/indirect/var-env-func-init-global-update-configurable.js
@@ -37,8 +37,11 @@ Object.defineProperty(this, 'f', {
 
 (0, eval)('initial = f; function f() { return 345; }');
 
-verifyEnumerable(this, 'f');
-verifyWritable(this, 'f');
-verifyConfigurable(this, 'f');
+verifyProperty(this, 'f', {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+
 assert.sameValue(typeof initial, 'function');
 assert.sameValue(initial(), 345);

--- a/test/language/eval-code/indirect/var-env-func-init-global-update-non-configurable.js
+++ b/test/language/eval-code/indirect/var-env-func-init-global-update-non-configurable.js
@@ -37,8 +37,11 @@ Object.defineProperty(this, 'f', {
 
 (0,eval)('initial = f; function f() { return 2222; }');
 
-verifyEnumerable(this, 'f');
-verifyWritable(this, 'f');
-verifyNotConfigurable(this, 'f');
+verifyProperty(this, 'f', {
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
+
 assert.sameValue(typeof initial, 'function');
 assert.sameValue(initial(), 2222);

--- a/test/language/eval-code/indirect/var-env-var-init-global-exstng.js
+++ b/test/language/eval-code/indirect/var-env-var-init-global-exstng.js
@@ -25,8 +25,11 @@ var x = 23;
 
 (0, eval)('initial = x; var x = 45;');
 
-verifyEnumerable(this, 'x');
-verifyWritable(this, 'x');
-verifyNotConfigurable(this, 'x');
+verifyProperty(this, 'x', {
+  value: 45,
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
 
 assert.sameValue(initial, 23);

--- a/test/language/eval-code/indirect/var-env-var-init-global-new.js
+++ b/test/language/eval-code/indirect/var-env-var-init-global-new.js
@@ -25,8 +25,11 @@ var initial = null;
 
 (0, eval)('initial = x; var x = 9;');
 
-verifyEnumerable(this, 'x');
-verifyWritable(this, 'x');
-verifyConfigurable(this, 'x');
+verifyProperty(this, 'x', {
+  value: 9,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
 
 assert.sameValue(initial, undefined);

--- a/test/language/expressions/arrow-function/length-dflt.js
+++ b/test/language/expressions/arrow-function/length-dflt.js
@@ -33,28 +33,36 @@ includes: [propertyHelper.js]
 
 var f1 = (x = 42) => {};
 
-assert.sameValue(f1.length, 0, 'FormalsList: x = 42');
-verifyNotEnumerable(f1, 'length');
-verifyNotWritable(f1, 'length');
-verifyConfigurable(f1, 'length');
+verifyProperty(f1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f2 = (x = 42, y) => {};
 
-assert.sameValue(f2.length, 0, 'FormalsList: x = 42, y');
-verifyNotEnumerable(f2, 'length');
-verifyNotWritable(f2, 'length');
-verifyConfigurable(f2, 'length');
+verifyProperty(f2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f3 = (x, y = 42) => {};
 
-assert.sameValue(f3.length, 1, 'FormalsList: x, y = 42');
-verifyNotEnumerable(f3, 'length');
-verifyNotWritable(f3, 'length');
-verifyConfigurable(f3, 'length');
+verifyProperty(f3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f4 = (x, y = 42, z) => {};
 
-assert.sameValue(f4.length, 1, 'FormalsList: x, y = 42, z');
-verifyNotEnumerable(f4, 'length');
-verifyNotWritable(f4, 'length');
-verifyConfigurable(f4, 'length');
+verifyProperty(f4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/assignment/fn-name-arrow.js
+++ b/test/language/expressions/assignment/fn-name-arrow.js
@@ -25,7 +25,9 @@ var arrow;
 
 arrow = () => {};
 
-assert.sameValue(arrow.name, 'arrow');
-verifyNotEnumerable(arrow, 'name');
-verifyNotWritable(arrow, 'name');
-verifyConfigurable(arrow, 'name');
+verifyProperty(arrow, 'name', {
+  value: 'arrow',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/assignment/fn-name-class.js
+++ b/test/language/expressions/assignment/fn-name-class.js
@@ -31,7 +31,9 @@ xCls2 = class { static name() {} };
 assert.notSameValue(xCls.name, 'xCls');
 assert.notSameValue(xCls2.name, 'xCls2');
 
-assert.sameValue(cls.name, 'cls');
-verifyNotEnumerable(cls, 'name');
-verifyNotWritable(cls, 'name');
-verifyConfigurable(cls, 'name');
+verifyProperty(cls, 'name', {
+  value: 'cls',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/assignment/fn-name-cover.js
+++ b/test/language/expressions/assignment/fn-name-cover.js
@@ -29,7 +29,9 @@ cover = (function() {});
 
 assert(xCover.name !== 'xCover');
 
-assert.sameValue(cover.name, 'cover');
-verifyNotEnumerable(cover, 'name');
-verifyNotWritable(cover, 'name');
-verifyConfigurable(cover, 'name');
+verifyProperty(cover, 'name', {
+  value: 'cover',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/assignment/fn-name-fn.js
+++ b/test/language/expressions/assignment/fn-name-fn.js
@@ -28,7 +28,9 @@ fn = function() {};
 
 assert(xFn.name !== 'xFn');
 
-assert.sameValue(fn.name, 'fn');
-verifyNotEnumerable(fn, 'name');
-verifyNotWritable(fn, 'name');
-verifyConfigurable(fn, 'name');
+verifyProperty(fn, 'name', {
+  value: 'fn',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/assignment/fn-name-gen.js
+++ b/test/language/expressions/assignment/fn-name-gen.js
@@ -29,7 +29,9 @@ gen = function*() {};
 
 assert(xGen.name !== 'xGen');
 
-assert.sameValue(gen.name, 'gen');
-verifyNotEnumerable(gen, 'name');
-verifyNotWritable(gen, 'name');
-verifyConfigurable(gen, 'name');
+verifyProperty(gen, 'name', {
+  value: 'gen',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/class/gen-method-length-dflt.js
+++ b/test/language/expressions/class/gen-method-length-dflt.js
@@ -32,28 +32,36 @@ includes: [propertyHelper.js]
 
 var m1 = class { *m(x = 42) {} }.prototype.m;
 
-assert.sameValue(m1.length, 0, 'formalslist: x = 42');
-verifyNotEnumerable(m1, 'length');
-verifyNotWritable(m1, 'length');
-verifyConfigurable(m1, 'length');
+verifyProperty(m1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var m2 = class { *m(x = 42, y) {} }.prototype.m;
 
-assert.sameValue(m2.length, 0, 'formalslist: x = 42, y');
-verifyNotEnumerable(m2, 'length');
-verifyNotWritable(m2, 'length');
-verifyConfigurable(m2, 'length');
+verifyProperty(m2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var m3 = class { *m(x, y = 42) {} }.prototype.m;
 
-assert.sameValue(m3.length, 1, 'formalslist: x, y = 42');
-verifyNotEnumerable(m3, 'length');
-verifyNotWritable(m3, 'length');
-verifyConfigurable(m3, 'length');
+verifyProperty(m3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var m4 = class { *m(x, y = 42, z) {} }.prototype.m;
 
-assert.sameValue(m4.length, 1, 'formalslist: x, y = 42, z');
-verifyNotEnumerable(m4, 'length');
-verifyNotWritable(m4, 'length');
-verifyConfigurable(m4, 'length');
+verifyProperty(m4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/class/method-length-dflt.js
+++ b/test/language/expressions/class/method-length-dflt.js
@@ -32,28 +32,36 @@ includes: [propertyHelper.js]
 
 var m1 = class { m(x = 42) {} }.prototype.m;
 
-assert.sameValue(m1.length, 0, 'formalslist: x = 42');
-verifyNotEnumerable(m1, 'length');
-verifyNotWritable(m1, 'length');
-verifyConfigurable(m1, 'length');
+verifyProperty(m1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var m2 = class { m(x = 42, y) {} }.prototype.m;
 
-assert.sameValue(m2.length, 0, 'formalslist: x = 42, y');
-verifyNotEnumerable(m2, 'length');
-verifyNotWritable(m2, 'length');
-verifyConfigurable(m2, 'length');
+verifyProperty(m2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var m3 = class { m(x, y = 42) {} }.prototype.m;
 
-assert.sameValue(m3.length, 1, 'formalslist: x, y = 42');
-verifyNotEnumerable(m3, 'length');
-verifyNotWritable(m3, 'length');
-verifyConfigurable(m3, 'length');
+verifyProperty(m3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var m4 = class { m(x, y = 42, z) {} }.prototype.m;
 
-assert.sameValue(m4.length, 1, 'formalslist: x, y = 42, z');
-verifyNotEnumerable(m4, 'length');
-verifyNotWritable(m4, 'length');
-verifyConfigurable(m4, 'length');
+verifyProperty(m4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/class/setter-length-dflt.js
+++ b/test/language/expressions/class/setter-length-dflt.js
@@ -33,7 +33,9 @@ includes: [propertyHelper.js]
 var C = class { set m(x = 42) {} };
 var set = Object.getOwnPropertyDescriptor(C.prototype, 'm').set;
 
-assert.sameValue(set.length, 0, 'FormalsList: x = 42');
-verifyNotEnumerable(set, 'length');
-verifyNotWritable(set, 'length');
-verifyConfigurable(set, 'length');
+verifyProperty(set, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/class/static-method-length-dflt.js
+++ b/test/language/expressions/class/static-method-length-dflt.js
@@ -32,28 +32,36 @@ includes: [propertyHelper.js]
 
 var m1 = class { static m(x = 42) {} }.m;
 
-assert.sameValue(m1.length, 0, 'formalslist: x = 42');
-verifyNotEnumerable(m1, 'length');
-verifyNotWritable(m1, 'length');
-verifyConfigurable(m1, 'length');
+verifyProperty(m1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var m2 = class { static m(x = 42, y) {} }.m;
 
-assert.sameValue(m2.length, 0, 'formalslist: x = 42, y');
-verifyNotEnumerable(m2, 'length');
-verifyNotWritable(m2, 'length');
-verifyConfigurable(m2, 'length');
+verifyProperty(m2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var m3 = class { static m(x, y = 42) {} }.m;
 
-assert.sameValue(m3.length, 1, 'formalslist: x, y = 42');
-verifyNotEnumerable(m3, 'length');
-verifyNotWritable(m3, 'length');
-verifyConfigurable(m3, 'length');
+verifyProperty(m3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var m4 = class { static m(x, y = 42, z) {} }.m;
 
-assert.sameValue(m4.length, 1, 'formalslist: x, y = 42, z');
-verifyNotEnumerable(m4, 'length');
-verifyNotWritable(m4, 'length');
-verifyConfigurable(m4, 'length');
+verifyProperty(m4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/function/length-dflt.js
+++ b/test/language/expressions/function/length-dflt.js
@@ -33,28 +33,36 @@ includes: [propertyHelper.js]
 
 var f1 = function (x = 42) {};
 
-assert.sameValue(f1.length, 0, 'FormalsList: x = 42');
-verifyNotEnumerable(f1, 'length');
-verifyNotWritable(f1, 'length');
-verifyConfigurable(f1, 'length');
+verifyProperty(f1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f2 = function (x = 42, y) {};
 
-assert.sameValue(f2.length, 0, 'FormalsList: x = 42, y');
-verifyNotEnumerable(f2, 'length');
-verifyNotWritable(f2, 'length');
-verifyConfigurable(f2, 'length');
+verifyProperty(f2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f3 = function (x, y = 42) {};
 
-assert.sameValue(f3.length, 1, 'FormalsList: x, y = 42');
-verifyNotEnumerable(f3, 'length');
-verifyNotWritable(f3, 'length');
-verifyConfigurable(f3, 'length');
+verifyProperty(f3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f4 = function (x, y = 42, z) {};
 
-assert.sameValue(f4.length, 1, 'FormalsList: x, y = 42, z');
-verifyNotEnumerable(f4, 'length');
-verifyNotWritable(f4, 'length');
-verifyConfigurable(f4, 'length');
+verifyProperty(f4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/generators/length-dflt.js
+++ b/test/language/expressions/generators/length-dflt.js
@@ -33,28 +33,36 @@ includes: [propertyHelper.js]
 
 var f1 = function* (x = 42) {};
 
-assert.sameValue(f1.length, 0, 'FormalsList: x = 42');
-verifyNotEnumerable(f1, 'length');
-verifyNotWritable(f1, 'length');
-verifyConfigurable(f1, 'length');
+verifyProperty(f1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f2 = function* (x = 42, y) {};
 
-assert.sameValue(f2.length, 0, 'FormalsList: x = 42, y');
-verifyNotEnumerable(f2, 'length');
-verifyNotWritable(f2, 'length');
-verifyConfigurable(f2, 'length');
+verifyProperty(f2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f3 = function* (x, y = 42) {};
 
-assert.sameValue(f3.length, 1, 'FormalsList: x, y = 42');
-verifyNotEnumerable(f3, 'length');
-verifyNotWritable(f3, 'length');
-verifyConfigurable(f3, 'length');
+verifyProperty(f3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f4 = function* (x, y = 42, z) {};
 
-assert.sameValue(f4.length, 1, 'FormalsList: x, y = 42, z');
-verifyNotEnumerable(f4, 'length');
-verifyNotWritable(f4, 'length');
-verifyConfigurable(f4, 'length');
+verifyProperty(f4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/generators/length-property-descriptor.js
+++ b/test/language/expressions/generators/length-property-descriptor.js
@@ -11,7 +11,9 @@ features: [generators]
 
 var g = function*() {};
 
-assert.sameValue(g.length, 0);
-verifyNotEnumerable(g, 'length');
-verifyNotWritable(g, 'length');
-verifyConfigurable(g, 'length');
+verifyProperty(g, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/generators/prototype-property-descriptor.js
+++ b/test/language/expressions/generators/prototype-property-descriptor.js
@@ -11,6 +11,8 @@ features: [generators]
 
 var g = function*() {};
 
-verifyNotEnumerable(g, 'prototype');
-verifyWritable(g, 'prototype');
-verifyNotConfigurable(g, 'prototype');
+verifyProperty(g, "prototype", {
+  writable: true,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/language/expressions/object/fn-name-accessor-get.js
+++ b/test/language/expressions/object/fn-name-accessor-get.js
@@ -24,19 +24,25 @@ o = {
 };
 
 getter = Object.getOwnPropertyDescriptor(o, 'id').get;
-assert.sameValue(getter.name, 'get id');
-verifyNotEnumerable(getter, 'name');
-verifyNotWritable(getter, 'name');
-verifyConfigurable(getter, 'name');
+verifyProperty(getter, 'name', {
+  value: 'get id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 getter = Object.getOwnPropertyDescriptor(o, anonSym).get;
-assert.sameValue(getter.name, 'get ');
-verifyNotEnumerable(getter, 'name');
-verifyNotWritable(getter, 'name');
-verifyConfigurable(getter, 'name');
+verifyProperty(getter, 'name', {
+  value: 'get ',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 getter = Object.getOwnPropertyDescriptor(o, namedSym).get;
-assert.sameValue(getter.name, 'get [test262]');
-verifyNotEnumerable(getter, 'name');
-verifyNotWritable(getter, 'name');
-verifyConfigurable(getter, 'name');
+verifyProperty(getter, 'name', {
+  value: 'get [test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/fn-name-accessor-set.js
+++ b/test/language/expressions/object/fn-name-accessor-set.js
@@ -25,19 +25,25 @@ o = {
 };
 
 setter = Object.getOwnPropertyDescriptor(o, 'id').set;
-assert.sameValue(setter.name, 'set id');
-verifyNotEnumerable(setter, 'name');
-verifyNotWritable(setter, 'name');
-verifyConfigurable(setter, 'name');
+verifyProperty(setter, 'name', {
+  value: 'set id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 setter = Object.getOwnPropertyDescriptor(o, anonSym).set;
-assert.sameValue(setter.name, 'set ');
-verifyNotEnumerable(setter, 'name');
-verifyNotWritable(setter, 'name');
-verifyConfigurable(setter, 'name');
+verifyProperty(setter, 'name', {
+  value: 'set ',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 setter = Object.getOwnPropertyDescriptor(o, namedSym).set;
-assert.sameValue(setter.name, 'set [test262]');
-verifyNotEnumerable(setter, 'name');
-verifyNotWritable(setter, 'name');
-verifyConfigurable(setter, 'name');
+verifyProperty(setter, 'name', {
+  value: 'set [test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/fn-name-arrow.js
+++ b/test/language/expressions/object/fn-name-arrow.js
@@ -24,17 +24,23 @@ o = {
   [namedSym]: () => {}
 };
 
-assert.sameValue(o.id.name, 'id', 'via IdentifierName');
-verifyNotEnumerable(o.id, 'name');
-verifyNotWritable(o.id, 'name');
-verifyConfigurable(o.id, 'name');
+verifyProperty(o.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[anonSym].name, '', 'via anonymous Symbol');
-verifyNotEnumerable(o[anonSym], 'name');
-verifyNotWritable(o[anonSym], 'name');
-verifyConfigurable(o[anonSym], 'name');
+verifyProperty(o[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[namedSym].name, '[test262]', 'via Symbol');
-verifyNotEnumerable(o[namedSym], 'name');
-verifyNotWritable(o[namedSym], 'name');
-verifyConfigurable(o[namedSym], 'name');
+verifyProperty(o[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/fn-name-class.js
+++ b/test/language/expressions/object/fn-name-class.js
@@ -27,17 +27,23 @@ o = {
 
 assert(o.xId.name !== 'xId');
 
-assert.sameValue(o.id.name, 'id', 'via IdentifierName');
-verifyNotEnumerable(o.id, 'name');
-verifyNotWritable(o.id, 'name');
-verifyConfigurable(o.id, 'name');
+verifyProperty(o.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[anonSym].name, '', 'via anonymous Symbol');
-verifyNotEnumerable(o[anonSym], 'name');
-verifyNotWritable(o[anonSym], 'name');
-verifyConfigurable(o[anonSym], 'name');
+verifyProperty(o[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[namedSym].name, '[test262]', 'via Symbol');
-verifyNotEnumerable(o[namedSym], 'name');
-verifyNotWritable(o[namedSym], 'name');
-verifyConfigurable(o[namedSym], 'name');
+verifyProperty(o[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/fn-name-cover.js
+++ b/test/language/expressions/object/fn-name-cover.js
@@ -28,17 +28,23 @@ o = {
 
 assert(o.xId.name !== 'xId');
 
-assert.sameValue(o.id.name, 'id', 'via IdentifierName');
-verifyNotEnumerable(o.id, 'name');
-verifyNotWritable(o.id, 'name');
-verifyConfigurable(o.id, 'name');
+verifyProperty(o.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[anonSym].name, '', 'via anonymous Symbol');
-verifyNotEnumerable(o[anonSym], 'name');
-verifyNotWritable(o[anonSym], 'name');
-verifyConfigurable(o[anonSym], 'name');
+verifyProperty(o[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[namedSym].name, '[test262]', 'via Symbol');
-verifyNotEnumerable(o[namedSym], 'name');
-verifyNotWritable(o[namedSym], 'name');
-verifyConfigurable(o[namedSym], 'name');
+verifyProperty(o[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/fn-name-fn.js
+++ b/test/language/expressions/object/fn-name-fn.js
@@ -27,17 +27,23 @@ o = {
 
 assert(o.xId.name !== 'xId');
 
-assert.sameValue(o.id.name, 'id', 'via IdentifierName');
-verifyNotEnumerable(o.id, 'name');
-verifyNotWritable(o.id, 'name');
-verifyConfigurable(o.id, 'name');
+verifyProperty(o.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[anonSym].name, '', 'via anonymous Symbol');
-verifyNotEnumerable(o[anonSym], 'name');
-verifyNotWritable(o[anonSym], 'name');
-verifyConfigurable(o[anonSym], 'name');
+verifyProperty(o[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[namedSym].name, '[test262]', 'via Symbol');
-verifyNotEnumerable(o[namedSym], 'name');
-verifyNotWritable(o[namedSym], 'name');
-verifyConfigurable(o[namedSym], 'name');
+verifyProperty(o[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/fn-name-gen.js
+++ b/test/language/expressions/object/fn-name-gen.js
@@ -28,17 +28,23 @@ o = {
 
 assert(o.xId.name !== 'xId');
 
-assert.sameValue(o.id.name, 'id', 'via IdentifierName');
-verifyNotEnumerable(o.id, 'name');
-verifyNotWritable(o.id, 'name');
-verifyConfigurable(o.id, 'name');
+verifyProperty(o.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[anonSym].name, '', 'via anonymous Symbol');
-verifyNotEnumerable(o[anonSym], 'name');
-verifyNotWritable(o[anonSym], 'name');
-verifyConfigurable(o[anonSym], 'name');
+verifyProperty(o[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[namedSym].name, '[test262]', 'via Symbol');
-verifyNotEnumerable(o[namedSym], 'name');
-verifyNotWritable(o[namedSym], 'name');
-verifyConfigurable(o[namedSym], 'name');
+verifyProperty(o[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/getter-prop-desc.js
+++ b/test/language/expressions/object/getter-prop-desc.js
@@ -29,8 +29,11 @@ includes: [propertyHelper.js]
 var obj = { get m() { return 1234; } };
 var desc = Object.getOwnPropertyDescriptor(obj, 'm');
 
-verifyEnumerable(obj, 'm');
-verifyConfigurable(obj, 'm');
+verifyProperty(obj, 'm', {
+  enumerable: true,
+  configurable: true,
+});
+
 assert.sameValue(desc.value, undefined, '`value` field');
 assert.sameValue(desc.set, undefined, '`set` field');
 assert.sameValue(typeof desc.get, 'function', 'type of `get` field');

--- a/test/language/expressions/object/method-definition/fn-name-fn.js
+++ b/test/language/expressions/object/method-definition/fn-name-fn.js
@@ -24,17 +24,23 @@ o = {
   [namedSym]() {}
 };
 
-assert.sameValue(o.id.name, 'id', 'via IdentifierName');
-verifyNotEnumerable(o.id, 'name');
-verifyNotWritable(o.id, 'name');
-verifyConfigurable(o.id, 'name');
+verifyProperty(o.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[anonSym].name, '', 'via anonymous Symbol');
-verifyNotEnumerable(o[anonSym], 'name');
-verifyNotWritable(o[anonSym], 'name');
-verifyConfigurable(o[anonSym], 'name');
+verifyProperty(o[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[namedSym].name, '[test262]', 'via Symbol');
-verifyNotEnumerable(o[namedSym], 'name');
-verifyNotWritable(o[namedSym], 'name');
-verifyConfigurable(o[namedSym], 'name');
+verifyProperty(o[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/fn-name-gen.js
+++ b/test/language/expressions/object/method-definition/fn-name-gen.js
@@ -25,17 +25,23 @@ o = {
   *[namedSym]() {}
 };
 
-assert.sameValue(o.id.name, 'id', 'via IdentifierName');
-verifyNotEnumerable(o.id, 'name');
-verifyNotWritable(o.id, 'name');
-verifyConfigurable(o.id, 'name');
+verifyProperty(o.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[anonSym].name, '', 'via anonymous Symbol');
-verifyNotEnumerable(o[anonSym], 'name');
-verifyNotWritable(o[anonSym], 'name');
-verifyConfigurable(o[anonSym], 'name');
+verifyProperty(o[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(o[namedSym].name, '[test262]', 'via Symbol');
-verifyNotEnumerable(o[namedSym], 'name');
-verifyNotWritable(o[namedSym], 'name');
-verifyConfigurable(o[namedSym], 'name');
+verifyProperty(o[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/generator-length-dflt.js
+++ b/test/language/expressions/object/method-definition/generator-length-dflt.js
@@ -33,28 +33,36 @@ includes: [propertyHelper.js]
 
 var f1 = { *m(x = 42) {} }.m;
 
-assert.sameValue(f1.length, 0, 'FormalsList: x = 42');
-verifyNotEnumerable(f1, 'length');
-verifyNotWritable(f1, 'length');
-verifyConfigurable(f1, 'length');
+verifyProperty(f1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f2 = { *m(x = 42, y) {} }.m;
 
-assert.sameValue(f2.length, 0, 'FormalsList: x = 42, y');
-verifyNotEnumerable(f2, 'length');
-verifyNotWritable(f2, 'length');
-verifyConfigurable(f2, 'length');
+verifyProperty(f2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f3 = { *m(x, y = 42) {} }.m;
 
-assert.sameValue(f3.length, 1, 'FormalsList: x, y = 42');
-verifyNotEnumerable(f3, 'length');
-verifyNotWritable(f3, 'length');
-verifyConfigurable(f3, 'length');
+verifyProperty(f3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f4 = { *m(x, y = 42, z) {} }.m;
 
-assert.sameValue(f4.length, 1, 'FormalsList: x, y = 42, z');
-verifyNotEnumerable(f4, 'length');
-verifyNotWritable(f4, 'length');
-verifyConfigurable(f4, 'length')
+verifyProperty(f4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/generator-length.js
+++ b/test/language/expressions/object/method-definition/generator-length.js
@@ -12,7 +12,9 @@ features: [generators]
 
 var method = { *method(a, b, c) {} }.method;
 
-assert.sameValue(method.length, 3);
-verifyNotEnumerable(method, 'length');
-verifyNotWritable(method, 'length');
-verifyConfigurable(method, 'length');
+verifyProperty(method, "length", {
+  value: 3,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/generator-name-prop-string.js
+++ b/test/language/expressions/object/method-definition/generator-name-prop-string.js
@@ -12,7 +12,9 @@ features: [generators]
 
 var method = { *method() {} }.method;
 
-assert.sameValue(method.name, 'method');
-verifyNotEnumerable(method, 'name');
-verifyNotWritable(method, 'name');
-verifyConfigurable(method, 'name');
+verifyProperty(method, 'name', {
+  value: 'method',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/generator-name-prop-symbol.js
+++ b/test/language/expressions/object/method-definition/generator-name-prop-symbol.js
@@ -13,7 +13,9 @@ features: [Symbol, generators]
 var m = Symbol('method');
 var method = { *[m]() {} }[m];
 
-assert.sameValue(method.name, '[method]');
-verifyNotEnumerable(method, 'name');
-verifyNotWritable(method, 'name');
-verifyConfigurable(method, 'name');
+verifyProperty(method, 'name', {
+  value: '[method]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/generator-property-desc.js
+++ b/test/language/expressions/object/method-definition/generator-property-desc.js
@@ -12,6 +12,8 @@ features: [generators]
 
 var obj = { *method() {} };
 
-verifyEnumerable(obj, 'method');
-verifyWritable(obj, 'method');
-verifyConfigurable(obj, 'method');
+verifyProperty(obj, "method", {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/generator-prototype-prop.js
+++ b/test/language/expressions/object/method-definition/generator-prototype-prop.js
@@ -12,11 +12,13 @@ features: [generators]
 var GeneratorPrototype = Object.getPrototypeOf(function* () {}).prototype;
 var method = { *method() {} }.method;
 
-verifyNotEnumerable(method, 'prototype');
-verifyWritable(method, 'prototype');
-verifyNotConfigurable(method, 'prototype');
-
 assert.sameValue(
   Object.getPrototypeOf(method.prototype),
   GeneratorPrototype
 );
+
+verifyProperty(method, "prototype", {
+  writable: true,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/language/expressions/object/method-definition/name-length-dflt.js
+++ b/test/language/expressions/object/method-definition/name-length-dflt.js
@@ -33,28 +33,36 @@ includes: [propertyHelper.js]
 
 var f1 = { m(x = 42) {} }.m;
 
-assert.sameValue(f1.length, 0, 'FormalsList: x = 42');
-verifyNotEnumerable(f1, 'length');
-verifyNotWritable(f1, 'length');
-verifyConfigurable(f1, 'length');
+verifyProperty(f1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f2 = { m(x = 42, y) {} }.m;
 
-assert.sameValue(f2.length, 0, 'FormalsList: x = 42, y');
-verifyNotEnumerable(f2, 'length');
-verifyNotWritable(f2, 'length');
-verifyConfigurable(f2, 'length');
+verifyProperty(f2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f3 = { m(x, y = 42) {} }.m;
 
-assert.sameValue(f3.length, 1, 'FormalsList: x, y = 42');
-verifyNotEnumerable(f3, 'length');
-verifyNotWritable(f3, 'length');
-verifyConfigurable(f3, 'length');
+verifyProperty(f3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 var f4 = { m(x, y = 42, z) {} }.m;
 
-assert.sameValue(f4.length, 1, 'FormalsList: x, y = 42, z');
-verifyNotEnumerable(f4, 'length');
-verifyNotWritable(f4, 'length');
-verifyConfigurable(f4, 'length');
+verifyProperty(f4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/name-length.js
+++ b/test/language/expressions/object/method-definition/name-length.js
@@ -11,7 +11,9 @@ includes: [propertyHelper.js]
 
 var method = { method(a, b, c) {} }.method;
 
-assert.sameValue(method.length, 3);
-verifyNotEnumerable(method, 'length');
-verifyNotWritable(method, 'length');
-verifyConfigurable(method, 'length');
+verifyProperty(method, "length", {
+  value: 3,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/name-name-prop-string.js
+++ b/test/language/expressions/object/method-definition/name-name-prop-string.js
@@ -11,7 +11,9 @@ includes: [propertyHelper.js]
 
 var method = { method() {} }.method;
 
-assert.sameValue(method.name, 'method');
-verifyNotEnumerable(method, 'name');
-verifyNotWritable(method, 'name');
-verifyConfigurable(method, 'name');
+verifyProperty(method, 'name', {
+  value: 'method',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/name-name-prop-symbol.js
+++ b/test/language/expressions/object/method-definition/name-name-prop-symbol.js
@@ -13,7 +13,9 @@ features: [Symbol]
 var m = Symbol('method');
 var method = { [m]() {} }[m];
 
-assert.sameValue(method.name, '[method]');
-verifyNotEnumerable(method, 'name');
-verifyNotWritable(method, 'name');
-verifyConfigurable(method, 'name');
+verifyProperty(method, 'name', {
+  value: '[method]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/method-definition/name-property-desc.js
+++ b/test/language/expressions/object/method-definition/name-property-desc.js
@@ -11,6 +11,8 @@ includes: [propertyHelper.js]
 
 var obj = { method() {} };
 
-verifyEnumerable(obj, 'method');
-verifyWritable(obj, 'method');
-verifyConfigurable(obj, 'method');
+verifyProperty(obj, "method", {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});

--- a/test/language/expressions/object/prop-def-id-valid.js
+++ b/test/language/expressions/object/prop-def-id-valid.js
@@ -15,7 +15,9 @@ var obj;
 
 obj = { attr };
 
-assert.sameValue(obj.attr, 23);
-verifyEnumerable(obj, 'attr');
-verifyWritable(obj, 'attr');
-verifyConfigurable(obj, 'attr');
+verifyProperty(obj, "attr", {
+  value: 23,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});

--- a/test/language/expressions/object/setter-length-dflt.js
+++ b/test/language/expressions/object/setter-length-dflt.js
@@ -33,7 +33,9 @@ includes: [propertyHelper.js]
 
 var set = Object.getOwnPropertyDescriptor({ set m(x = 42) {} }, 'm').set;
 
-assert.sameValue(set.length, 0, 'FormalsList: x = 42');
-verifyNotEnumerable(set, 'length');
-verifyNotWritable(set, 'length');
-verifyConfigurable(set, 'length');
+verifyProperty(set, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/expressions/object/setter-prop-desc.js
+++ b/test/language/expressions/object/setter-prop-desc.js
@@ -29,8 +29,11 @@ includes: [propertyHelper.js]
 var obj = { set m(x) { return x; } };
 var desc = Object.getOwnPropertyDescriptor(obj, 'm');
 
-verifyEnumerable(obj, 'm');
-verifyConfigurable(obj, 'm');
+verifyProperty(obj, 'm', {
+  enumerable: true,
+  configurable: true,
+});
+
 assert.sameValue(desc.value, undefined, '`value` field');
 assert.sameValue(desc.get, undefined, '`get` field');
 assert.sameValue(typeof desc.set, 'function', 'type of `set` field');

--- a/test/language/function-code/10.4.3-1-1-s.js
+++ b/test/language/function-code/10.4.3-1-1-s.js
@@ -7,17 +7,16 @@ description: this is not coerced to an object in strict mode (Number)
 flags: [noStrict]
 ---*/
 
-  function foo()
-  {
-    'use strict';
-    return typeof(this);
-  }
+function foo()
+{
+  'use strict';
+  return typeof(this);
+}
 
-  function bar()
-  {
-    return typeof(this);
-  }
-
+function bar()
+{
+  return typeof(this);
+}
 
 assert.sameValue(foo.call(1), 'number', 'foo.call(1)');
 assert.sameValue(bar.call(1), 'object', 'bar.call(1)');

--- a/test/language/function-code/10.4.3-1-100gs.js
+++ b/test/language/function-code/10.4.3-1-100gs.js
@@ -16,5 +16,5 @@ function f() {
     return "a";
 }
 if (("ab".replace("b", f)!=="aa") || (x!==undefined)) {
-        throw "'this' had incorrect value!";
+    throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-101gs.js
+++ b/test/language/function-code/10.4.3-1-101gs.js
@@ -17,5 +17,5 @@ function f() {
 }
 
 if ( (!(function() {"use strict"; return "ab".replace("b", f)==="aa";}())) || (x!==this)) {
-     throw "'this' had incorrect value!";
+    throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-102-s.js
+++ b/test/language/function-code/10.4.3-1-102-s.js
@@ -11,10 +11,10 @@ description: >
 var x = 3;
 
 assert.sameValue("ab".replace("b", (function () {
-                                "use strict";
-                                return function () {
-                                    x = this;
-                                    return "a";
-                                }
-                           })()), "aa");
+    "use strict";
+    return function () {
+        x = this;
+        return "a";
+    }
+})()), "aa");
 assert.sameValue(x, undefined, 'x');

--- a/test/language/function-code/10.4.3-1-102gs.js
+++ b/test/language/function-code/10.4.3-1-102gs.js
@@ -10,11 +10,11 @@ description: >
 
 var x = 3;
 if ( ("ab".replace("b", (function () { 
-                                "use strict";
-                                return function () {
-                                    x = this;
-                                    return "a";
-                                }
-                           })())!=="aa") || (x!==undefined)) {
-     throw "'this' had incorrect value!";
+    "use strict";
+    return function () {
+        x = this;
+        return "a";
+    }
+})())!=="aa") || (x!==undefined)) {
+    throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-103.js
+++ b/test/language/function-code/10.4.3-1-103.js
@@ -8,7 +8,7 @@ description: >
     Abstract equality operator should succeed.
 ---*/
 
-  Object.defineProperty(Object.prototype, "x", { get: function () { return this; } }); 
+Object.defineProperty(Object.prototype, "x", { get: function () { return this; } });
 
 assert.sameValue((5).x == 0, false, '(5).x == 0');
 assert((5).x == 5, '(5).x == 5');

--- a/test/language/function-code/10.4.3-1-104.js
+++ b/test/language/function-code/10.4.3-1-104.js
@@ -9,6 +9,6 @@ description: >
 flags: [onlyStrict]
 ---*/
 
-  Object.defineProperty(Object.prototype, "x", { get: function () { return this; } }); 
+Object.defineProperty(Object.prototype, "x", { get: function () { return this; } });
 
 assert((5).x === 5, '(5).x === 5');

--- a/test/language/function-code/10.4.3-1-105.js
+++ b/test/language/function-code/10.4.3-1-105.js
@@ -12,7 +12,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-  Object.defineProperty(Object.prototype, "x", { get: function () { return this; } }); 
+Object.defineProperty(Object.prototype, "x", { get: function () { return this; } });
 
 assert.sameValue((5).x === 5, false, '(5).x === 5');
 assert.sameValue(typeof (5).x, "object", 'typeof (5).x');

--- a/test/language/function-code/10.4.3-1-106.js
+++ b/test/language/function-code/10.4.3-1-106.js
@@ -12,6 +12,6 @@ description: >
 flags: [onlyStrict]
 ---*/
 
-  Object.defineProperty(Object.prototype, "x", { get: function () { return this; } }); 
+Object.defineProperty(Object.prototype, "x", { get: function () { return this; } });
 
 assert.sameValue(typeof (5).x, "number", 'typeof (5).x');

--- a/test/language/function-code/10.4.3-1-2-s.js
+++ b/test/language/function-code/10.4.3-1-2-s.js
@@ -7,17 +7,16 @@ description: this is not coerced to an object in strict mode (string)
 flags: [noStrict]
 ---*/
 
-  function foo()
-  {
-    'use strict';
-    return typeof(this);
-  }
+function foo()
+{
+  'use strict';
+  return typeof(this);
+}
 
-  function bar()
-  {
-    return typeof(this);
-  }
-
+function bar()
+{
+  return typeof(this);
+}
 
 assert.sameValue(foo.call('1'), 'string', 'foo.call("1")');
 assert.sameValue(bar.call('1'), 'object', 'bar.call("1")');

--- a/test/language/function-code/10.4.3-1-3-s.js
+++ b/test/language/function-code/10.4.3-1-3-s.js
@@ -7,16 +7,16 @@ description: this is not coerced to an object in strict mode (undefined)
 flags: [noStrict]
 ---*/
 
-  function foo()
-  {
-    'use strict';
-    return typeof(this);
-  }
+function foo()
+{
+  'use strict';
+  return typeof(this);
+}
 
-  function bar()
-  {
-    return typeof(this);
-  }
+function bar()
+{
+  return typeof(this);
+}
 
 assert.sameValue(foo.call(undefined), 'undefined', 'foo.call(undefined)');
 assert.sameValue(bar.call(), 'object', 'bar.call()');

--- a/test/language/function-code/10.4.3-1-4-s.js
+++ b/test/language/function-code/10.4.3-1-4-s.js
@@ -7,17 +7,16 @@ description: this is not coerced to an object in strict mode (boolean)
 flags: [noStrict]
 ---*/
 
-  function foo()
-  {
-    'use strict';
-    return typeof(this);
-  }
+function foo()
+{
+  'use strict';
+  return typeof(this);
+}
 
-  function bar()
-  {
-    return typeof(this);
-  }
-
+function bar()
+{
+  return typeof(this);
+}
 
 assert.sameValue(foo.call(true), 'boolean', 'foo.call(true)');
 assert.sameValue(bar.call(true), 'object', 'bar.call(true)');

--- a/test/language/function-code/10.4.3-1-5-s.js
+++ b/test/language/function-code/10.4.3-1-5-s.js
@@ -6,20 +6,20 @@ es5id: 10.4.3-1-5-s
 description: this is not coerced to an object (function)
 ---*/
 
-  function foo()
-  {
-    'use strict';
-    return typeof(this);
-  } 
+function foo()
+{
+  'use strict';
+  return typeof(this);
+}
 
-  function bar()
-  {
-    return typeof(this);
-  }
+function bar()
+{
+  return typeof(this);
+}
 
-  function foobar()
-  {
-  }
+function foobar()
+{
+}
 
 assert.sameValue(foo.call(foobar), 'function', 'foo.call(foobar)');
 assert.sameValue(bar.call(foobar), 'function', 'bar.call(foobar)');

--- a/test/language/global-code/decl-func.js
+++ b/test/language/global-code/decl-func.js
@@ -41,8 +41,10 @@ includes: [propertyHelper.js]
 assert.sameValue(
   typeof brandNew, 'function', 'new binding on an extensible global object'
 );
-verifyEnumerable(this, 'brandNew');
-verifyWritable(this, 'brandNew');
-verifyNotConfigurable(this, 'brandNew');
+verifyProperty(this, 'brandNew', {
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
 
 function brandNew() {}

--- a/test/language/global-code/decl-var.js
+++ b/test/language/global-code/decl-var.js
@@ -32,11 +32,11 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(
-  this.brandNew, undefined, 'new binding on an extensible global object'
-);
-verifyEnumerable(this, 'brandNew');
-verifyWritable(this, 'brandNew');
-verifyNotConfigurable(this, 'brandNew');
+verifyProperty(this, "brandNew", {
+  value: undefined,
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
 
 var brandNew;

--- a/test/language/global-code/script-decl-func.js
+++ b/test/language/global-code/script-decl-func.js
@@ -43,9 +43,11 @@ $262.evalScript('function brandNew() {}');
 assert.sameValue(
   typeof brandNew, 'function', 'new binding on an extensible global object'
 );
-verifyEnumerable(this, 'brandNew');
-verifyWritable(this, 'brandNew');
-verifyNotConfigurable(this, 'brandNew');
+verifyProperty(this, 'brandNew', {
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
 
 Object.defineProperty(this, 'configurable', { configurable: true, value: 0 });
 Object.defineProperty(
@@ -63,9 +65,11 @@ $262.evalScript('function configurable() {}');
 assert.sameValue(
   typeof configurable, 'function', 'like-named configurable property'
 );
-verifyEnumerable(this, 'configurable')
-verifyWritable(this, 'configurable');
-verifyNotConfigurable(this, 'configurable');
+verifyProperty(this, 'configurable', {
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
 
 $262.evalScript('function nonConfigurable() {}');
 
@@ -74,6 +78,8 @@ assert.sameValue(
   'function',
   'like-named non-configurable data property that is writable and enumerable'
 );
-verifyEnumerable(this, 'nonConfigurable');
-verifyWritable(this, 'nonConfigurable');
-verifyNotConfigurable(this, 'nonConfigurable');
+verifyProperty(this, 'nonConfigurable', {
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});

--- a/test/language/global-code/script-decl-var.js
+++ b/test/language/global-code/script-decl-var.js
@@ -34,12 +34,12 @@ includes: [propertyHelper.js]
 
 $262.evalScript('var brandNew;');
 
-assert.sameValue(
-  this.brandNew, undefined, 'new binding on an extensible global object'
-);
-verifyEnumerable(this, 'brandNew');
-verifyWritable(this, 'brandNew');
-verifyNotConfigurable(this, 'brandNew');
+verifyProperty(this, 'brandNew', {
+  value: undefined,
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
 
 Object.defineProperty(
   this,
@@ -58,14 +58,18 @@ Object.preventExtensions(this);
 
 $262.evalScript('var configurable;');
 
-assert.sameValue(configurable, 0, 'like-named configurable property');
-verifyNotEnumerable(this, 'configurable');
-verifyNotWritable(this, 'configurable');
-verifyConfigurable(this, 'configurable');
+verifyProperty(this, 'configurable', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 $262.evalScript('var nonConfigurable;');
 
-assert.sameValue(nonConfigurable, 0, 'like-named non-configurable property');
-verifyNotEnumerable(this, 'nonConfigurable');
-verifyNotWritable(this, 'nonConfigurable');
-verifyNotConfigurable(this, 'nonConfigurable');
+verifyProperty(this, 'nonConfigurable', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/language/literals/regexp/lastIndex.js
+++ b/test/language/literals/regexp/lastIndex.js
@@ -29,8 +29,9 @@ includes: [propertyHelper.js]
 
 var re = /./;
 
-assert.sameValue(re.lastIndex, 0);
-
-verifyNotEnumerable(re, 'lastIndex');
-verifyWritable(re, 'lastIndex');
-verifyNotConfigurable(re, 'lastIndex');
+verifyProperty(re, "lastIndex", {
+  value: 0,
+  writable: true,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/language/statements/class/definition/fn-name-accessor-get.js
+++ b/test/language/statements/class/definition/fn-name-accessor-get.js
@@ -27,37 +27,49 @@ class A {
 }
 
 getter = Object.getOwnPropertyDescriptor(A.prototype, 'id').get;
-assert.sameValue(getter.name, 'get id');
-verifyNotEnumerable(getter, 'name');
-verifyNotWritable(getter, 'name');
-verifyConfigurable(getter, 'name');
+verifyProperty(getter, 'name', {
+  value: 'get id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 getter = Object.getOwnPropertyDescriptor(A.prototype, anonSym).get;
-assert.sameValue(getter.name, 'get ');
-verifyNotEnumerable(getter, 'name');
-verifyNotWritable(getter, 'name');
-verifyConfigurable(getter, 'name');
+verifyProperty(getter, 'name', {
+  value: 'get ',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 getter = Object.getOwnPropertyDescriptor(A.prototype, namedSym).get;
-assert.sameValue(getter.name, 'get [test262]');
-verifyNotEnumerable(getter, 'name');
-verifyNotWritable(getter, 'name');
-verifyConfigurable(getter, 'name');
+verifyProperty(getter, 'name', {
+  value: 'get [test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 getter = Object.getOwnPropertyDescriptor(A, 'id').get;
-assert.sameValue(getter.name, 'get id');
-verifyNotEnumerable(getter, 'name');
-verifyNotWritable(getter, 'name');
-verifyConfigurable(getter, 'name');
+verifyProperty(getter, 'name', {
+  value: 'get id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 getter = Object.getOwnPropertyDescriptor(A, anonSym).get;
-assert.sameValue(getter.name, 'get ');
-verifyNotEnumerable(getter, 'name');
-verifyNotWritable(getter, 'name');
-verifyConfigurable(getter, 'name');
+verifyProperty(getter, 'name', {
+  value: 'get ',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 getter = Object.getOwnPropertyDescriptor(A, namedSym).get;
-assert.sameValue(getter.name, 'get [test262]');
-verifyNotEnumerable(getter, 'name');
-verifyNotWritable(getter, 'name');
-verifyConfigurable(getter, 'name');
+verifyProperty(getter, 'name', {
+  value: 'get [test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/definition/fn-name-accessor-set.js
+++ b/test/language/statements/class/definition/fn-name-accessor-set.js
@@ -28,37 +28,49 @@ class A {
 }
 
 setter = Object.getOwnPropertyDescriptor(A.prototype, 'id').set;
-assert.sameValue(setter.name, 'set id');
-verifyNotEnumerable(setter, 'name');
-verifyNotWritable(setter, 'name');
-verifyConfigurable(setter, 'name');
+verifyProperty(setter, 'name', {
+  value: 'set id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 setter = Object.getOwnPropertyDescriptor(A.prototype, anonSym).set;
-assert.sameValue(setter.name, 'set ');
-verifyNotEnumerable(setter, 'name');
-verifyNotWritable(setter, 'name');
-verifyConfigurable(setter, 'name');
+verifyProperty(setter, 'name', {
+  value: 'set ',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 setter = Object.getOwnPropertyDescriptor(A.prototype, namedSym).set;
-assert.sameValue(setter.name, 'set [test262]');
-verifyNotEnumerable(setter, 'name');
-verifyNotWritable(setter, 'name');
-verifyConfigurable(setter, 'name');
+verifyProperty(setter, 'name', {
+  value: 'set [test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 setter = Object.getOwnPropertyDescriptor(A, 'id').set;
-assert.sameValue(setter.name, 'set id');
-verifyNotEnumerable(setter, 'name');
-verifyNotWritable(setter, 'name');
-verifyConfigurable(setter, 'name');
+verifyProperty(setter, 'name', {
+  value: 'set id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 setter = Object.getOwnPropertyDescriptor(A, anonSym).set;
-assert.sameValue(setter.name, 'set ');
-verifyNotEnumerable(setter, 'name');
-verifyNotWritable(setter, 'name');
-verifyConfigurable(setter, 'name');
+verifyProperty(setter, 'name', {
+  value: 'set ',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 setter = Object.getOwnPropertyDescriptor(A, namedSym).set;
-assert.sameValue(setter.name, 'set [test262]');
-verifyNotEnumerable(setter, 'name');
-verifyNotWritable(setter, 'name');
-verifyConfigurable(setter, 'name');
+verifyProperty(setter, 'name', {
+  value: 'set [test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/definition/fn-name-gen-method.js
+++ b/test/language/statements/class/definition/fn-name-gen-method.js
@@ -27,32 +27,44 @@ class A {
   static *[namedSym]() {}
 }
 
-assert.sameValue(A.prototype.id.name, 'id', 'via IdentifierName');
-verifyNotEnumerable(A.prototype.id, 'name');
-verifyNotWritable(A.prototype.id, 'name');
-verifyConfigurable(A.prototype.id, 'name');
+verifyProperty(A.prototype.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(A.prototype[anonSym].name, '', 'via anonymous Symbol');
-verifyNotEnumerable(A.prototype[anonSym], 'name');
-verifyNotWritable(A.prototype[anonSym], 'name');
-verifyConfigurable(A.prototype[anonSym], 'name');
+verifyProperty(A.prototype[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(A.prototype[namedSym].name, '[test262]', 'via Symbol');
-verifyNotEnumerable(A.prototype[namedSym], 'name');
-verifyNotWritable(A.prototype[namedSym], 'name');
-verifyConfigurable(A.prototype[namedSym], 'name');
+verifyProperty(A.prototype[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(A.id.name, 'id', 'static via IdentifierName');
-verifyNotEnumerable(A.id, 'name');
-verifyNotWritable(A.id, 'name');
-verifyConfigurable(A.id, 'name');
+verifyProperty(A.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(A[anonSym].name, '', 'static via anonymous Symbol');
-verifyNotEnumerable(A[anonSym], 'name');
-verifyNotWritable(A[anonSym], 'name');
-verifyConfigurable(A[anonSym], 'name');
+verifyProperty(A[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(A[namedSym].name, '[test262]', 'static via Symbol');
-verifyNotEnumerable(A[namedSym], 'name');
-verifyNotWritable(A[namedSym], 'name');
-verifyConfigurable(A[namedSym], 'name');
+verifyProperty(A[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/definition/fn-name-method.js
+++ b/test/language/statements/class/definition/fn-name-method.js
@@ -26,32 +26,44 @@ class A {
   static [namedSym]() {}
 }
 
-assert.sameValue(A.prototype.id.name, 'id', 'via IdentifierName');
-verifyNotEnumerable(A.prototype.id, 'name');
-verifyNotWritable(A.prototype.id, 'name');
-verifyConfigurable(A.prototype.id, 'name');
+verifyProperty(A.prototype.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(A.prototype[anonSym].name, '', 'via anonymous Symbol');
-verifyNotEnumerable(A.prototype[anonSym], 'name');
-verifyNotWritable(A.prototype[anonSym], 'name');
-verifyConfigurable(A.prototype[anonSym], 'name');
+verifyProperty(A.prototype[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(A.prototype[namedSym].name, '[test262]', 'via Symbol');
-verifyNotEnumerable(A.prototype[namedSym], 'name');
-verifyNotWritable(A.prototype[namedSym], 'name');
-verifyConfigurable(A.prototype[namedSym], 'name');
+verifyProperty(A.prototype[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(A.id.name, 'id', 'static via IdentifierName');
-verifyNotEnumerable(A.id, 'name');
-verifyNotWritable(A.id, 'name');
-verifyConfigurable(A.id, 'name');
+verifyProperty(A.id, 'name', {
+  value: 'id',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(A[anonSym].name, '', 'static via anonymous Symbol');
-verifyNotEnumerable(A[anonSym], 'name');
-verifyNotWritable(A[anonSym], 'name');
-verifyConfigurable(A[anonSym], 'name');
+verifyProperty(A[anonSym], 'name', {
+  value: '',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
-assert.sameValue(A[namedSym].name, '[test262]', 'static via Symbol');
-verifyNotEnumerable(A[namedSym], 'name');
-verifyNotWritable(A[namedSym], 'name');
-verifyConfigurable(A[namedSym], 'name');
+verifyProperty(A[namedSym], 'name', {
+  value: '[test262]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/definition/getters-prop-desc.js
+++ b/test/language/statements/class/definition/getters-prop-desc.js
@@ -9,8 +9,10 @@ includes: [propertyHelper.js]
 
 function assertGetterDescriptor(object, name) {
   var desc = Object.getOwnPropertyDescriptor(object, name);
-  verifyNotEnumerable(object, name);
-  verifyConfigurable(object, name);
+  verifyProperty(object, name, {
+    enumerable: false,
+    configurable: true,
+  });
   assert.sameValue(typeof desc.get, 'function', "`typeof desc.get` is `'function'`");
   assert.sameValue('prototype' in desc.get, false, "The result of `'prototype' in desc.get` is `false`");
   assert.sameValue(desc.set, undefined, "The value of `desc.set` is `undefined`");

--- a/test/language/statements/class/definition/setters-prop-desc.js
+++ b/test/language/statements/class/definition/setters-prop-desc.js
@@ -9,8 +9,10 @@ includes: [propertyHelper.js]
 
 function assertSetterDescriptor(object, name) {
   var descr = Object.getOwnPropertyDescriptor(object, name);
-  verifyNotEnumerable(object, name);
-  verifyConfigurable(object, name);
+  verifyProperty(object, name, {
+    enumerable: false,
+    configurable: true,
+  });
   assert.sameValue(typeof descr.set, 'function', "`typeof descr.set` is `'function'`");
   assert.sameValue('prototype' in descr.set, false, "The result of `'prototype' in descr.set` is `false`");
   assert.sameValue(descr.get, undefined, "The value of `descr.get` is `undefined`");

--- a/test/language/statements/class/gen-method-length-dflt.js
+++ b/test/language/statements/class/gen-method-length-dflt.js
@@ -34,34 +34,42 @@ class C1 { *m(x = 42) {} }
 
 var m1 = C1.prototype.m;
 
-assert.sameValue(m1.length, 0, 'formalslist: x = 42');
-verifyNotEnumerable(m1, 'length');
-verifyNotWritable(m1, 'length');
-verifyConfigurable(m1, 'length');
+verifyProperty(m1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 class C2 { *m(x = 42, y) {} }
 
 var m2 = C2.prototype.m;
 
-assert.sameValue(m2.length, 0, 'formalslist: x = 42, y');
-verifyNotEnumerable(m2, 'length');
-verifyNotWritable(m2, 'length');
-verifyConfigurable(m2, 'length');
+verifyProperty(m2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 class C3 { *m(x, y = 42) {} }
 
 var m3 = C3.prototype.m;
 
-assert.sameValue(m3.length, 1, 'formalslist: x, y = 42');
-verifyNotEnumerable(m3, 'length');
-verifyNotWritable(m3, 'length');
-verifyConfigurable(m3, 'length');
+verifyProperty(m3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 class C4 { *m(x, y = 42, z) {} }
 
 var m4 = C4.prototype.m;
 
-assert.sameValue(m4.length, 1, 'formalslist: x, y = 42, z');
-verifyNotEnumerable(m4, 'length');
-verifyNotWritable(m4, 'length');
-verifyConfigurable(m4, 'length');
+verifyProperty(m4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/method-length-dflt.js
+++ b/test/language/statements/class/method-length-dflt.js
@@ -34,34 +34,42 @@ class C1 { m(x = 42) {} }
 
 var m1 = C1.prototype.m;
 
-assert.sameValue(m1.length, 0, 'formalslist: x = 42');
-verifyNotEnumerable(m1, 'length');
-verifyNotWritable(m1, 'length');
-verifyConfigurable(m1, 'length');
+verifyProperty(m1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 class C2 { m(x = 42, y) {} }
 
 var m2 = C2.prototype.m;
 
-assert.sameValue(m2.length, 0, 'formalslist: x = 42, y');
-verifyNotEnumerable(m2, 'length');
-verifyNotWritable(m2, 'length');
-verifyConfigurable(m2, 'length');
+verifyProperty(m2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 class C3 { m(x, y = 42) {} }
 
 var m3 = C3.prototype.m;
 
-assert.sameValue(m3.length, 1, 'formalslist: x, y = 42');
-verifyNotEnumerable(m3, 'length');
-verifyNotWritable(m3, 'length');
-verifyConfigurable(m3, 'length');
+verifyProperty(m3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 class C4 { m(x, y = 42, z) {} }
 
 var m4 = C4.prototype.m;
 
-assert.sameValue(m4.length, 1, 'formalslist: x, y = 42, z');
-verifyNotEnumerable(m4, 'length');
-verifyNotWritable(m4, 'length');
-verifyConfigurable(m4, 'length');
+verifyProperty(m4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/name.js
+++ b/test/language/statements/class/name.js
@@ -15,7 +15,9 @@ includes: [propertyHelper.js]
 
 class Test262 {}
 
-assert.sameValue(Test262.name, 'Test262');
-verifyNotEnumerable(Test262, 'name');
-verifyNotWritable(Test262, 'name');
-verifyConfigurable(Test262, 'name');
+verifyProperty(Test262, "name", {
+  value: "Test262",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/setter-length-dflt.js
+++ b/test/language/statements/class/setter-length-dflt.js
@@ -33,7 +33,9 @@ includes: [propertyHelper.js]
 class C { set m(x = 42) {} }
 var set = Object.getOwnPropertyDescriptor(C.prototype, 'm').set;
 
-assert.sameValue(set.length, 0, 'FormalsList: x = 42');
-verifyNotEnumerable(set, 'length');
-verifyNotWritable(set, 'length');
-verifyConfigurable(set, 'length');
+verifyProperty(set, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/static-method-length-dflt.js
+++ b/test/language/statements/class/static-method-length-dflt.js
@@ -34,34 +34,42 @@ class C1 { static m(x = 42) {} }
 
 var m1 = C1.m;
 
-assert.sameValue(m1.length, 0, 'formalslist: x = 42');
-verifyNotEnumerable(m1, 'length');
-verifyNotWritable(m1, 'length');
-verifyConfigurable(m1, 'length');
+verifyProperty(m1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 class C2 { static m(x = 42, y) {} }
 
 var m2 = C2.m;
 
-assert.sameValue(m2.length, 0, 'formalslist: x = 42, y');
-verifyNotEnumerable(m2, 'length');
-verifyNotWritable(m2, 'length');
-verifyConfigurable(m2, 'length');
+verifyProperty(m2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 class C3 { static m(x, y = 42) {} }
 
 var m3 = C3.m;
 
-assert.sameValue(m3.length, 1, 'formalslist: x, y = 42');
-verifyNotEnumerable(m3, 'length');
-verifyNotWritable(m3, 'length');
-verifyConfigurable(m3, 'length');
+verifyProperty(m3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 class C4 { static m(x, y = 42, z) {} }
 
 var m4 = C4.m;
 
-assert.sameValue(m4.length, 1, 'formalslist: x, y = 42, z');
-verifyNotEnumerable(m4, 'length');
-verifyNotWritable(m4, 'length');
-verifyConfigurable(m4, 'length');
+verifyProperty(m4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/subclass/builtin-objects/Error/message-property-assignment.js
+++ b/test/language/statements/class/subclass/builtin-objects/Error/message-property-assignment.js
@@ -24,12 +24,13 @@ class Err extends Error {}
 Err.prototype.message = 'custom-error';
 
 var err1 = new Err('foo 42');
-assert.sameValue(err1.message, 'foo 42');
-assert(err1.hasOwnProperty('message'));
 
-verifyWritable(err1, 'message');
-verifyNotEnumerable(err1, 'message');
-verifyConfigurable(err1, 'message');
+verifyProperty(err1, 'message', {
+  value: 'foo 42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
 
 var err2 = new Err();
 assert.sameValue(err2.hasOwnProperty('message'), false);

--- a/test/language/statements/class/subclass/builtin-objects/Function/instance-length.js
+++ b/test/language/statements/class/subclass/builtin-objects/Function/instance-length.js
@@ -20,8 +20,9 @@ class Fn extends Function {}
 
 var fn = new Fn('a', 'b', 'return a + b');
 
-assert.sameValue(fn.length, 2);
-
-verifyNotEnumerable(fn, 'length');
-verifyNotWritable(fn, 'length');
-verifyConfigurable(fn, 'length');
+verifyProperty(fn, 'length', {
+  value: 2,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/subclass/builtin-objects/Function/instance-name.js
+++ b/test/language/statements/class/subclass/builtin-objects/Function/instance-name.js
@@ -29,11 +29,9 @@ class Fn extends Function {}
 
 var fn = new Fn('a', 'b', 'return a + b');
 
-assert.sameValue(
-  fn.name, 'anonymous',
-  'Dynamic Functions are called anonymous'
-);
-
-verifyNotEnumerable(fn, 'name');
-verifyNotWritable(fn, 'name');
-verifyConfigurable(fn, 'name');
+verifyProperty(fn, 'name', {
+  value: 'anonymous',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-length.js
+++ b/test/language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-length.js
@@ -24,8 +24,9 @@ class GFn extends GeneratorFunction {}
 
 var gfn = new GFn('a', 'b', 'return a + b');
 
-assert.sameValue(gfn.length, 2);
-
-verifyNotEnumerable(gfn, 'length');
-verifyNotWritable(gfn, 'length');
-verifyConfigurable(gfn, 'length');
+verifyProperty(gfn, 'length', {
+  value: 2,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-name.js
+++ b/test/language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-name.js
@@ -36,11 +36,9 @@ class GFn extends GeneratorFunction {}
 
 var gfn = new GFn('a', 'b', 'return a + b');
 
-assert.sameValue(
-  gfn.name, 'anonymous',
-  'Dynamic Functions are called anonymous'
-);
-
-verifyNotEnumerable(gfn, 'name');
-verifyNotWritable(gfn, 'name');
-verifyConfigurable(gfn, 'name');
+verifyProperty(gfn, 'name', {
+  value: 'anonymous',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-prototype.js
+++ b/test/language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-prototype.js
@@ -33,6 +33,8 @@ assert.sameValue(
   'prototype has no constructor reference'
 );
 
-verifyNotEnumerable(gfn, 'prototype');
-verifyWritable(gfn, 'prototype');
-verifyNotConfigurable(gfn, 'prototype');
+verifyProperty(gfn, 'prototype', {
+  writable: true,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/language/statements/class/subclass/builtin-objects/NativeError/EvalError-message.js
+++ b/test/language/statements/class/subclass/builtin-objects/NativeError/EvalError-message.js
@@ -23,12 +23,13 @@ class Err extends EvalError {}
 Err.prototype.message = 'custom-eval-error';
 
 var err1 = new Err('foo 42');
-assert.sameValue(err1.message, 'foo 42');
-assert(err1.hasOwnProperty('message'));
 
-verifyWritable(err1, 'message');
-verifyNotEnumerable(err1, 'message');
-verifyConfigurable(err1, 'message');
+verifyProperty(err1, 'message', {
+  value: 'foo 42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
 
 var err2 = new Err();
 assert.sameValue(err2.hasOwnProperty('message'), false);

--- a/test/language/statements/class/subclass/builtin-objects/NativeError/RangeError-message.js
+++ b/test/language/statements/class/subclass/builtin-objects/NativeError/RangeError-message.js
@@ -23,12 +23,13 @@ class Err extends RangeError {}
 Err.prototype.message = 'custom-range-error';
 
 var err1 = new Err('foo 42');
-assert.sameValue(err1.message, 'foo 42');
-assert(err1.hasOwnProperty('message'));
 
-verifyWritable(err1, 'message');
-verifyNotEnumerable(err1, 'message');
-verifyConfigurable(err1, 'message');
+verifyProperty(err1, 'message', {
+  value: 'foo 42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
 
 var err2 = new Err();
 assert.sameValue(err2.hasOwnProperty('message'), false);

--- a/test/language/statements/class/subclass/builtin-objects/NativeError/ReferenceError-message.js
+++ b/test/language/statements/class/subclass/builtin-objects/NativeError/ReferenceError-message.js
@@ -23,12 +23,13 @@ class Err extends ReferenceError {}
 Err.prototype.message = 'custom-reference-error';
 
 var err1 = new Err('foo 42');
-assert.sameValue(err1.message, 'foo 42');
-assert(err1.hasOwnProperty('message'));
 
-verifyWritable(err1, 'message');
-verifyNotEnumerable(err1, 'message');
-verifyConfigurable(err1, 'message');
+verifyProperty(err1, 'message', {
+  value: 'foo 42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
 
 var err2 = new Err();
 assert.sameValue(err2.hasOwnProperty('message'), false);

--- a/test/language/statements/class/subclass/builtin-objects/NativeError/SyntaxError-message.js
+++ b/test/language/statements/class/subclass/builtin-objects/NativeError/SyntaxError-message.js
@@ -23,12 +23,13 @@ class Err extends SyntaxError {}
 Err.prototype.message = 'custom-syntax-error';
 
 var err1 = new Err('foo 42');
-assert.sameValue(err1.message, 'foo 42');
-assert(err1.hasOwnProperty('message'));
 
-verifyWritable(err1, 'message');
-verifyNotEnumerable(err1, 'message');
-verifyConfigurable(err1, 'message');
+verifyProperty(err1, 'message', {
+  value: 'foo 42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
 
 var err2 = new Err();
 assert.sameValue(err2.hasOwnProperty('message'), false);

--- a/test/language/statements/class/subclass/builtin-objects/NativeError/TypeError-message.js
+++ b/test/language/statements/class/subclass/builtin-objects/NativeError/TypeError-message.js
@@ -23,12 +23,13 @@ class Err extends TypeError {}
 Err.prototype.message = 'custom-type-error';
 
 var err1 = new Err('foo 42');
-assert.sameValue(err1.message, 'foo 42');
-assert(err1.hasOwnProperty('message'));
 
-verifyWritable(err1, 'message');
-verifyNotEnumerable(err1, 'message');
-verifyConfigurable(err1, 'message');
+verifyProperty(err1, 'message', {
+  value: 'foo 42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
 
 var err2 = new Err();
 assert.sameValue(err2.hasOwnProperty('message'), false);

--- a/test/language/statements/class/subclass/builtin-objects/NativeError/URIError-message.js
+++ b/test/language/statements/class/subclass/builtin-objects/NativeError/URIError-message.js
@@ -23,12 +23,13 @@ class Err extends URIError {}
 Err.prototype.message = 'custom-uri-error';
 
 var err1 = new Err('foo 42');
-assert.sameValue(err1.message, 'foo 42');
-assert(err1.hasOwnProperty('message'));
 
-verifyWritable(err1, 'message');
-verifyNotEnumerable(err1, 'message');
-verifyConfigurable(err1, 'message');
+verifyProperty(err1, 'message', {
+  value: 'foo 42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
 
 var err2 = new Err();
 assert.sameValue(err2.hasOwnProperty('message'), false);

--- a/test/language/statements/class/subclass/builtin-objects/RegExp/lastIndex.js
+++ b/test/language/statements/class/subclass/builtin-objects/RegExp/lastIndex.js
@@ -19,8 +19,9 @@ var re = new RE('39?');
 
 re.exec('TC39');
 
-assert.sameValue(re.lastIndex, 0);
-
-verifyWritable(re, 'lastIndex');
-verifyNotEnumerable(re, 'lastIndex');
-verifyNotConfigurable(re, 'lastIndex');
+verifyProperty(re, 'lastIndex', {
+  value: 0,
+  writable: true,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/language/statements/class/subclass/builtin-objects/String/length.js
+++ b/test/language/statements/class/subclass/builtin-objects/String/length.js
@@ -16,15 +16,19 @@ includes: [propertyHelper.js]
 class S extends String {}
 
 var s1 = new S();
-assert.sameValue(s1.length, 0);
 
-verifyNotWritable(s1, 'length');
-verifyNotEnumerable(s1, 'length');
-verifyNotConfigurable(s1, 'length');
+verifyProperty(s1, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});
 
 var s2 = new S('test262');
-assert.sameValue(s2.length, 7);
 
-verifyNotWritable(s2, 'length');
-verifyNotEnumerable(s2, 'length');
-verifyNotConfigurable(s2, 'length');
+verifyProperty(s2, 'length', {
+  value: 7,
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/language/statements/const/fn-name-arrow.js
+++ b/test/language/statements/const/fn-name-arrow.js
@@ -18,7 +18,9 @@ includes: [propertyHelper.js]
 
 const arrow = () => {};
 
-assert.sameValue(arrow.name, 'arrow');
-verifyNotEnumerable(arrow, 'name');
-verifyNotWritable(arrow, 'name');
-verifyConfigurable(arrow, 'name');
+verifyProperty(arrow, "name", {
+  value: "arrow",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/const/fn-name-class.js
+++ b/test/language/statements/const/fn-name-class.js
@@ -24,7 +24,9 @@ const xCls2 = class { static name() {} };
 assert.notSameValue(xCls.name, 'xCls');
 assert.notSameValue(xCls2.name, 'xCls2');
 
-assert.sameValue(cls.name, 'cls');
-verifyNotEnumerable(cls, 'name');
-verifyNotWritable(cls, 'name');
-verifyConfigurable(cls, 'name');
+verifyProperty(cls, 'name', {
+  value: 'cls',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/const/fn-name-cover.js
+++ b/test/language/statements/const/fn-name-cover.js
@@ -22,7 +22,9 @@ const cover = (function() {});
 
 assert(xCover.name !== 'xCover');
 
-assert.sameValue(cover.name, 'cover');
-verifyNotEnumerable(cover, 'name');
-verifyNotWritable(cover, 'name');
-verifyConfigurable(cover, 'name');
+verifyProperty(cover, 'name', {
+  value: 'cover',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/const/fn-name-fn.js
+++ b/test/language/statements/const/fn-name-fn.js
@@ -21,7 +21,9 @@ const fn = function() {};
 
 assert(xFn.name !== 'xFn');
 
-assert.sameValue(fn.name, 'fn');
-verifyNotEnumerable(fn, 'name');
-verifyNotWritable(fn, 'name');
-verifyConfigurable(fn, 'name');
+verifyProperty(fn, 'name', {
+  value: 'fn',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/const/fn-name-gen.js
+++ b/test/language/statements/const/fn-name-gen.js
@@ -22,7 +22,9 @@ const gen = function*() {};
 
 assert(xGen.name !== 'xGen');
 
-assert.sameValue(gen.name, 'gen');
-verifyNotEnumerable(gen, 'name');
-verifyNotWritable(gen, 'name');
-verifyConfigurable(gen, 'name');
+verifyProperty(gen, 'name', {
+  value: 'gen',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/function/13.0-12-s.js
+++ b/test/language/statements/function/13.0-12-s.js
@@ -13,5 +13,5 @@ description: >
 flags: [onlyStrict]
 ---*/
 
-        var _13_0_12_fun = new Function(" ","eval = 42;");
-        _13_0_12_fun();
+var _13_0_12_fun = new Function(" ","eval = 42;");
+_13_0_12_fun();

--- a/test/language/statements/function/13.0-13-s.js
+++ b/test/language/statements/function/13.0-13-s.js
@@ -13,7 +13,6 @@ description: >
 flags: [noStrict]
 ---*/
 
-       
 assert.throws(SyntaxError, function() {
-            eval("var _13_0_13_fun = new Function(\" \", \"'use strict'; eval = 42;\"); _13_0_13_fun();");
+    eval("var _13_0_13_fun = new Function(\" \", \"'use strict'; eval = 42;\"); _13_0_13_fun();");
 });

--- a/test/language/statements/function/13.0-14-s.js
+++ b/test/language/statements/function/13.0-14-s.js
@@ -13,8 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-
 assert.throws(SyntaxError, function() {
-            var _13_0_14_fun = new Function(" ", "'use strict'; eval = 42; ");
-            _13_0_14_fun();
+    var _13_0_14_fun = new Function(" ", "'use strict'; eval = 42; ");
+    _13_0_14_fun();
 });

--- a/test/language/statements/function/13.0-15-s.js
+++ b/test/language/statements/function/13.0-15-s.js
@@ -13,8 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; function _13_0_15_fun() {eval = 42;};");
-            _13_0_15_fun();
+    eval("'use strict'; function _13_0_15_fun() {eval = 42;};");
+    _13_0_15_fun();
 });

--- a/test/language/statements/function/13.0-16-s.js
+++ b/test/language/statements/function/13.0-16-s.js
@@ -15,6 +15,6 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; var _13_0_16_fun = function () {eval = 42;};");
-            _13_0_16_fun();
+    eval("'use strict'; var _13_0_16_fun = function () {eval = 42;};");
+    _13_0_16_fun();
 });

--- a/test/language/statements/function/13.0-17-s.js
+++ b/test/language/statements/function/13.0-17-s.js
@@ -13,4 +13,4 @@ description: >
 flags: [noStrict]
 ---*/
 
-        eval("'use strict'; var _13_0_17_fun = new Function('eval = 42;'); _13_0_17_fun();");
+eval("'use strict'; var _13_0_17_fun = new Function('eval = 42;'); _13_0_17_fun();");

--- a/test/language/statements/function/13.0-7-s.js
+++ b/test/language/statements/function/13.0-7-s.js
@@ -13,8 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; function _13_0_7_fun() {eval = 42;};");
-            _13_0_7_fun();
+    eval("'use strict'; function _13_0_7_fun() {eval = 42;};");
+    _13_0_7_fun();
 });

--- a/test/language/statements/function/13.0-8-s.js
+++ b/test/language/statements/function/13.0-8-s.js
@@ -14,6 +14,6 @@ flags: [onlyStrict]
 ---*/
 
 assert.throws(SyntaxError, function() {
-            eval("var _13_0_8_fun = function () {eval = 42;};");
-            _13_0_8_fun();
+    eval("var _13_0_8_fun = function () {eval = 42;};");
+    _13_0_8_fun();
 });

--- a/test/language/statements/function/13.1-19-s.js
+++ b/test/language/statements/function/13.1-19-s.js
@@ -16,5 +16,5 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("'use strict';function _13_1_19_fun(arguments) { }");
+    eval("'use strict';function _13_1_19_fun(arguments) { }");
 });

--- a/test/language/statements/function/13.1-2-s.js
+++ b/test/language/statements/function/13.1-2-s.js
@@ -14,7 +14,6 @@ description: >
 flags: [onlyStrict]
 ---*/
 
-
 assert.throws(SyntaxError, function() {
-            eval("var _13_1_2_fun = function (eval) { }");
+    eval("var _13_1_2_fun = function (eval) { }");
 });

--- a/test/language/statements/function/13.1-21-s.js
+++ b/test/language/statements/function/13.1-21-s.js
@@ -16,5 +16,5 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; var _13_1_21_fun = function (arguments) { }");
+    eval("'use strict'; var _13_1_21_fun = function (arguments) { }");
 });

--- a/test/language/statements/function/13.1-22-s.js
+++ b/test/language/statements/function/13.1-22-s.js
@@ -16,5 +16,5 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("var _13_1_22_fun = function (arguments) { 'use strict'; }");
+    eval("var _13_1_22_fun = function (arguments) { 'use strict'; }");
 });

--- a/test/language/statements/function/13.1-23-s.js
+++ b/test/language/statements/function/13.1-23-s.js
@@ -16,5 +16,5 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; function _13_1_23_fun(param, param) { }");
+    eval("'use strict'; function _13_1_23_fun(param, param) { }");
 });

--- a/test/language/statements/function/13.1-25-s.js
+++ b/test/language/statements/function/13.1-25-s.js
@@ -17,5 +17,5 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; function _13_1_25_fun(param1, param2, param1) { }");
+    eval("'use strict'; function _13_1_25_fun(param1, param2, param1) { }");
 });

--- a/test/language/statements/function/13.1-27-s.js
+++ b/test/language/statements/function/13.1-27-s.js
@@ -16,5 +16,5 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; function _13_1_27_fun(param, param, param) { }");
+    eval("'use strict'; function _13_1_27_fun(param, param, param) { }");
 });

--- a/test/language/statements/function/13.1-29-s.js
+++ b/test/language/statements/function/13.1-29-s.js
@@ -16,5 +16,5 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; var _13_1_29_fun = function (param, param) { };");
+    eval("'use strict'; var _13_1_29_fun = function (param, param) { };");
 });

--- a/test/language/statements/function/13.1-31-s.js
+++ b/test/language/statements/function/13.1-31-s.js
@@ -17,5 +17,5 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; var _13_1_31_fun = function (param1, param2, param1) { };");
+    eval("'use strict'; var _13_1_31_fun = function (param1, param2, param1) { };");
 });

--- a/test/language/statements/function/13.1-33-s.js
+++ b/test/language/statements/function/13.1-33-s.js
@@ -16,5 +16,5 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; var _13_1_33_fun = function (param, param, param) { };")
+    eval("'use strict'; var _13_1_33_fun = function (param, param, param) { };")
 });

--- a/test/language/statements/function/13.1-39-s.js
+++ b/test/language/statements/function/13.1-39-s.js
@@ -11,5 +11,5 @@ flags: [noStrict]
 
 
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; function arguments() { };")
+    eval("'use strict'; function arguments() { };")
 });

--- a/test/language/statements/function/13.1-4-s.js
+++ b/test/language/statements/function/13.1-4-s.js
@@ -14,7 +14,6 @@ description: >
 flags: [onlyStrict]
 ---*/
 
-
 assert.throws(SyntaxError, function() {
-            eval("var _13_1_4_fun = function (arguments) { };");
+    eval("var _13_1_4_fun = function (arguments) { };");
 });

--- a/test/language/statements/function/13.1-41-s.js
+++ b/test/language/statements/function/13.1-41-s.js
@@ -9,7 +9,8 @@ description: >
 flags: [noStrict]
 ---*/
 
-        var _13_1_41_s = {};
+var _13_1_41_s = {};
+
 assert.throws(SyntaxError, function() {
-            eval("'use strict'; _13_1_41_s.x = function arguments() {};");
+    eval("'use strict'; _13_1_41_s.x = function arguments() {};");
 });

--- a/test/language/statements/function/13.2-1-s.js
+++ b/test/language/statements/function/13.2-1-s.js
@@ -8,9 +8,9 @@ description: >
     function objects is allowed under both strict and normal modes.
 ---*/
 
-        var foo = function () {
-            this.caller = 12;
-        }
-        var obj = new foo();
+var foo = function () {
+    this.caller = 12;
+}
+var obj = new foo();
 
 assert.sameValue(obj.caller, 12, 'obj.caller');

--- a/test/language/statements/function/13.2-10-s.js
+++ b/test/language/statements/function/13.2-10-s.js
@@ -8,7 +8,8 @@ description: >
     is not allowed outside the function
 ---*/
 
-        var foo = Function("'use strict';");
+var foo = Function("'use strict';");
+
 assert.throws(TypeError, function() {
-            foo.caller = 41;
+    foo.caller = 41;
 });

--- a/test/language/statements/function/13.2-11-s.js
+++ b/test/language/statements/function/13.2-11-s.js
@@ -8,8 +8,8 @@ description: >
     'caller' fails outside of the function
 ---*/
 
-        var foo = Function("'use strict';");
-        
-        for (var tempIndex in foo) {
-            assert.notSameValue(tempIndex, "caller", 'tempIndex');
-        }
+var foo = Function("'use strict';");
+
+for (var tempIndex in foo) {
+    assert.notSameValue(tempIndex, "caller", 'tempIndex');
+}

--- a/test/language/statements/function/13.2-12-s.js
+++ b/test/language/statements/function/13.2-12-s.js
@@ -8,5 +8,5 @@ description: >
     'caller' fails inside the function
 ---*/
 
-            var foo = Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'caller', 'tempIndex');}");
-            foo.call(foo);
+var foo = Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'caller', 'tempIndex');}");
+foo.call(foo);

--- a/test/language/statements/function/13.2-13-s.js
+++ b/test/language/statements/function/13.2-13-s.js
@@ -8,7 +8,8 @@ description: >
     objects is not allowed outside the function
 ---*/
 
-        var foo = new Function("'use strict';");
+var foo = new Function("'use strict';");
+
 assert.throws(TypeError, function() {
-            var temp = foo.arguments;
+    var temp = foo.arguments;
 });

--- a/test/language/statements/function/13.2-14-s.js
+++ b/test/language/statements/function/13.2-14-s.js
@@ -8,7 +8,8 @@ description: >
     objects is not allowed outside the function
 ---*/
 
-        var foo = new Function("'use strict';");
+var foo = new Function("'use strict';");
+
 assert.throws(TypeError, function() {
-            foo.arguments = 41;
+    foo.arguments = 41;
 });

--- a/test/language/statements/function/13.2-15-1.js
+++ b/test/language/statements/function/13.2-15-1.js
@@ -11,9 +11,9 @@ includes: [propertyHelper.js]
 
 var fun = function (x, y) { };
 
-assert(fun.hasOwnProperty("length"));
-assert.sameValue(fun.length, 2);
-
-verifyNotEnumerable(fun, "length");
-verifyNotWritable(fun, "length");
-verifyConfigurable(fun, "length");
+verifyProperty(fun, "length", {
+  value: 2,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/function/13.2-15-s.js
+++ b/test/language/statements/function/13.2-15-s.js
@@ -8,8 +8,8 @@ description: >
     'arguments' fails outside of the function
 ---*/
 
-        var foo = new Function("'use strict';");
-        
-        for (var tempIndex in foo) {
-            assert.notSameValue(tempIndex, "arguments", 'tempIndex');
-        }
+var foo = new Function("'use strict';");
+
+for (var tempIndex in foo) {
+    assert.notSameValue(tempIndex, "arguments", 'tempIndex');
+}

--- a/test/language/statements/function/13.2-16-s.js
+++ b/test/language/statements/function/13.2-16-s.js
@@ -8,5 +8,5 @@ description: >
     'arguments' fails inside the function
 ---*/
 
-            var foo = new Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'arguments', 'tempIndex');}");
-            foo.call(foo);
+var foo = new Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'arguments', 'tempIndex');}");
+foo.call(foo);

--- a/test/language/statements/function/13.2-17-1.js
+++ b/test/language/statements/function/13.2-17-1.js
@@ -10,24 +10,24 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var desc = Object.getOwnPropertyDescriptor(Object.prototype, "constructor");
+var desc = Object.getOwnPropertyDescriptor(Object.prototype, "constructor");
 
-            var getFunc = function () {
-                return 100;
-            };
+var getFunc = function () {
+    return 100;
+};
 
-            var data = "data";
-            var setFunc = function (value) {
-                data = value;
-            };
+var data = "data";
+var setFunc = function (value) {
+    data = value;
+};
 
-            Object.defineProperty(Object.prototype, "constructor", {
-                get: getFunc,
-                set: setFunc,
-                configurable: true
-            });
+Object.defineProperty(Object.prototype, "constructor", {
+    get: getFunc,
+    set: setFunc,
+    configurable: true
+});
 
-            var fun = function () {};
+var fun = function () {};
 
 assert.sameValue(typeof fun.prototype.constructor, "function");
 

--- a/test/language/statements/function/13.2-17-1.js
+++ b/test/language/statements/function/13.2-17-1.js
@@ -7,6 +7,7 @@ description: >
     Function Object has 'constructor' as its own property, it is not
     enumerable and does not invoke the setter defined on
     Function.prototype.constructor (Step 17)
+includes: [propertyHelper.js]
 ---*/
 
         var desc = Object.getOwnPropertyDescriptor(Object.prototype, "constructor");
@@ -28,26 +29,12 @@ description: >
 
             var fun = function () {};
 
-            var verifyValue = false;
-            verifyValue = typeof fun.prototype.constructor === "function";
+assert.sameValue(typeof fun.prototype.constructor, "function");
 
-            var verifyEnumerable = false;
-            for (var p in fun.prototype) {
-                if (p === "constructor" && fun.prototype.hasOwnProperty("constructor")) {
-                    verifyEnumerable = true;
-                }
-            }
+verifyProperty(fun.prototype, "constructor", {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});
 
-            var verifyWritable = false;
-            fun.prototype.constructor = 12;
-            verifyWritable = (fun.prototype.constructor === 12);
-
-            var verifyConfigurable = false;
-            delete fun.prototype.constructor;
-            verifyConfigurable = fun.hasOwnProperty("constructor");
-
-assert(verifyValue, 'verifyValue !== true');
-assert(verifyWritable, 'verifyWritable !== true');
-assert.sameValue(verifyEnumerable, false, 'verifyEnumerable');
-assert.sameValue(verifyConfigurable, false, 'verifyConfigurable');
 assert.sameValue(data, "data", 'data');

--- a/test/language/statements/function/13.2-17-s.js
+++ b/test/language/statements/function/13.2-17-s.js
@@ -8,7 +8,8 @@ description: >
     objects is not allowed outside the function
 ---*/
 
-        var foo = Function("'use strict';");
+var foo = Function("'use strict';");
+
 assert.throws(TypeError, function() {
-            var temp = foo.arguments;
+    var temp = foo.arguments;
 });

--- a/test/language/statements/function/13.2-18-1.js
+++ b/test/language/statements/function/13.2-18-1.js
@@ -30,9 +30,11 @@ try {
     assert.notSameValue(fun.prototype, 100);
     assert.sameValue(fun.prototype.toString(), "[object Object]");
 
-    verifyNotEnumerable(fun, "prototype");
-    verifyWritable(fun, "prototype");
-    verifyNotConfigurable(fun, "prototype");
+    verifyProperty(fun, "prototype", {
+        writable: true,
+        enumerable: false,
+        configurable: false,
+    });
 
     assert.sameValue(data, "data");
 } finally {

--- a/test/language/statements/function/13.2-18-s.js
+++ b/test/language/statements/function/13.2-18-s.js
@@ -8,7 +8,8 @@ description: >
     objects is not allowed outside the function
 ---*/
 
-        var foo = Function("'use strict';");
+var foo = Function("'use strict';");
+
 assert.throws(TypeError, function() {
-            foo.arguments = 41;
+    foo.arguments = 41;
 });

--- a/test/language/statements/function/13.2-19-s.js
+++ b/test/language/statements/function/13.2-19-s.js
@@ -8,8 +8,8 @@ description: >
     'arguments' fails outside of the function
 ---*/
 
-        var foo = Function("'use strict';");
-        
-        for (var tempIndex in foo) {
-            assert.notSameValue(tempIndex, "arguments", 'tempIndex');
-        }
+var foo = Function("'use strict';");
+
+for (var tempIndex in foo) {
+    assert.notSameValue(tempIndex, "arguments", 'tempIndex');
+}

--- a/test/language/statements/function/13.2-2-s.js
+++ b/test/language/statements/function/13.2-2-s.js
@@ -11,7 +11,7 @@ flags: [onlyStrict]
 
 
 assert.throws(TypeError, function() {
-            var foo = function () {
-            }
-            foo.caller = 20;
+    var foo = function () {
+    }
+    foo.caller = 20;
 });

--- a/test/language/statements/function/13.2-20-s.js
+++ b/test/language/statements/function/13.2-20-s.js
@@ -9,5 +9,5 @@ description: >
 flags: [noStrict]
 ---*/
 
-            var foo = Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'arguments', 'tempIndex');}");
-            foo.call(foo);
+var foo = Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'arguments', 'tempIndex');}");
+foo.call(foo);

--- a/test/language/statements/function/13.2-21-s.js
+++ b/test/language/statements/function/13.2-21-s.js
@@ -9,7 +9,8 @@ description: >
 flags: [noStrict]
 ---*/
 
-        function foo () {"use strict";}
+function foo () {"use strict";}
+
 assert.throws(TypeError, function() {
-            var temp = foo.caller;
+    var temp = foo.caller;
 });

--- a/test/language/statements/function/13.2-22-s.js
+++ b/test/language/statements/function/13.2-22-s.js
@@ -9,7 +9,8 @@ description: >
 flags: [noStrict]
 ---*/
 
-        function foo () {"use strict";}
+function foo () {"use strict";}
+
 assert.throws(TypeError, function() {
-            foo.caller = 41;
+    foo.caller = 41;
 });

--- a/test/language/statements/function/13.2-23-s.js
+++ b/test/language/statements/function/13.2-23-s.js
@@ -9,7 +9,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-        function foo () {"use strict";}
-        for (var tempIndex in foo) {
-            assert.notSameValue(tempIndex, "caller", 'tempIndex');
-        }
+function foo () {"use strict";}
+for (var tempIndex in foo) {
+    assert.notSameValue(tempIndex, "caller", 'tempIndex');
+}

--- a/test/language/statements/function/13.2-24-s.js
+++ b/test/language/statements/function/13.2-24-s.js
@@ -9,11 +9,11 @@ description: >
 flags: [noStrict]
 ---*/
 
-            function foo () {
-                "use strict"; 
-                for (var tempIndex in this) {
-                    assert.notSameValue(tempIndex, "caller", 'tempIndex');
-                } 
-            }
+function foo () {
+    "use strict";
+    for (var tempIndex in this) {
+        assert.notSameValue(tempIndex, "caller", 'tempIndex');
+    }
+}
 
 foo.call(foo);

--- a/test/language/statements/function/13.2-25-s.js
+++ b/test/language/statements/function/13.2-25-s.js
@@ -9,7 +9,8 @@ description: >
 flags: [noStrict]
 ---*/
 
-        function foo () {"use strict";}
+function foo () {"use strict";}
+
 assert.throws(TypeError, function() {
-            var temp = foo.arguments;
+    var temp = foo.arguments;
 });

--- a/test/language/statements/function/13.2-26-s.js
+++ b/test/language/statements/function/13.2-26-s.js
@@ -9,7 +9,8 @@ description: >
 flags: [noStrict]
 ---*/
 
-        function foo () {"use strict";}
+function foo () {"use strict";}
+
 assert.throws(TypeError, function() {
-            foo.arguments = 41;
+    foo.arguments = 41;
 });

--- a/test/language/statements/function/13.2-27-s.js
+++ b/test/language/statements/function/13.2-27-s.js
@@ -9,8 +9,8 @@ description: >
 flags: [noStrict]
 ---*/
 
-        function foo () {"use strict";}
-        
-        for (var tempIndex in foo) {
-            assert.notSameValue(tempIndex, "arguments", 'tempIndex');
-        }
+function foo () {"use strict";}
+
+for (var tempIndex in foo) {
+    assert.notSameValue(tempIndex, "arguments", 'tempIndex');
+}

--- a/test/language/statements/function/13.2-28-s.js
+++ b/test/language/statements/function/13.2-28-s.js
@@ -9,10 +9,10 @@ description: >
 flags: [noStrict]
 ---*/
 
-            function foo() {
-                "use strict"; 
-                for (var tempIndex in this) {
-                    assert.notSameValue(tempIndex, "arguments", 'tempIndex');
-                } 
-            }
-            foo.call(foo);
+function foo() {
+    "use strict";
+    for (var tempIndex in this) {
+        assert.notSameValue(tempIndex, "arguments", 'tempIndex');
+    }
+}
+foo.call(foo);

--- a/test/language/statements/function/13.2-3-s.js
+++ b/test/language/statements/function/13.2-3-s.js
@@ -8,9 +8,9 @@ description: >
     of function objects is allowed under both strict and normal modes.
 ---*/
 
-        var foo = function () {
-            this.arguments = 12;
-        } 
-        var obj = new foo();
+var foo = function () {
+    this.arguments = 12;
+}
+var obj = new foo();
 
 assert.sameValue(obj.arguments, 12, 'obj.arguments');

--- a/test/language/statements/function/13.2-4-s.js
+++ b/test/language/statements/function/13.2-4-s.js
@@ -11,7 +11,7 @@ flags: [onlyStrict]
 
 
 assert.throws(TypeError, function() {
-            var foo = function () {
-            }
-            foo.arguments = 20;
+    var foo = function () {
+    }
+    foo.arguments = 20;
 });

--- a/test/language/statements/function/13.2-5-s.js
+++ b/test/language/statements/function/13.2-5-s.js
@@ -9,7 +9,8 @@ description: >
 flags: [noStrict]
 ---*/
 
-        var foo = new Function("'use strict';");
+var foo = new Function("'use strict';");
+
 assert.throws(TypeError, function() {
-            var temp = foo.caller;
+    var temp = foo.caller;
 });

--- a/test/language/statements/function/13.2-6-s.js
+++ b/test/language/statements/function/13.2-6-s.js
@@ -9,7 +9,8 @@ description: >
 flags: [noStrict]
 ---*/
 
-        var foo = new Function("'use strict';");
+var foo = new Function("'use strict';");
+
 assert.throws(TypeError, function() {
-            foo.caller = 41;
+    foo.caller = 41;
 });

--- a/test/language/statements/function/13.2-7-s.js
+++ b/test/language/statements/function/13.2-7-s.js
@@ -9,8 +9,8 @@ description: >
 flags: [noStrict]
 ---*/
 
-        var foo = new Function("'use strict';");
-        
-        for (var tempIndex in foo) {
-            assert.notSameValue(tempIndex, "caller", 'tempIndex');
-        }
+var foo = new Function("'use strict';");
+
+for (var tempIndex in foo) {
+    assert.notSameValue(tempIndex, "caller", 'tempIndex');
+}

--- a/test/language/statements/function/13.2-8-s.js
+++ b/test/language/statements/function/13.2-8-s.js
@@ -9,5 +9,5 @@ description: >
 flags: [noStrict]
 ---*/
 
-            var foo = new Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'caller', 'tempIndex');}");
-            foo.call(foo);
+var foo = new Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'caller', 'tempIndex');}");
+foo.call(foo);

--- a/test/language/statements/function/13.2-9-s.js
+++ b/test/language/statements/function/13.2-9-s.js
@@ -9,7 +9,8 @@ description: >
 flags: [noStrict]
 ---*/
 
-        var foo = Function("'use strict';");
+var foo = Function("'use strict';");
+
 assert.throws(TypeError, function() {
-            var temp = foo.caller;
+    var temp = foo.caller;
 });

--- a/test/language/statements/function/length-dflt.js
+++ b/test/language/statements/function/length-dflt.js
@@ -33,28 +33,36 @@ includes: [propertyHelper.js]
 
 function f1(x = 42) {}
 
-assert.sameValue(f1.length, 0, 'FormalsList: x = 42');
-verifyNotEnumerable(f1, 'length');
-verifyNotWritable(f1, 'length');
-verifyConfigurable(f1, 'length');
+verifyProperty(f1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 function f2(x = 42, y) {}
 
-assert.sameValue(f2.length, 0, 'FormalsList: x = 42, y');
-verifyNotEnumerable(f2, 'length');
-verifyNotWritable(f2, 'length');
-verifyConfigurable(f2, 'length');
+verifyProperty(f2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 function f3(x, y = 42) {}
 
-assert.sameValue(f3.length, 1, 'FormalsList: x, y = 42');
-verifyNotEnumerable(f3, 'length');
-verifyNotWritable(f3, 'length');
-verifyConfigurable(f3, 'length');
+verifyProperty(f3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 function f4(x, y = 42, z) {}
 
-assert.sameValue(f4.length, 1, 'FormalsList: x, y = 42, z');
-verifyNotEnumerable(f4, 'length');
-verifyNotWritable(f4, 'length');
-verifyConfigurable(f4, 'length');
+verifyProperty(f4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/function/name.js
+++ b/test/language/statements/function/name.js
@@ -18,7 +18,9 @@ includes: [propertyHelper.js]
 
 function func() {}
 
-assert.sameValue(func.name, 'func');
-verifyNotEnumerable(func, 'name');
-verifyNotWritable(func, 'name');
-verifyConfigurable(func, 'name');
+verifyProperty(func, "name", {
+  value: "func",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/generators/length-dflt.js
+++ b/test/language/statements/generators/length-dflt.js
@@ -33,28 +33,36 @@ includes: [propertyHelper.js]
 
 function* f1(x = 42) {}
 
-assert.sameValue(f1.length, 0, 'FormalsList: x = 42');
-verifyNotEnumerable(f1, 'length');
-verifyNotWritable(f1, 'length');
-verifyConfigurable(f1, 'length');
+verifyProperty(f1, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 function* f2(x = 42, y) {}
 
-assert.sameValue(f2.length, 0, 'FormalsList: x = 42, y');
-verifyNotEnumerable(f2, 'length');
-verifyNotWritable(f2, 'length');
-verifyConfigurable(f2, 'length');
+verifyProperty(f2, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 function* f3(x, y = 42) {}
 
-assert.sameValue(f3.length, 1, 'FormalsList: x, y = 42');
-verifyNotEnumerable(f3, 'length');
-verifyNotWritable(f3, 'length');
-verifyConfigurable(f3, 'length');
+verifyProperty(f3, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 function* f4(x, y = 42, z) {}
 
-assert.sameValue(f4.length, 1, 'FormalsList: x, y = 42, z');
-verifyNotEnumerable(f4, 'length');
-verifyNotWritable(f4, 'length');
-verifyConfigurable(f4, 'length');
+verifyProperty(f4, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/generators/length-property-descriptor.js
+++ b/test/language/statements/generators/length-property-descriptor.js
@@ -11,7 +11,9 @@ features: [generators]
 
 function* g() {}
 
-assert.sameValue(g.length, 0);
-verifyNotEnumerable(g, 'length');
-verifyNotWritable(g, 'length');
-verifyConfigurable(g, 'length');
+verifyProperty(g, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/generators/name.js
+++ b/test/language/statements/generators/name.js
@@ -16,7 +16,9 @@ features: [generators]
 
 function* g() {}
 
-assert.sameValue(g.name, 'g');
-verifyNotEnumerable(g, 'name');
-verifyNotWritable(g, 'name');
-verifyConfigurable(g, 'name');
+verifyProperty(g, "name", {
+  value: "g",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/generators/prototype-property-descriptor.js
+++ b/test/language/statements/generators/prototype-property-descriptor.js
@@ -11,6 +11,8 @@ features: [generators]
 
 function* g() {}
 
-verifyNotEnumerable(g, 'prototype');
-verifyWritable(g, 'prototype');
-verifyNotConfigurable(g, 'prototype');
+verifyProperty(g, "prototype", {
+  writable: true,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/language/statements/let/fn-name-arrow.js
+++ b/test/language/statements/let/fn-name-arrow.js
@@ -18,7 +18,9 @@ includes: [propertyHelper.js]
 
 let arrow = () => {};
 
-assert.sameValue(arrow.name, 'arrow');
-verifyNotEnumerable(arrow, 'name');
-verifyNotWritable(arrow, 'name');
-verifyConfigurable(arrow, 'name');
+verifyProperty(arrow, 'name', {
+  value: 'arrow',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/let/fn-name-class.js
+++ b/test/language/statements/let/fn-name-class.js
@@ -24,7 +24,9 @@ let xCls2 = class { static name() {} };
 assert.notSameValue(xCls.name, 'xCls');
 assert.notSameValue(xCls2.name, 'xCls2');
 
-assert.sameValue(cls.name, 'cls');
-verifyNotEnumerable(cls, 'name');
-verifyNotWritable(cls, 'name');
-verifyConfigurable(cls, 'name');
+verifyProperty(cls, 'name', {
+  value: 'cls',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/let/fn-name-cover.js
+++ b/test/language/statements/let/fn-name-cover.js
@@ -22,7 +22,9 @@ let cover = (function() {});
 
 assert(xCover.name !== 'xCover');
 
-assert.sameValue(cover.name, 'cover');
-verifyNotEnumerable(cover, 'name');
-verifyNotWritable(cover, 'name');
-verifyConfigurable(cover, 'name');
+verifyProperty(cover, 'name', {
+  value: 'cover',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/let/fn-name-fn.js
+++ b/test/language/statements/let/fn-name-fn.js
@@ -21,7 +21,9 @@ let fn = function() {};
 
 assert(xFn.name !== 'xFn');
 
-assert.sameValue(fn.name, 'fn');
-verifyNotEnumerable(fn, 'name');
-verifyNotWritable(fn, 'name');
-verifyConfigurable(fn, 'name');
+verifyProperty(fn, 'name', {
+  value: 'fn',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/let/fn-name-gen.js
+++ b/test/language/statements/let/fn-name-gen.js
@@ -22,7 +22,9 @@ let gen = function*() {};
 
 assert(xGen.name !== 'xGen');
 
-assert.sameValue(gen.name, 'gen');
-verifyNotEnumerable(gen, 'name');
-verifyNotWritable(gen, 'name');
-verifyConfigurable(gen, 'name');
+verifyProperty(gen, 'name', {
+  value: 'gen',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/variable/fn-name-arrow.js
+++ b/test/language/statements/variable/fn-name-arrow.js
@@ -18,7 +18,9 @@ includes: [propertyHelper.js]
 
 var arrow = () => {};
 
-assert.sameValue(arrow.name, 'arrow');
-verifyNotEnumerable(arrow, 'name');
-verifyNotWritable(arrow, 'name');
-verifyConfigurable(arrow, 'name');
+verifyProperty(arrow, 'name', {
+  value: 'arrow',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/variable/fn-name-class.js
+++ b/test/language/statements/variable/fn-name-class.js
@@ -24,7 +24,9 @@ var xCls2 = class { static name() {} };
 assert.notSameValue(xCls.name, 'xCls');
 assert.notSameValue(xCls2.name, 'xCls2');
 
-assert.sameValue(cls.name, 'cls');
-verifyNotEnumerable(cls, 'name');
-verifyNotWritable(cls, 'name');
-verifyConfigurable(cls, 'name');
+verifyProperty(cls, 'name', {
+  value: 'cls',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/variable/fn-name-cover.js
+++ b/test/language/statements/variable/fn-name-cover.js
@@ -22,7 +22,9 @@ var cover = (function() {});
 
 assert(xCover.name !== 'xCover');
 
-assert.sameValue(cover.name, 'cover');
-verifyNotEnumerable(cover, 'name');
-verifyNotWritable(cover, 'name');
-verifyConfigurable(cover, 'name');
+verifyProperty(cover, 'name', {
+  value: 'cover',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/variable/fn-name-fn.js
+++ b/test/language/statements/variable/fn-name-fn.js
@@ -21,7 +21,9 @@ var fn = function() {};
 
 assert(xFn.name !== 'xFn');
 
-assert.sameValue(fn.name, 'fn');
-verifyNotEnumerable(fn, 'name');
-verifyNotWritable(fn, 'name');
-verifyConfigurable(fn, 'name');
+verifyProperty(fn, 'name', {
+  value: 'fn',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/language/statements/variable/fn-name-gen.js
+++ b/test/language/statements/variable/fn-name-gen.js
@@ -22,7 +22,9 @@ var gen = function*() {};
 
 assert(xGen.name !== 'xGen');
 
-assert.sameValue(gen.name, 'gen');
-verifyNotEnumerable(gen, 'name');
-verifyNotWritable(gen, 'name');
-verifyConfigurable(gen, 'name');
+verifyProperty(gen, 'name', {
+  value: 'gen',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});


### PR DESCRIPTION
190d71c78aff0703947cb77a31665bbaaad1568a
- Change `verifyProperty` to also test the object value in addition to the descriptor value.
- This helps to verify `[[Get]]` is correctly implemented in addition to `[[GetOwnProperty]]`.

1392ed70acdbe5e6cb121c606caa2de2726ab7dd
- Validate that the descriptor passed to `verifyProperty` has the correct properties.
- And fix some tests which had typos in the descriptor properties.

b9a68616cff5f5e16d851c2ab737c621f2f75b1d
- It looks like these tests were never updated to use `verify(Not){Enumerable,Writable,Configurable}` functions.

All other commits:
- Replace `verify(Not){Enumerable,Writable,Configurable}` with `verifyProperty`.