### PR TITLE
Fix comment in allow-nlt-before-with.js

### DIFF
--- a/test/language/module-code/import-attributes/allow-nlt-before-with.js
+++ b/test/language/module-code/import-attributes/allow-nlt-before-with.js
@@ -7,7 +7,7 @@ description: >
 esid: sec-modules
 info: |
   ImportDeclaration:
-    import ModuleSpecifier[no LineTerminator here] WithClause;
+    import ModuleSpecifier WithClause;
 
   WithClause:
     AttributesKeyword {}


### PR DESCRIPTION
The description of the test states that `WithClause` can be preceded by a line terminator, but the syntax states the opposite.