### PR TITLE
Only lint js and json files

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -72,6 +72,9 @@ def lint(file_names):
     errors = dict()
 
     for file_name in file_names:
+        if not file_name.endswith((".js", ".json")):
+            continue
+
         with open(file_name, 'r') as f:
             content = f.read()
         meta = lib.frontmatter.parse(content)


### PR DESCRIPTION
CheckFileName is the only one that could arguably be valid for other files, but it doesn't seem worth the complexity to run it.