### PR TITLE
Update Intl.DurationFormat tests

### DIFF
--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -2509,12 +2509,73 @@ function isCanonicalizedStructurallyValidTimeZoneName(timeZone) {
 /**
  * @description Simplified PartitionDurationFormatPattern implementation which
  * only supports the "en" locale.
+ * @param {Object} durationFormat the duration format object
  * @param {Object} duration the duration record
- * @param {String} style the duration format style
  * @result {Array} an array with formatted duration parts
  */
 
-function partitionDurationFormatPattern(duration, style = "short") {
+function partitionDurationFormatPattern(durationFormat, duration) {
+  function durationToFractional(duration, exponent) {
+    let {
+      seconds = 0,
+      milliseconds = 0,
+      microseconds = 0,
+      nanoseconds = 0,
+    } = duration;
+
+    // Directly return the duration amount when no sub-seconds are present.
+    switch (exponent) {
+      case 9: {
+        if (milliseconds === 0 && microseconds === 0 && nanoseconds === 0) {
+          return seconds;
+        }
+        break;
+      }
+      case 6: {
+        if (microseconds === 0 && nanoseconds === 0) {
+          return milliseconds;
+        }
+        break;
+      }
+      case 3: {
+        if (nanoseconds === 0) {
+          return microseconds;
+        }
+        break;
+      }
+    }
+
+    // Otherwise compute the overall amount of nanoseconds using BigInt to avoid
+    // loss of precision.
+    let ns = BigInt(nanoseconds);
+    switch (exponent) {
+      case 9:
+        ns += BigInt(seconds) * 1_000_000_000n;
+        // fallthrough
+      case 6:
+        ns += BigInt(milliseconds) * 1_000_000n;
+        // fallthrough
+      case 3:
+        ns += BigInt(microseconds) * 1_000n;
+        // fallthrough
+    }
+
+    let e = BigInt(10 ** exponent);
+
+    // Split the nanoseconds amount into an integer and its fractional part.
+    let q = ns / e;
+    let r = ns % e;
+
+    // Pad fractional part, without any leading negative sign, to |exponent| digits.
+    if (r < 0) {
+      r = -r;
+    }
+    r = String(r).padStart(exponent, "0");
+
+    // Return the result as a decimal string.
+    return `${q}.${r}`;
+  }
+
   const units = [
     "years",
     "months",
@@ -2528,39 +2589,7 @@ function partitionDurationFormatPattern(duration, style = "short") {
     "nanoseconds",
   ];
 
-  function durationToFractionalSeconds(duration) {
-    let {
-      seconds = 0,
-      milliseconds = 0,
-      microseconds = 0,
-      nanoseconds = 0,
-    } = duration;
-
-    // Directly return seconds when no sub-seconds are present.
-    if (milliseconds === 0 && microseconds === 0 && nanoseconds === 0) {
-      return seconds;
-    }
-
-    // Otherwise compute the overall amount of nanoseconds using BigInt to avoid
-    // loss of precision.
-    let ns_sec = BigInt(seconds) * 1_000_000_000n;
-    let ns_ms = BigInt(milliseconds) * 1_000_000n;
-    let ns_us = BigInt(microseconds) * 1_000n;
-    let ns = ns_sec + ns_ms + ns_us + BigInt(nanoseconds);
-
-    // Split the nanoseconds amount into seconds and sub-seconds.
-    let q = ns / 1_000_000_000n;
-    let r = ns % 1_000_000_000n;
-
-    // Pad sub-seconds, without any leading negative sign, to nine digits.
-    if (r < 0) {
-      r = -r;
-    }
-    r = String(r).padStart(9, "0");
-
-    // Return seconds with fractional part as a decimal string.
-    return `${q}.${r}`;
-  }
+  let options = durationFormat.resolvedOptions();
 
   // Only "en" is supported.
   const locale = "en";
@@ -2568,116 +2597,131 @@ function partitionDurationFormatPattern(duration, style = "short") {
   const timeSeparator = ":";
 
   let result = [];
-  let separated = false;
+  let needSeparator = false;
+  let displayNegativeSign = true;
 
   for (let unit of units) {
     // Absent units default to zero.
     let value = duration[unit] ?? 0;
 
-    let display = "auto";
-    if (style === "digital") {
-      // Always display numeric units per GetDurationUnitOptions.
-      if (unit === "hours" || unit === "minutes" || unit === "seconds") {
-        display = "always";
-      }
+    let style = options[unit];
+    let display = options[unit + "Display"];
 
-      // Numeric seconds and sub-seconds are combined into a single value.
-      if (unit === "seconds") {
-        value = durationToFractionalSeconds(duration);
+    // NumberFormat requires singular unit names.
+    let numberFormatUnit = unit.slice(0, -1);
+
+    // Compute the matching NumberFormat options.
+    let nfOpts = Object.create(null);
+
+    // Numeric seconds and sub-seconds are combined into a single value.
+    let done = false;
+    if (unit === "seconds" || unit === "milliseconds" || unit === "microseconds") {
+      let nextStyle = options[units[units.indexOf(unit) + 1]];
+      if (nextStyle === "numeric") {
+        if (unit === "seconds") {
+          value = durationToFractional(duration, 9);
+        } else if (unit === "milliseconds") {
+          value = durationToFractional(duration, 6);
+        } else {
+          value = durationToFractional(duration, 3);
+        }
+
+        nfOpts.maximumFractionDigits = options.fractionalDigits ?? 9;
+        nfOpts.minimumFractionDigits = options.fractionalDigits ?? 0;
+        nfOpts.roundingMode = "trunc";
+
+        done = true;
       }
     }
 
+    // Display zero numeric minutes when seconds will be displayed.
+    let displayRequired = false;
+    if (unit === "minutes" && needSeparator) {
+      displayRequired = options.secondsDisplay === "always" ||
+                        (duration.seconds ?? 0) !== 0 ||
+                        (duration.milliseconds ?? 0) !== 0 ||
+                        (duration.microseconds ?? 0) !== 0 ||
+                        (duration.nanoseconds ?? 0) !== 0;
+    }
+
     // "auto" display omits zero units.
-    if (value !== 0 || display !== "auto") {
-      // Map the DurationFormat style to a NumberFormat style.
-      let unitStyle = style;
-      if (style === "digital") {
-        if (unit === "hours") {
-          unitStyle = "numeric";
-        } else if (unit === "minutes" || unit === "seconds") {
-          unitStyle = "2-digit";
-        } else {
-          unitStyle = "short";
+    if (value !== 0 || display !== "auto" || displayRequired) {
+      // Display only the first negative value.
+      if (displayNegativeSign) {
+        displayNegativeSign = false;
+
+        // Set to negative zero to ensure the sign is displayed.
+        if (value === 0) {
+          let negative = units.some(unit => (duration[unit] ?? 0) < 0);
+          if (negative) {
+            value = -0;
+          }
         }
+      } else {
+        nfOpts.signDisplay = "never";
       }
 
-      // NumberFormat requires singular unit names.
-      let numberFormatUnit = unit.slice(0, -1);
+      nfOpts.numberingSystem = options.numberingSystem;
 
-      // Compute the matching NumberFormat options.
-      let nfOpts;
-      if (unitStyle !== "numeric" && unitStyle !== "2-digit") {
-        // The value is formatted as a standalone unit.
-        nfOpts = {
-          numberingSystem,
-          style: "unit",
-          unit: numberFormatUnit,
-          unitDisplay: unitStyle,
-        };
-      } else {
-        let roundingMode = undefined;
-        let minimumFractionDigits = undefined;
-        let maximumFractionDigits = undefined;
+      // If the value is formatted as a 2-digit numeric value.
+      if (style === "2-digit") {
+        nfOpts.minimumIntegerDigits = 2;
+      }
 
-        // Numeric seconds include any sub-seconds.
-        if (style === "digital" && unit === "seconds") {
-          roundingMode = "trunc";
-          minimumFractionDigits = 0;
-          maximumFractionDigits = 9;
-        }
-
-        // The value is formatted as a numeric unit.
-        nfOpts = {
-          numberingSystem,
-          minimumIntegerDigits: (unitStyle === "2-digit" ? 2 : 1),
-          roundingMode,
-          minimumFractionDigits,
-          maximumFractionDigits,
-        };
+      // If the value is formatted as a standalone unit.
+      if (style !== "numeric" && style !== "2-digit") {
+        nfOpts.style = "unit";
+        nfOpts.unit = numberFormatUnit;
+        nfOpts.unitDisplay = style;
       }
 
       let nf = new Intl.NumberFormat(locale, nfOpts);
-      let formatted = nf.formatToParts(value);
+
+      let list;
+      if (!needSeparator) {
+        list = [];
+      } else {
+        list = result[result.length - 1];
+
+        // Prepend the time separator before the formatted number.
+        list.push({
+          type: "literal",
+          value: timeSeparator,
+        });
+      }
+
+      // Format the numeric value.
+      let parts = nf.formatToParts(value);
 
       // Add |numberFormatUnit| to the formatted number.
-      let list = [];
-      for (let {value, type} of formatted) {
+      for (let {value, type} of parts) {
         list.push({type, value, unit: numberFormatUnit});
       }
 
-      if (!separated) {
+      if (!needSeparator) {
         // Prepend the separator before the next numeric unit.
-        if (unitStyle === "2-digit" || unitStyle === "numeric") {
-          separated = true;
+        if (style === "2-digit" || style === "numeric") {
+          needSeparator = true;
         }
 
         // Append the formatted number to |result|.
         result.push(list);
-      } else {
-        let last = result[result.length - 1];
-
-        // Prepend the time separator before the formatted number.
-        last.push({
-          type: "literal",
-          value: timeSeparator,
-        });
-
-        // Concatenate |last| and the formatted number.
-        last.push(...list);
       }
-    } else {
-      separated = false;
     }
 
-    // No further units possible after "seconds" when style is "digital".
-    if (style === "digital" && unit === "seconds") {
+    if (done) {
       break;
     }
   }
 
+  let listStyle = options.style;
+  if (listStyle === "digital") {
+    listStyle = "short";
+  }
+
   let lf = new Intl.ListFormat(locale, {
     type: "unit",
-    style: (style !== "digital" ? style : "short"),
+    style: listStyle,
   });
 
   // Collect all formatted units into a list of strings.
@@ -2705,11 +2749,12 @@ function partitionDurationFormatPattern(duration, style = "short") {
 
 /**
  * @description Return the formatted string from partitionDurationFormatPattern.
+ * @param {Object} durationFormat the duration format object
  * @param {Object} duration the duration record
- * @param {String} style the duration format style
  * @result {String} a string containing the formatted duration
  */
 
-function formatDurationFormatPattern(duration, style) {
-  return partitionDurationFormatPattern(duration, style).reduce((acc, e) => acc + e.value, "");
+function formatDurationFormatPattern(durationFormat, duration) {
+  let parts = partitionDurationFormatPattern(durationFormat, duration);
+  return parts.reduce((acc, e) => acc + e.value, "");
 }

--- a/test/intl402/DurationFormat/prototype/format/negative-duration-style-default-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-duration-style-default-en.js
@@ -23,9 +23,10 @@ const duration = {
   nanoseconds: -9,
 };
 
-const expected = formatDurationFormatPattern(duration);
-
 const df = new Intl.DurationFormat("en");
+
+const expected = formatDurationFormatPattern(df, duration);
+
 assert.sameValue(
   df.format(duration),
   expected,

--- a/test/intl402/DurationFormat/prototype/format/negative-duration-style-short-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-duration-style-short-en.js
@@ -25,9 +25,10 @@ const duration = {
   nanoseconds: -9,
 };
 
-const expected = formatDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", {style});
+
+const expected = formatDurationFormatPattern(df, duration);
+
 assert.sameValue(
   df.format(duration),
   expected,

--- a/test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-default-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-default-en.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.format
+description: >
+  Test format method with negative duration and leading zero using the default style.
+locale: [en-US]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+const duration = {
+  hours: 0,
+  seconds: -1,
+};
+
+const df = new Intl.DurationFormat("en", {hoursDisplay: "always"});
+
+const expected = formatDurationFormatPattern(df, duration);
+
+assert.sameValue(
+  df.format(duration),
+  expected,
+  `DurationFormat format output using default style option`
+);

--- a/test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-digital-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-digital-en.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.format
+description: >
+  Test format method with negative duration and leading zero using the "digital" style.
+locale: [en-US]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+const style = "digital";
+
+const duration = {
+  hours: 0,
+  seconds: -1,
+};
+
+const df = new Intl.DurationFormat("en", {style, hoursDisplay: "always"});
+
+const expected = formatDurationFormatPattern(df, duration);
+
+assert.sameValue(
+  df.format(duration),
+  expected,
+  `DurationFormat format output using ${style} style option`
+);

--- a/test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-long-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-long-en.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.format
+description: >
+  Test format method with negative duration and leading zero using the "long" style.
+locale: [en-US]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+const style = "long";
+
+const duration = {
+  hours: 0,
+  seconds: -1,
+};
+
+const df = new Intl.DurationFormat("en", {style, hoursDisplay: "always"});
+
+const expected = formatDurationFormatPattern(df, duration);
+
+assert.sameValue(
+  df.format(duration),
+  expected,
+  `DurationFormat format output using ${style} style option`
+);

--- a/test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-narrow-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-narrow-en.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.format
+description: >
+  Test format method with negative duration and leading zero using the "narrow" style.
+locale: [en-US]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+const style = "narrow";
+
+const duration = {
+  hours: 0,
+  seconds: -1,
+};
+
+const df = new Intl.DurationFormat("en", {style, hoursDisplay: "always"});
+
+const expected = formatDurationFormatPattern(df, duration);
+
+assert.sameValue(
+  df.format(duration),
+  expected,
+  `DurationFormat format output using ${style} style option`
+);

--- a/test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-short-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-short-en.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.format
+description: >
+  Test format method with negative duration and leading zero using the "short" style.
+locale: [en-US]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+const style = "short";
+
+const duration = {
+  hours: 0,
+  seconds: -1,
+};
+
+const df = new Intl.DurationFormat("en", {style, hoursDisplay: "always"});
+
+const expected = formatDurationFormatPattern(df, duration);
+
+assert.sameValue(
+  df.format(duration),
+  expected,
+  `DurationFormat format output using ${style} style option`
+);

--- a/test/intl402/DurationFormat/prototype/format/negative-durationstyle-digital-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-durationstyle-digital-en.js
@@ -25,9 +25,10 @@ const duration = {
   nanoseconds: -9,
 };
 
-const expected = formatDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", {style});
+
+const expected = formatDurationFormatPattern(df, duration);
+
 assert.sameValue(
   df.format(duration),
   expected,

--- a/test/intl402/DurationFormat/prototype/format/negative-durationstyle-long-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-durationstyle-long-en.js
@@ -25,9 +25,10 @@ const duration = {
   nanoseconds: -9,
 };
 
-const expected = formatDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", {style});
+
+const expected = formatDurationFormatPattern(df, duration);
+
 assert.sameValue(
   df.format(duration),
   expected,

--- a/test/intl402/DurationFormat/prototype/format/negative-durationstyle-narrow-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-durationstyle-narrow-en.js
@@ -25,9 +25,10 @@ const duration = {
   nanoseconds: -9,
 };
 
-const expected = formatDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", {style});
+
+const expected = formatDurationFormatPattern(df, duration);
+
 assert.sameValue(
   df.format(duration),
   expected,

--- a/test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display-and-zero-fractional.js
+++ b/test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display-and-zero-fractional.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 André Bargull. All rights reserved.
+// Copyright (C) 2024 André Bargull. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -13,6 +13,13 @@ features: [Intl.DurationFormat]
 const df = new Intl.DurationFormat("en", {
   // hours must be numeric, so that a time separator is used for the following units.
   hours: "numeric",
+
+  // Use "auto" display for sub-hours units.
+  minutesDisplay: "auto",
+  secondsDisplay: "auto",
+
+  // Zero fractional digits to omit sub-second units.
+  fractionalDigits: 0,
 });
 
 const durations = [
@@ -29,6 +36,9 @@ const durations = [
 
   // Additionally test when hours is non-zero and a sub-seconds unit is non-zero,
   // but minutes and seconds are both zero.
+  //
+  // Note: The "fractionalDigits" option is not taken into account when computing
+  // whether the seconds unit should appear in the output.
   {hours: 1, minutes: 0, seconds: 0, milliseconds: 1},
   {hours: 1, minutes: 0, seconds: 0, microseconds: 1},
   {hours: 1, minutes: 0, seconds: 0, nanoseconds: 1},

--- a/test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display.js
+++ b/test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 André Bargull. All rights reserved.
+// Copyright (C) 2024 André Bargull. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -13,6 +13,10 @@ features: [Intl.DurationFormat]
 const df = new Intl.DurationFormat("en", {
   // hours must be numeric, so that a time separator is used for the following units.
   hours: "numeric",
+
+  // Use "auto" display for sub-hours units.
+  minutesDisplay: "auto",
+  secondsDisplay: "auto",
 });
 
 const durations = [

--- a/test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds.js
+++ b/test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds.js
@@ -6,17 +6,13 @@ esid: sec-Intl.DurationFormat.prototype.format
 description: >
   The correct separator is used for numeric hours with zero minutes and non-zero seconds.
 locale: [en-US]
+includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/
 
 const df = new Intl.DurationFormat("en", {
   // hours must be numeric, so that a time separator is used for the following units.
   hours: "numeric",
-});
-
-const lf = new Intl.ListFormat("en", {
-  type: "unit",
-  style: "short",
 });
 
 const duration = {
@@ -29,10 +25,7 @@ const duration = {
   seconds: 3,
 };
 
-const expected = lf.format([
-  new Intl.NumberFormat("en", {minimumIntegerDigits: 1}).format(duration.hours),
-  new Intl.NumberFormat("en", {minimumIntegerDigits: 2}).format(duration.seconds),
-]);
+const expected = formatDurationFormatPattern(df, duration);
 
 assert.sameValue(
   df.format(duration),

--- a/test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js
+++ b/test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js
@@ -84,7 +84,7 @@ const durations = [
 const df = new Intl.DurationFormat("en", {style: "digital"});
 
 for (let duration of durations) {
-  let expected = formatDurationFormatPattern(duration, "digital");
+  let expected = formatDurationFormatPattern(df, duration);
   assert.sameValue(
     df.format(duration),
     expected,

--- a/test/intl402/DurationFormat/prototype/format/style-default-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-default-en.js
@@ -22,7 +22,8 @@ const duration = {
   nanoseconds: 9,
 };
 
-const expected = formatDurationFormatPattern(duration);
-
 const df = new Intl.DurationFormat("en");
+
+const expected = formatDurationFormatPattern(df, duration);
+
 assert.sameValue(df.format(duration), expected, `Assert DurationFormat format output using default style option`);

--- a/test/intl402/DurationFormat/prototype/format/style-digital-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-en.js
@@ -25,7 +25,8 @@ const duration = {
   nanoseconds: 9,
 };
 
-const expected = formatDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", {style});
+
+const expected = formatDurationFormatPattern(df, duration);
+
 assert.sameValue(df.format(duration), expected, `Assert DurationFormat format output using ${style} style option`);

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined.js
@@ -34,7 +34,7 @@ const durationMicro = {
   microseconds: 222
 };
 
-const durationMill = {
+const durationMilli = {
   hours: 1,
   minutes: 22,
   seconds: 33,
@@ -45,6 +45,14 @@ const durationNoSubsecond = {
   hours: 1,
   minutes: 22,
   seconds: 33
+};
+
+const durationFiveFractional = {
+  hours: 2,
+  minutes: 30,
+  seconds: 10,
+  milliseconds: 111,
+  microseconds: 220,
 };
 
 const durationSevenFractional = {
@@ -64,5 +72,5 @@ assert.sameValue(df.format(durationMicro), "1:22:33.111222", `format output with
 assert.sameValue(df.format(durationMilli), "1:22:33.111", `format output with millisecond digits and fractionalDigits: undefined using ${style} style option`);
 assert.sameValue(df.format(durationNoSubsecond), "1:22:33", `format output with no subsecond digits and fractionalDigits: undefined using ${style} style option`);
 
-assert.sameValue(df.format(durationFiveFractional), "2:30:11122", `format output with five subsecond digits and fractionalDigits: undefined using ${style} style option`);
-assert.sameValue(df.format(durationSevenFractional), "2:30:1112203", `format output with seven subsecond digits and fractionalDigits: undefined using ${style} style option`);
+assert.sameValue(df.format(durationFiveFractional), "2:30:10.11122", `format output with five subsecond digits and fractionalDigits: undefined using ${style} style option`);
+assert.sameValue(df.format(durationSevenFractional), "2:30:10.1112203", `format output with seven subsecond digits and fractionalDigits: undefined using ${style} style option`);

--- a/test/intl402/DurationFormat/prototype/format/style-long-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-long-en.js
@@ -24,7 +24,8 @@ const duration = {
   nanoseconds: 9,
 };
 
-const expected = formatDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", {style});
+
+const expected = formatDurationFormatPattern(df, duration);
+
 assert.sameValue(df.format(duration), expected, `Assert DurationFormat format output using ${style} style option`);

--- a/test/intl402/DurationFormat/prototype/format/style-narrow-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-narrow-en.js
@@ -24,7 +24,8 @@ const duration = {
   nanoseconds: 9,
 };
 
-const expected = formatDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", {style});
+
+const expected = formatDurationFormatPattern(df, duration);
+
 assert.sameValue(df.format(duration), expected, `Assert DurationFormat format output using ${style} style option`);

--- a/test/intl402/DurationFormat/prototype/format/style-short-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-short-en.js
@@ -24,7 +24,8 @@ const duration = {
   nanoseconds: 9,
 };
 
-const expected = formatDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", {style});
+
+const expected = formatDurationFormatPattern(df, duration);
+
 assert.sameValue(df.format(duration), expected, `Assert DurationFormat format output using ${style} style option`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-default-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-default-en.js
@@ -38,7 +38,8 @@ const duration = {
   nanoseconds: 789,
 };
 
-const expected = partitionDurationFormatPattern(duration);
+const df = new Intl.DurationFormat('en');
 
-let df = new Intl.DurationFormat('en');
+const expected = partitionDurationFormatPattern(df, duration);
+
 compare(df.formatToParts(duration), expected, `Using style : default`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-digital-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-digital-en.js
@@ -40,7 +40,8 @@ const duration = {
 
 const style = "digital";
 
-const expected = partitionDurationFormatPattern(duration, style);
+const df = new Intl.DurationFormat('en', { style });
 
-let df = new Intl.DurationFormat('en', { style });
+const expected = partitionDurationFormatPattern(df, duration);
+
 compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-long-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-long-en.js
@@ -40,7 +40,8 @@ const duration = {
 
 const style = "long";
 
-const expected = partitionDurationFormatPattern(duration, style);
+const df = new Intl.DurationFormat('en', { style });
 
-let df = new Intl.DurationFormat('en', { style });
+const expected = partitionDurationFormatPattern(df, duration);
+
 compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-narrow-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-narrow-en.js
@@ -40,7 +40,8 @@ const duration = {
 
 const style = "narrow";
 
-const expected = partitionDurationFormatPattern(duration, style);
+const df = new Intl.DurationFormat('en', { style });
 
-let df = new Intl.DurationFormat('en', { style });
+const expected = partitionDurationFormatPattern(df, duration);
+
 compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-short-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-short-en.js
@@ -40,7 +40,8 @@ const duration = {
 
 const style = "short";
 
-const expected = partitionDurationFormatPattern(duration, style);
+const df = new Intl.DurationFormat('en', { style });
 
-let df = new Intl.DurationFormat('en', { style });
+const expected = partitionDurationFormatPattern(df, duration);
+
 compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-default-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-default-en.js
@@ -41,7 +41,8 @@ const duration = {
   nanoseconds: -789,
 };
 
-const expected = partitionDurationFormatPattern(duration);
-
 const df = new Intl.DurationFormat("en");
+
+const expected = partitionDurationFormatPattern(df, duration);
+
 compare(df.formatToParts(duration), expected, `Using style : default`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-digital-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-digital-en.js
@@ -43,7 +43,8 @@ const duration = {
   nanoseconds: -789,
 };
 
-const expected = partitionDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", { style });
+
+const expected = partitionDurationFormatPattern(df, duration);
+
 compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-long-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-long-en.js
@@ -43,7 +43,8 @@ const duration = {
   nanoseconds: -789,
 };
 
-const expected = partitionDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", { style });
+
+const expected = partitionDurationFormatPattern(df, duration);
+
 compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-narrow-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-narrow-en.js
@@ -43,7 +43,8 @@ const duration = {
   nanoseconds: -789,
 };
 
-const expected = partitionDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", { style });
+
+const expected = partitionDurationFormatPattern(df, duration);
+
 compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-short-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-short-en.js
@@ -43,7 +43,8 @@ const duration = {
   nanoseconds: -789,
 };
 
-const expected = partitionDurationFormatPattern(duration, style);
-
 const df = new Intl.DurationFormat("en", { style });
+
+const expected = partitionDurationFormatPattern(df, duration);
+
 compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-default-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-default-en.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.formatToParts
+description: >
+  Test formatToParts method with negative duration and leading zero using the default style.
+locale: [en-US]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+function compare(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < expected.length; ++i) {
+    let actualEntry = actual[i];
+    let expectedEntry = expected[i];
+
+    assert.sameValue(actualEntry.type, expectedEntry.type, `type for entry ${i}`);
+    assert.sameValue(actualEntry.value, expectedEntry.value, `value for entry ${i}`);
+    assert.sameValue("unit" in actualEntry, "unit" in expectedEntry, `unit for entry ${i}`);
+    if ("unit" in expectedEntry) {
+      assert.sameValue(actualEntry.unit, expectedEntry.unit, `unit for entry ${i}`);
+    }
+  }
+}
+
+const duration = {
+  hours: 0,
+  seconds: -1,
+};
+
+const df = new Intl.DurationFormat("en", {hoursDisplay: "always"});
+
+const expected = partitionDurationFormatPattern(df, duration);
+
+compare(df.formatToParts(duration), expected, `Using style : default`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-digital-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-digital-en.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.formatToParts
+description: >
+  Test formatToParts method with negative duration and leading zero using the "digital" style.
+locale: [en-US]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+function compare(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < expected.length; ++i) {
+    let actualEntry = actual[i];
+    let expectedEntry = expected[i];
+
+    assert.sameValue(actualEntry.type, expectedEntry.type, `type for entry ${i}`);
+    assert.sameValue(actualEntry.value, expectedEntry.value, `value for entry ${i}`);
+    assert.sameValue("unit" in actualEntry, "unit" in expectedEntry, `unit for entry ${i}`);
+    if ("unit" in expectedEntry) {
+      assert.sameValue(actualEntry.unit, expectedEntry.unit, `unit for entry ${i}`);
+    }
+  }
+}
+
+const style = "digital";
+
+const duration = {
+  hours: 0,
+  seconds: -1,
+};
+
+const df = new Intl.DurationFormat("en", {style, hoursDisplay: "always"});
+
+const expected = partitionDurationFormatPattern(df, duration);
+
+compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-long-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-long-en.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.formatToParts
+description: >
+  Test formatToParts method with negative duration and leading zero using the "long" style.
+locale: [en-US]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+function compare(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < expected.length; ++i) {
+    let actualEntry = actual[i];
+    let expectedEntry = expected[i];
+
+    assert.sameValue(actualEntry.type, expectedEntry.type, `type for entry ${i}`);
+    assert.sameValue(actualEntry.value, expectedEntry.value, `value for entry ${i}`);
+    assert.sameValue("unit" in actualEntry, "unit" in expectedEntry, `unit for entry ${i}`);
+    if ("unit" in expectedEntry) {
+      assert.sameValue(actualEntry.unit, expectedEntry.unit, `unit for entry ${i}`);
+    }
+  }
+}
+
+const style = "long";
+
+const duration = {
+  hours: 0,
+  seconds: -1,
+};
+
+const df = new Intl.DurationFormat("en", {style, hoursDisplay: "always"});
+
+const expected = partitionDurationFormatPattern(df, duration);
+
+compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-narrow-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-narrow-en.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.formatToParts
+description: >
+  Test formatToParts method with negative duration and leading zero using the "narrow" style.
+locale: [en-US]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+function compare(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < expected.length; ++i) {
+    let actualEntry = actual[i];
+    let expectedEntry = expected[i];
+
+    assert.sameValue(actualEntry.type, expectedEntry.type, `type for entry ${i}`);
+    assert.sameValue(actualEntry.value, expectedEntry.value, `value for entry ${i}`);
+    assert.sameValue("unit" in actualEntry, "unit" in expectedEntry, `unit for entry ${i}`);
+    if ("unit" in expectedEntry) {
+      assert.sameValue(actualEntry.unit, expectedEntry.unit, `unit for entry ${i}`);
+    }
+  }
+}
+
+const style = "narrow";
+
+const duration = {
+  hours: 0,
+  seconds: -1,
+};
+
+const df = new Intl.DurationFormat("en", {style, hoursDisplay: "always"});
+
+const expected = partitionDurationFormatPattern(df, duration);
+
+compare(df.formatToParts(duration), expected, `Using style : ${style}`);

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-short-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-short-en.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.formatToParts
+description: >
+  Test formatToParts method with negative duration and leading zero using the "short" style.
+locale: [en-US]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+function compare(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < expected.length; ++i) {
+    let actualEntry = actual[i];
+    let expectedEntry = expected[i];
+
+    assert.sameValue(actualEntry.type, expectedEntry.type, `type for entry ${i}`);
+    assert.sameValue(actualEntry.value, expectedEntry.value, `value for entry ${i}`);
+    assert.sameValue("unit" in actualEntry, "unit" in expectedEntry, `unit for entry ${i}`);
+    if ("unit" in expectedEntry) {
+      assert.sameValue(actualEntry.unit, expectedEntry.unit, `unit for entry ${i}`);
+    }
+  }
+}
+
+const style = "short";
+
+const duration = {
+  hours: 0,
+  seconds: -1,
+};
+
+const df = new Intl.DurationFormat("en", {style, hoursDisplay: "always"});
+
+const expected = partitionDurationFormatPattern(df, duration);
+
+compare(df.formatToParts(duration), expected, `Using style : ${style}`);


### PR DESCRIPTION
Update `Intl.DurationFormat` tests to match the current draft spec and add tests to cover:
- https://github.com/tc39/proposal-intl-duration-format/pull/183
- https://github.com/tc39/proposal-intl-duration-format/pull/184