### PR TITLE
Two tests previously assumed 'en' as locale for DurationFormat, assumption now made explicit

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-en.js
@@ -13,6 +13,7 @@ info: |
   5. Else,
     a. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", durationFormat.[[FractionalDigits]]).
     b. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", durationFormat.[[FractionalDigits]]).
+locale: [en-US]
 features: [Intl.DurationFormat]
 ---*/
 

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-en.js
@@ -27,12 +27,12 @@ const duration = {
 
 
 const style = "digital";
-const df = new Intl.DurationFormat(undefined, {style, fractionalDigits: 0});
-const dfMilli = new Intl.DurationFormat(undefined, {style, fractionalDigits: 3});
-const dfFourDigits = new Intl.DurationFormat(undefined, {style, fractionalDigits: 4});
-const dfMicro = new Intl.DurationFormat(undefined, {style, fractionalDigits: 6});
-const dfEightDigits = new Intl.DurationFormat(undefined, {style, fractionalDigits: 8});
-const dfNano = new Intl.DurationFormat(undefined, {style, fractionalDigits: 9});
+const df = new Intl.DurationFormat("en", {style, fractionalDigits: 0});
+const dfMilli = new Intl.DurationFormat("en", {style, fractionalDigits: 3});
+const dfFourDigits = new Intl.DurationFormat("en", {style, fractionalDigits: 4});
+const dfMicro = new Intl.DurationFormat("en", {style, fractionalDigits: 6});
+const dfEightDigits = new Intl.DurationFormat("en", {style, fractionalDigits: 8});
+const dfNano = new Intl.DurationFormat("en", {style, fractionalDigits: 9});
 
 assert.sameValue(df.format(duration), "1:22:33", `format output without sub-second digits using ${style} style option`);
 

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined-en.js
@@ -13,6 +13,7 @@ info: |
   5. Else,
     a. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", durationFormat.[[FractionalDigits]]).
     b. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", durationFormat.[[FractionalDigits]]).
+locale: [en-US]
 features: [Intl.DurationFormat]
 ---*/
 

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined-en.js
@@ -57,7 +57,7 @@ const durationSevenFractional = {
 };
 
 const style = "digital";
-const df = new Intl.DurationFormat(undefined, {style, fractionalDigits: undefined});
+const df = new Intl.DurationFormat("en", {style, fractionalDigits: undefined});
 
 assert.sameValue(df.format(durationNano), "1:22:33.111222333", `format output with nanosecond digits and fractionalDigits: undefined using ${style} style option`);
 assert.sameValue(df.format(durationMicro), "1:22:33.111222", `format output with microsecond digits and fractionalDigits: undefined using ${style} style option`);


### PR DESCRIPTION
 Two tests compared output against hardcoded strings formatted as in 'en', despite the locale for the DurationFormat being set to `*undefined*`. updated to explicitly give 'en' as locale for DurationFormat