### PR TITLE
Consolidate set methods features

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -101,6 +101,10 @@ iterator-helpers
 # https://github.com/tc39/proposal-promise-with-resolvers
 promise-with-resolvers
 
+# Set methods
+# https://github.com/tc39/proposal-set-methods
+set-methods
+
 ## Standard language features
 #
 # Language features that have been included in a published version of the
@@ -210,7 +214,6 @@ regexp-named-groups
 regexp-unicode-property-escapes
 rest-parameters
 Set
-Set-methods
 SharedArrayBuffer
 string-trimming
 String.fromCodePoint
@@ -264,7 +267,3 @@ __setter__
 
 IsHTMLDDA
 host-gc-required
-
-# Set methods
-# https://github.com/tc39/proposal-set-methods
-set-methods

--- a/test/built-ins/Set/prototype/union/add-not-called.js
+++ b/test/built-ins/Set/prototype/union/add-not-called.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union should not call Set.prototype.add
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/allows-set-like-class.js
+++ b/test/built-ins/Set/prototype/union/allows-set-like-class.js
@@ -10,7 +10,7 @@ info: |
     7. Let has be ? Get(obj, "has").
     ...
     9. Let keys be ? Get(obj, "keys").
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/allows-set-like-object.js
+++ b/test/built-ins/Set/prototype/union/allows-set-like-object.js
@@ -10,7 +10,7 @@ info: |
     7. Let has be ? Get(obj, "has").
     ...
     9. Let keys be ? Get(obj, "keys").
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/appends-new-values.js
+++ b/test/built-ins/Set/prototype/union/appends-new-values.js
@@ -5,7 +5,7 @@ esid: sec-set.prototype.union
 description: Set.prototype.union appends new values to a copy of the original Set
 info: |
     7.b.iii.1 Append nextValue to resultSetData.
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/array-throws.js
+++ b/test/built-ins/Set/prototype/union/array-throws.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union doesn't work with arrays
-features: [Set-methods]
+features: [set-methods]
 ---*/
 
 const s1 = new Set([1, 2]);

--- a/test/built-ins/Set/prototype/union/builtins.js
+++ b/test/built-ins/Set/prototype/union/builtins.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Tests that Set.prototype.union meets the requirements for built-in objects
-features: [Set-methods]
+features: [set-methods]
 ---*/
 
 assert.sameValue(

--- a/test/built-ins/Set/prototype/union/called-with-object.js
+++ b/test/built-ins/Set/prototype/union/called-with-object.js
@@ -5,7 +5,7 @@ esid: sec-getsetrecord
 description: GetSetRecord throws if obj is not an object
 info: |
     1. If obj is not an Object, throw a TypeError exception.
-features: [Set-methods]
+features: [set-methods]
 ---*/
 
 let s1 = new Set([1]);

--- a/test/built-ins/Set/prototype/union/combines-Map.js
+++ b/test/built-ins/Set/prototype/union/combines-Map.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union combines with Map
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/combines-empty-sets.js
+++ b/test/built-ins/Set/prototype/union/combines-empty-sets.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union can combine empty Sets
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/combines-itself.js
+++ b/test/built-ins/Set/prototype/union/combines-itself.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union is successful when called on itself
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/combines-same-sets.js
+++ b/test/built-ins/Set/prototype/union/combines-same-sets.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union can combine Sets that have the same content
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/combines-sets.js
+++ b/test/built-ins/Set/prototype/union/combines-sets.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union combines Sets
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/converts-negative-zero.js
+++ b/test/built-ins/Set/prototype/union/converts-negative-zero.js
@@ -5,7 +5,7 @@ esid: sec-set.prototype.union
 description: Set.prototype.union converts -0𝔽 to +0𝔽
 info: |
     7.b.ii. If nextValue is -0𝔽, set nextValue to +0𝔽.
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/has-is-callable.js
+++ b/test/built-ins/Set/prototype/union/has-is-callable.js
@@ -6,7 +6,7 @@ description: GetSetRecord throws an exception if the Set-like object's 'has' pro
 info: |
     7. Let has be ? Get(obj, "has").
     8. If IsCallable(has) is false, throw a TypeError exception.
-features: [Set-methods]
+features: [set-methods]
 ---*/
 
 const s1 = new Set([1, 2]);

--- a/test/built-ins/Set/prototype/union/keys-is-callable.js
+++ b/test/built-ins/Set/prototype/union/keys-is-callable.js
@@ -6,7 +6,7 @@ description: GetSetRecord throws an exception if the Set-like object's 'keys' pr
 info: |
     9. Let keys be ? Get(obj, "keys").
     10. If IsCallable(keys) is false, throw a TypeError exception.
-features: [Set-methods]
+features: [set-methods]
 ---*/
 
 const s1 = new Set([1, 2]);

--- a/test/built-ins/Set/prototype/union/length.js
+++ b/test/built-ins/Set/prototype/union/length.js
@@ -6,7 +6,7 @@ description: Set.prototype.union length property
 info: |
     Set.prototype.union ( other )]
 includes: [propertyHelper.js]
-features: [Set-methods]
+features: [set-methods]
 ---*/
 assert.sameValue(typeof Set.prototype.union, "function");
 

--- a/test/built-ins/Set/prototype/union/name.js
+++ b/test/built-ins/Set/prototype/union/name.js
@@ -6,7 +6,7 @@ description: Set.prototype.union name property
 info: |
     Set.prototype.union ( other )]
 includes: [propertyHelper.js]
-features: [Set-methods]
+features: [set-methods]
 ---*/
 assert.sameValue(typeof Set.prototype.union, "function");
 

--- a/test/built-ins/Set/prototype/union/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/union/not-a-constructor.js
@@ -4,7 +4,7 @@
 esid: sec-set.prototype.union
 description: Set.prototype.union does not implement [[Construct]], is not new-able
 includes: [isConstructor.js]
-features: [Reflect.construct, Set-methods]
+features: [Reflect.construct, set-methods]
 ---*/
 
 assert.sameValue(

--- a/test/built-ins/Set/prototype/union/receiver-not-set.js
+++ b/test/built-ins/Set/prototype/union/receiver-not-set.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union throws when receiver is not a Set
-features: [Set-methods]
+features: [set-methods]
 ---*/
 
 class MySetLike {

--- a/test/built-ins/Set/prototype/union/require-internal-slot.js
+++ b/test/built-ins/Set/prototype/union/require-internal-slot.js
@@ -5,7 +5,7 @@ esid: sec-set.prototype.union
 description: Set.prototype.union RequireInternalSlot
 info: |
     2. Perform ? RequireInternalSlot(O, [[SetData]])
-features: [Set-methods]
+features: [set-methods]
 ---*/
 
 const union = Set.prototype.union;

--- a/test/built-ins/Set/prototype/union/set-like-array.js
+++ b/test/built-ins/Set/prototype/union/set-like-array.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union consumes a set-like array as a set-like, not an array
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/set-like-class-mutation.js
+++ b/test/built-ins/Set/prototype/union/set-like-class-mutation.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union maintains values even when a custom Set-like class mutates the receiver
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/set-like-class-order.js
+++ b/test/built-ins/Set/prototype/union/set-like-class-order.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union calls a Set-like class's methods in order
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/size-is-a-number.js
+++ b/test/built-ins/Set/prototype/union/size-is-a-number.js
@@ -8,7 +8,7 @@ info: |
     3. Let numSize be ? ToNumber(rawSize).
     4. NOTE: If rawSize is undefined, then numSize will be NaN.
     5. If numSize is NaN, throw a TypeError exception.
-features: [Set-methods]
+features: [set-methods]
 ---*/
 
 const s1 = new Set([1, 2]);

--- a/test/built-ins/Set/prototype/union/subclass-receiver-methods.js
+++ b/test/built-ins/Set/prototype/union/subclass-receiver-methods.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union works on subclasses of Set, but never calls the receiver's size/has/keys methods
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/subclass-symbol-species.js
+++ b/test/built-ins/Set/prototype/union/subclass-symbol-species.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union works on subclasses of Set, but returns an instance of Set even when Symbol.species is overridden.
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 var count = 0;

--- a/test/built-ins/Set/prototype/union/subclass.js
+++ b/test/built-ins/Set/prototype/union/subclass.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-set.prototype.union
 description: Set.prototype.union works on subclasses of Set, but returns an instance of Set
-features: [Set-methods]
+features: [set-methods]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Set/prototype/union/union-properties.js
+++ b/test/built-ins/Set/prototype/union/union-properties.js
@@ -4,7 +4,7 @@
 esid: sec-set.prototype.union
 description: Set.prototype.union properties
 includes: [propertyHelper.js]
-features: [Set-methods]
+features: [set-methods]
 ---*/
 
 assert.sameValue(


### PR DESCRIPTION
After https://github.com/tc39/test262/pull/3816 we accidentally had two "set-methods" features, whoops.