### PR TITLE
Temporal: Tests for balancing units after rounding

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/round/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/round-cross-unit-boundary.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: Rounding can cross unit boundaries up to the implicit largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const relativeTo = new Temporal.PlainDate(2022, 1, 1);
+const roundingMode = "expand";
+
+// Positive, date units
+{
+  const duration = new Temporal.Duration(1, 11, 0, 24);
+  const result = duration.round({ smallestUnit: "months", roundingMode, relativeTo });
+  TemporalHelpers.assertDuration(result, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "1 year 12 months balances to 2 years");
+}
+
+// Negative, date units
+{
+  const duration = new Temporal.Duration(-1, -11, 0, -24);
+  const result = duration.round({ smallestUnit: "months", roundingMode, relativeTo });
+  TemporalHelpers.assertDuration(result, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "-1 year -12 months balances to -2 years");
+}
+
+// Positive, time units
+{
+  const duration = new Temporal.Duration(0, 0, 0, 0, 1, 59, 59, 900);
+  const result = duration.round({ smallestUnit: "seconds", roundingMode });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, "1:59:60 balances to 2 hours");
+}
+
+// Negative, time units
+{
+  const duration = new Temporal.Duration(0, 0, 0, 0, -1, -59, -59, -900);
+  const result = duration.round({ smallestUnit: "seconds", roundingMode });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, -2, 0, 0, 0, 0, 0, "-1:59:60 balances to -2 hours");
+}
+
+// No balancing if smallest unit is largest unit
+{
+  const duration = new Temporal.Duration(0, 11, 0, 24);
+  const result = duration.round({ smallestUnit: "months", roundingMode, relativeTo });
+  TemporalHelpers.assertDuration(result, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, "12 months stays as is");
+}

--- a/test/built-ins/Temporal/Duration/prototype/toString/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/round-cross-unit-boundary.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: Rounding can cross unit boundaries up to days
+features: [Temporal]
+---*/
+
+const roundingMode = "expand";
+
+// Positive, time units
+{
+  const duration = new Temporal.Duration(0, 0, 0, 0, 1, 59, 59, 900);
+  assert.sameValue(duration.toString({ fractionalSecondDigits: 0, roundingMode }), "PT2H0S", "1:59:60 balances to 2 hours");
+}
+
+// Negative, time units
+{
+  const duration = new Temporal.Duration(0, 0, 0, 0, -1, -59, -59, -900);
+  assert.sameValue(duration.toString({ fractionalSecondDigits: 0, roundingMode }), "-PT2H0S", "-1:59:60 balances to -2 hours");
+}
+
+// Positive, date and time units
+{
+  const duration = new Temporal.Duration(1, 11, 0, 30, 23, 59, 59, 999, 999, 999);
+  assert.sameValue(duration.toString({ fractionalSecondDigits: 8, roundingMode }), "P1Y11M31DT0.00000000S", "units balance only up to days (positive)");
+}
+
+// Negative, date and time units
+{
+  const duration = new Temporal.Duration(-1, -11, 0, -30, -23, -59, -59, -999, -999, -999);
+  assert.sameValue(duration.toString({ fractionalSecondDigits: 8, roundingMode }), "-P1Y11M31DT0.00000000S", "units balance only up to days (negative)");
+}
+
+// No balancing if smallest unit is largest unit
+{
+  const duration = new Temporal.Duration(0, 0, 0, 0, 0, 0, 59, 900);
+  assert.sameValue(duration.toString({ fractionalSecondDigits: 0, roundingMode }), "PT60S", "60 seconds stays as is");
+}

--- a/test/built-ins/Temporal/Instant/prototype/since/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/round-cross-unit-boundary.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.Instant(0n);
+const later = new Temporal.Instant(7199_000_000_000n);
+const duration = earlier.since(later, { largestUnit: "hours", smallestUnit: "minutes", roundingMode: "expand" });
+TemporalHelpers.assertDuration(duration, 0, 0, 0, 0, -2, 0, 0, 0, 0, 0, "-1:59 balances to -2 hours");

--- a/test/built-ins/Temporal/Instant/prototype/until/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/round-cross-unit-boundary.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.Instant(0n);
+const later = new Temporal.Instant(7199_000_000_000n);
+const duration = earlier.until(later, { largestUnit: "hours", smallestUnit: "minutes", roundingMode: "expand" });
+TemporalHelpers.assertDuration(duration, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, "1:59 balances to 2 hours");

--- a/test/built-ins/Temporal/PlainDate/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/order-of-operations.js
@@ -136,7 +136,13 @@ const expectedOpsForYearRounding = expected.concat([
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateUntil",  // 7.o
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.s not called because other units can't add up to >1 year at this point)
+  // (7.s not called because other units can't add up to >1 year at this point)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.since(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
 actual.splice(0); // clear
@@ -159,7 +165,13 @@ const expectedOpsForYearRoundingSameMonth = expected.concat([
   "call this.calendar.dateAdd",    // 7.e
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.o not called because months and weeks == 0)
+  // (7.o not called because months and weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.since(otherDatePropertyBagSameMonth, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRoundingSameMonth, "order of operations with smallestUnit = years and no excess months/weeks");
 actual.splice(0); // clear
@@ -175,7 +187,10 @@ const expectedOpsForMonthRounding = expected.concat([
   "call this.calendar.dateAdd",    // 10.c
   "call this.calendar.dateAdd",    // 10.e
   "call this.calendar.dateAdd",    // 10.k MoveRelativeDate
-]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 12.b MoveRelativeDate
+]);
 instance.since(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
 actual.splice(0); // clear
@@ -189,6 +204,9 @@ const expectedOpsForWeekRounding = expected.concat([
   "call this.calendar.dateUntil",
   // RoundDuration
   "call this.calendar.dateAdd",  // 11.d MoveRelativeDate
-]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 13.c MoveRelativeDate
+]);
 instance.since(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with smallestUnit = weeks");

--- a/test/built-ins/Temporal/PlainDate/prototype/since/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/round-cross-unit-boundary.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainDate(2022, 1, 1);
+const later = new Temporal.PlainDate(2023, 12, 25);
+const duration = earlier.since(later, { largestUnit: "years", smallestUnit: "months", roundingMode: "expand" });
+TemporalHelpers.assertDuration(duration, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "-1 year -11 months balances to -2 years");

--- a/test/built-ins/Temporal/PlainDate/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/order-of-operations.js
@@ -137,7 +137,13 @@ const expectedOpsForYearRounding = expected.concat([
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateUntil",  // 7.o
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.s not called because other units can't add up to >1 year at this point)
+  // (7.s not called because other units can't add up to >1 year at this point)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.until(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
 actual.splice(0); // clear
@@ -160,7 +166,13 @@ const expectedOpsForYearRoundingSameMonth = expected.concat([
   "call this.calendar.dateAdd",    // 7.e
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.o not called because months and weeks == 0)
+  // (7.o not called because months and weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.until(otherDatePropertyBagSameMonth, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRoundingSameMonth, "order of operations with smallestUnit = years and no excess months/weeks");
 actual.splice(0); // clear
@@ -176,7 +188,10 @@ const expectedOpsForMonthRounding = expected.concat([
   "call this.calendar.dateAdd",    // 10.c
   "call this.calendar.dateAdd",    // 10.e
   "call this.calendar.dateAdd",    // 10.k MoveRelativeDate
-]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 12.b MoveRelativeDate
+]);
 instance.until(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
 actual.splice(0); // clear
@@ -190,6 +205,9 @@ const expectedOpsForWeekRounding = expected.concat([
   "call this.calendar.dateUntil",
   // RoundDuration
   "call this.calendar.dateAdd",  // 11.d MoveRelativeDate
-]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 13.c MoveRelativeDate
+]);
 instance.until(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with smallestUnit = weeks");

--- a/test/built-ins/Temporal/PlainDate/prototype/until/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/round-cross-unit-boundary.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainDate(2022, 1, 1);
+const later = new Temporal.PlainDate(2023, 12, 25);
+const duration = earlier.until(later, { largestUnit: "years", smallestUnit: "months", roundingMode: "expand" });
+TemporalHelpers.assertDuration(duration, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "1 year 11 months balances to 2 years");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/order-of-operations.js
@@ -166,7 +166,13 @@ const expectedOpsForYearRounding = expected.concat([
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateUntil",  // 7.o
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.s not called because other units can't add up to >1 year at this point)
+  // (7.s not called because other units can't add up to >1 year at this point)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
 actual.splice(0); // clear
@@ -195,7 +201,13 @@ const expectedOpsForYearRoundingSameMonth = expected.concat([
   "call this.calendar.dateAdd",    // 7.e
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.o not called because months and weeks == 0)
+  // (7.o not called because months and weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.until(otherDatePropertyBagSameMonth, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRoundingSameMonth, "order of operations with smallestUnit = years and no excess months/weeks");
 actual.splice(0); // clear
@@ -211,7 +223,10 @@ const expectedOpsForMonthRounding = expected.concat([
   "call this.calendar.dateAdd",    // 10.c
   "call this.calendar.dateAdd",    // 10.e
   "call this.calendar.dateAdd",    // 10.k MoveRelativeDate
-]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 12.b MoveRelativeDate
+]);
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
 actual.splice(0); // clear
@@ -225,6 +240,9 @@ const expectedOpsForWeekRounding = expected.concat([
   "call this.calendar.dateUntil",
   // RoundDuration
   "call this.calendar.dateAdd",  // 11.d MoveRelativeDate
-]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 13.c MoveRelativeDate
+]);
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with smallestUnit = weeks");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/round-cross-unit-boundary.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+// Date units
+{
+  const earlier = new Temporal.PlainDateTime(2022, 1, 1);
+  const later = new Temporal.PlainDateTime(2023, 12, 25);
+  const duration = earlier.since(later, { largestUnit: "years", smallestUnit: "months", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "-1 year -11 months balances to -2 years");
+}
+
+// Time units
+{
+  const earlier = new Temporal.PlainDateTime(2000, 5, 2);
+  const later = new Temporal.PlainDateTime(2000, 5, 2, 1, 59, 59);
+  const duration = earlier.since(later, { largestUnit: "hours", smallestUnit: "minutes", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, 0, 0, 0, 0, -2, 0, 0, 0, 0, 0, "-1:59 balances to -2 hours");
+}
+
+// Both
+{
+  const earlier = new Temporal.PlainDateTime(1970, 1, 1);
+  const later = new Temporal.PlainDateTime(1971, 12, 31, 23, 59, 59, 999, 999, 999);
+  const duration = earlier.since(later, { largestUnit: "years", smallestUnit: "microseconds", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "rounding down 1 ns balances to -2 years");
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/order-of-operations.js
@@ -166,7 +166,13 @@ const expectedOpsForYearRounding = expected.concat([
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateUntil",  // 7.o
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.s not called because other units can't add up to >1 year at this point)
+  // (7.s not called because other units can't add up to >1 year at this point)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
 actual.splice(0); // clear
@@ -195,7 +201,13 @@ const expectedOpsForYearRoundingSameMonth = expected.concat([
   "call this.calendar.dateAdd",    // 7.e
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.o not called because months and weeks == 0)
+  // (7.o not called because months and weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.until(otherDatePropertyBagSameMonth, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRoundingSameMonth, "order of operations with smallestUnit = years and no excess months/weeks");
 actual.splice(0); // clear
@@ -211,7 +223,10 @@ const expectedOpsForMonthRounding = expected.concat([
   "call this.calendar.dateAdd",    // 10.c
   "call this.calendar.dateAdd",    // 10.e
   "call this.calendar.dateAdd",    // 10.k MoveRelativeDate
-]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 12.b MoveRelativeDate
+]);
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = years");
 actual.splice(0); // clear
@@ -225,6 +240,9 @@ const expectedOpsForWeekRounding = expected.concat([
   "call this.calendar.dateUntil",
   // RoundDuration
   "call this.calendar.dateAdd",  // 11.d MoveRelativeDate
-]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 13.c MoveRelativeDate
+]);
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with smallestUnit = weeks");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/round-cross-unit-boundary.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+// Date units
+{
+  const earlier = new Temporal.PlainDateTime(2022, 1, 1);
+  const later = new Temporal.PlainDateTime(2023, 12, 25);
+  const duration = earlier.until(later, { largestUnit: "years", smallestUnit: "months", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "1 year 11 months balances to 2 years");
+}
+
+// Time units
+{
+  const earlier = new Temporal.PlainDateTime(2000, 5, 2);
+  const later = new Temporal.PlainDateTime(2000, 5, 2, 1, 59, 59);
+  const duration = earlier.until(later, { largestUnit: "hours", smallestUnit: "minutes", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, "1:59 balances to 2 hours");
+}
+
+// Both
+{
+  const earlier = new Temporal.PlainDateTime(1970, 1, 1);
+  const later = new Temporal.PlainDateTime(1971, 12, 31, 23, 59, 59, 999, 999, 999);
+  const duration = earlier.until(later, { largestUnit: "years", smallestUnit: "microseconds", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "rounding up 1 ns balances to 2 years");
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/since/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/round-cross-unit-boundary.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainTime();
+const later = new Temporal.PlainTime(1, 59, 59);
+const duration = earlier.since(later, { largestUnit: "hours", smallestUnit: "minutes", roundingMode: "expand" });
+TemporalHelpers.assertDuration(duration, 0, 0, 0, 0, -2, 0, 0, 0, 0, 0, "-1:60 balances to -2 hours");

--- a/test/built-ins/Temporal/PlainTime/prototype/until/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/round-cross-unit-boundary.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainTime();
+const later = new Temporal.PlainTime(1, 59, 59);
+const duration = earlier.until(later, { largestUnit: "hours", smallestUnit: "minutes", roundingMode: "expand" });
+TemporalHelpers.assertDuration(duration, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, "1:60 balances to 2 hours");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
@@ -161,11 +161,18 @@ actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat([
+  // RoundDuration
   "call this.calendar.dateAdd",    // 7.e
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateUntil",  // 7.o
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.s not called because other units can't add up to >1 year at this point)
+  // (7.s not called because other units can't add up to >1 year at this point)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.since(otherYearMonthPropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
 actual.splice(0); // clear
@@ -181,16 +188,29 @@ const expectedOpsForYearRoundingSameMonth = expected.concat([
   "call this.calendar.dateAdd",    // 7.e
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.o not called because months and weeks == 0)
+  // (7.o not called because months and weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.since(otherYearMonthPropertyBagSameMonth, createOptionsObserver({ smallestUnit: "years" }));
-assert.compareArray(actual, expectedOpsForYearRoundingSameMonth, "order of operations with smallestUnit = years");
+assert.compareArray(actual, expectedOpsForYearRoundingSameMonth, "order of operations with smallestUnit = years and no excess months");
 actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat([
+  // RoundDuration
   "call this.calendar.dateAdd",    // 10.c
   "call this.calendar.dateAdd",    // 10.e
   "call this.calendar.dateAdd",    // 10.k MoveRelativeDate
-]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.since(otherYearMonthPropertyBag, createOptionsObserver({ smallestUnit: "months", roundingIncrement: 2 }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/round-cross-unit-boundary.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainYearMonth(2022, 1);
+const later = new Temporal.PlainYearMonth(2023, 12);
+const duration = earlier.since(later, { largestUnit: "years", smallestUnit: "months", roundingIncrement: 3, roundingMode: "expand" });
+TemporalHelpers.assertDuration(duration, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "-1 year -12 months balances to -2 years");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-non-integer.js
@@ -20,5 +20,5 @@ const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2000, 10);
 const result = later.since(earlier, { roundingIncrement: 2.5, roundingMode: "trunc" });
 TemporalHelpers.assertDuration(result, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 truncates to 2");
-const result2 = later.since(earlier, { smallestUnit: "months", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
+const result2 = later.since(earlier, { largestUnit: "months", smallestUnit: "months", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
 TemporalHelpers.assertDuration(result2, 0, 1e9, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
@@ -161,11 +161,18 @@ actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat([
+  // RoundDuration
   "call this.calendar.dateAdd",    // 7.e
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateUntil",  // 7.o
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.s not called because other units can't add up to >1 year at this point)
+  // (7.s not called because other units can't add up to >1 year at this point)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.until(otherYearMonthPropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
 actual.splice(0); // clear
@@ -181,17 +188,30 @@ const expectedOpsForYearRoundingSameMonth = expected.concat([
   "call this.calendar.dateAdd",    // 7.e
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.o not called because months and weeks == 0)
+  // (7.o not called because months and weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.until(otherYearMonthPropertyBagSameMonth, createOptionsObserver({ smallestUnit: "years" }));
-assert.compareArray(actual, expectedOpsForYearRoundingSameMonth, "order of operations with smallestUnit = years");
+assert.compareArray(actual, expectedOpsForYearRoundingSameMonth, "order of operations with smallestUnit = years and no excess months");
 actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat([
+  // RoundDuration
   "call this.calendar.dateAdd",    // 10.c
   "call this.calendar.dateAdd",    // 10.e
   "call this.calendar.dateAdd",    // 10.k MoveRelativeDate
-]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.until(otherYearMonthPropertyBag, createOptionsObserver({ smallestUnit: "months", roundingIncrement: 2 }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
 actual.splice(0); // clear

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/round-cross-unit-boundary.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainYearMonth(2022, 1);
+const later = new Temporal.PlainYearMonth(2023, 12);
+const duration = earlier.until(later, { largestUnit: "years", smallestUnit: "months", roundingIncrement: 3, roundingMode: "expand" });
+TemporalHelpers.assertDuration(duration, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "1 year 12 months balances to 2 years");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-non-integer.js
@@ -20,5 +20,5 @@ const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2000, 10);
 const result = earlier.until(later, { roundingIncrement: 2.5, roundingMode: "trunc" });
 TemporalHelpers.assertDuration(result, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 truncates to 2");
-const result2 = earlier.until(later, { smallestUnit: "months", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
+const result2 = earlier.until(later, { largestUnit: "months", smallestUnit: "months", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
 TemporalHelpers.assertDuration(result2, 0, 1e9, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/calendar-dateadd-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/calendar-dateadd-called-with-options-undefined.js
@@ -29,8 +29,9 @@ assert.sameValue(calendar.dateAddCallCount, 1, "basic difference with largestUni
 //   RoundDuration ->
 //     MoveRelativeZonedDateTime -> AddZonedDateTime -> calendar.dateAdd()
 //     MoveRelativeDate -> calendar.dateAdd()
+//   BalanceDurationRelative -> MoveRelativeDate -> calendar.dateAdd()
 
 calendar.dateAddCallCount = 0;
 
 later1.since(earlier, { smallestUnit: "weeks" });
-assert.sameValue(calendar.dateAddCallCount, 3, "rounding difference with calendar smallestUnit");
+assert.sameValue(calendar.dateAddCallCount, 4, "rounding difference with calendar smallestUnit");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
@@ -77,7 +77,7 @@ TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
     later.since(earlier, { largestUnit, roundingIncrement: 2, roundingMode: 'ceil' });
   },
   {
-    years: ["year", "year"],
+    years: ["year", "year", "month"],
     months: ["month", "month"],
     weeks: ["week", "week"],
     days: [],
@@ -100,7 +100,7 @@ TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
     later.since(earlier, { smallestUnit });
   },
   {
-    years: ["year", "year"],
+    years: ["year", "year", "month"],
     months: ["month"],
     weeks: ["week"],
     days: [],

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
@@ -358,29 +358,44 @@ actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
+  // RoundDuration
   "call this.calendar.dateAdd",    // 7.e
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateUntil",  // 7.o
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.s not called because other units can't add up to >1 year at this point)
+  // (7.s not called because other units can't add up to >1 year at this point)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
 actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
+  // RoundDuration
   "call this.calendar.dateAdd",    // 10.c
   "call this.calendar.dateAdd",    // 10.e
   "call this.calendar.dateAdd",    // 10.k MoveRelativeDate
-]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 12.b MoveRelativeDate
+]);
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
 actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest week:
 const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
+  // RoundDuration
   "call this.calendar.dateAdd",  // 11.d MoveRelativeDate
-]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 13.c MoveRelativeDate
+]);
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with smallestUnit = weeks");
 actual.splice(0); // clear

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/round-cross-unit-boundary.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+// Date units
+{
+  const earlier = new Temporal.ZonedDateTime(1640995200_000_000_000n /* = 2022-01-01T00 */, "UTC");
+  const later = new Temporal.ZonedDateTime(1703462400_000_000_000n /* = 2023-12-25T00 */, "UTC");
+  const duration = earlier.since(later, { largestUnit: "years", smallestUnit: "months", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "-1 year -11 months balances to -2 years");
+}
+
+// Time units
+{
+  const earlier = new Temporal.ZonedDateTime(0n, "UTC");
+  const later = new Temporal.ZonedDateTime(7199_000_000_000n, "UTC");
+  const duration = earlier.since(later, { largestUnit: "hours", smallestUnit: "minutes", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, 0, 0, 0, 0, -2, 0, 0, 0, 0, 0, "-1:59 balances to -2 hours");
+}
+
+// Both
+{
+  const earlier = new Temporal.ZonedDateTime(0n, "UTC");
+  const later = new Temporal.ZonedDateTime(63071999_999_999_999n /* = 1971-12-31T23:59:59.999999999 */, "UTC");
+  const duration = earlier.since(later, { largestUnit: "years", smallestUnit: "microseconds", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "rounding down 1 ns balances to -2 years");
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/calendar-dateadd-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/calendar-dateadd-called-with-options-undefined.js
@@ -29,8 +29,9 @@ assert.sameValue(calendar.dateAddCallCount, 1, "basic difference with largestUni
 //   RoundDuration ->
 //     MoveRelativeZonedDateTime -> AddZonedDateTime -> calendar.dateAdd()
 //     MoveRelativeDate -> calendar.dateAdd()
+//   BalanceDurationRelative -> MoveRelativeDate -> calendar.dateAdd()
 
 calendar.dateAddCallCount = 0;
 
 earlier.until(later1, { smallestUnit: "weeks" });
-assert.sameValue(calendar.dateAddCallCount, 3, "rounding difference with calendar smallestUnit");
+assert.sameValue(calendar.dateAddCallCount, 4, "rounding difference with calendar smallestUnit");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
@@ -77,7 +77,7 @@ TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
     earlier.until(later, { largestUnit, roundingIncrement: 2, roundingMode: 'ceil' });
   },
   {
-    years: ["year", "year"],
+    years: ["year", "year", "month"],
     months: ["month", "month"],
     weeks: ["week", "week"],
     days: [],
@@ -100,7 +100,7 @@ TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
     earlier.until(later, { smallestUnit });
   },
   {
-    years: ["year", "year"],
+    years: ["year", "year", "month"],
     months: ["month"],
     weeks: ["week"],
     days: [],

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
@@ -358,29 +358,44 @@ actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
+  // RoundDuration
   "call this.calendar.dateAdd",    // 7.e
   "call this.calendar.dateAdd",    // 7.g
   "call this.calendar.dateUntil",  // 7.o
   "call this.calendar.dateAdd",    // 7.y MoveRelativeDate
-]);  // (7.s not called because other units can't add up to >1 year at this point)
+  // (7.s not called because other units can't add up to >1 year at this point)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 11.c MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.g MoveRelativeDate
+  "call this.calendar.dateAdd",    // 11.k
+  "call this.calendar.dateUntil"   // 11.n
+]);
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
 actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
+  // RoundDuration
   "call this.calendar.dateAdd",    // 10.c
   "call this.calendar.dateAdd",    // 10.e
   "call this.calendar.dateAdd",    // 10.k MoveRelativeDate
-]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // (10.n.iii MoveRelativeDate not called because weeks == 0)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 12.b MoveRelativeDate
+]);
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
 actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest week:
 const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDifference, expectedOpsForCalendarRounding, [
+  // RoundDuration
   "call this.calendar.dateAdd",  // 11.d MoveRelativeDate
-]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // (11.g.iii MoveRelativeDate not called because days already balanced)
+  // BalanceDurationRelative
+  "call this.calendar.dateAdd",    // 13.c MoveRelativeDate
+]);
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with smallestUnit = weeks");
 actual.splice(0);  // clear

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/round-cross-unit-boundary.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/round-cross-unit-boundary.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Rounding can cross unit boundaries up to largestUnit
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+// Date units
+{
+  const earlier = new Temporal.ZonedDateTime(1640995200_000_000_000n /* = 2022-01-01T00 */, "UTC");
+  const later = new Temporal.ZonedDateTime(1703462400_000_000_000n /* = 2023-12-25T00 */, "UTC");
+  const duration = earlier.until(later, { largestUnit: "years", smallestUnit: "months", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "1 year 11 months balances to 2 years");
+}
+
+// Time units
+{
+  const earlier = new Temporal.ZonedDateTime(0n, "UTC");
+  const later = new Temporal.ZonedDateTime(7199_000_000_000n, "UTC");
+  const duration = earlier.until(later, { largestUnit: "hours", smallestUnit: "minutes", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, "1:59 balances to 2 hours");
+}
+
+// Both
+{
+  const earlier = new Temporal.ZonedDateTime(0n, "UTC");
+  const later = new Temporal.ZonedDateTime(63071999_999_999_999n /* = 1971-12-31T23:59:59.999999999 */, "UTC");
+  const duration = earlier.until(later, { largestUnit: "years", smallestUnit: "microseconds", roundingMode: "expand" });
+  TemporalHelpers.assertDuration(duration, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "rounding up 1 ns balances to 2 years");
+}

--- a/test/staging/Temporal/Duration/old/toString.js
+++ b/test/staging/Temporal/Duration/old/toString.js
@@ -23,10 +23,3 @@ var d = Temporal.Duration.from({
   microseconds: Number.MAX_SAFE_INTEGER
 });
 assert.sameValue(`${ d }`, "PT9016206453995.731991S");
-
-// rounding can affect units up to seconds
-var d4 = Temporal.Duration.from("P1Y1M1W1DT23H59M59.999999999S");
-assert.sameValue(d4.toString({
-  fractionalSecondDigits: 8,
-  roundingMode: "halfExpand"
-}), "P1Y1M1W1DT23H59M60.00000000S");


### PR DESCRIPTION
This PR contains tests that cover normative changes to Temporal that reached consensus in May 2023.
Normative PR: https://github.com/tc39/proposal-temporal/pull/2571