### PR TITLE
Add test with non-IANA time zone names

### DIFF
--- a/test/intl402/DateTimeFormat/timezone-legacy-non-iana.js
+++ b/test/intl402/DateTimeFormat/timezone-legacy-non-iana.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializedatetimeformat
+description: Only IANA time zone identifiers are allowed.
+---*/
+
+// List of non-IANA link names, copied from:
+// https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/tzcode/icuzones
+const invalidTimeZones = [
+  "ACT",
+  "AET",
+  "AGT",
+  "ART",
+  "AST",
+  "BET",
+  "BST",
+  "CAT",
+  "CNT",
+  "CST",
+  "CTT",
+  "EAT",
+  "ECT",
+  "IET",
+  "IST",
+  "JST",
+  "MIT",
+  "NET",
+  "NST",
+  "PLT",
+  "PNT",
+  "PRT",
+  "PST",
+  "SST",
+  "VST",
+];
+
+for (let timeZone of invalidTimeZones) {
+  assert.throws(RangeError, () => {
+    new Intl.DateTimeFormat(undefined, {timeZone});
+  }, "Time zone: " + timeZone);
+}

--- a/test/intl402/Temporal/TimeZone/from/timezone-string-legacy-non-iana.js
+++ b/test/intl402/Temporal/TimeZone/from/timezone-string-legacy-non-iana.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.from
+description: Only IANA time zone identifiers are allowed.
+features: [Temporal]
+---*/
+
+// List of non-IANA link names, copied from:
+// https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/tzcode/icuzones
+const invalidTimeZones = [
+  "ACT",
+  "AET",
+  "AGT",
+  "ART",
+  "AST",
+  "BET",
+  "BST",
+  "CAT",
+  "CNT",
+  "CST",
+  "CTT",
+  "EAT",
+  "ECT",
+  "IET",
+  "IST",
+  "JST",
+  "MIT",
+  "NET",
+  "NST",
+  "PLT",
+  "PNT",
+  "PRT",
+  "PST",
+  "SST",
+  "VST",
+];
+
+for (let timeZone of invalidTimeZones) {
+  assert.throws(RangeError, () => {
+    Temporal.TimeZone.from(timeZone);
+  }, "Time zone: " + timeZone);
+}

--- a/test/intl402/Temporal/TimeZone/legacy-non-iana.js
+++ b/test/intl402/Temporal/TimeZone/legacy-non-iana.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone
+description: Only IANA time zone identifiers are allowed.
+features: [Temporal]
+---*/
+
+// List of non-IANA link names, copied from:
+// https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/tzcode/icuzones
+const invalidTimeZones = [
+  "ACT",
+  "AET",
+  "AGT",
+  "ART",
+  "AST",
+  "BET",
+  "BST",
+  "CAT",
+  "CNT",
+  "CST",
+  "CTT",
+  "EAT",
+  "ECT",
+  "IET",
+  "IST",
+  "JST",
+  "MIT",
+  "NET",
+  "NST",
+  "PLT",
+  "PNT",
+  "PRT",
+  "PST",
+  "SST",
+  "VST",
+];
+
+for (let timeZone of invalidTimeZones) {
+  assert.throws(RangeError, () => {
+    new Temporal.TimeZone(timeZone);
+  }, "Time zone: " + timeZone);
+}


### PR DESCRIPTION
Time zone identifiers supported by ICU, but which aren't valid IANA identifiers.