### PR TITLE
Async-from-sync test the iterator closes when .throw() is undefined

### DIFF
--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-null.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-null.js
@@ -53,7 +53,7 @@ asyncIterator.next().then(function() {
   throw new Test262Error("Promise should be rejected, got: " + result.value);
 }, function(err) {
   assert.sameValue(err.constructor, TypeError, "TypeError");
-  assert.sameValue(err.message, 'The iterator does not provide a throw method');
+  assert.sameValue(err instanceof TypeError, true);
 
   return asyncIterator.next().then(function(result) {
     assert.sameValue(result.value, undefined);

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-null.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-null.js
@@ -24,6 +24,7 @@ info: |
   3. If func is either undefined or null, return undefined.
 flags: [async]
 features: [async-iteration]
+includes: [asyncHelpers.js]
 ---*/
 
 var throwGets = 0;
@@ -47,16 +48,12 @@ async function* asyncGenerator() {
 var asyncIterator = asyncGenerator();
 var thrownError = { name: "err" };
 
-asyncIterator.next().then(function() {
-  return asyncIterator.throw(thrownError);
-}).then(function(result) {
-  throw new Test262Error("Promise should be rejected, got: " + result.value);
-}, function(err) {
-  assert.sameValue(err.constructor, TypeError, "TypeError");
-  assert.sameValue(err instanceof TypeError, true);
-
-  return asyncIterator.next().then(function(result) {
-    assert.sameValue(result.value, undefined);
-    assert.sameValue(result.done, true);
-  });
-}).then($DONE, $DONE);
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async () => {
+    await asyncIterator.next();
+    return asyncIterator.throw(thrownError);
+  }, "Promise should be rejected");
+  const result = await asyncIterator.next();
+  assert(result.done, "the iterator is completed");
+  assert.sameValue(result.value, undefined, "value is undefined");
+})

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-null.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-null.js
@@ -10,11 +10,12 @@ info: |
   %AsyncFromSyncIteratorPrototype%.throw ( value )
 
   [...]
-  5. Let throw be GetMethod(syncIterator, "throw").
+  6. Let throw be GetMethod(syncIterator, "throw").
   [...]
-  7. If throw is undefined, then
-    a. Perform ! Call(promiseCapability.[[Reject]], undefined, « value »).
-    b. Return promiseCapability.[[Promise]].
+  8. If throw is undefined, then
+    ...
+    g. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
+    h. Return promiseCapability.[[Promise]].
 
   GetMethod ( V, P )
 
@@ -51,7 +52,9 @@ asyncIterator.next().then(function() {
 }).then(function(result) {
   throw new Test262Error("Promise should be rejected, got: " + result.value);
 }, function(err) {
-  assert.sameValue(err, thrownError);
+  assert.sameValue(err.constructor, TypeError, "TypeError");
+  assert.sameValue(err.message, 'The iterator does not provide a throw method');
+
   return asyncIterator.next().then(function(result) {
     assert.sameValue(result.value, undefined);
     assert.sameValue(result.done, true);

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-get-return-undefined.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-get-return-undefined.js
@@ -35,6 +35,7 @@ info: |
 
 flags: [async]
 features: [async-iteration]
+includes: [asyncHelpers.js]
 ---*/
 
 var returnCount = 0;
@@ -59,22 +60,14 @@ async function* wrapper() {
 
 var iter = wrapper();
 
-iter.next().then(function(result) {
-  iter.throw().then(
-    function (result) {
-      throw new Test262Error("Promise should be rejected, got: " + result.value);
-    },
-    function (err) {
-      assert.sameValue(err.constructor, TypeError, "TypeError");
-      assert.sameValue(err instanceof TypeError, true);
-      assert.sameValue(returnCount, 1, 'iterator closed properly');
-
-      iter.next().then(function (result) {
-        assert.sameValue(result.done, true, 'the iterator is completed');
-        assert.sameValue(result.value, undefined, 'value is undefined');
-      }).then($DONE, $DONE);
-    }
-  ).then($DONE, $DONE);
-
-}).then($DONE, $DONE);
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async () => {
+    await iter.next();
+    return iter.throw();
+  }, "Promise should be rejected");
+  assert.sameValue(returnCount, 1, 'iterator closed properly');
+  const result = await iter.next();
+  assert(result.done, "the iterator is completed");
+  assert.sameValue(result.value, undefined, "value is undefined");
+})
 

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-get-return-undefined.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-get-return-undefined.js
@@ -66,15 +66,15 @@ iter.next().then(function(result) {
     },
     function (err) {
       assert.sameValue(err.constructor, TypeError, "TypeError");
-      assert.sameValue(err.message, 'The iterator does not provide a throw method');
+      assert.sameValue(err instanceof TypeError, true);
       assert.sameValue(returnCount, 1, 'iterator closed properly');
 
-      iter.next().then(({ done, value }) => {
-        assert.sameValue(done, true, 'the iterator is completed');
-        assert.sameValue(value, undefined, 'value is undefined');
+      iter.next().then(function (result) {
+        assert.sameValue(result.done, true, 'the iterator is completed');
+        assert.sameValue(result.value, undefined, 'value is undefined');
       }).then($DONE, $DONE);
     }
-  ).catch($DONE);
+  ).then($DONE, $DONE);
 
-}).catch($DONE);
+}).then($DONE, $DONE);
 

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-get-return-undefined.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-get-return-undefined.js
@@ -1,0 +1,80 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%asyncfromsynciteratorprototype%.throw
+description: >
+ If syncIterator's "throw" method is `undefined`,
+ and its "return" method returns `undefined`,
+ the iterator will close returning the `undefined` value,
+ which will be ignored and instead a rejected Promise with a new TypeError is returned.
+info: |
+  %AsyncFromSyncIteratorPrototype%.throw ( value )
+  ...
+  2. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+  ...
+  5. Let return be GetMethod(syncIterator, "throw").
+  6. IfAbruptRejectPromise(throw, promiseCapability).
+  7. If throw is undefined, then
+    a. NOTE: If syncIterator does not have a throw method, close it to give it a chance to clean up before we reject the capability.
+    b. Let closeCompletion be Completion { [[Type]]: normal, [[Value]]: empty, [[Target]]: empty }.
+    c. Set result to IteratorClose(syncIteratorRecord, closeCompletion).
+    ...
+    g. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
+    h. Return promiseCapability.[[Promise]].
+    ...
+
+  IteratorClose ( iterator, completion )
+  ...
+  2. Let iterator be iteratorRecord.[[Iterator]].
+  3. Let innerResult be Completion(GetMethod(iterator, "return")).
+  4. If innerResult.[[Type]] is normal, then
+    a. Let return be innerResult.[[Value]].
+    b. If return is undefined, return ? completion.
+  ...
+
+flags: [async]
+features: [async-iteration]
+---*/
+
+var returnCount = 0;
+
+const obj = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return {value: 1, done: false};
+      },
+      get return() {
+        returnCount += 1;
+        return undefined;
+      }
+    };
+  }
+};
+
+async function* wrapper() {
+  yield* obj;
+}
+
+var iter = wrapper();
+
+iter.next().then(function(result) {
+  iter.throw().then(
+    function (result) {
+      throw new Test262Error("Promise should be rejected, got: " + result.value);
+    },
+    function (err) {
+      assert.sameValue(err.constructor, TypeError, "TypeError");
+      assert.sameValue(err.message, 'The iterator does not provide a throw method');
+      assert.sameValue(returnCount, 1, 'iterator closed properly');
+
+      iter.next().then(({ done, value }) => {
+        assert.sameValue(done, true, 'the iterator is completed');
+        assert.sameValue(value, undefined, 'value is undefined');
+      }).then($DONE, $DONE);
+    }
+  ).catch($DONE);
+
+}).catch($DONE);
+

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-poisoned-return.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-poisoned-return.js
@@ -72,11 +72,11 @@ iter.next().then(function(result) {
       assert.sameValue(err, thrownError, "Promise should be rejected with thrown error");
       assert.sameValue(returnCount, 1, 'iterator closed properly');
 
-      iter.next().then(({ done, value }) => {
-        assert.sameValue(done, true, 'the iterator is completed');
-        assert.sameValue(value, undefined, 'value is undefined');
+      iter.next().then(function (result) {
+        assert.sameValue(result.done, true, 'the iterator is completed');
+        assert.sameValue(result.value, undefined, 'value is undefined');
       }).then($DONE, $DONE);
     }
-  ).catch($DONE);
+  ).then($DONE, $DONE);
 
-}).catch($DONE);
+}).then($DONE, $DONE);

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-poisoned-return.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-poisoned-return.js
@@ -1,0 +1,82 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%asyncfromsynciteratorprototype%.throw
+description: throw() will close the iterator and return rejected promise if sync `throw` undefined
+info: |
+  %AsyncFromSyncIteratorPrototype%.throw ( value )
+  ...
+  2. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+  ...
+  5. Let return be GetMethod(syncIterator, "throw").
+  6. IfAbruptRejectPromise(throw, promiseCapability).
+  7. If throw is undefined, then
+    a. NOTE: If syncIterator does not have a throw method, close it to give it a chance to clean up before we reject the capability.
+    b. Let closeCompletion be Completion { [[Type]]: normal, [[Value]]: empty, [[Target]]: empty }.
+    c. Set result to IteratorClose(syncIteratorRecord, closeCompletion).
+    d. IfAbruptRejectPromise(result, promiseCapability).
+    e. NOTE: The next step throws a TypeError to indicate that there was a protocol violation: syncIterator does not have a throw method.
+    f. NOTE: If closing syncIterator does not throw then the result of that operation is ignored, even if it yields a rejected promise.
+    g. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
+    h. Return promiseCapability.[[Promise]].
+
+  IteratorClose ( iterator, completion )
+  ...
+  2. Let iterator be iteratorRecord.[[Iterator]].
+  3. Let innerResult be Completion(GetMethod(iterator, "return")).
+  ...
+  6. If innerResult.[[Type]] is throw, return ? innerResult.
+  ...
+
+  IfAbruptRejectPromise ( value, capability )
+  1. Assert: value is a Completion Record.
+  2. If value is an abrupt completion, then
+    a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »).
+    b. Return capability.[[Promise]].
+  ...
+
+flags: [async]
+features: [async-iteration]
+---*/
+
+var returnCount = 0;
+var thrownError = new Error("Catch me.");
+
+const obj = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return {value: 1, done: false};
+      },
+      get return() {
+        returnCount += 1;
+        throw thrownError;
+      }
+    };
+  }
+};
+
+async function* wrapper() {
+  yield* obj;
+}
+
+var iter = wrapper();
+
+iter.next().then(function(result) {
+  iter.throw().then(
+    function (result) {
+      throw new Test262Error("Promise should be rejected, got: " + result.value);
+    },
+    function (err) {
+      assert.sameValue(err, thrownError, "Promise should be rejected with thrown error");
+      assert.sameValue(returnCount, 1, 'iterator closed properly');
+
+      iter.next().then(({ done, value }) => {
+        assert.sameValue(done, true, 'the iterator is completed');
+        assert.sameValue(value, undefined, 'value is undefined');
+      }).then($DONE, $DONE);
+    }
+  ).catch($DONE);
+
+}).catch($DONE);

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-not-object.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-not-object.js
@@ -43,6 +43,7 @@ info: |
 
 flags: [async]
 features: [async-iteration]
+includes: [asyncHelpers.js]
 ---*/
 
 var returnCount = 0;
@@ -67,21 +68,13 @@ async function* wrapper() {
 
 var iter = wrapper();
 
-iter.next().then(function (result) {
-  iter.throw().then(
-    function (result) {
-      throw new Test262Error("Promise should be rejected, got: " + result.value);
-    },
-    function (err) {
-      assert.sameValue(err.constructor, TypeError, "TypeError");
-      assert.sameValue(err instanceof TypeError, true);
-      assert.sameValue(returnCount, 1, 'iterator closed properly');
-
-      iter.next().then(function (result) {
-        assert.sameValue(result.done, true, 'the iterator is completed');
-        assert.sameValue(result.value, undefined, 'value is undefined');
-      }).then($DONE, $DONE);
-    }
-  ).then($DONE, $DONE);
-
-}).then($DONE, $DONE);
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async () => {
+    await iter.next();
+    return iter.throw();
+  }, "Promise should be rejected");
+  assert.sameValue(returnCount, 1, 'iterator closed properly');
+  const result = await iter.next();
+  assert(result.done, "the iterator is completed");
+  assert.sameValue(result.value, undefined, "value is undefined");
+})

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-not-object.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-not-object.js
@@ -1,0 +1,87 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%asyncfromsynciteratorprototype%.throw
+description: >
+ If syncIterator's "throw" method is `undefined`,
+ and its "return" method returns `undefined`,
+ the iterator will close returning the `undefined` value,
+ which will be ignored and instead a rejected Promise with a new TypeError is returned.
+info: |
+  %AsyncFromSyncIteratorPrototype%.throw ( value )
+  ...
+  2. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+  ...
+  5. Let return be GetMethod(syncIterator, "throw").
+  6. IfAbruptRejectPromise(throw, promiseCapability).
+  7. If throw is undefined, then
+    a. NOTE: If syncIterator does not have a throw method, close it to give it a chance to clean up before we reject the capability.
+    b. Let closeCompletion be Completion { [[Type]]: normal, [[Value]]: empty, [[Target]]: empty }.
+    c. Set result to IteratorClose(syncIteratorRecord, closeCompletion).
+    d. IfAbruptRejectPromise(result, promiseCapability).
+    ...
+
+  IteratorClose ( iterator, completion )
+  ...
+  2. Let iterator be iteratorRecord.[[Iterator]].
+  3. Let innerResult be Completion(GetMethod(iterator, "return")).
+  4. If innerResult.[[Type]] is normal, then
+    a. Let return be innerResult.[[Value]].
+    ...
+    c. Set innerResult to Completion(Call(return, iterator)).
+  ...
+  7. If innerResult.[[Value]] is not an Object, throw a TypeError exception.
+  ...
+
+  IfAbruptRejectPromise ( value, capability )
+  1. Assert: value is a Completion Record.
+  2. If value is an abrupt completion, then
+    a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »).
+    b. Return capability.[[Promise]].
+  ...
+
+flags: [async]
+features: [async-iteration]
+---*/
+
+var returnCount = 0;
+
+const obj = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return {value: 1, done: false};
+      },
+      return() {
+        returnCount += 1;
+        return 2;
+      }
+    };
+  }
+};
+
+async function* wrapper() {
+  yield* obj;
+}
+
+var iter = wrapper();
+
+iter.next().then(function(result) {
+  iter.throw().then(
+    function (result) {
+      throw new Test262Error("Promise should be rejected, got: " + result.value);
+    },
+    function (err) {
+      assert.sameValue(err.constructor, TypeError, "TypeError");
+      assert.sameValue(err.message, '2 is not an object');
+      assert.sameValue(returnCount, 1, 'iterator closed properly');
+
+      iter.next().then(({ done, value }) => {
+        assert.sameValue(done, true, 'the iterator is completed');
+        assert.sameValue(value, undefined, 'value is undefined');
+      }).then($DONE, $DONE);
+    }
+  ).catch($DONE);
+
+}).catch($DONE);

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-not-object.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-not-object.js
@@ -67,21 +67,21 @@ async function* wrapper() {
 
 var iter = wrapper();
 
-iter.next().then(function(result) {
+iter.next().then(function (result) {
   iter.throw().then(
     function (result) {
       throw new Test262Error("Promise should be rejected, got: " + result.value);
     },
     function (err) {
       assert.sameValue(err.constructor, TypeError, "TypeError");
-      assert.sameValue(err.message, '2 is not an object');
+      assert.sameValue(err instanceof TypeError, true);
       assert.sameValue(returnCount, 1, 'iterator closed properly');
 
-      iter.next().then(({ done, value }) => {
-        assert.sameValue(done, true, 'the iterator is completed');
-        assert.sameValue(value, undefined, 'value is undefined');
+      iter.next().then(function (result) {
+        assert.sameValue(result.done, true, 'the iterator is completed');
+        assert.sameValue(result.value, undefined, 'value is undefined');
       }).then($DONE, $DONE);
     }
-  ).catch($DONE);
+  ).then($DONE, $DONE);
 
-}).catch($DONE);
+}).then($DONE, $DONE);

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js
@@ -37,6 +37,7 @@ info: |
 
 flags: [async]
 features: [async-iteration]
+includes: [asyncHelpers.js]
 ---*/
 
 var returnCount = 0;
@@ -61,22 +62,13 @@ async function* wrapper() {
 
 var iter = wrapper();
 
-iter.next().then(function(result) {
-  iter.throw().then(
-    function (result) {
-      throw new Test262Error("Promise should be rejected, got: " + result.value);
-    },
-    function (err) {
-      assert.sameValue(err.constructor, TypeError, "TypeError");
-      assert.sameValue(err instanceof TypeError, true);
-      assert.sameValue(returnCount, 1, 'iterator closed properly');
-
-      iter.next().then(function (result) {
-        assert.sameValue(result.done, true, 'the iterator is completed');
-        assert.sameValue(result.value, undefined, 'value is undefined');
-      }).then($DONE, $DONE);
-    }
-  ).then($DONE, $DONE);
-
-}).then($DONE, $DONE);
-
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async () => {
+    await iter.next();
+    return iter.throw();
+  }, "Promise should be rejected");
+  assert.sameValue(returnCount, 1, 'iterator closed properly');
+  const result = await iter.next();
+  assert(result.done, "the iterator is completed");
+  assert.sameValue(result.value, undefined, "value is undefined");
+})

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js
@@ -1,0 +1,82 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%asyncfromsynciteratorprototype%.throw
+description: >
+ If syncIterator's "throw" method is `undefined`,
+ and its "return" method returns `undefined`,
+ the iterator will close returning the `undefined` value,
+ which will be ignored and instead a rejected Promise with a new TypeError is returned.
+info: |
+  %AsyncFromSyncIteratorPrototype%.throw ( value )
+  ...
+  2. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+  ...
+  5. Let return be GetMethod(syncIterator, "throw").
+  ...
+  7. If throw is undefined, then
+    a. NOTE: If syncIterator does not have a throw method, close it to give it a chance to clean up before we reject the capability.
+    b. Let closeCompletion be Completion { [[Type]]: normal, [[Value]]: empty, [[Target]]: empty }.
+    c. Set result to IteratorClose(syncIteratorRecord, closeCompletion).
+    ...
+    g. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
+    h. Return promiseCapability.[[Promise]].
+    ...
+
+  IteratorClose ( iterator, completion )
+  ...
+  2. Let iterator be iteratorRecord.[[Iterator]].
+  3. Let innerResult be Completion(GetMethod(iterator, "return")).
+  4. If innerResult.[[Type]] is normal, then
+    a. Let return be innerResult.[[Value]].
+    ...
+    c. Set innerResult to Completion(Call(return, iterator)).
+  ...
+  8. Return ? completion.
+
+flags: [async]
+features: [async-iteration]
+---*/
+
+var returnCount = 0;
+
+const obj = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return {value: 1, done: false};
+      },
+      return() {
+        returnCount += 1;
+        return {value: 2, done: true};
+      }
+    };
+  }
+};
+
+async function* wrapper() {
+  yield* obj;
+}
+
+var iter = wrapper();
+
+iter.next().then(function(result) {
+  iter.throw().then(
+    function (result) {
+      throw new Test262Error("Promise should be rejected, got: " + result.value);
+    },
+    function (err) {
+      assert.sameValue(err.constructor, TypeError, "TypeError");
+      assert.sameValue(err.message, 'The iterator does not provide a throw method');
+      assert.sameValue(returnCount, 1, 'iterator closed properly');
+
+      iter.next().then(({ done, value }) => {
+        assert.sameValue(done, true, 'the iterator is completed');
+        assert.sameValue(value, undefined, 'value is undefined');
+      }).then($DONE, $DONE);
+    }
+  ).catch($DONE);
+
+}).catch($DONE);
+

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js
@@ -68,15 +68,15 @@ iter.next().then(function(result) {
     },
     function (err) {
       assert.sameValue(err.constructor, TypeError, "TypeError");
-      assert.sameValue(err.message, 'The iterator does not provide a throw method');
+      assert.sameValue(err instanceof TypeError, true);
       assert.sameValue(returnCount, 1, 'iterator closed properly');
 
-      iter.next().then(({ done, value }) => {
-        assert.sameValue(done, true, 'the iterator is completed');
-        assert.sameValue(value, undefined, 'value is undefined');
+      iter.next().then(function (result) {
+        assert.sameValue(result.done, true, 'the iterator is completed');
+        assert.sameValue(result.value, undefined, 'value is undefined');
       }).then($DONE, $DONE);
     }
-  ).catch($DONE);
+  ).then($DONE, $DONE);
 
-}).catch($DONE);
+}).then($DONE, $DONE);
 

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined.js
@@ -9,11 +9,12 @@ info: |
   ...
   2. Let promiseCapability be ! NewPromiseCapability(%Promise%).
   ...
-  5. Let return be GetMethod(syncIterator, "throw").
-  6. IfAbruptRejectPromise(throw, promiseCapability).
-  7. If throw is undefined, then
-    a. Perform ! Call(promiseCapability.[[Reject]], undefined, « value »).
-    b. Return promiseCapability.[[Promise]].
+  6. Let throw be GetMethod(syncIterator, "throw").
+  [...]
+  8. If throw is undefined, then
+    ...
+    g. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
+    h. Return promiseCapability.[[Promise]].
 
 flags: [async]
 features: [async-iteration]
@@ -41,7 +42,8 @@ iter.next().then(function(result) {
       throw new Test262Error("Promise should be rejected, got: " + result.value);
     },
     function (err) {
-      assert.sameValue(err, undefined, "Promise should be rejected with undefined");
+      assert.sameValue(err.constructor, TypeError, "TypeError");
+      assert.sameValue(err.message, 'The iterator does not provide a throw method');
 
       iter.next().then(({ done, value }) => {
         assert.sameValue(done, true, 'the iterator is completed');

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined.js
@@ -43,7 +43,7 @@ iter.next().then(function(result) {
     },
     function (err) {
       assert.sameValue(err.constructor, TypeError, "TypeError");
-      assert.sameValue(err.message, 'The iterator does not provide a throw method');
+      assert.sameValue(err instanceof TypeError, true);
 
       iter.next().then(({ done, value }) => {
         assert.sameValue(done, true, 'the iterator is completed');

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined.js
@@ -18,6 +18,7 @@ info: |
 
 flags: [async]
 features: [async-iteration]
+includes: [asyncHelpers.js]
 ---*/
 
 var obj = {
@@ -36,20 +37,12 @@ async function* asyncg() {
 
 var iter = asyncg();
 
-iter.next().then(function(result) {
-  iter.throw().then(
-    function (result) {
-      throw new Test262Error("Promise should be rejected, got: " + result.value);
-    },
-    function (err) {
-      assert.sameValue(err.constructor, TypeError, "TypeError");
-      assert.sameValue(err instanceof TypeError, true);
-
-      iter.next().then(({ done, value }) => {
-        assert.sameValue(done, true, 'the iterator is completed');
-        assert.sameValue(value, undefined, 'value is undefined');
-      }).then($DONE, $DONE);
-    }
-  ).catch($DONE);
-
-}).catch($DONE);
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async () => {
+    await iter.next();
+    return iter.throw();
+  }, "Promise should be rejected");
+  const result = await iter.next();
+  assert(result.done, "the iterator is completed");
+  assert.sameValue(result.value, undefined, "value is undefined");
+})


### PR DESCRIPTION
This adds tests for the normative changes in https://github.com/tc39/ecma262/pull/2600 for the new steps in ` %AsyncFromSyncIteratorPrototype%.throw`, also modifying two existing tests.

These tests have been tested with this PR of engine262, which implements the normative changes: https://github.com/engine262/engine262/pull/230

Partly fixes #3387 