### PR TITLE
Add test for async module not blocking sync siblings

### DIFF
--- a/test/language/module-code/top-level-await/async-module-does-not-block-sibling-modules.js
+++ b/test/language/module-code/top-level-await/async-module-does-not-block-sibling-modules.js
@@ -13,3 +13,4 @@ features: [top-level-await]
 import "./async-module-tla_FIXTURE.js";
 import { check } from "./async-module-sync_FIXTURE.js";
 assert.sameValue(check, false);
+$DONE();

--- a/test/language/module-code/top-level-await/async-module-does-not-block-sibling-modules.js
+++ b/test/language/module-code/top-level-await/async-module-does-not-block-sibling-modules.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-innermoduleevaluation
+description: >
+  While an asynchronous module is waiting for a promise resolution,
+  sibling modules in the modules graph must be evaluated.
+flags: [module, async]
+features: [top-level-await]
+---*/
+
+import "./async-module-tla_FIXTURE.js";
+import { check } from "./async-module-sync_FIXTURE.js";
+assert.sameValue(check, false);

--- a/test/language/module-code/top-level-await/async-module-sync_FIXTURE.js
+++ b/test/language/module-code/top-level-await/async-module-sync_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export const { check } = globalThis;

--- a/test/language/module-code/top-level-await/async-module-tla_FIXTURE.js
+++ b/test/language/module-code/top-level-await/async-module-tla_FIXTURE.js
@@ -1,0 +1,6 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+globalThis.check = false;
+await 0;
+globalThis.check = true;


### PR DESCRIPTION
cc @guybedford @codehag for reviews

Currently Chrome, Deno and Node.js pass this test, while Safari, Firefox and Bun fail it. This seems to suggest a JS engine difference (V8 passes, JSC/SM fail), but given that this is related to modules I'm not sure whether the bug lives in the engine or in the embedder. Maybe it's worth duplicating this test in WPT?