### PR TITLE
Allow @tc39-staging to modify features.txt

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 * @tc39/test262-maintainers
+/features.txt @tc39/test262-staging @tc39/test262-maintainers
 /test/staging/ @tc39/test262-staging @tc39/test262-maintainers


### PR DESCRIPTION
This came up while working on the V8 test262 2-way sync bot for `staging/`. It is likely that tests added to staging/ will be for a new feature that requires a new entry in `features.txt`, so the staging group should have write access to that file.

cc @rmahdav 