### PR TITLE
Update likely subtags tests for CLDR 44

### DIFF
--- a/test/intl402/Locale/likely-subtags.js
+++ b/test/intl402/Locale/likely-subtags.js
@@ -35,12 +35,13 @@ const testDataMaximal = {
     "und": "en-Latn-US",
     "und-Thai": "th-Thai-TH",
     "und-419": "es-Latn-419",
-    "und-150": "ru-Cyrl-RU",
+    "und-150": "en-Latn-150",
     "und-AT": "de-Latn-AT",
     "und-Cyrl-RO": "bg-Cyrl-RO",
 
-    // Undefined primary language not required to change in all cases.
-    "und-AQ": "und-Latn-AQ",
+    // Before CLDR 44, "und" primary language subtag was left unchanged in some
+    // cases. Starting with CLDR 44, the "und" language subtag is always replaced.
+    "und-AQ": "en-Latn-AQ",
 };
 
 const testDataMinimal = {
@@ -67,7 +68,7 @@ const testDataMinimal = {
     "ru-Cyrl-RU": "ru",
     "de-Latn-AT": "de-AT",
     "bg-Cyrl-RO": "bg-RO",
-    "und-Latn-AQ": "und-AQ",
+    "und-Latn-AQ": "en-AQ",
 };
 
 // Add variants, extensions, and privateuse subtags and ensure they don't

--- a/test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
+++ b/test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
@@ -23,7 +23,7 @@ var testDataMinimal = {
     "und": "en",
     "und-Thai": "th",
     "und-419": "es-419",
-    "und-150": "ru",
+    "und-150": "en-150",
     "und-AT": "de-AT",
 
     // https://unicode-org.atlassian.net/browse/ICU-13786


### PR DESCRIPTION
CLDR 44 changed likely-subtags mappings for "und" language tags, so we have to update these two tests. 
