### PR TITLE
added missing features: line to metadata for two tests

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined.js
@@ -13,7 +13,7 @@ info: |
   5. Else,
     a. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", durationFormat.[[FractionalDigits]]).
     b. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", durationFormat.[[FractionalDigits]]).
-    
+features: [Intl.DurationFormat]
 ---*/
 
 

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits.js
@@ -13,6 +13,7 @@ info: |
   5. Else,
     a. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", durationFormat.[[FractionalDigits]]).
     b. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", durationFormat.[[FractionalDigits]]).
+features: [Intl.DurationFormat]
 ---*/
 
 const duration = {


### PR DESCRIPTION
Previously merged 3890  was missing features: line, this corrects that.