### PR TITLE
Fix an error in expected value of difference set method 

### DIFF
--- a/test/built-ins/Set/prototype/difference/subclass-receiver-methods.js
+++ b/test/built-ins/Set/prototype/difference/subclass-receiver-methods.js
@@ -30,7 +30,7 @@ class MySet extends Set {
 
 const s1 = new MySet([1, 2]);
 const s2 = new Set([2, 3]);
-const expected = [2];
+const expected = [1];
 const combined = s1.difference(s2);
 
 assert.compareArray([...combined], expected);


### PR DESCRIPTION
The difference between two sets is `[1]`.