### PR TITLE
Use correct variables in time zone case insensitive test

### DIFF
--- a/test/intl402/Temporal/TimeZone/prototype/equals/timezone-case-insensitive.js
+++ b/test/intl402/Temporal/TimeZone/prototype/equals/timezone-case-insensitive.js
@@ -602,7 +602,6 @@ const timeZoneIdentifiers = [
   'US/Michigan',
   'US/Mountain',
   'US/Pacific',
-  'US/Pacific-New',
   'US/Samoa',
   'UTC',
   'Universal',
@@ -620,7 +619,6 @@ for (const id of ids) {
   const lower = id.toLowerCase();
   const upper = id.toUpperCase();
   const tz = new Temporal.TimeZone(id);
-  assert.sameValue(tz.equals(id), true,  `Time zone "${id}" compared to string "${upper}"`);
-  assert.sameValue(tz.equals(id), true, `Time zone "${id}" compared to string "${lower}"`);
+  assert.sameValue(tz.equals(upper), true, `Time zone "${id}" compared to string "${upper}"`);
+  assert.sameValue(tz.equals(lower), true, `Time zone "${id}" compared to string "${lower}"`);
 }
-


### PR DESCRIPTION
Also remove `US/Pacific-New` which has been removed from tz data since release 2020b.