### PR TITLE
Some extra test coverage for Temporal

### DIFF
--- a/test/built-ins/Temporal/Duration/compare/exhaustive.js
+++ b/test/built-ins/Temporal/Duration/compare/exhaustive.js
@@ -1,0 +1,513 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: Tests for compare() with each possible outcome
+features: [Temporal]
+---*/
+
+const plainDate = new Temporal.PlainDate(2000, 1, 1);
+
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(6),
+    new Temporal.Duration(5),
+    { relativeTo: plainDate }
+  ),
+  1,
+  "years >, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(3),
+    new Temporal.Duration(4),
+    { relativeTo: plainDate }
+  ),
+  -1,
+  "years <, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 6),
+    new Temporal.Duration(2, 5),
+    { relativeTo: plainDate }
+  ),
+  1,
+  "months >, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 3),
+    new Temporal.Duration(4, 4),
+    { relativeTo: plainDate }
+  ),
+  -1,
+  "months <, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 6),
+    new Temporal.Duration(2, 1, 5),
+    { relativeTo: plainDate }
+  ),
+  1,
+  "weeks >, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 3),
+    new Temporal.Duration(4, 7, 4),
+    { relativeTo: plainDate }
+  ),
+  -1,
+  "weeks <, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 6),
+    new Temporal.Duration(2, 1, 3, 5),
+    { relativeTo: plainDate }
+  ),
+  1,
+  "days >, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 3),
+    new Temporal.Duration(4, 7, 2, 4),
+    { relativeTo: plainDate }
+  ),
+  -1,
+  "days <, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6),
+    new Temporal.Duration(2, 1, 3, 12, 5),
+    { relativeTo: plainDate }
+  ),
+  1,
+  "hours >, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 3),
+    new Temporal.Duration(4, 7, 2, 40, 4),
+    { relativeTo: plainDate }
+  ),
+  -1,
+  "hours <, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6, 6),
+    new Temporal.Duration(2, 1, 3, 12, 6, 5),
+    { relativeTo: plainDate }
+  ),
+  1,
+  "minutes >, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 3),
+    new Temporal.Duration(4, 7, 2, 40, 12, 4),
+    { relativeTo: plainDate }
+  ),
+  -1,
+  "minutes <, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 6),
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 5),
+    { relativeTo: plainDate }
+  ),
+  1,
+  "seconds >, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 3),
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 4),
+    { relativeTo: plainDate }
+  ),
+  -1,
+  "seconds <, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 6),
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 5),
+    { relativeTo: plainDate }
+  ),
+  1,
+  "milliseconds >, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 3),
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 4),
+    { relativeTo: plainDate }
+  ),
+  -1,
+  "milliseconds <, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 222, 6),
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 222, 5),
+    { relativeTo: plainDate }
+  ),
+  1,
+  "microseconds >, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 3),
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 4),
+    { relativeTo: plainDate }
+  ),
+  -1,
+  "microseconds <, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 222, 444, 6),
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 222, 444, 5),
+    { relativeTo: plainDate }
+  ),
+  1,
+  "nanoseconds >, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 777, 3),
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 777, 4),
+    { relativeTo: plainDate }
+  ),
+  -1,
+  "nanoseconds <, relativeTo PlainDate"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 777, 111),
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 777, 111),
+    { relativeTo: plainDate }
+  ),
+  0,
+  "equal, relativeTo PlainDate"
+);
+
+const zonedDateTime = new Temporal.ZonedDateTime(0n, "UTC");
+
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(6),
+    new Temporal.Duration(5),
+    { relativeTo: zonedDateTime }
+  ),
+  1,
+  "years >, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(3),
+    new Temporal.Duration(4),
+    { relativeTo: zonedDateTime }
+  ),
+  -1,
+  "years <, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 6),
+    new Temporal.Duration(2, 5),
+    { relativeTo: zonedDateTime }
+  ),
+  1,
+  "months >, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 3),
+    new Temporal.Duration(4, 4),
+    { relativeTo: zonedDateTime }
+  ),
+  -1,
+  "months <, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 6),
+    new Temporal.Duration(2, 1, 5),
+    { relativeTo: zonedDateTime }
+  ),
+  1,
+  "weeks >, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 3),
+    new Temporal.Duration(4, 7, 4),
+    { relativeTo: zonedDateTime }
+  ),
+  -1,
+  "weeks <, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 6),
+    new Temporal.Duration(2, 1, 3, 5),
+    { relativeTo: zonedDateTime }
+  ),
+  1,
+  "days >, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 3),
+    new Temporal.Duration(4, 7, 2, 4),
+    { relativeTo: zonedDateTime }
+  ),
+  -1,
+  "days <, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6),
+    new Temporal.Duration(2, 1, 3, 12, 5),
+    { relativeTo: zonedDateTime }
+  ),
+  1,
+  "hours >, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 3),
+    new Temporal.Duration(4, 7, 2, 40, 4),
+    { relativeTo: zonedDateTime }
+  ),
+  -1,
+  "hours <, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6, 6),
+    new Temporal.Duration(2, 1, 3, 12, 6, 5),
+    { relativeTo: zonedDateTime }
+  ),
+  1,
+  "minutes >, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 3),
+    new Temporal.Duration(4, 7, 2, 40, 12, 4),
+    { relativeTo: zonedDateTime }
+  ),
+  -1,
+  "minutes <, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 6),
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 5),
+    { relativeTo: zonedDateTime }
+  ),
+  1,
+  "seconds >, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 3),
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 4),
+    { relativeTo: zonedDateTime }
+  ),
+  -1,
+  "seconds <, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 6),
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 5),
+    { relativeTo: zonedDateTime }
+  ),
+  1,
+  "milliseconds >, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 3),
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 4),
+    { relativeTo: zonedDateTime }
+  ),
+  -1,
+  "milliseconds <, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 222, 6),
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 222, 5),
+    { relativeTo: zonedDateTime }
+  ),
+  1,
+  "microseconds >, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 3),
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 4),
+    { relativeTo: zonedDateTime }
+  ),
+  -1,
+  "microseconds <, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 222, 444, 6),
+    new Temporal.Duration(2, 1, 3, 12, 6, 30, 15, 222, 444, 5),
+    { relativeTo: zonedDateTime }
+  ),
+  1,
+  "nanoseconds >, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 777, 3),
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 777, 4),
+    { relativeTo: zonedDateTime }
+  ),
+  -1,
+  "nanoseconds <, relativeTo ZonedDateTime"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 777, 111),
+    new Temporal.Duration(4, 7, 2, 40, 12, 15, 45, 333, 777, 111),
+    { relativeTo: zonedDateTime }
+  ),
+  0,
+  "equal, relativeTo ZonedDateTime"
+);
+
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 6),
+    new Temporal.Duration(0, 0, 0, 5)
+  ),
+  1,
+  "days >, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 3),
+    new Temporal.Duration(0, 0, 0, 4)
+  ),
+  -1,
+  "days <, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 12, 6),
+    new Temporal.Duration(0, 0, 0, 12, 5)
+  ),
+  1,
+  "hours >, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 40, 3),
+    new Temporal.Duration(0, 0, 0, 40, 4)
+  ),
+  -1,
+  "hours <, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 12, 6, 6),
+    new Temporal.Duration(0, 0, 0, 12, 6, 5)
+  ),
+  1,
+  "minutes >, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 40, 12, 3),
+    new Temporal.Duration(0, 0, 0, 40, 12, 4)
+  ),
+  -1,
+  "minutes <, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 12, 6, 30, 6),
+    new Temporal.Duration(0, 0, 0, 12, 6, 30, 5)
+  ),
+  1,
+  "seconds >, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 40, 12, 15, 3),
+    new Temporal.Duration(0, 0, 0, 40, 12, 15, 4)
+  ),
+  -1,
+  "seconds <, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 12, 6, 30, 15, 6),
+    new Temporal.Duration(0, 0, 0, 12, 6, 30, 15, 5)
+  ),
+  1,
+  "milliseconds >, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 40, 12, 15, 45, 3),
+    new Temporal.Duration(0, 0, 0, 40, 12, 15, 45, 4)
+  ),
+  -1,
+  "milliseconds <, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 12, 6, 30, 15, 222, 6),
+    new Temporal.Duration(0, 0, 0, 12, 6, 30, 15, 222, 5)
+  ),
+  1,
+  "microseconds >, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 40, 12, 15, 45, 333, 3),
+    new Temporal.Duration(0, 0, 0, 40, 12, 15, 45, 333, 4)
+  ),
+  -1,
+  "microseconds <, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 12, 6, 30, 15, 222, 444, 6),
+    new Temporal.Duration(0, 0, 0, 12, 6, 30, 15, 222, 444, 5)
+  ),
+  1,
+  "nanoseconds >, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 40, 12, 15, 45, 333, 777, 3),
+    new Temporal.Duration(0, 0, 0, 40, 12, 15, 45, 333, 777, 4)
+  ),
+  -1,
+  "nanoseconds <, relativeTo nothing"
+);
+assert.sameValue(
+  Temporal.Duration.compare(
+    new Temporal.Duration(0, 0, 0, 40, 12, 15, 45, 333, 777, 111),
+    new Temporal.Duration(0, 0, 0, 40, 12, 15, 45, 333, 777, 111)
+  ),
+  0,
+  "equal, relativeTo nothing"
+);

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.compare
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+const relativeTo = { year: 2000, month: 5, day: 2, timeZone, calendar: nonBuiltinISOCalendar };
+
+Temporal.Duration.compare(new Temporal.Duration(1), new Temporal.Duration(2), { relativeTo });
+
+assert.sameValue(timeZone.calls, 6, "getPossibleInstantsFor should have been called 6 times");

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+const relativeTo = { year: 2000, month: 5, day: 2, timeZone, calendar: nonBuiltinISOCalendar };
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
+
+assert.sameValue(timeZone.calls, 6, "getPossibleInstantsFor should have been called 6 times");

--- a/test/built-ins/Temporal/Duration/prototype/round/duration-out-of-range-added-to-relativeto.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/duration-out-of-range-added-to-relativeto.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: RangeError thrown when calendar part of duration added to relativeTo is out of range
+features: [Temporal]
+info: |
+  RoundDuration:
+  8.k. Let _isoResult_ be ! AddISODate(_plainRelativeTo_.[[ISOYear]]. _plainRelativeTo_.[[ISOMonth]], _plainRelativeTo_.[[ISODay]], 0, 0, 0, truncate(_fractionalDays_), *"constrain"*).
+    l. Let _wholeDaysLater_ be ? CreateTemporalDate(_isoResult_.[[Year]], _isoResult_.[[Month]], _isoResult_.[[Day]], _calendar_).
+---*/
+
+// Based on a test case by André Bargull <andre.bargull@gmail.com>
+
+const instance = new Temporal.Duration(0, 0, 0, /* days = */ 500_000_000);
+const relativeTo = new Temporal.PlainDate(2000, 1, 1);
+assert.throws(RangeError, () => instance.round({relativeTo, smallestUnit: "years"}));
+
+const negInstance = new Temporal.Duration(0, 0, 0, /* days = */ -500_000_000);
+assert.throws(RangeError, () => negInstance.round({relativeTo, smallestUnit: "years"}));

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+const relativeTo = { year: 2000, month: 5, day: 2, timeZone, calendar: nonBuiltinISOCalendar };
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+instance.round({ largestUnit: "years", relativeTo });
+
+assert.sameValue(timeZone.calls, 6, "getPossibleInstantsFor should have been called 6 times");

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+const relativeTo = { year: 2000, month: 5, day: 2, timeZone, calendar: nonBuiltinISOCalendar };
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
+
+assert.sameValue(timeZone.calls, 6, "getPossibleInstantsFor should have been called 6 times");

--- a/test/built-ins/Temporal/Duration/prototype/total/duration-out-of-range-added-to-relativeto.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/duration-out-of-range-added-to-relativeto.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: RangeError thrown when calendar part of duration added to relativeTo is out of range
+features: [Temporal]
+info: |
+  RoundDuration:
+  8.k. Let _isoResult_ be ! AddISODate(_plainRelativeTo_.[[ISOYear]]. _plainRelativeTo_.[[ISOMonth]], _plainRelativeTo_.[[ISODay]], 0, 0, 0, truncate(_fractionalDays_), *"constrain"*).
+    l. Let _wholeDaysLater_ be ? CreateTemporalDate(_isoResult_.[[Year]], _isoResult_.[[Month]], _isoResult_.[[Day]], _calendar_).
+---*/
+
+// Based on a test case by André Bargull <andre.bargull@gmail.com>
+
+const instance = new Temporal.Duration(0, 0, 0, /* days = */ 500_000_000);
+const relativeTo = new Temporal.PlainDate(2000, 1, 1);
+assert.throws(RangeError, () => instance.total({relativeTo, unit: "years"}));
+
+const negInstance = new Temporal.Duration(0, 0, 0, /* days = */ -500_000_000);
+assert.throws(RangeError, () => negInstance.total({relativeTo, unit: "years"}));

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+const relativeTo = { year: 2000, month: 5, day: 2, timeZone, calendar: nonBuiltinISOCalendar };
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+instance.total({ unit: "days", relativeTo });
+
+assert.sameValue(timeZone.calls, 10, "getPossibleInstantsFor should have been called 10 times");

--- a/test/built-ins/Temporal/Instant/compare/exhaustive.js
+++ b/test/built-ins/Temporal/Instant/compare/exhaustive.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.compare
+description: Tests for compare() with each possible outcome
+features: [Temporal]
+---*/
+
+assert.sameValue(
+  Temporal.Instant.compare(new Temporal.Instant(1_000_000_000_000_000_000n), new Temporal.Instant(500_000_000_000_000_000n)),
+  1,
+  ">"
+);
+assert.sameValue(
+  Temporal.Instant.compare(new Temporal.Instant(-1000n), new Temporal.Instant(1000n)),
+  -1,
+  "<"
+);
+assert.sameValue(
+  Temporal.Instant.compare(new Temporal.Instant(123_456_789n), new Temporal.Instant(123_456_789n)),
+  0,
+  "="
+);

--- a/test/built-ins/Temporal/PlainDate/compare/exhaustive.js
+++ b/test/built-ins/Temporal/PlainDate/compare/exhaustive.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: Tests for compare() with each possible outcome
+features: [Temporal]
+---*/
+
+const cal1 = "iso8601";
+const cal2 = new (class extends Temporal.Calendar { id = "custom"; })("iso8601");
+
+assert.sameValue(
+  Temporal.PlainDate.compare(
+    new Temporal.PlainDate(2000, 5, 31, cal1),
+    new Temporal.PlainDate(1987, 5, 31, cal2)
+  ),
+  1,
+  "year >"
+);
+assert.sameValue(
+  Temporal.PlainDate.compare(
+    new Temporal.PlainDate(1981, 12, 15, cal1),
+    new Temporal.PlainDate(2048, 12, 15, cal2)
+  ),
+  -1,
+  "year <"
+);
+assert.sameValue(
+  Temporal.PlainDate.compare(
+    new Temporal.PlainDate(2000, 5, 31, cal1),
+    new Temporal.PlainDate(2000, 3, 31, cal2)
+  ),
+  1,
+  "month >"
+);
+assert.sameValue(
+  Temporal.PlainDate.compare(
+    new Temporal.PlainDate(1981, 4, 15, cal1),
+    new Temporal.PlainDate(1981, 12, 15, cal2)
+  ),
+  -1,
+  "month <"
+);
+assert.sameValue(
+  Temporal.PlainDate.compare(
+    new Temporal.PlainDate(2000, 5, 31, cal1),
+    new Temporal.PlainDate(2000, 5, 14, cal2)
+  ),
+  1,
+  "day >"
+);
+assert.sameValue(
+  Temporal.PlainDate.compare(
+    new Temporal.PlainDate(1981, 4, 15, cal1),
+    new Temporal.PlainDate(1981, 4, 21, cal2)
+  ),
+  -1,
+  "day <"
+);
+assert.sameValue(
+  Temporal.PlainDate.compare(
+    new Temporal.PlainDate(2000, 5, 31, cal1),
+    new Temporal.PlainDate(2000, 5, 31, cal2)
+  ),
+  0,
+  "="
+);

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+
+const instance = new Temporal.PlainDate(2000, 5, 2, nonBuiltinISOCalendar);
+instance.toZonedDateTime(timeZone);
+
+assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");

--- a/test/built-ins/Temporal/PlainDateTime/compare/exhaustive.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/exhaustive.js
@@ -1,0 +1,164 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: Tests for compare() with each possible outcome
+features: [Temporal]
+---*/
+
+const cal1 = "iso8601";
+const cal2 = new (class extends Temporal.Calendar { id = "custom"; })("iso8601");
+
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 777, 111, cal1),
+    new Temporal.PlainDateTime(1987, 5, 31, 12, 15, 45, 333, 777, 111, cal2)
+  ),
+  1,
+  "year >"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(1981, 12, 15, 6, 30, 15, 222, 444, 6, cal1),
+    new Temporal.PlainDateTime(2048, 12, 15, 6, 30, 15, 222, 444, 6, cal2)
+  ),
+  -1,
+  "year <"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 777, 111, cal1),
+    new Temporal.PlainDateTime(2000, 3, 31, 12, 15, 45, 333, 777, 111, cal2)
+  ),
+  1,
+  "month >"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 15, 222, 444, 6, cal1),
+    new Temporal.PlainDateTime(1981, 12, 15, 6, 30, 15, 222, 444, 6, cal2)
+  ),
+  -1,
+  "month <"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 777, 111, cal1),
+    new Temporal.PlainDateTime(2000, 5, 14, 12, 15, 45, 333, 777, 111, cal2)
+  ),
+  1,
+  "day >"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 15, 222, 444, 6, cal1),
+    new Temporal.PlainDateTime(1981, 4, 21, 6, 30, 15, 222, 444, 6, cal2)
+  ),
+  -1,
+  "day <"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 777, 111, cal1),
+    new Temporal.PlainDateTime(2000, 5, 31, 6, 15, 45, 333, 777, 111, cal2)
+  ),
+  1,
+  "hour >"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 15, 222, 444, 6, cal1),
+    new Temporal.PlainDateTime(1981, 4, 15, 22, 30, 15, 222, 444, 6, cal2)
+  ),
+  -1,
+  "hour <"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 777, 111, cal1),
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 22, 333, 777, 111, cal2)
+  ),
+  1,
+  "minute >"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 15, 222, 444, 6, cal1),
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 57, 15, 222, 444, 6, cal2)
+  ),
+  -1,
+  "minute <"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 6, 333, 777, 111, cal1),
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 5, 333, 777, 111, cal2)
+  ),
+  1,
+  "second >"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 3, 222, 444, 6, cal1),
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 4, 222, 444, 6, cal2)
+  ),
+  -1,
+  "second <"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 6, 777, 111, cal1),
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 5, 777, 111, cal2)
+  ),
+  1,
+  "millisecond >"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 15, 3, 444, 6, cal1),
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 15, 4, 444, 6, cal2)
+  ),
+  -1,
+  "millisecond <"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 6, 111, cal1),
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 5, 111, cal2)
+  ),
+  1,
+  "microsecond >"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 15, 222, 3, 6, cal1),
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 15, 222, 4, 6, cal2)
+  ),
+  -1,
+  "microsecond <"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 777, 999, cal1),
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 777, 111, cal2)
+  ),
+  1,
+  "nanosecond >"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 15, 222, 444, 0, cal1),
+    new Temporal.PlainDateTime(1981, 4, 15, 6, 30, 15, 222, 444, 6, cal2)
+  ),
+  -1,
+  "nanosecond <"
+);
+assert.sameValue(
+  Temporal.PlainDateTime.compare(
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 777, 111, cal1),
+    new Temporal.PlainDateTime(2000, 5, 31, 12, 15, 45, 333, 777, 111, cal2)
+  ),
+  0,
+  "="
+);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tozoneddatetime
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0, nonBuiltinISOCalendar);
+instance.toZonedDateTime(timeZone);
+
+assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");

--- a/test/built-ins/Temporal/PlainTime/compare/exhaustive.js
+++ b/test/built-ins/Temporal/PlainTime/compare/exhaustive.js
@@ -1,0 +1,116 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.compare
+description: Tests for compare() with each possible outcome
+features: [Temporal]
+---*/
+
+const cal1 = "iso8601";
+const cal2 = new (class extends Temporal.Calendar { id = "custom"; })("iso8601");
+
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(12, 15, 45, 333, 777, 111, cal1),
+    new Temporal.PlainTime(6, 15, 45, 333, 777, 111, cal2)
+  ),
+  1,
+  "hour >"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(6, 30, 15, 222, 444, 6, cal1),
+    new Temporal.PlainTime(22, 30, 15, 222, 444, 6, cal2)
+  ),
+  -1,
+  "hour <"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(12, 45, 15, 333, 777, 111, cal1),
+    new Temporal.PlainTime(12, 15, 22, 333, 777, 111, cal2)
+  ),
+  1,
+  "minute >"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(6, 30, 15, 222, 444, 6, cal1),
+    new Temporal.PlainTime(6, 57, 15, 222, 444, 6, cal2)
+  ),
+  -1,
+  "minute <"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(12, 15, 6, 333, 777, 111, cal1),
+    new Temporal.PlainTime(12, 15, 5, 333, 777, 111, cal2)
+  ),
+  1,
+  "second >"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(6, 30, 3, 222, 444, 6, cal1),
+    new Temporal.PlainTime(6, 30, 4, 222, 444, 6, cal2)
+  ),
+  -1,
+  "second <"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(12, 15, 45, 6, 777, 111, cal1),
+    new Temporal.PlainTime(12, 15, 45, 5, 777, 111, cal2)
+  ),
+  1,
+  "millisecond >"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(6, 30, 15, 3, 444, 6, cal1),
+    new Temporal.PlainTime(6, 30, 15, 4, 444, 6, cal2)
+  ),
+  -1,
+  "millisecond <"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(12, 15, 45, 333, 6, 111, cal1),
+    new Temporal.PlainTime(12, 15, 45, 333, 5, 111, cal2)
+  ),
+  1,
+  "microsecond >"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(6, 30, 15, 222, 3, 6, cal1),
+    new Temporal.PlainTime(6, 30, 15, 222, 4, 6, cal2)
+  ),
+  -1,
+  "microsecond <"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(12, 15, 45, 333, 777, 999, cal1),
+    new Temporal.PlainTime(12, 15, 45, 333, 777, 111, cal2)
+  ),
+  1,
+  "nanosecond >"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(6, 30, 15, 222, 444, 0, cal1),
+    new Temporal.PlainTime(6, 30, 15, 222, 444, 6, cal2)
+  ),
+  -1,
+  "nanosecond <"
+);
+assert.sameValue(
+  Temporal.PlainTime.compare(
+    new Temporal.PlainTime(12, 15, 45, 333, 777, 111, cal1),
+    new Temporal.PlainTime(12, 15, 45, 333, 777, 111, cal2)
+  ),
+  0,
+  "="
+);

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+
+const instance = new Temporal.PlainTime(12, 34, 56);
+instance.toZonedDateTime({ timeZone, plainDate: new Temporal.PlainDate(2000, 5, 2, nonBuiltinISOCalendar) });
+
+assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");

--- a/test/built-ins/Temporal/PlainYearMonth/compare/exhaustive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/exhaustive.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: Tests for compare() with each possible outcome
+features: [Temporal]
+---*/
+
+const cal1 = "iso8601";
+const cal2 = new (class extends Temporal.Calendar { id = "custom"; })("iso8601");
+
+assert.sameValue(
+  Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2000, 5, cal1), new Temporal.PlainYearMonth(1987, 5, cal2)),
+  1,
+  "year >"
+);
+assert.sameValue(
+  Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(1981, 12, cal1), new Temporal.PlainYearMonth(2048, 12, cal2)),
+  -1,
+  "year <"
+);
+assert.sameValue(
+  Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2000, 5, cal1), new Temporal.PlainYearMonth(2000, 3, cal2)),
+  1,
+  "month >"
+);
+assert.sameValue(
+  Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(1981, 4, cal1), new Temporal.PlainYearMonth(1981, 12, cal2)),
+  -1,
+  "month <"
+);
+assert.sameValue(
+  Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2000, 5, cal1, 30), new Temporal.PlainYearMonth(2000, 5, cal2, 14)),
+  1,
+  "reference day >"
+);
+assert.sameValue(
+  Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(1981, 4, cal1, 1), new Temporal.PlainYearMonth(1981, 4, cal2, 12)),
+  -1,
+  "reference day <"
+);
+assert.sameValue(
+  Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2000, 5, cal1), new Temporal.PlainYearMonth(2000, 5, cal2)),
+  0,
+  "="
+);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/end-of-month-out-of-range.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/end-of-month-out-of-range.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: RangeError thrown when adding negative duration and end of month is out of range
+features: [Temporal]
+info: |
+  AddDurationToOrSubtractDurationFromPlainYearMonth:
+  12. If _sign_ &lt; 0, then
+    a. Let _oneMonthDuration_ be ! CreateTemporalDuration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0).
+    b. Let _nextMonth_ be ? CalendarDateAdd(_calendar_, _intermediateDate_, _oneMonthDuration_, *undefined*, _dateAdd_).
+    c. Let _endOfMonthISO_ be ! AddISODate(_nextMonth_.[[ISOYear]], _nextMonth_.[[ISOMonth]], _nextMonth_.[[ISODay]], 0, 0, 0, -1, *"constrain"*).
+    d. Let _endOfMonth_ be ? CreateTemporalDate(_endOfMonthISO_.[[Year]], _endOfMonthISO_.[[Month]], _endOfMonthISO_.[[Day]], _calendar_).
+---*/
+
+// Based on a test case by André Bargull <andre.bargull@gmail.com>
+
+const duration = new Temporal.Duration(0, 0, 0, -1);
+
+// Calendar addition result is out of range
+assert.throws(RangeError, () => new Temporal.PlainYearMonth(275760, 9).add(duration), "Addition of 1 month to receiver out of range");
+
+// Calendar addition succeeds, but subtracting 1 day gives out of range result
+const cal = new class extends Temporal.Calendar {
+  dateAdd() {
+    return new Temporal.PlainDate(-271821, 4, 19);
+  }
+}("iso8601");
+assert.throws(RangeError, () => new Temporal.PlainYearMonth(2000, 1, cal).add(duration), "Subtraction of 1 day from next month out of range");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/end-of-month-out-of-range.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/end-of-month-out-of-range.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: RangeError thrown when subtracting positive duration and end of month is out of range
+features: [Temporal]
+info: |
+  AddDurationToOrSubtractDurationFromPlainYearMonth:
+  12. If _sign_ &lt; 0, then
+    a. Let _oneMonthDuration_ be ! CreateTemporalDuration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0).
+    b. Let _nextMonth_ be ? CalendarDateAdd(_calendar_, _intermediateDate_, _oneMonthDuration_, *undefined*, _dateAdd_).
+    c. Let _endOfMonthISO_ be ! AddISODate(_nextMonth_.[[ISOYear]], _nextMonth_.[[ISOMonth]], _nextMonth_.[[ISODay]], 0, 0, 0, -1, *"constrain"*).
+    d. Let _endOfMonth_ be ? CreateTemporalDate(_endOfMonthISO_.[[Year]], _endOfMonthISO_.[[Month]], _endOfMonthISO_.[[Day]], _calendar_).
+---*/
+
+// Based on a test case by André Bargull <andre.bargull@gmail.com>
+
+const duration = new Temporal.Duration(0, 0, 0, 1);
+
+// Calendar addition result is out of range
+assert.throws(RangeError, () => new Temporal.PlainYearMonth(275760, 9).subtract(duration), "Addition of 1 month to receiver out of range");
+
+// Calendar addition succeeds, but subtracting 1 day gives out of range result
+const cal = new class extends Temporal.Calendar {
+  dateAdd() {
+    return new Temporal.PlainDate(-271821, 4, 19);
+  }
+}("iso8601");
+assert.throws(RangeError, () => new Temporal.PlainYearMonth(2000, 1, cal).subtract(duration), "Subtraction of 1 day from next month out of range");

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+
+for (const disambiguation of ["earlier", "later", "compatible"]) {
+  const timeZone = new SkippedDateTime();
+  timeZone.getInstantFor(new Temporal.PlainDateTime(2000, 3, 4, 12, 34, 56, 0, 0, 0, nonBuiltinISOCalendar), { disambiguation });
+
+  assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");
+}

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.compare
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone1 = new SkippedDateTime();
+const arg1 = { year: 2000, month: 5, day: 2, timeZone: timeZone1, calendar: nonBuiltinISOCalendar };
+const timeZone2 = new SkippedDateTime();
+const arg2 = { year: 2000, month: 5, day: 2, timeZone: timeZone2, calendar: nonBuiltinISOCalendar };
+
+Temporal.ZonedDateTime.compare(arg1, arg2);
+
+assert.sameValue(timeZone1.calls, 2, "getPossibleInstantsFor should have been called 2 times on first time zone");
+assert.sameValue(timeZone2.calls, 2, "getPossibleInstantsFor should have been called 2 times on second time zone");

--- a/test/built-ins/Temporal/ZonedDateTime/compare/exhaustive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/exhaustive.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: Tests for compare() with each possible outcome
+features: [Temporal]
+---*/
+
+const tz1 = "UTC";
+const tz2 = "-00:30";
+const cal1 = "iso8601";
+const cal2 = new (class extends Temporal.Calendar { id = "custom"; })("iso8601");
+
+assert.sameValue(
+  Temporal.ZonedDateTime.compare(new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, tz1, cal1), new Temporal.ZonedDateTime(500_000_000_000_000_000n, tz2, cal2)),
+  1,
+  ">"
+);
+assert.sameValue(
+  Temporal.ZonedDateTime.compare(new Temporal.ZonedDateTime(-1000n, tz1, cal1), new Temporal.ZonedDateTime(1000n, tz2, cal2)),
+  -1,
+  "<"
+);
+assert.sameValue(
+  Temporal.ZonedDateTime.compare(new Temporal.ZonedDateTime(123_456_789n, tz1, cal1), new Temporal.ZonedDateTime(123_456_789n, tz2, cal2)),
+  0,
+  "="
+);

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.from
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+const arg = { year: 2000, month: 5, day: 2, timeZone, calendar: nonBuiltinISOCalendar };
+
+Temporal.ZonedDateTime.from(arg);
+
+assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+const arg = { year: 2000, month: 5, day: 2, timeZone, calendar: nonBuiltinISOCalendar };
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+instance.equals(arg);
+
+assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/hoursInDay/getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/hoursInDay/getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.hoursinday
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone, nonBuiltinISOCalendar);
+instance.hoursInDay;
+
+assert.sameValue(timeZone.calls, 4, "getPossibleInstantsFor should have been called 4 times");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.round
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone, nonBuiltinISOCalendar);
+instance.round({ smallestUnit: "hours" });
+
+assert.sameValue(timeZone.calls, 6, "getPossibleInstantsFor should have been called 6 times");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+const arg = { year: 2000, month: 5, day: 2, timeZone, calendar: nonBuiltinISOCalendar };
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+instance.since(arg);
+
+assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/startOfDay/getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/startOfDay/getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.startofday
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone, nonBuiltinISOCalendar);
+instance.startOfDay();
+
+assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+const arg = { year: 2000, month: 5, day: 2, timeZone, calendar: nonBuiltinISOCalendar };
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+instance.until(arg);
+
+assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.with
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+
+for (const disambiguation of ["earlier", "later", "compatible"]) {
+  const timeZone = new SkippedDateTime();
+  const instance = new Temporal.ZonedDateTime(0n, timeZone, nonBuiltinISOCalendar);
+
+  instance.with({ day: 1 }, { disambiguation });
+
+  assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone, nonBuiltinISOCalendar);
+instance.withPlainDate(new Temporal.PlainDate(2000, 5, 2, nonBuiltinISOCalendar));
+
+assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/getpossibleinstantsfor-called-with-iso8601-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/getpossibleinstantsfor-called-with-iso8601-calendar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaintime
+description: >
+  Time zone's getPossibleInstantsFor is called with a PlainDateTime with the
+  built-in ISO 8601 calendar
+features: [Temporal]
+info: |
+  DisambiguatePossibleInstants:
+  2. Let _n_ be _possibleInstants_'s length.
+  ...
+  5. Assert: _n_ = 0.
+  ...
+  19. If _disambiguation_ is *"earlier"*, then
+    ...
+    c. Let _earlierDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+    d. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+    ...
+  20. Assert: _disambiguation_ is *"compatible"* or *"later"*.
+  ...
+  23. Let _laterDateTime_ be ! CreateTemporalDateTime(..., *"iso8601"*).
+  24. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+---*/
+
+class SkippedDateTime extends Temporal.TimeZone {
+  constructor() {
+    super("UTC");
+    this.calls = 0;
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    // Calls occur in pairs. For the first one return no possible instants so
+    // that DisambiguatePossibleInstants will call it again
+    if (this.calls++ % 2 == 0) {
+      return [];
+    }
+
+    assert.sameValue(
+      dateTime.getISOFields().calendar,
+      "iso8601",
+      "getPossibleInstantsFor called with dateTime with built-in ISO 8601 calendar"
+    );
+    return super.getPossibleInstantsFor(dateTime);
+  }
+}
+
+const nonBuiltinISOCalendar = new Temporal.Calendar("iso8601");
+const timeZone = new SkippedDateTime();
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone, nonBuiltinISOCalendar);
+instance.withPlainTime();
+
+assert.sameValue(timeZone.calls, 2, "getPossibleInstantsFor should have been called 2 times");


### PR DESCRIPTION
Here is some extra test coverage for Temporal for gaps that were highlighted by some editorial issues that @anba reported.

None of this reflects any changed behaviour, just coverage gaps.

See tc39/proposal-temporal#2708.