### PR TITLE
Fix import assertions tests

### DIFF
--- a/test/language/module-code/import-assertions/ensure-linking-error_FIXTURE.js
+++ b/test/language/module-code/import-assertions/ensure-linking-error_FIXTURE.js
@@ -6,4 +6,4 @@
 // It can be used to assert that there is a linking error, which means
 // that there are no parsing errors.
 
-import { nonExistent } from "./import-assertion-ensure-resolution-error_FIXTURE.js";
+import { nonExistent } from "./ensure-linking-error_FIXTURE.js";

--- a/test/language/module-code/import-assertions/import-assertion-empty.js
+++ b/test/language/module-code/import-assertions/import-assertion-empty.js
@@ -27,4 +27,3 @@ import './import-assertion-2_FIXTURE.js' assert {};
 export * from './import-assertion-3_FIXTURE.js' assert {};
 
 assert.sameValue(x, 262.1);
-assert.sameValue(globalThis.test262, 262.2);


### PR DESCRIPTION
- Correct file paths in "ensure-linking-error_FIXTURE.js"
- Remove no longer valid assertion in "import-assertion-empty.js".

See also #3919.