### PR TITLE
(Shared)ArrayBuffer constructor validation happens in correct order

### DIFF
--- a/test/built-ins/ArrayBuffer/options-maxbytelength-allocation-limit.js
+++ b/test/built-ins/ArrayBuffer/options-maxbytelength-allocation-limit.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Throws a RangeError if the requested Data Block is too large.
+info: |
+  ArrayBuffer ( length [ , options ] )
+
+  ...
+  4. Return ? AllocateArrayBuffer(NewTarget, byteLength, requestedMaxByteLength).
+
+  AllocateArrayBuffer ( constructor, byteLength [ , maxByteLength ] )
+
+  ...
+  5. Let block be ? CreateByteDataBlock(byteLength).
+  ...
+
+  CreateByteDataBlock ( size )
+
+  ...
+  2. Let db be a new Data Block value consisting of size bytes. If it is
+     impossible to create such a Data Block, throw a RangeError exception.
+  ...
+
+features: [resizable-arraybuffer]
+---*/
+
+assert.throws(RangeError, function() {
+  // Allocating 7 PiB should fail with a RangeError.
+  // Math.pow(1024, 5) = 1125899906842624
+  new ArrayBuffer(0, {maxByteLength: 7 * 1125899906842624});
+}, "`maxByteLength` option is 7 PiB");
+
+assert.throws(RangeError, function() {
+  // Allocating almost 8 PiB should fail with a RangeError.
+  // Math.pow(2, 53) = 9007199254740992
+  new ArrayBuffer(0, {maxByteLength: 9007199254740992 - 1});
+}, "`maxByteLength` option is Math.pow(2, 53) - 1");

--- a/test/built-ins/ArrayBuffer/options-maxbytelength-compared-before-object-creation.js
+++ b/test/built-ins/ArrayBuffer/options-maxbytelength-compared-before-object-creation.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  The byteLength argument is validated before OrdinaryCreateFromConstructor.
+info: |
+  ArrayBuffer ( length [ , options ] )
+
+  ...
+  4. Return ? AllocateArrayBuffer(NewTarget, byteLength, requestedMaxByteLength).
+
+  AllocateArrayBuffer ( constructor, byteLength [ , maxByteLength ] )
+
+  ...
+  3. If allocatingResizableBuffer is true, then
+    a. If byteLength > maxByteLength, throw a RangeError exception.
+  ...
+  4. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%ArrayBuffer.prototype%", slots).
+  ...
+
+features: [resizable-arraybuffer, Reflect.construct]
+---*/
+
+let newTarget = Object.defineProperty(function(){}.bind(null), "prototype", {
+  get() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(RangeError, function() {
+  let byteLength = 10;
+  let options = {
+    maxByteLength: 0,
+  };
+
+  // Throws a RangeError, because `byteLength` is larger than `options.maxByteLength`.
+  Reflect.construct(ArrayBuffer, [byteLength, options], newTarget);
+});

--- a/test/built-ins/ArrayBuffer/options-maxbytelength-data-allocation-after-object-creation.js
+++ b/test/built-ins/ArrayBuffer/options-maxbytelength-data-allocation-after-object-creation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  The new ArrayBuffer instance is created prior to allocating the Data Block.
+info: |
+  ArrayBuffer ( length [ , options ] )
+
+  ...
+  4. Return ? AllocateArrayBuffer(NewTarget, byteLength, requestedMaxByteLength).
+
+  AllocateArrayBuffer ( constructor, byteLength [ , maxByteLength ] )
+
+  ...
+  4. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%ArrayBuffer.prototype%", slots).
+  5. Let block be ? CreateByteDataBlock(byteLength).
+  ...
+
+features: [resizable-arraybuffer, Reflect.construct]
+---*/
+
+function DummyError() {}
+
+let newTarget = Object.defineProperty(function(){}.bind(null), "prototype", {
+  get() {
+    throw new DummyError();
+  }
+});
+
+assert.throws(DummyError, function() {
+  let byteLength = 0;
+  let options = {
+    maxByteLength: 7 * 1125899906842624
+  };
+
+  // Allocating 7 PiB should fail with a RangeError.
+  // Math.pow(1024, 5) = 1125899906842624
+  Reflect.construct(ArrayBuffer, [], newTarget);
+});

--- a/test/built-ins/SharedArrayBuffer/options-maxbytelength-allocation-limit.js
+++ b/test/built-ins/SharedArrayBuffer/options-maxbytelength-allocation-limit.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-sharedarraybuffer-length
+description: >
+  Throws a RangeError if the requested Data Block is too large.
+info: |
+  SharedArrayBuffer ( length [ , options ] )
+
+  ...
+  4. Return ? AllocateSharedArrayBuffer(NewTarget, byteLength, requestedMaxByteLength).
+
+  AllocateSharedArrayBuffer ( constructor, byteLength [ , maxByteLength ] )
+
+  ...
+  7. Let block be ? CreateSharedByteDataBlock(allocLength).
+  ...
+
+  CreateSharedByteDataBlock ( size )
+
+  1. Let db be a new Shared Data Block value consisting of size bytes. If it is
+     impossible to create such a Shared Data Block, throw a RangeError exception.
+
+features: [SharedArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.throws(RangeError, function() {
+  // Allocating 7 PiB should fail with a RangeError.
+  // Math.pow(1024, 5) = 1125899906842624
+  new SharedArrayBuffer(0, {maxByteLength: 7 * 1125899906842624});
+}, "`maxByteLength` option is 7 PiB");
+
+assert.throws(RangeError, function() {
+  // Allocating almost 8 PiB should fail with a RangeError.
+  // Math.pow(2, 53) = 9007199254740992
+  new SharedArrayBuffer(0, {maxByteLength: 9007199254740992 - 1});
+}, "`maxByteLength` option is Math.pow(2, 53) - 1");

--- a/test/built-ins/SharedArrayBuffer/options-maxbytelength-compared-before-object-creation.js
+++ b/test/built-ins/SharedArrayBuffer/options-maxbytelength-compared-before-object-creation.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-sharedarraybuffer-length
+description: >
+  The byteLength argument is validated before OrdinaryCreateFromConstructor.
+info: |
+  SharedArrayBuffer ( length [ , options ] )
+
+  ...
+  4. Return ? AllocateSharedArrayBuffer(NewTarget, byteLength, requestedMaxByteLength).
+
+  AllocateSharedArrayBuffer ( constructor, byteLength [ , maxByteLength ] )
+
+  ...
+  3. If allocatingGrowableBuffer is true, then
+    a. If byteLength > maxByteLength, throw a RangeError exception.
+  ...
+  5. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%SharedArrayBuffer.prototype%", slots).
+  ...
+
+features: [SharedArrayBuffer, resizable-arraybuffer, Reflect.construct]
+---*/
+
+let newTarget = Object.defineProperty(function(){}.bind(null), "prototype", {
+  get() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(RangeError, function() {
+  let byteLength = 10;
+  let options = {
+    maxByteLength: 0,
+  };
+
+  // Throws a RangeError, because `byteLength` is larger than `options.maxByteLength`.
+  Reflect.construct(SharedArrayBuffer, [byteLength, options], newTarget);
+});

--- a/test/built-ins/SharedArrayBuffer/options-maxbytelength-data-allocation-after-object-creation.js
+++ b/test/built-ins/SharedArrayBuffer/options-maxbytelength-data-allocation-after-object-creation.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-sharedarraybuffer-length
+description: >
+  The new SharedArrayBuffer instance is created prior to allocating the Data Block.
+info: |
+  SharedArrayBuffer ( length [ , options ] )
+
+  ...
+  4. Return ? AllocateSharedArrayBuffer(NewTarget, byteLength, requestedMaxByteLength).
+
+  AllocateSharedArrayBuffer( constructor, byteLength )
+
+  ...
+  5. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%SharedArrayBuffer.prototype%", slots).
+  ...
+  7. Let block be ? CreateSharedByteDataBlock(allocLength).
+  ...
+
+features: [SharedArrayBuffer, resizable-arraybuffer, Reflect.construct]
+---*/
+
+function DummyError() {}
+
+let newTarget = Object.defineProperty(function(){}.bind(null), "prototype", {
+  get() {
+    throw new DummyError();
+  }
+});
+
+assert.throws(DummyError, function() {
+  let byteLength = 0;
+  let options = {
+    maxByteLength: 7 * 1125899906842624
+  };
+
+  // Allocating 7 PiB should fail with a RangeError.
+  // Math.pow(1024, 5) = 1125899906842624
+  Reflect.construct(SharedArrayBuffer, [], newTarget);
+});


### PR DESCRIPTION
Add tests to ensure that:
1. First `byteLength` isn't larger than `maxByteLength`.
2. Then `OrdinaryCreateFromConstructor` is called.
3. And finally `Create{Shared}ByteDataBlock` is called.