### PR TITLE
Fixed website section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Test262 runs CI tests against every PR and commit. The only tests that are requi
 
 ### Where did `website/` go?
 
-It's been removed. If you need to access the code that contained in that directory, you can find the PR which removed it [here](https://github.com/tc39/test262/pull/2677).
+It's been removed. If you need to access the code that contained in that directory, you can find it [here](hhttps://github.com/tc39/test262/tree/3fac29109a4e86142796ec89c4c381c5ca255e94/website).

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Test262 runs CI tests against every PR and commit. The only tests that are requi
 
 ### Where did `website/` go?
 
-It's been removed. If you need to access the code that contained in that directory, you can find the PR [here](https://github.com/tc39/test262/pull/2677).
+It's been removed. If you need to access the code that contained in that directory, you can find the PR which removed it [here](https://github.com/tc39/test262/pull/2677).

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Test262 runs CI tests against every PR and commit. The only tests that are requi
 
 ### Where did `website/` go?
 
-It's been removed. If you need to access the code that contained in that directory, you can find it [here](hhttps://github.com/tc39/test262/tree/3fac29109a4e86142796ec89c4c381c5ca255e94/website).
+It's been removed. If you need to access the code that contained in that directory, you can find it [here](https://github.com/tc39/test262/tree/3fac29109a4e86142796ec89c4c381c5ca255e94/website).

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Test262 runs CI tests against every PR and commit. The only tests that are requi
 
 ### Where did `website/` go?
 
-It's been removed. If you need to access the code that contained in that directory, we've preserved it in a branch, [available here](https://github.com/tc39/test262/tree/preserved-website-directory).
+It's been removed. If you need to access the code that contained in that directory, you can find the PR [here](https://github.com/tc39/test262/pull/2677).


### PR DESCRIPTION
Currently it links to a dead page, which is odd.
Let's link to the PR which removed the code, to give the reader some kind of thread to follow.