### PR TITLE
Do not expect specific error type in `import-attributes/allow-nlt-before-with.js`

### DIFF
--- a/test/language/module-code/import-attributes/allow-nlt-before-with.js
+++ b/test/language/module-code/import-attributes/allow-nlt-before-with.js
@@ -19,7 +19,6 @@ info: |
 
 negative:
   phase: resolution
-  type: SyntaxError
 features: [import-attributes, globalThis]
 flags: [module, raw]
 ---*/

--- a/test/language/module-code/import-attributes/allow-nlt-before-with.js
+++ b/test/language/module-code/import-attributes/allow-nlt-before-with.js
@@ -19,6 +19,7 @@ info: |
 
 negative:
   phase: resolution
+  type: SyntaxError
 features: [import-attributes, globalThis]
 flags: [module, raw]
 ---*/
@@ -29,4 +30,4 @@ import "./ensure-linking-error_FIXTURE.js";
 
 import * as x from './import-attribute-1_FIXTURE.js'
 with
-{ type: 'foo' };
+{};


### PR DESCRIPTION
Hosts are free to throw whatever error they want during module loading: there is no guarantee that the error thrown due to the import with `type: "foo"` is a SyntaxError (it could also be, for example, an `Error` caused by a network failure). Technically this is also true when loading just JS, but not specifying `type` reduces variance and in practice all test262 runners will not fail when loading JS modules that exist :)