### PR TITLE
Fix symbol-tag-generators-builtin.js

### DIFF
--- a/test/built-ins/Object/prototype/toString/symbol-tag-generators-builtin.js
+++ b/test/built-ins/Object/prototype/toString/symbol-tag-generators-builtin.js
@@ -11,18 +11,20 @@ info: |
   15. Let tag be ? Get(O, @@toStringTag).
   16. If Type(tag) is not String, set tag to builtinTag.
   17. Return the string-concatenation of "[object ", tag, and "]".
-features: [Symbol.toStringTag, Symbol.iterator, generators, iterator-helpers]
+features: [Symbol.toStringTag, Symbol.iterator, generators]
 ---*/
 
 var toString = Object.prototype.toString;
 
 var genFn = function* () {};
-assert.sameValue(toString.call(gen), '[object GeneratorFunction]');
+assert.sameValue(toString.call(genFn), '[object GeneratorFunction]');
 
 var gen = genFn();
 assert.sameValue(toString.call(gen), '[object Generator]');
 
 var genProto = Object.getPrototypeOf(gen);
+assert.sameValue(genProto, genFn.prototype);
+
 Object.defineProperty(genProto, Symbol.toStringTag, {
   configurable: true,
   get: function() { return {}; },
@@ -30,4 +32,4 @@ Object.defineProperty(genProto, Symbol.toStringTag, {
 assert.sameValue(toString.call(gen), '[object Object]');
 
 delete genProto[Symbol.toStringTag];
-assert.sameValue(toString.call(gen), '[object Iterator]');
+assert.sameValue(toString.call(gen), '[object Generator]');


### PR DESCRIPTION
Two issues:
1. There was a typo, the first `gen` should have been `genFn`.
2. And the last `toString` result should be `'[object Generator]'`, because `Object.getPrototypeOf(gen) == genFn.prototype`. And the `@@toStringTag` property of `genFn.prototype` is inherited from `Generator.prototype[@@toStringTag]`.

That also means the "iterator-helpers" flag isn't needed for this test.