### PR TITLE
Update two Array.fromAsync `this-constructor` tests to test the correct behavior 

### DIFF
--- a/test/built-ins/Array/fromAsync/this-constructor-operations.js
+++ b/test/built-ins/Array/fromAsync/this-constructor-operations.js
@@ -61,7 +61,6 @@ asyncTest(async function () {
   // Note https://github.com/tc39/proposal-array-from-async/issues/35
   const expectedCallsForArrayLike = [
     "construct MyArray",
-    "construct MyArray",
     "defineProperty A[0]",
     "defineProperty A[1]",
     "set A.length"

--- a/test/built-ins/Array/fromAsync/this-constructor.js
+++ b/test/built-ins/Array/fromAsync/this-constructor.js
@@ -47,7 +47,6 @@ asyncTest(async function () {
   assert.sameValue(result.length, 2, "length is set on result");
   assert.sameValue(result[0], 1, "element 0 is set on result");
   assert.sameValue(result[1], 2, "element 1 is set on result");
-  assert.sameValue(constructorCalls.length, 2, "constructor is called twice");
-  assert.compareArray(constructorCalls[0], [], "constructor is called first with no arguments");
-  assert.compareArray(constructorCalls[1], [2], "constructor is called second with a length argument");
+  assert.sameValue(constructorCalls.length, 1, "constructor is called once");
+  assert.compareArray(constructorCalls[0], [2], "constructor is called with a length argument");
 });

--- a/test/staging/SetMethods/set-intersection-other-is-map.js
+++ b/test/staging/SetMethods/set-intersection-other-is-map.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+features: [set-methods]
+includes: [compareArray.js]
+---*/
+
+const firstSet = new Set();
+firstSet.add(42);
+firstSet.add(43);
+
+const other = new Map();
+other.set(42);
+other.set(46);
+other.set(47);
+
+const resultSet = new Set();
+resultSet.add(42);
+
+const resultArray = Array.from(resultSet);
+const intersectionArray = Array.from(firstSet.intersection(other));
+
+assert.compareArray(resultArray, intersectionArray);

--- a/test/staging/SetMethods/set-intersection-other-is-set-like.js
+++ b/test/staging/SetMethods/set-intersection-other-is-set-like.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+features: [set-methods]
+includes: [compareArray.js]
+---*/
+
+const SetLike = {
+    arr: [42, 43, 45],
+    size: 3,
+        keys() {
+            return this.arr[Symbol.iterator]();
+        },
+        has(key) {
+            return this.arr.indexOf(key) != -1;
+        }
+    };
+
+const firstSet = new Set();
+firstSet.add(42);
+firstSet.add(43);
+
+const resultSet = new Set();
+resultSet.add(42);
+resultSet.add(43);
+
+const resultArray = Array.from(resultSet);
+const intersectionArray = Array.from(firstSet.intersection(SetLike));
+
+assert.compareArray(resultArray, intersectionArray);

--- a/test/staging/SetMethods/set-intersection-other-is-set.js
+++ b/test/staging/SetMethods/set-intersection-other-is-set.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+features: [set-methods]
+includes: [compareArray.js]
+---*/
+
+const firstSet = new Set();
+firstSet.add(42);
+firstSet.add(43);
+firstSet.add(44);
+
+const otherSet = new Set();
+otherSet.add(42);
+otherSet.add(45);
+
+const resultSet = new Set();
+resultSet.add(42);
+
+const resultArray = Array.from(resultSet);
+const intersectionArray = Array.from(firstSet.intersection(otherSet));
+
+assert.compareArray(resultArray, intersectionArray);


### PR DESCRIPTION
Based on [this fix](https://github.com/tc39/proposal-array-from-async/pull/41) on Array.fromAsync spec to avoid calling constructor twice, the following two tests needed to be updated:
built-ins/Array/fromAsync/this-constructor
built-ins/Array/fromAsync/this-constructor-operations