### PR TITLE
Remove locales with explicit u-hc Unicode extension

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js
@@ -21,25 +21,33 @@ info: |
         c. If hc is null, set hc to dataLocaleData.[[hourCycle]].
   27. Set dateTimeFormat.[[HourCycle]] to hc.
 
-locale: [en, fr, it, ja, zh, ko, ar, hi, en-u-hc-h24]
+locale: [en, fr, it, ja, zh, ko, ar, hi]
 ---*/
 
-let locales = ["en", "fr", "it", "ja", "ja-u-hc-h11", "zh", "ko", "ar", "hi", "en-u-hc-h24"];
+let locales = ["en", "fr", "it", "ja", "zh", "ko", "ar", "hi"];
 
-locales.forEach(function(locale) {
-  let hcDefault = new Intl.DateTimeFormat(locale, { hour: "numeric" }).resolvedOptions().hourCycle;
+for (let locale of locales) {
+  let hcDefault = new Intl.DateTimeFormat(locale, {hour: "numeric"}).resolvedOptions().hourCycle;
+  assert(
+    hcDefault === "h11" || hcDefault === "h12" || hcDefault === "h23" || hcDefault === "h24",
+    "hcDefault is one of [h11, h12, h23, h24]"
+  );
+
+  let hour12 = new Intl.DateTimeFormat(locale, {hour: "numeric", hour12: true}).resolvedOptions().hourCycle;
+  assert(hour12 === "h11" || hour12 === "h12", "hour12 is one of [h11, h12]");
+
+  let hour24 = new Intl.DateTimeFormat(locale, {hour: "numeric", hour12: false}).resolvedOptions().hourCycle;
+  assert(hour24 === "h23" || hour24 === "h24", "hour24 is one of [h23, h24]");
+
   if (hcDefault === "h11" || hcDefault === "h12") {
-    assert.sameValue(new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: true }).resolvedOptions().hourCycle, hcDefault);
-
-    // no locale has "h24" as a default. see https://github.com/tc39/ecma402/pull/758#issue-1622377292
-    assert.sameValue(new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: false }).resolvedOptions().hourCycle, "h23");
+    assert.sameValue(hour12, hcDefault, "hour12 matches hcDefault");
+  } else {
+    assert.sameValue(hour24, hcDefault, "hour24 matches hcDefault");
   }
 
-  // however, "h24" can be set via locale extension.
-  if (hcDefault === "h23" || hcDefault === "h24") {
-    assert.sameValue(new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: false }).resolvedOptions().hourCycle, hcDefault);
-  }
+  // 24-hour clock uses the "h23" format in all locales.
+  assert.sameValue(hour24, "h23");
 
-  let hcHour12 = new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: true }).resolvedOptions().hourCycle;
-  assert(hcHour12 === "h11" || hcHour12 === "h12", "Expected `hourCycle`: " + hcHour12 + " to be in [\"h11\", \"h12\"]");
-});
+  // 12-hour clock uses the "h12" format in all locales except "ja".
+  assert.sameValue(hour12, locale === "ja" ? "h11" : "h12");
+}


### PR DESCRIPTION
The tests are passing an explicit `hour12` option, which disables any `hourCycle` option and any `u-hc` Unicode extension. Therefore passing input locales with `u-hc` is invalid.

```js
let locale = "en-u-hc-h24";
let hcDefault = new Intl.DateTimeFormat(locale, { hour: "numeric" }).resolvedOptions().hourCycle;

assert.sameValue(hcDefault, "h24", "hour-cycle through Unicode extension");

let hc24 = new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: false }).resolvedOptions().hourCycle;

// Incorrect assertion, because |hc24| uses |hour12|, which disables any
// hour-cycle option and the hour-cycle is determined from the locale "en".
// That means |hc24| will be "h23".
assert.sameValue(hc24, hcDefault);
```