### PR TITLE
remove some auto-generated error messages in "assert.throws" tests

### DIFF
--- a/test/annexB/built-ins/Date/prototype/getYear/not-a-constructor.js
+++ b/test/annexB/built-ins/Date/prototype/getYear/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getYear();
-}, '`let date = new Date(Date.now()); new date.getYear()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/Date/prototype/setYear/not-a-constructor.js
+++ b/test/annexB/built-ins/Date/prototype/setYear/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setYear();
-}, '`let date = new Date(Date.now()); new date.setYear()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/Date/prototype/toGMTString/not-a-constructor.js
+++ b/test/annexB/built-ins/Date/prototype/toGMTString/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.toGMTString();
-}, '`let date = new Date(Date.now()); new date.toGMTString()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/RegExp/prototype/compile/this-cross-realm-instance.js
+++ b/test/annexB/built-ins/RegExp/prototype/compile/this-cross-realm-instance.js
@@ -15,9 +15,7 @@ assert.throws(
   TypeError,
   function () {
     RegExp.prototype.compile.call(otherRealm_regexp);
-  },
-  "`RegExp.prototype.compile.call(otherRealm_regexp)` throws TypeError"
-);
+  });
 
 assert.throws(
   other.TypeError,

--- a/test/annexB/built-ins/RegExp/prototype/compile/this-subclass-instance.js
+++ b/test/annexB/built-ins/RegExp/prototype/compile/this-subclass-instance.js
@@ -12,14 +12,10 @@ assert.throws(
   TypeError,
   function () {
     subclass_regexp.compile();
-  },
-  "`subclass_regexp.compile()` throws TypeError"
-);
+  });
 
 assert.throws(
   TypeError,
   function () {
     RegExp.prototype.compile.call(subclass_regexp);
-  },
-  "`RegExp.prototype.compile.call(subclass_regexp)` throws TypeError"
-);
+  });

--- a/test/annexB/built-ins/String/prototype/anchor/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/anchor/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.anchor();
-}, '`new String.prototype.anchor()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/big/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/big/not-a-constructor.js
@@ -24,5 +24,5 @@ assert.sameValue(isConstructor(String.prototype.big), false, 'isConstructor(Stri
 
 assert.throws(TypeError, () => {
   new String.prototype.big();
-}, '`new String.prototype.big()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/blink/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/blink/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.blink();
-}, '`new String.prototype.blink()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/bold/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/bold/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.bold();
-}, '`new String.prototype.bold()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/fixed/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/fixed/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.fixed();
-}, '`new String.prototype.fixed()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/fontcolor/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/fontcolor/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.fontcolor();
-}, '`new String.prototype.fontcolor()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/fontsize/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/fontsize/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.fontsize();
-}, '`new String.prototype.fontsize()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/italics/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/italics/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.italics();
-}, '`new String.prototype.italics()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/link/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/link/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.link();
-}, '`new String.prototype.link()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/small/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/small/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.small();
-}, '`new String.prototype.small()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/strike/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/strike/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.strike();
-}, '`new String.prototype.strike()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/sub/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/sub/not-a-constructor.js
@@ -24,5 +24,5 @@ assert.sameValue(isConstructor(String.prototype.sub), false, 'isConstructor(Stri
 
 assert.throws(TypeError, () => {
   new String.prototype.sub();
-}, '`new String.prototype.sub()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/substr/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/substr/not-a-constructor.js
@@ -28,5 +28,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.substr();
-}, '`new String.prototype.substr()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/String/prototype/sup/not-a-constructor.js
+++ b/test/annexB/built-ins/String/prototype/sup/not-a-constructor.js
@@ -24,5 +24,5 @@ assert.sameValue(isConstructor(String.prototype.sup), false, 'isConstructor(Stri
 
 assert.throws(TypeError, () => {
   new String.prototype.sup();
-}, '`new String.prototype.sup()` throws TypeError');
+});
 

--- a/test/annexB/built-ins/escape/not-a-constructor.js
+++ b/test/annexB/built-ins/escape/not-a-constructor.js
@@ -24,5 +24,5 @@ assert.sameValue(isConstructor(escape), false, 'isConstructor(escape) must retur
 
 assert.throws(TypeError, () => {
   new escape('');
-}, '`new escape(\'\')` throws TypeError');
+});
 

--- a/test/annexB/built-ins/unescape/not-a-constructor.js
+++ b/test/annexB/built-ins/unescape/not-a-constructor.js
@@ -24,5 +24,5 @@ assert.sameValue(isConstructor(unescape), false, 'isConstructor(unescape) must r
 
 assert.throws(TypeError, () => {
   new unescape('');
-}, '`new unescape(\'\')` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/Symbol.iterator/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/Symbol.iterator/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype[Symbol.iterator]();
-}, '`new Array.prototype[Symbol.iterator]()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/copyWithin/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/copyWithin/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.copyWithin();
-}, '`new Array.prototype.copyWithin()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/entries/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/entries/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.entries();
-}, '`new Array.prototype.entries()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/every/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/every/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.every(() => {});
-}, '`new Array.prototype.every(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/fill/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/fill/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.fill), false, 'isConstructor(Arra
 
 assert.throws(TypeError, () => {
   new Array.prototype.fill();
-}, '`new Array.prototype.fill()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/filter/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/filter/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.filter(() => {});
-}, '`new Array.prototype.filter(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/find/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/find/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.find), false, 'isConstructor(Arra
 
 assert.throws(TypeError, () => {
   new Array.prototype.find(() => {});
-}, '`new Array.prototype.find(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/findIndex/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/findIndex/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.findIndex(() => {});
-}, '`new Array.prototype.findIndex(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/findLast/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/findLast/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.findLast), false, 'isConstructor(
 
 assert.throws(TypeError, () => {
   new Array.prototype.findLast(() => {});
-}, '`new Array.prototype.findLast(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/findLastIndex/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/findLastIndex/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.findLastIndex(() => {});
-}, '`new Array.prototype.findLastIndex(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/flat/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/flat/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.flat), false, 'isConstructor(Arra
 
 assert.throws(TypeError, () => {
   new Array.prototype.flat();
-}, '`new Array.prototype.flat()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/flatMap/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/flatMap/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.flatMap(() => {});
-}, '`new Array.prototype.flatMap(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/forEach/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/forEach/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.forEach(() => {});
-}, '`new Array.prototype.forEach(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/includes/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/includes/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.includes(1);
-}, '`new Array.prototype.includes(1)` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/indexOf/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/indexOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.indexOf();
-}, '`new Array.prototype.indexOf()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/join/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/join/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.join), false, 'isConstructor(Arra
 
 assert.throws(TypeError, () => {
   new Array.prototype.join();
-}, '`new Array.prototype.join()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/keys/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/keys/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.keys), false, 'isConstructor(Arra
 
 assert.throws(TypeError, () => {
   new Array.prototype.keys();
-}, '`new Array.prototype.keys()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/lastIndexOf/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.lastIndexOf();
-}, '`new Array.prototype.lastIndexOf()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/map/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/map/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.map), false, 'isConstructor(Array
 
 assert.throws(TypeError, () => {
   new Array.prototype.map(() => {});
-}, '`new Array.prototype.map(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/pop/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/pop/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.pop), false, 'isConstructor(Array
 
 assert.throws(TypeError, () => {
   new Array.prototype.pop();
-}, '`new Array.prototype.pop()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/push/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/push/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.push), false, 'isConstructor(Arra
 
 assert.throws(TypeError, () => {
   new Array.prototype.push();
-}, '`new Array.prototype.push()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/reduce/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/reduce/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.reduce(() => {}, []);
-}, '`new Array.prototype.reduce(() => {}, [])` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/reduceRight/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/reduceRight/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.reduceRight(() => {}, []);
-}, '`new Array.prototype.reduceRight(() => {}, [])` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/reverse/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/reverse/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.reverse();
-}, '`new Array.prototype.reverse()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/shift/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/shift/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.shift();
-}, '`new Array.prototype.shift()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/slice/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/slice/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.slice();
-}, '`new Array.prototype.slice()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/some/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/some/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.some), false, 'isConstructor(Arra
 
 assert.throws(TypeError, () => {
   new Array.prototype.some(() => {});
-}, '`new Array.prototype.some(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/sort/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/sort/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Array.prototype.sort), false, 'isConstructor(Arra
 
 assert.throws(TypeError, () => {
   new Array.prototype.sort();
-}, '`new Array.prototype.sort()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/splice/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/splice/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.splice();
-}, '`new Array.prototype.splice()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/toLocaleString/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/toLocaleString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.toLocaleString();
-}, '`new Array.prototype.toLocaleString()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/toReversed/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/toReversed/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.toReversed();
-}, '`new Array.prototype.toReversed()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/toReversed/this-value-nullish.js
+++ b/test/built-ins/Array/prototype/toReversed/this-value-nullish.js
@@ -15,8 +15,8 @@ features: [change-array-by-copy]
 
 assert.throws(TypeError, () => {
   Array.prototype.toReversed.call(null);
-}, '`Array.prototype.toReversed.call(null)` throws TypeError');
+});
 
 assert.throws(TypeError, () => {
   Array.prototype.toReversed.call(undefined);
-}, '`Array.prototype.toReversed.call(undefined)` throws TypeError');
+});

--- a/test/built-ins/Array/prototype/toSorted/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/toSorted/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.toSorted();
-}, '`new Array.prototype.toSorted()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/toSorted/this-value-nullish.js
+++ b/test/built-ins/Array/prototype/toSorted/this-value-nullish.js
@@ -15,8 +15,8 @@ features: [change-array-by-copy]
 
 assert.throws(TypeError, () => {
   Array.prototype.toSorted.call(null);
-}, '`Array.prototype.toSorted.call(null)` throws TypeError');
+});
 
 assert.throws(TypeError, () => {
   Array.prototype.toSorted.call(undefined);
-}, '`Array.prototype.toSorted.call(undefined)` throws TypeError');
+});

--- a/test/built-ins/Array/prototype/toSpliced/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/toSpliced/not-a-constructor.js
@@ -29,4 +29,4 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.toSpliced();
-}, '`new Array.prototype.toSpliced()` throws TypeError');
+});

--- a/test/built-ins/Array/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/toString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.toString();
-}, '`new Array.prototype.toString()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/unshift/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/unshift/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.unshift();
-}, '`new Array.prototype.unshift()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/values/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/values/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.values();
-}, '`new Array.prototype.values()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/with/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/with/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Array.prototype.with();
-}, '`new Array.prototype.with()` throws TypeError');
+});
 

--- a/test/built-ins/Array/prototype/with/this-value-nullish.js
+++ b/test/built-ins/Array/prototype/with/this-value-nullish.js
@@ -15,8 +15,8 @@ features: [change-array-by-copy]
 
 assert.throws(TypeError, () => {
   Array.prototype.with.call(null, 0, 0);
-}, '`Array.prototype.with.call(null, 0, 0)` throws TypeError');
+});
 
 assert.throws(TypeError, () => {
   Array.prototype.with.call(undefined, 0, 0);
-}, '`Array.prototype.with.call(undefined, 0, 0)` throws TypeError');
+});

--- a/test/built-ins/ArrayBuffer/isView/not-a-constructor.js
+++ b/test/built-ins/ArrayBuffer/isView/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(ArrayBuffer.isView), false, 'isConstructor(ArrayB
 
 assert.throws(TypeError, () => {
   new ArrayBuffer.isView();
-}, '`new ArrayBuffer.isView()` throws TypeError');
+});
 

--- a/test/built-ins/ArrayBuffer/prototype/slice/not-a-constructor.js
+++ b/test/built-ins/ArrayBuffer/prototype/slice/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let ab = new ArrayBuffer(); new ab.slice();
-}, '`let ab = new ArrayBuffer(); new ab.slice()` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/add/bad-range.js
+++ b/test/built-ins/Atomics/add/bad-range.js
@@ -17,6 +17,6 @@ testWithTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.add(view, IdxGen(view), 10);
-    }, '`Atomics.add(view, IdxGen(view), 10)` throws RangeError');
+    });
   });
 }, views);

--- a/test/built-ins/Atomics/add/bigint/bad-range.js
+++ b/test/built-ins/Atomics/add/bigint/bad-range.js
@@ -15,6 +15,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.add(view, IdxGen(view), 10n);
-    }, '`Atomics.add(view, IdxGen(view), 10n)` throws RangeError');
+    });
   });
 });

--- a/test/built-ins/Atomics/add/non-views.js
+++ b/test/built-ins/Atomics/add/non-views.js
@@ -12,5 +12,5 @@ features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray
 testWithAtomicsNonViewValues(function(view) {
   assert.throws(TypeError, function() {
     Atomics.add(view, 0, 0);
-  }, '`Atomics.add(view, 0, 0)` throws TypeError');
+  });
 });

--- a/test/built-ins/Atomics/add/not-a-constructor.js
+++ b/test/built-ins/Atomics/add/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Atomics.add), false, 'isConstructor(Atomics.add) 
 
 assert.throws(TypeError, () => {
   new Atomics.add(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.add(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/and/bad-range.js
+++ b/test/built-ins/Atomics/and/bad-range.js
@@ -17,6 +17,6 @@ testWithTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.and(view, IdxGen(view), 10);
-    }, '`Atomics.and(view, IdxGen(view), 10)` throws RangeError');
+    });
   });
 }, views);

--- a/test/built-ins/Atomics/and/bigint/bad-range.js
+++ b/test/built-ins/Atomics/and/bigint/bad-range.js
@@ -15,6 +15,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.and(view, IdxGen(view), 10n);
-    }, '`Atomics.and(view, IdxGen(view), 10n)` throws RangeError');
+    });
   });
 });

--- a/test/built-ins/Atomics/and/non-views.js
+++ b/test/built-ins/Atomics/and/non-views.js
@@ -12,5 +12,5 @@ features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray
 testWithAtomicsNonViewValues(function(view) {
   assert.throws(TypeError, function() {
     Atomics.and(view, 0, 0);
-  }, '`Atomics.and(view, 0, 0)` throws TypeError');
+  });
 });

--- a/test/built-ins/Atomics/and/not-a-constructor.js
+++ b/test/built-ins/Atomics/and/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Atomics.and), false, 'isConstructor(Atomics.and) 
 
 assert.throws(TypeError, () => {
   new Atomics.and(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.and(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/compareExchange/bad-range.js
+++ b/test/built-ins/Atomics/compareExchange/bad-range.js
@@ -17,6 +17,6 @@ testWithTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.compareExchange(view, IdxGen(view), 10, 0);
-    }, '`Atomics.compareExchange(view, IdxGen(view), 10, 0)` throws RangeError');
+    });
   });
 }, views);

--- a/test/built-ins/Atomics/compareExchange/bigint/bad-range.js
+++ b/test/built-ins/Atomics/compareExchange/bigint/bad-range.js
@@ -15,6 +15,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.compareExchange(view, IdxGen(view), 10, 0n);
-    }, '`Atomics.compareExchange(view, IdxGen(view), 10, 0n)` throws RangeError');
+    });
   });
 });

--- a/test/built-ins/Atomics/compareExchange/non-views.js
+++ b/test/built-ins/Atomics/compareExchange/non-views.js
@@ -12,5 +12,5 @@ features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray
 testWithAtomicsNonViewValues(function(view) {
   assert.throws(TypeError, function() {
     Atomics.compareExchange(view, 0, 0, 0);
-  }, '`Atomics.compareExchange(view, 0, 0, 0)` throws TypeError');
+  });
 });

--- a/test/built-ins/Atomics/compareExchange/not-a-constructor.js
+++ b/test/built-ins/Atomics/compareExchange/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Atomics.compareExchange(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.compareExchange(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/exchange/bad-range.js
+++ b/test/built-ins/Atomics/exchange/bad-range.js
@@ -17,6 +17,6 @@ testWithTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.exchange(view, IdxGen(view), 10, 0);
-    }, '`Atomics.exchange(view, IdxGen(view), 10, 0)` throws RangeError');
+    });
   });
 }, views);

--- a/test/built-ins/Atomics/exchange/bigint/bad-range.js
+++ b/test/built-ins/Atomics/exchange/bigint/bad-range.js
@@ -15,6 +15,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.exchange(view, IdxGen(view), 10n, 0n);
-    }, '`Atomics.exchange(view, IdxGen(view), 10n, 0n)` throws RangeError');
+    });
   });
 });

--- a/test/built-ins/Atomics/exchange/non-views.js
+++ b/test/built-ins/Atomics/exchange/non-views.js
@@ -12,5 +12,5 @@ features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray
 testWithAtomicsNonViewValues(function(view) {
   assert.throws(TypeError, function() {
     Atomics.exchange(view, 0, 0);
-  }, '`Atomics.exchange(view, 0, 0)` throws TypeError');
+  });
 });

--- a/test/built-ins/Atomics/exchange/not-a-constructor.js
+++ b/test/built-ins/Atomics/exchange/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Atomics.exchange), false, 'isConstructor(Atomics.
 
 assert.throws(TypeError, () => {
   new Atomics.exchange(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.exchange(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/isLockFree/not-a-constructor.js
+++ b/test/built-ins/Atomics/isLockFree/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Atomics.isLockFree), false, 'isConstructor(Atomic
 
 assert.throws(TypeError, () => {
   new Atomics.isLockFree(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.isLockFree(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/load/bad-range.js
+++ b/test/built-ins/Atomics/load/bad-range.js
@@ -17,6 +17,6 @@ testWithTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.load(view, IdxGen(view));
-    }, '`Atomics.load(view, IdxGen(view))` throws RangeError');
+    });
   });
 }, views);

--- a/test/built-ins/Atomics/load/bigint/bad-range.js
+++ b/test/built-ins/Atomics/load/bigint/bad-range.js
@@ -16,6 +16,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.load(view, IdxGen(view));
-    }, '`Atomics.load(view, IdxGen(view))` throws RangeError');
+    });
   });
 });

--- a/test/built-ins/Atomics/load/non-views.js
+++ b/test/built-ins/Atomics/load/non-views.js
@@ -12,5 +12,5 @@ features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray
 testWithAtomicsNonViewValues(function(view) {
   assert.throws(TypeError, function() {
     Atomics.load(view, 0);
-  }, '`Atomics.load(view, 0)` throws TypeError');
+  });
 });

--- a/test/built-ins/Atomics/load/not-a-constructor.js
+++ b/test/built-ins/Atomics/load/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Atomics.load), false, 'isConstructor(Atomics.load
 
 assert.throws(TypeError, () => {
   new Atomics.load(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.load(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/notify/bad-range.js
+++ b/test/built-ins/Atomics/notify/bad-range.js
@@ -22,5 +22,5 @@ const i32a = new Int32Array(
 testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
   assert.throws(RangeError, function() {
     Atomics.notify(i32a, IdxGen(i32a), 0);
-  }, '`Atomics.notify(i32a, IdxGen(i32a), 0)` throws RangeError');
+  });
 });

--- a/test/built-ins/Atomics/notify/bigint/bad-range.js
+++ b/test/built-ins/Atomics/notify/bigint/bad-range.js
@@ -22,5 +22,5 @@ const i64a = new BigInt64Array(
 testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
   assert.throws(RangeError, function() {
     Atomics.notify(i64a, IdxGen(i64a), 0);
-  }, '`Atomics.notify(i64a, IdxGen(i64a), 0)` throws RangeError');
+  });
 });

--- a/test/built-ins/Atomics/notify/bigint/non-bigint64-typedarray-throws.js
+++ b/test/built-ins/Atomics/notify/bigint/non-bigint64-typedarray-throws.js
@@ -27,8 +27,8 @@ const poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.wait(i64a, 0, 0);
-}, '`Atomics.wait(i64a, 0, 0)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(i64a, poisoned, poisoned);
-}, '`Atomics.wait(i64a, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/notify/bigint/non-shared-bufferdata-count-evaluation-throws.js
+++ b/test/built-ins/Atomics/notify/bigint/non-shared-bufferdata-count-evaluation-throws.js
@@ -30,4 +30,4 @@ const poisoned = {
 
 assert.throws(Test262Error, function() {
   Atomics.notify(i64a, poisoned, 0);
-}, '`Atomics.notify(i64a, poisoned, 0)` throws Test262Error');
+});

--- a/test/built-ins/Atomics/notify/bigint/non-shared-bufferdata-index-evaluation-throws.js
+++ b/test/built-ins/Atomics/notify/bigint/non-shared-bufferdata-index-evaluation-throws.js
@@ -27,6 +27,6 @@ const poisoned = {
 
 assert.throws(Test262Error, function() {
   Atomics.notify(i64a, 0, poisoned);
-}, '`Atomics.notify(i64a, 0, poisoned)` throws Test262Error');
+});
 
 

--- a/test/built-ins/Atomics/notify/bigint/non-shared-bufferdata-non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/notify/bigint/non-shared-bufferdata-non-shared-int-views-throws.js
@@ -18,4 +18,4 @@ const poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.notify(new BigUint64Array(nonsab), poisoned, poisoned);
-}, '`Atomics.notify(new BigUint64Array(nonsab), poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/notify/bigint/null-bufferdata-throws.js
+++ b/test/built-ins/Atomics/notify/bigint/null-bufferdata-throws.js
@@ -33,4 +33,4 @@ try {
 
 assert.throws(TypeError, function() {
   Atomics.notify(i64a, poisoned, poisoned);
-}, '`Atomics.notify(i64a, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/notify/count-symbol-throws.js
+++ b/test/built-ins/Atomics/notify/count-symbol-throws.js
@@ -23,4 +23,4 @@ const i32a = new Int32Array(
 
 assert.throws(TypeError, function() {
   Atomics.notify(i32a, 0, Symbol());
-}, '`Atomics.notify(i32a, 0, Symbol())` throws TypeError');
+});

--- a/test/built-ins/Atomics/notify/count-tointeger-throws-then-wake-throws.js
+++ b/test/built-ins/Atomics/notify/count-tointeger-throws-then-wake-throws.js
@@ -29,4 +29,4 @@ const poisoned = {
 
 assert.throws(Test262Error, function() {
   Atomics.notify(i32a, 0, poisoned);
-}, '`Atomics.notify(i32a, 0, poisoned)` throws Test262Error');
+});

--- a/test/built-ins/Atomics/notify/negative-index-throws.js
+++ b/test/built-ins/Atomics/notify/negative-index-throws.js
@@ -28,13 +28,13 @@ const poisoned = {
 
 assert.throws(RangeError, function() {
   Atomics.notify(i32a, -Infinity, poisoned);
-}, '`Atomics.notify(i32a, -Infinity, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.notify(i32a, -7.999, poisoned);
-}, '`Atomics.notify(i32a, -7.999, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.notify(i32a, -1, poisoned);
-}, '`Atomics.notify(i32a, -1, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.notify(i32a, -300, poisoned);
-}, '`Atomics.notify(i32a, -300, poisoned)` throws RangeError');
+});

--- a/test/built-ins/Atomics/notify/non-int32-typedarray-throws.js
+++ b/test/built-ins/Atomics/notify/non-int32-typedarray-throws.js
@@ -26,14 +26,14 @@ assert.throws(TypeError, function() {
     new SharedArrayBuffer(Float64Array.BYTES_PER_ELEMENT * 8)
   );
   Atomics.notify(view, poisoned, poisoned);
-}, '`const view = new Float64Array( new SharedArrayBuffer(Float64Array.BYTES_PER_ELEMENT * 8) ); Atomics.notify(view, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Float32Array(
     new SharedArrayBuffer(Float32Array.BYTES_PER_ELEMENT * 4)
   );
   Atomics.notify(view, poisoned, poisoned);
-}, '`const view = new Float32Array( new SharedArrayBuffer(Float32Array.BYTES_PER_ELEMENT * 4) ); Atomics.notify(view, poisoned, poisoned)` throws TypeError');
+});
 
 if (typeof Float16Array !== 'undefined') {
   assert.throws(TypeError, function() {
@@ -41,7 +41,7 @@ if (typeof Float16Array !== 'undefined') {
       new SharedArrayBuffer(Float16Array.BYTES_PER_ELEMENT * 2)
     );
     Atomics.notify(view, poisoned, poisoned);
-  }, '`const view = new Float16Array( new SharedArrayBuffer(Float16Array.BYTES_PER_ELEMENT * 2) ); Atomics.notify(view, poisoned, poisoned)` throws TypeError');
+  });
 }
 
 assert.throws(TypeError, function() {
@@ -49,39 +49,39 @@ assert.throws(TypeError, function() {
     new SharedArrayBuffer(Int16Array.BYTES_PER_ELEMENT * 2)
   );
   Atomics.notify(view, poisoned, poisoned);
-}, '`const view = new Int16Array( new SharedArrayBuffer(Int16Array.BYTES_PER_ELEMENT * 2) ); Atomics.notify(view, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Int8Array(
     new SharedArrayBuffer(Int8Array.BYTES_PER_ELEMENT)
   );
   Atomics.notify(view, poisoned, poisoned);
-}, '`const view = new Int8Array( new SharedArrayBuffer(Int8Array.BYTES_PER_ELEMENT) ); Atomics.notify(view, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Uint32Array(
     new SharedArrayBuffer(Uint32Array.BYTES_PER_ELEMENT * 4)
   );
   Atomics.notify(new Uint32Array(),  poisoned, poisoned);
-}, '`const view = new Uint32Array( new SharedArrayBuffer(Uint32Array.BYTES_PER_ELEMENT * 4) ); Atomics.notify(new Uint32Array(), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Uint16Array(
     new SharedArrayBuffer(Uint16Array.BYTES_PER_ELEMENT * 2)
   );
   Atomics.notify(view, poisoned, poisoned);
-}, '`const view = new Uint16Array( new SharedArrayBuffer(Uint16Array.BYTES_PER_ELEMENT * 2) ); Atomics.notify(view, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Uint8Array(
     new SharedArrayBuffer(Uint8Array.BYTES_PER_ELEMENT)
   );
   Atomics.notify(view, poisoned, poisoned);
-}, '`const view = new Uint8Array( new SharedArrayBuffer(Uint8Array.BYTES_PER_ELEMENT) ); Atomics.notify(view, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Uint8ClampedArray(
     new SharedArrayBuffer(Uint8ClampedArray.BYTES_PER_ELEMENT)
   );
   Atomics.notify(view, poisoned, poisoned);
-}, '`const view = new Uint8ClampedArray( new SharedArrayBuffer(Uint8ClampedArray.BYTES_PER_ELEMENT) ); Atomics.notify(view, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/notify/non-shared-bufferdata-count-evaluation-throws.js
+++ b/test/built-ins/Atomics/notify/non-shared-bufferdata-count-evaluation-throws.js
@@ -31,6 +31,6 @@ const poisoned = {
 
 assert.throws(Test262Error, function() {
   Atomics.notify(i32a, 0, poisoned);
-}, '`Atomics.notify(i32a, 0, poisoned)` throws Test262Error');
+});
 
 

--- a/test/built-ins/Atomics/notify/non-shared-bufferdata-index-evaluation-throws.js
+++ b/test/built-ins/Atomics/notify/non-shared-bufferdata-index-evaluation-throws.js
@@ -27,6 +27,6 @@ const poisoned = {
 
 assert.throws(Test262Error, function() {
   Atomics.notify(i32a, poisoned, 0);
-}, '`Atomics.notify(i32a, poisoned, 0)` throws Test262Error');
+});
 
 

--- a/test/built-ins/Atomics/notify/non-shared-bufferdata-non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/notify/non-shared-bufferdata-non-shared-int-views-throws.js
@@ -18,24 +18,24 @@ const poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Int16Array(nonsab), poisoned, poisoned);
-}, '`Atomics.notify(new Int16Array(nonsab), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Int8Array(nonsab), poisoned, poisoned);
-}, '`Atomics.notify(new Int8Array(nonsab), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Uint32Array(nonsab), poisoned, poisoned);
-}, '`Atomics.notify(new Uint32Array(nonsab), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Uint16Array(nonsab), poisoned, poisoned);
-}, '`Atomics.notify(new Uint16Array(nonsab), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Uint8Array(nonsab), poisoned, poisoned);
-}, '`Atomics.notify(new Uint8Array(nonsab), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Uint8ClampedArray(nonsab), poisoned, poisoned);
-}, '`Atomics.notify(new Uint8ClampedArray(nonsab), poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/notify/non-shared-int-views.js
+++ b/test/built-ins/Atomics/notify/non-shared-int-views.js
@@ -18,24 +18,24 @@ const poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Int16Array(sab), poisoned, poisoned);
-}, '`Atomics.notify(new Int16Array(sab), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Int8Array(sab), poisoned, poisoned);
-}, '`Atomics.notify(new Int8Array(sab), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Uint32Array(sab),  poisoned, poisoned);
-}, '`Atomics.notify(new Uint32Array(sab), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Uint16Array(sab), poisoned, poisoned);
-}, '`Atomics.notify(new Uint16Array(sab), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Uint8Array(sab), poisoned, poisoned);
-}, '`Atomics.notify(new Uint8Array(sab), poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(new Uint8ClampedArray(sab), poisoned, poisoned);
-}, '`Atomics.notify(new Uint8ClampedArray(sab), poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/notify/non-views.js
+++ b/test/built-ins/Atomics/notify/non-views.js
@@ -12,5 +12,5 @@ features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray
 testWithAtomicsNonViewValues(function(nonView) {
   assert.throws(TypeError, function() {
     Atomics.notify(nonView, 0, 0);
-  }, '`Atomics.notify(nonView, 0, 0)` throws TypeError'); // Even with count == 0
+  }); // Even with count == 0
 });

--- a/test/built-ins/Atomics/notify/not-a-constructor.js
+++ b/test/built-ins/Atomics/notify/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Atomics.notify), false, 'isConstructor(Atomics.no
 
 assert.throws(TypeError, () => {
   new Atomics.notify(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.notify(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/notify/not-a-typedarray-throws.js
+++ b/test/built-ins/Atomics/notify/not-a-typedarray-throws.js
@@ -22,8 +22,8 @@ const poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.wait({}, 0, 0, 0);
-}, '`Atomics.wait({}, 0, 0, 0)` throws TypeError');
+});
 
 assert.throws(TypeError, function () {
   Atomics.wait({}, poisoned, poisoned, poisoned);
-}, '`Atomics.wait({}, poisoned, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/notify/not-an-object-throws.js
+++ b/test/built-ins/Atomics/notify/not-an-object-throws.js
@@ -21,28 +21,28 @@ const poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.notify(null, poisoned, poisoned);
-}, '`Atomics.notify(null, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(undefined, poisoned, poisoned);
-}, '`Atomics.notify(undefined, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(true, poisoned, poisoned);
-}, '`Atomics.notify(true, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(false, poisoned, poisoned);
-}, '`Atomics.notify(false, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify('***string***', poisoned, poisoned);
-}, '`Atomics.notify(\'***string***\', poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(Number.NEGATIVE_INFINITY, poisoned, poisoned);
-}, '`Atomics.notify(Number.NEGATIVE_INFINITY, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(Symbol('***symbol***'), poisoned, poisoned);
-}, '`Atomics.notify(Symbol(\'***symbol***\'), poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/notify/null-bufferdata-throws.js
+++ b/test/built-ins/Atomics/notify/null-bufferdata-throws.js
@@ -40,4 +40,4 @@ try {
 
 assert.throws(TypeError, function() {
   Atomics.notify(i32a, poisoned, poisoned);
-}, '`Atomics.notify(i32a, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/notify/out-of-range-index-throws.js
+++ b/test/built-ins/Atomics/notify/out-of-range-index-throws.js
@@ -28,10 +28,10 @@ var poisoned = {
 
 assert.throws(RangeError, function() {
   Atomics.notify(i32a, Infinity, poisoned);
-}, '`Atomics.notify(i32a, Infinity, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.notify(i32a, 4, poisoned);
-}, '`Atomics.notify(i32a, 4, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.notify(i32a, 200, poisoned);
-}, '`Atomics.notify(i32a, 200, poisoned)` throws RangeError');
+});

--- a/test/built-ins/Atomics/notify/symbol-for-index-throws.js
+++ b/test/built-ins/Atomics/notify/symbol-for-index-throws.js
@@ -46,16 +46,16 @@ const poisonedToPrimitive = {
 
 assert.throws(Test262Error, function() {
   Atomics.notify(i32a, poisonedValueOf, poisonedValueOf);
-}, '`Atomics.notify(i32a, poisonedValueOf, poisonedValueOf)` throws Test262Error');
+});
 
 assert.throws(Test262Error, function() {
   Atomics.notify(i32a, poisonedToPrimitive, poisonedToPrimitive);
-}, '`Atomics.notify(i32a, poisonedToPrimitive, poisonedToPrimitive)` throws Test262Error');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(i32a, Symbol("foo"), poisonedValueOf);
-}, '`Atomics.notify(i32a, Symbol("foo"), poisonedValueOf)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.notify(i32a, Symbol("foo"), poisonedToPrimitive);
-}, '`Atomics.notify(i32a, Symbol("foo"), poisonedToPrimitive)` throws TypeError');
+});

--- a/test/built-ins/Atomics/or/bad-range.js
+++ b/test/built-ins/Atomics/or/bad-range.js
@@ -17,6 +17,6 @@ testWithTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.or(view, IdxGen(view), 10);
-    }, '`Atomics.or(view, IdxGen(view), 10)` throws RangeError');
+    });
   });
 }, views);

--- a/test/built-ins/Atomics/or/bigint/bad-range.js
+++ b/test/built-ins/Atomics/or/bigint/bad-range.js
@@ -15,6 +15,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.or(view, IdxGen(view), 10n);
-    }, '`Atomics.or(view, IdxGen(view), 10n)` throws RangeError');
+    });
   });
 });

--- a/test/built-ins/Atomics/or/non-views.js
+++ b/test/built-ins/Atomics/or/non-views.js
@@ -12,5 +12,5 @@ features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray
 testWithAtomicsNonViewValues(function(view) {
   assert.throws(TypeError, function() {
     Atomics.or(view, 0, 0);
-  }, '`Atomics.or(view, 0, 0)` throws TypeError');
+  });
 });

--- a/test/built-ins/Atomics/or/not-a-constructor.js
+++ b/test/built-ins/Atomics/or/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Atomics.or), false, 'isConstructor(Atomics.or) mu
 
 assert.throws(TypeError, () => {
   new Atomics.or(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.or(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/prop-desc.js
+++ b/test/built-ins/Atomics/prop-desc.js
@@ -28,11 +28,11 @@ assert.sameValue(typeof Atomics, "object", 'The value of `typeof Atomics` is "ob
 
 assert.throws(TypeError, function() {
   Atomics();
-}, '`Atomics()` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   new Atomics();
-}, '`new Atomics()` throws TypeError');
+});
 
 verifyProperty(this, "Atomics", {
   enumerable: false,

--- a/test/built-ins/Atomics/store/bad-range.js
+++ b/test/built-ins/Atomics/store/bad-range.js
@@ -17,6 +17,6 @@ testWithTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.store(view, IdxGen(view), 10);
-    }, '`Atomics.store(view, IdxGen(view), 10)` throws RangeError');
+    });
   });
 }, views);

--- a/test/built-ins/Atomics/store/bigint/bad-range.js
+++ b/test/built-ins/Atomics/store/bigint/bad-range.js
@@ -15,6 +15,6 @@ testWithBigIntTypedArrayConstructors(TA => {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.store(view, IdxGen(view), 10n);
-    }, '`Atomics.store(view, IdxGen(view), 10n)` throws RangeError');
+    });
   });
 });

--- a/test/built-ins/Atomics/store/non-views.js
+++ b/test/built-ins/Atomics/store/non-views.js
@@ -12,5 +12,5 @@ features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray
 testWithAtomicsNonViewValues(function(view) {
   assert.throws(TypeError, function() {
     Atomics.store(view, 0, 0);
-  }, '`Atomics.store(view, 0, 0)` throws TypeError');
+  });
 });

--- a/test/built-ins/Atomics/store/not-a-constructor.js
+++ b/test/built-ins/Atomics/store/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Atomics.store), false, 'isConstructor(Atomics.sto
 
 assert.throws(TypeError, () => {
   new Atomics.store(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.store(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/sub/bad-range.js
+++ b/test/built-ins/Atomics/sub/bad-range.js
@@ -17,6 +17,6 @@ testWithTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.sub(view, IdxGen(view), 10);
-    }, '`Atomics.sub(view, IdxGen(view), 10)` throws RangeError');
+    });
   });
 }, views);

--- a/test/built-ins/Atomics/sub/bigint/bad-range.js
+++ b/test/built-ins/Atomics/sub/bigint/bad-range.js
@@ -15,6 +15,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.sub(view, IdxGen(view), 10n);
-    }, '`Atomics.sub(view, IdxGen(view), 10n)` throws RangeError');
+    });
   });
 });

--- a/test/built-ins/Atomics/sub/non-views.js
+++ b/test/built-ins/Atomics/sub/non-views.js
@@ -12,5 +12,5 @@ features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray
 testWithAtomicsNonViewValues(function(view) {
   assert.throws(TypeError, function() {
     Atomics.sub(view, 0, 0);
-  }, '`Atomics.sub(view, 0, 0)` throws TypeError');
+  });
 });

--- a/test/built-ins/Atomics/sub/not-a-constructor.js
+++ b/test/built-ins/Atomics/sub/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Atomics.sub), false, 'isConstructor(Atomics.sub) 
 
 assert.throws(TypeError, () => {
   new Atomics.sub(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.sub(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/Atomics/wait/bad-range.js
+++ b/test/built-ins/Atomics/wait/bad-range.js
@@ -22,5 +22,5 @@ const i32a = new Int32Array(
 testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
   assert.throws(RangeError, function() {
     Atomics.wait(i32a, IdxGen(i32a), 0, 0);
-  }, '`Atomics.wait(i32a, IdxGen(i32a), 0, 0)` throws RangeError');
+  });
 });

--- a/test/built-ins/Atomics/wait/bigint/bad-range.js
+++ b/test/built-ins/Atomics/wait/bigint/bad-range.js
@@ -22,5 +22,5 @@ const i64a = new BigInt64Array(
 testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
   assert.throws(RangeError, function() {
     Atomics.wait(i64a, IdxGen(i64a), 0n, 0);
-  }, '`Atomics.wait(i64a, IdxGen(i64a), 0n, 0)` throws RangeError');
+  });
 });

--- a/test/built-ins/Atomics/wait/bigint/cannot-suspend-throws.js
+++ b/test/built-ins/Atomics/wait/bigint/cannot-suspend-throws.js
@@ -21,4 +21,4 @@ const i64a = new BigInt64Array(new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELE
 
 assert.throws(TypeError, function() {
   Atomics.wait(i64a, 0, 0n, 0);
-}, '`Atomics.wait(i64a, 0, 0n, 0)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/bigint/negative-index-throws.js
+++ b/test/built-ins/Atomics/wait/bigint/negative-index-throws.js
@@ -27,13 +27,13 @@ const poisoned = {
 
 assert.throws(RangeError, function() {
   Atomics.wait(i64a, -Infinity, poisoned, poisoned);
-}, '`Atomics.wait(i64a, -Infinity, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i64a, -7.999, poisoned, poisoned);
-}, '`Atomics.wait(i64a, -7.999, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i64a, -1, poisoned, poisoned);
-}, '`Atomics.wait(i64a, -1, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i64a, -300, poisoned, poisoned);
-}, '`Atomics.wait(i64a, -300, poisoned, poisoned)` throws RangeError');
+});

--- a/test/built-ins/Atomics/wait/bigint/non-bigint64-typedarray-throws.js
+++ b/test/built-ins/Atomics/wait/bigint/non-bigint64-typedarray-throws.js
@@ -34,8 +34,8 @@ const poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.wait(i64a, 0, 0n, 0);
-}, '`Atomics.wait(i64a, 0, 0n, 0)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(i64a, poisoned, poisoned, poisoned);
-}, '`Atomics.wait(i64a, poisoned, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/bigint/non-shared-bufferdata-throws.js
+++ b/test/built-ins/Atomics/wait/bigint/non-shared-bufferdata-throws.js
@@ -24,8 +24,8 @@ const poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.wait(i64a, 0, 0n, 0);
-}, '`Atomics.wait(i64a, 0, 0n, 0)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(i64a, poisoned, poisoned, poisoned);
-}, '`Atomics.wait(i64a, poisoned, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/bigint/null-bufferdata-throws.js
+++ b/test/built-ins/Atomics/wait/bigint/null-bufferdata-throws.js
@@ -42,4 +42,4 @@ try {
 
 assert.throws(TypeError, function() {
   Atomics.wait(i64a, poisoned, poisoned, poisoned);
-}, '`Atomics.wait(i64a, poisoned, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/bigint/out-of-range-index-throws.js
+++ b/test/built-ins/Atomics/wait/bigint/out-of-range-index-throws.js
@@ -28,10 +28,10 @@ const poisoned = {
 
 assert.throws(RangeError, function() {
   Atomics.wait(i64a, Infinity, poisoned, poisoned);
-}, '`Atomics.wait(i64a, Infinity, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i64a, 8, poisoned, poisoned);
-}, '`Atomics.wait(i64a, 8, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i64a, 200, poisoned, poisoned);
-}, '`Atomics.wait(i64a, 200, poisoned, poisoned)` throws RangeError');
+});

--- a/test/built-ins/Atomics/wait/cannot-suspend-throws.js
+++ b/test/built-ins/Atomics/wait/cannot-suspend-throws.js
@@ -24,4 +24,4 @@ const i32a = new Int32Array(
 
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, 0, 0, 0);
-}, '`Atomics.wait(i32a, 0, 0, 0)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/negative-index-throws.js
+++ b/test/built-ins/Atomics/wait/negative-index-throws.js
@@ -29,13 +29,13 @@ const poisoned = {
 
 assert.throws(RangeError, function() {
   Atomics.wait(i32a, -Infinity, poisoned, poisoned);
-}, '`Atomics.wait(i32a, -Infinity, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i32a, -7.999, poisoned, poisoned);
-}, '`Atomics.wait(i32a, -7.999, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i32a, -1, poisoned, poisoned);
-}, '`Atomics.wait(i32a, -1, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i32a, -300, poisoned, poisoned);
-}, '`Atomics.wait(i32a, -300, poisoned, poisoned)` throws RangeError');
+});

--- a/test/built-ins/Atomics/wait/non-int32-typedarray-throws.js
+++ b/test/built-ins/Atomics/wait/non-int32-typedarray-throws.js
@@ -26,14 +26,14 @@ assert.throws(TypeError, function() {
     new SharedArrayBuffer(Float64Array.BYTES_PER_ELEMENT * 8)
   );
   Atomics.wait(view, poisoned, poisoned, poisoned);
-}, '`const view = new Float64Array( new SharedArrayBuffer(Float64Array.BYTES_PER_ELEMENT * 8) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Float32Array(
     new SharedArrayBuffer(Float32Array.BYTES_PER_ELEMENT * 4)
   );
   Atomics.wait(view, poisoned, poisoned, poisoned);
-}, '`const view = new Float32Array( new SharedArrayBuffer(Float32Array.BYTES_PER_ELEMENT * 4) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 if (typeof Float16Array !== 'undefined') {
   assert.throws(TypeError, function() {
@@ -41,7 +41,7 @@ if (typeof Float16Array !== 'undefined') {
       new SharedArrayBuffer(Float16Array.BYTES_PER_ELEMENT * 2)
     );
     Atomics.wait(view, poisoned, poisoned, poisoned);
-  }, '`const view = new Float16Array( new SharedArrayBuffer(Float16Array.BYTES_PER_ELEMENT * 2) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
+  });
 }
 
 assert.throws(TypeError, function() {
@@ -49,39 +49,39 @@ assert.throws(TypeError, function() {
     new SharedArrayBuffer(Int16Array.BYTES_PER_ELEMENT * 2)
   );
   Atomics.wait(view, poisoned, poisoned, poisoned);
-}, '`const view = new Int16Array( new SharedArrayBuffer(Int16Array.BYTES_PER_ELEMENT * 2) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Int8Array(
     new SharedArrayBuffer(Int8Array.BYTES_PER_ELEMENT)
   );
   Atomics.wait(view, poisoned, poisoned, poisoned);
-}, '`const view = new Int8Array( new SharedArrayBuffer(Int8Array.BYTES_PER_ELEMENT) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Uint32Array(
     new SharedArrayBuffer(Uint32Array.BYTES_PER_ELEMENT * 4)
   );
   Atomics.wait(view, poisoned, poisoned, poisoned);
-}, '`const view = new Uint32Array( new SharedArrayBuffer(Uint32Array.BYTES_PER_ELEMENT * 4) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Uint16Array(
     new SharedArrayBuffer(Uint16Array.BYTES_PER_ELEMENT * 2)
   );
   Atomics.wait(view, poisoned, poisoned, poisoned);
-}, '`const view = new Uint16Array( new SharedArrayBuffer(Uint16Array.BYTES_PER_ELEMENT * 2) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Uint8Array(
     new SharedArrayBuffer(Uint8Array.BYTES_PER_ELEMENT)
   );
   Atomics.wait(view, poisoned, poisoned, poisoned);
-}, '`const view = new Uint8Array( new SharedArrayBuffer(Uint8Array.BYTES_PER_ELEMENT) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   const view = new Uint8ClampedArray(
     new SharedArrayBuffer(Uint8ClampedArray.BYTES_PER_ELEMENT)
   );
   Atomics.wait(view, poisoned, poisoned, poisoned);
-}, '`const view = new Uint8ClampedArray( new SharedArrayBuffer(Uint8ClampedArray.BYTES_PER_ELEMENT) ); Atomics.wait(view, poisoned, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/non-shared-bufferdata-throws.js
+++ b/test/built-ins/Atomics/wait/non-shared-bufferdata-throws.js
@@ -27,8 +27,8 @@ const poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, 0, 0, 0);
-}, '`Atomics.wait(i32a, 0, 0, 0)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, poisoned, poisoned, poisoned);
-}, '`Atomics.wait(i32a, poisoned, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/not-a-typedarray-throws.js
+++ b/test/built-ins/Atomics/wait/not-a-typedarray-throws.js
@@ -22,8 +22,8 @@ var poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.wait({}, 0, 0, 0);
-}, '`Atomics.wait({}, 0, 0, 0)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait({}, poisoned, poisoned, poisoned);
-}, '`Atomics.wait({}, poisoned, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/not-an-object-throws.js
+++ b/test/built-ins/Atomics/wait/not-an-object-throws.js
@@ -21,28 +21,28 @@ var poisoned = {
 
 assert.throws(TypeError, function() {
   Atomics.wait(null, poisoned, poisoned, poisoned);
-}, '`Atomics.wait(null, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(undefined, poisoned, poisoned, poisoned);
-}, '`Atomics.wait(undefined, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(true, poisoned, poisoned, poisoned);
-}, '`Atomics.wait(true, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(false, poisoned, poisoned, poisoned);
-}, '`Atomics.wait(false, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait('***string***', poisoned, poisoned, poisoned);
-}, '`Atomics.wait(\'***string***\', poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(Number.NEGATIVE_INFINITY, poisoned, poisoned, poisoned);
-}, '`Atomics.wait(Number.NEGATIVE_INFINITY, poisoned, poisoned, poisoned)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(Symbol('***symbol***'), poisoned, poisoned, poisoned);
-}, '`Atomics.wait(Symbol(\'***symbol***\'), poisoned, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/null-bufferdata-throws.js
+++ b/test/built-ins/Atomics/wait/null-bufferdata-throws.js
@@ -40,4 +40,4 @@ try {
 
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, poisoned, poisoned, poisoned);
-}, '`Atomics.wait(i32a, poisoned, poisoned, poisoned)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/out-of-range-index-throws.js
+++ b/test/built-ins/Atomics/wait/out-of-range-index-throws.js
@@ -28,13 +28,13 @@ const poisoned = {
 
 assert.throws(RangeError, function() {
   Atomics.wait(i32a, Infinity, poisoned, poisoned);
-}, '`Atomics.wait(i32a, Infinity, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i32a, -1, poisoned, poisoned);
-}, '`Atomics.wait(i32a, -1, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i32a, 4, poisoned, poisoned);
-}, '`Atomics.wait(i32a, 4, poisoned, poisoned)` throws RangeError');
+});
 assert.throws(RangeError, function() {
   Atomics.wait(i32a, 200, poisoned, poisoned);
-}, '`Atomics.wait(i32a, 200, poisoned, poisoned)` throws RangeError');
+});

--- a/test/built-ins/Atomics/wait/poisoned-object-for-timeout-throws.js
+++ b/test/built-ins/Atomics/wait/poisoned-object-for-timeout-throws.js
@@ -36,8 +36,8 @@ const poisonedToPrimitive = {
 
 assert.throws(Test262Error, function() {
   Atomics.wait(i32a, 0, 0, poisonedValueOf);
-}, '`Atomics.wait(i32a, 0, 0, poisonedValueOf)` throws Test262Error');
+});
 
 assert.throws(Test262Error, function() {
   Atomics.wait(i32a, 0, 0, poisonedToPrimitive);
-}, '`Atomics.wait(i32a, 0, 0, poisonedToPrimitive)` throws Test262Error');
+});

--- a/test/built-ins/Atomics/wait/symbol-for-index-throws.js
+++ b/test/built-ins/Atomics/wait/symbol-for-index-throws.js
@@ -46,16 +46,16 @@ const poisonedToPrimitive = {
 
 assert.throws(Test262Error, function() {
   Atomics.wait(i32a, poisonedValueOf, poisonedValueOf, poisonedValueOf);
-}, '`Atomics.wait(i32a, poisonedValueOf, poisonedValueOf, poisonedValueOf)` throws Test262Error');
+});
 
 assert.throws(Test262Error, function() {
   Atomics.wait(i32a, poisonedToPrimitive, poisonedToPrimitive, poisonedToPrimitive);
-}, '`Atomics.wait(i32a, poisonedToPrimitive, poisonedToPrimitive, poisonedToPrimitive)` throws Test262Error');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, Symbol('foo'), poisonedValueOf, poisonedValueOf);
-}, '`Atomics.wait(i32a, Symbol(\'foo\'), poisonedValueOf, poisonedValueOf)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, Symbol('foo'), poisonedToPrimitive, poisonedToPrimitive);
-}, '`Atomics.wait(i32a, Symbol(\'foo\'), poisonedToPrimitive, poisonedToPrimitive)` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/symbol-for-timeout-throws.js
+++ b/test/built-ins/Atomics/wait/symbol-for-timeout-throws.js
@@ -32,16 +32,16 @@ var poisonedToPrimitive = {
 
 assert.throws(Test262Error, function() {
   Atomics.wait(i32a, 0, 0, poisonedValueOf);
-}, '`Atomics.wait(i32a, 0, 0, poisonedValueOf)` throws Test262Error');
+});
 
 assert.throws(Test262Error, function() {
   Atomics.wait(i32a, 0, 0, poisonedToPrimitive);
-}, '`Atomics.wait(i32a, 0, 0, poisonedToPrimitive)` throws Test262Error');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, 0, 0, Symbol("foo"));
-}, '`Atomics.wait(i32a, 0, 0, Symbol("foo"))` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, 0, 0, Symbol("foo"));
-}, '`Atomics.wait(i32a, 0, 0, Symbol("foo"))` throws TypeError');
+});

--- a/test/built-ins/Atomics/wait/symbol-for-value-throws.js
+++ b/test/built-ins/Atomics/wait/symbol-for-value-throws.js
@@ -37,16 +37,16 @@ const poisonedToPrimitive = {
 
 assert.throws(Test262Error, function() {
   Atomics.wait(i32a, 0, poisonedValueOf, poisonedValueOf);
-}, '`Atomics.wait(i32a, 0, poisonedValueOf, poisonedValueOf)` throws Test262Error');
+});
 
 assert.throws(Test262Error, function() {
   Atomics.wait(i32a, 0, poisonedToPrimitive, poisonedToPrimitive);
-}, '`Atomics.wait(i32a, 0, poisonedToPrimitive, poisonedToPrimitive)` throws Test262Error');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, 0, Symbol("foo"), poisonedValueOf);
-}, '`Atomics.wait(i32a, 0, Symbol("foo"), poisonedValueOf)` throws TypeError');
+});
 
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, 0, Symbol("foo"), poisonedToPrimitive);
-}, '`Atomics.wait(i32a, 0, Symbol("foo"), poisonedToPrimitive)` throws TypeError');
+});

--- a/test/built-ins/Atomics/xor/bad-range.js
+++ b/test/built-ins/Atomics/xor/bad-range.js
@@ -17,6 +17,6 @@ testWithTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.xor(view, IdxGen(view), 0);
-    }, '`Atomics.xor(view, IdxGen(view), 0)` throws RangeError');
+    });
   });
 }, views);

--- a/test/built-ins/Atomics/xor/bigint/bad-range.js
+++ b/test/built-ins/Atomics/xor/bigint/bad-range.js
@@ -16,6 +16,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     assert.throws(RangeError, function() {
       Atomics.xor(view, IdxGen(view), 10);
-    }, '`Atomics.xor(view, IdxGen(view), 10)` throws RangeError');
+    });
   });
 });

--- a/test/built-ins/Atomics/xor/non-views.js
+++ b/test/built-ins/Atomics/xor/non-views.js
@@ -12,5 +12,5 @@ features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray
 testWithAtomicsNonViewValues(function(view) {
   assert.throws(TypeError, function() {
     Atomics.xor(view, 0, 0);
-  }, '`Atomics.xor(view, 0, 0)` throws TypeError');
+  });
 });

--- a/test/built-ins/Atomics/xor/not-a-constructor.js
+++ b/test/built-ins/Atomics/xor/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Atomics.xor), false, 'isConstructor(Atomics.xor) 
 
 assert.throws(TypeError, () => {
   new Atomics.xor(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)));
-}, '`new Atomics.xor(new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)))` throws TypeError');
+});
 

--- a/test/built-ins/BigInt/asIntN/not-a-constructor.js
+++ b/test/built-ins/BigInt/asIntN/not-a-constructor.js
@@ -23,4 +23,4 @@ assert.sameValue(isConstructor(BigInt.asIntN), false, 'isConstructor(BigInt.asIn
 
 assert.throws(TypeError, () => {
   new BigInt.asIntN(64, 1n);
-}, '`new BigInt.asIntN(64, 1n)` throws TypeError');
+});

--- a/test/built-ins/BigInt/asUintN/not-a-constructor.js
+++ b/test/built-ins/BigInt/asUintN/not-a-constructor.js
@@ -23,4 +23,4 @@ assert.sameValue(isConstructor(BigInt.asUintN), false, 'isConstructor(BigInt.asU
 
 assert.throws(TypeError, () => {
   new BigInt.asUintN(64, 1n);
-}, '`new BigInt.asUintN(64, 1n)` throws TypeError');
+});

--- a/test/built-ins/BigInt/prototype/toLocaleString/not-a-constructor.js
+++ b/test/built-ins/BigInt/prototype/toLocaleString/not-a-constructor.js
@@ -28,4 +28,4 @@ assert.sameValue(
 assert.throws(TypeError, () => {
   let n = 1n;
   new n.toLocaleString();
-}, '`let n = 1n; new n.toLocaleString()` throws TypeError');
+});

--- a/test/built-ins/BigInt/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/BigInt/prototype/toString/not-a-constructor.js
@@ -28,4 +28,4 @@ assert.sameValue(
 assert.throws(TypeError, () => {
   let n = 1n;
   new n.toString();
-}, '`let n = 1n; new n.toString()` throws TypeError');
+});

--- a/test/built-ins/BigInt/prototype/valueOf/not-a-constructor.js
+++ b/test/built-ins/BigInt/prototype/valueOf/not-a-constructor.js
@@ -28,4 +28,4 @@ assert.sameValue(
 assert.throws(TypeError, () => {
   let n = 1n;
   new n.valueOf();
-}, '`let n = 1n; new n.valueOf()` throws TypeError');
+});

--- a/test/built-ins/Boolean/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/Boolean/prototype/toString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Boolean.prototype.toString();
-}, '`new Boolean.prototype.toString()` throws TypeError');
+});
 

--- a/test/built-ins/Boolean/prototype/valueOf/not-a-constructor.js
+++ b/test/built-ins/Boolean/prototype/valueOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Boolean.prototype.valueOf();
-}, '`new Boolean.prototype.valueOf()` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/getBigInt64/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/getBigInt64/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.getBigInt64(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.getBigInt64(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/getBigUint64/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/getBigUint64/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.getBigUint64(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.getBigUint64(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/getFloat32/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/getFloat32/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.getFloat32(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.getFloat32(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/getFloat64/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/getFloat64/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.getFloat64(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.getFloat64(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/getInt16/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/getInt16/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.getInt16(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.getInt16(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/getInt32/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/getInt32/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.getInt32(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.getInt32(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/getInt8/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/getInt8/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.getInt8(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.getInt8(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/getUint16/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/getUint16/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.getUint16(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.getUint16(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/getUint32/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/getUint32/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.getUint32(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.getUint32(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/getUint8/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/getUint8/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.getUint8(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.getUint8(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/setBigInt64/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/setBigInt64/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.setBigInt64(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.setBigInt64(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/setBigUint64/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/setBigUint64/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.setBigUint64(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.setBigUint64(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/setFloat32/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/setFloat32/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.setFloat32(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.setFloat32(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/setFloat64/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/setFloat64/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.setFloat64(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.setFloat64(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/setInt16/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/setInt16/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.setInt16(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.setInt16(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/setInt32/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/setInt32/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.setInt32(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.setInt32(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/setInt8/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/setInt8/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.setInt8(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.setInt8(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/setUint16/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/setUint16/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.setUint16(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.setUint16(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/setUint32/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/setUint32/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.setUint32(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.setUint32(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/DataView/prototype/setUint8/not-a-constructor.js
+++ b/test/built-ins/DataView/prototype/setUint8/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let dv = new DataView(new ArrayBuffer(16)); new dv.setUint8(0, 0);
-}, '`let dv = new DataView(new ArrayBuffer(16)); new dv.setUint8(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/Date/UTC/not-a-constructor.js
+++ b/test/built-ins/Date/UTC/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Date.UTC), false, 'isConstructor(Date.UTC) must r
 
 assert.throws(TypeError, () => {
   new Date.UTC();
-}, '`new Date.UTC()` throws TypeError');
+});
 

--- a/test/built-ins/Date/now/not-a-constructor.js
+++ b/test/built-ins/Date/now/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Date.now), false, 'isConstructor(Date.now) must r
 
 assert.throws(TypeError, () => {
   new Date.now();
-}, '`new Date.now()` throws TypeError');
+});
 

--- a/test/built-ins/Date/parse/not-a-constructor.js
+++ b/test/built-ins/Date/parse/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Date.parse), false, 'isConstructor(Date.parse) mu
 
 assert.throws(TypeError, () => {
   new Date.parse();
-}, '`new Date.parse()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getDate/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getDate/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getDate();
-}, '`let date = new Date(Date.now()); new date.getDate()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getDay/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getDay/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getDay();
-}, '`let date = new Date(Date.now()); new date.getDay()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getFullYear/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getFullYear/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getFullYear();
-}, '`let date = new Date(Date.now()); new date.getFullYear()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getHours/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getHours/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getHours();
-}, '`let date = new Date(Date.now()); new date.getHours()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getMilliseconds/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getMilliseconds/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getMilliseconds();
-}, '`let date = new Date(Date.now()); new date.getMilliseconds()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getMinutes/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getMinutes/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getMinutes();
-}, '`let date = new Date(Date.now()); new date.getMinutes()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getMonth/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getMonth/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getMonth();
-}, '`let date = new Date(Date.now()); new date.getMonth()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getSeconds/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getSeconds/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getSeconds();
-}, '`let date = new Date(Date.now()); new date.getSeconds()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getTime/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getTime/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getTime();
-}, '`let date = new Date(Date.now()); new date.getTime()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getTimezoneOffset/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getTimezoneOffset/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getTimezoneOffset();
-}, '`let date = new Date(Date.now()); new date.getTimezoneOffset()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getUTCDate/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getUTCDate/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getUTCDate();
-}, '`let date = new Date(Date.now()); new date.getUTCDate()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getUTCDay/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getUTCDay/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getUTCDay();
-}, '`let date = new Date(Date.now()); new date.getUTCDay()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getUTCFullYear/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getUTCFullYear/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getUTCFullYear();
-}, '`let date = new Date(Date.now()); new date.getUTCFullYear()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getUTCHours/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getUTCHours/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getUTCHours();
-}, '`let date = new Date(Date.now()); new date.getUTCHours()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getUTCMilliseconds/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getUTCMilliseconds/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getUTCMilliseconds();
-}, '`let date = new Date(Date.now()); new date.getUTCMilliseconds()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getUTCMinutes/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getUTCMinutes/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getUTCMinutes();
-}, '`let date = new Date(Date.now()); new date.getUTCMinutes()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getUTCMonth/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getUTCMonth/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getUTCMonth();
-}, '`let date = new Date(Date.now()); new date.getUTCMonth()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/getUTCSeconds/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/getUTCSeconds/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.getUTCSeconds();
-}, '`let date = new Date(Date.now()); new date.getUTCSeconds()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setDate/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setDate/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setDate();
-}, '`let date = new Date(Date.now()); new date.setDate()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setFullYear/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setFullYear/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setFullYear();
-}, '`let date = new Date(Date.now()); new date.setFullYear()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setHours/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setHours/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setHours();
-}, '`let date = new Date(Date.now()); new date.setHours()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setMilliseconds/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setMilliseconds();
-}, '`let date = new Date(Date.now()); new date.setMilliseconds()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setMinutes/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setMinutes/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setMinutes();
-}, '`let date = new Date(Date.now()); new date.setMinutes()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setMonth/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setMonth/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setMonth();
-}, '`let date = new Date(Date.now()); new date.setMonth()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setSeconds/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setSeconds/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setSeconds();
-}, '`let date = new Date(Date.now()); new date.setSeconds()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setTime/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setTime/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setTime();
-}, '`let date = new Date(Date.now()); new date.setTime()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setUTCDate/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setUTCDate/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setUTCDate();
-}, '`let date = new Date(Date.now()); new date.setUTCDate()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setUTCFullYear/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setUTCFullYear/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setUTCFullYear();
-}, '`let date = new Date(Date.now()); new date.setUTCFullYear()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setUTCHours/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setUTCHours/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setUTCHours();
-}, '`let date = new Date(Date.now()); new date.setUTCHours()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setUTCMilliseconds/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setUTCMilliseconds/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setUTCMilliseconds();
-}, '`let date = new Date(Date.now()); new date.setUTCMilliseconds()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setUTCMinutes/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setUTCMinutes/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setUTCMinutes();
-}, '`let date = new Date(Date.now()); new date.setUTCMinutes()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setUTCMonth/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setUTCMonth/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setUTCMonth();
-}, '`let date = new Date(Date.now()); new date.setUTCMonth()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/setUTCSeconds/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/setUTCSeconds/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.setUTCSeconds();
-}, '`let date = new Date(Date.now()); new date.setUTCSeconds()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/toDateString/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/toDateString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.toDateString();
-}, '`let date = new Date(Date.now()); new date.toDateString()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/toISOString/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/toISOString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.toISOString();
-}, '`let date = new Date(Date.now()); new date.toISOString()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/toJSON/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/toJSON/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.toJSON();
-}, '`let date = new Date(Date.now()); new date.toJSON()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/toLocaleDateString/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/toLocaleDateString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.toLocaleDateString();
-}, '`let date = new Date(Date.now()); new date.toLocaleDateString()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/toLocaleString/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/toLocaleString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.toLocaleString();
-}, '`let date = new Date(Date.now()); new date.toLocaleString()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/toLocaleTimeString/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/toLocaleTimeString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.toLocaleTimeString();
-}, '`let date = new Date(Date.now()); new date.toLocaleTimeString()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/toString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.toString();
-}, '`let date = new Date(Date.now()); new date.toString()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/toTimeString/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/toTimeString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.toTimeString();
-}, '`let date = new Date(Date.now()); new date.toTimeString()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/toUTCString/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/toUTCString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.toUTCString();
-}, '`let date = new Date(Date.now()); new date.toUTCString()` throws TypeError');
+});
 

--- a/test/built-ins/Date/prototype/valueOf/not-a-constructor.js
+++ b/test/built-ins/Date/prototype/valueOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let date = new Date(Date.now()); new date.valueOf();
-}, '`let date = new Date(Date.now()); new date.valueOf()` throws TypeError');
+});
 

--- a/test/built-ins/Error/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/Error/prototype/toString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Error.prototype.toString();
-}, '`new Error.prototype.toString()` throws TypeError');
+});
 

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/not-a-constructor.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let fr = new FinalizationRegistry(() => {}); new fr.cleanupSome(() => {});
-}, '`let fr = new FinalizationRegistry(() => {}); new fr.cleanupSome(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/FinalizationRegistry/prototype/register/not-a-constructor.js
+++ b/test/built-ins/FinalizationRegistry/prototype/register/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let fr = new FinalizationRegistry(() => {}); new fr.register({});
-}, '`let fr = new FinalizationRegistry(() => {}); new fr.register({})` throws TypeError');
+});
 

--- a/test/built-ins/FinalizationRegistry/prototype/unregister/not-a-constructor.js
+++ b/test/built-ins/FinalizationRegistry/prototype/unregister/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let fr = new FinalizationRegistry(() => {}); let token = {}; fr.register(token); new fr.unregister(token);
-}, '`let fr = new FinalizationRegistry(() => {}); let token = {}; fr.register(token); new fr.unregister(token)` throws TypeError');
+});
 

--- a/test/built-ins/Function/prototype/apply/not-a-constructor.js
+++ b/test/built-ins/Function/prototype/apply/not-a-constructor.js
@@ -29,8 +29,8 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Function.prototype.apply;
-}, '`new Function.prototype.apply` throws TypeError');
+});
 
 assert.throws(TypeError, () => {
   new Function.prototype.apply();
-}, '`new Function.prototype.apply()` throws TypeError');
+});

--- a/test/built-ins/Function/prototype/bind/not-a-constructor.js
+++ b/test/built-ins/Function/prototype/bind/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Function.prototype.bind();
-}, '`new Function.prototype.bind()` throws TypeError');
+});
 

--- a/test/built-ins/Function/prototype/call/not-a-constructor.js
+++ b/test/built-ins/Function/prototype/call/not-a-constructor.js
@@ -29,11 +29,11 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Function.prototype.call();
-}, '`new Function.prototype.call()` throws TypeError');
+});
 
 assert.throws(TypeError, () => {
   new Function.prototype.call;
-}, '`new Function.prototype.call` throws TypeError');
+});
 
 var call = Function.prototype.call;
 assert.throws(TypeError, () => {

--- a/test/built-ins/Function/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/Function/prototype/toString/not-a-constructor.js
@@ -29,9 +29,9 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Function.prototype.toString();
-}, '`new Function.prototype.toString()` throws TypeError');
+});
 
 var toString = Function.prototype.toString;
 assert.throws(TypeError, () => {
   new toString;
-}, '`new toString` throws TypeError');
+});

--- a/test/built-ins/GeneratorPrototype/next/not-a-constructor.js
+++ b/test/built-ins/GeneratorPrototype/next/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   function* g() {} let iterator = g(); new iterator.next();
-}, '`function* g() {} let iterator = g(); new iterator.next()` throws TypeError');
+});
 

--- a/test/built-ins/GeneratorPrototype/return/not-a-constructor.js
+++ b/test/built-ins/GeneratorPrototype/return/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   function* g() {} let iterator = g(); new iterator.return();
-}, '`function* g() {} let iterator = g(); new iterator.return()` throws TypeError');
+});
 

--- a/test/built-ins/GeneratorPrototype/throw/not-a-constructor.js
+++ b/test/built-ins/GeneratorPrototype/throw/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   function* g() {} let expected = new Test262Error(); let iterator = g();try {new iterator.throw(expected);} catch (e) {if (e !== expected) {throw e;}}
-}, '`function* g() {} let expected = new Test262Error(); let iterator = g();try {new iterator.throw(expected);} catch (e) {if (e !== expected) {throw e;}}` throws TypeError');
+});
 

--- a/test/built-ins/JSON/parse/not-a-constructor.js
+++ b/test/built-ins/JSON/parse/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(JSON.parse), false, 'isConstructor(JSON.parse) mu
 
 assert.throws(TypeError, () => {
   new JSON.parse('{}');
-}, '`new JSON.parse(\'{}\')` throws TypeError');
+});
 

--- a/test/built-ins/JSON/stringify/not-a-constructor.js
+++ b/test/built-ins/JSON/stringify/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(JSON.stringify), false, 'isConstructor(JSON.strin
 
 assert.throws(TypeError, () => {
   new JSON.stringify({});
-}, '`new JSON.stringify({})` throws TypeError');
+});
 

--- a/test/built-ins/Map/prototype/Symbol.iterator/not-a-constructor.js
+++ b/test/built-ins/Map/prototype/Symbol.iterator/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let m = new Map(); new m[Symbol.iterator]();
-}, '`let m = new Map(); new m[Symbol.iterator]()` throws TypeError');
+});
 

--- a/test/built-ins/Map/prototype/clear/not-a-constructor.js
+++ b/test/built-ins/Map/prototype/clear/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Map.prototype.clear), false, 'isConstructor(Map.p
 
 assert.throws(TypeError, () => {
   let m = new Map(); new m.clear();
-}, '`let m = new Map(); new m.clear()` throws TypeError');
+});
 

--- a/test/built-ins/Map/prototype/delete/not-a-constructor.js
+++ b/test/built-ins/Map/prototype/delete/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Map.prototype.delete), false, 'isConstructor(Map.
 
 assert.throws(TypeError, () => {
   let m = new Map(); new m.delete();
-}, '`let m = new Map(); new m.delete()` throws TypeError');
+});
 

--- a/test/built-ins/Map/prototype/entries/not-a-constructor.js
+++ b/test/built-ins/Map/prototype/entries/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let m = new Map(); new m.entries();
-}, '`let m = new Map(); new m.entries()` throws TypeError');
+});
 

--- a/test/built-ins/Map/prototype/forEach/not-a-constructor.js
+++ b/test/built-ins/Map/prototype/forEach/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let m = new Map(); new m.forEach();
-}, '`let m = new Map(); new m.forEach()` throws TypeError');
+});
 

--- a/test/built-ins/Map/prototype/get/not-a-constructor.js
+++ b/test/built-ins/Map/prototype/get/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Map.prototype.get), false, 'isConstructor(Map.pro
 
 assert.throws(TypeError, () => {
   let m = new Map(); new m.get();
-}, '`let m = new Map(); new m.get()` throws TypeError');
+});
 

--- a/test/built-ins/Map/prototype/has/not-a-constructor.js
+++ b/test/built-ins/Map/prototype/has/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Map.prototype.has), false, 'isConstructor(Map.pro
 
 assert.throws(TypeError, () => {
   let m = new Map(); new m.has();
-}, '`let m = new Map(); new m.has()` throws TypeError');
+});
 

--- a/test/built-ins/Map/prototype/keys/not-a-constructor.js
+++ b/test/built-ins/Map/prototype/keys/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Map.prototype.keys), false, 'isConstructor(Map.pr
 
 assert.throws(TypeError, () => {
   let m = new Map(); new m.keys();
-}, '`let m = new Map(); new m.keys()` throws TypeError');
+});
 

--- a/test/built-ins/Map/prototype/set/not-a-constructor.js
+++ b/test/built-ins/Map/prototype/set/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Map.prototype.set), false, 'isConstructor(Map.pro
 
 assert.throws(TypeError, () => {
   let m = new Map(); new m.set();
-}, '`let m = new Map(); new m.set()` throws TypeError');
+});
 

--- a/test/built-ins/Map/prototype/values/not-a-constructor.js
+++ b/test/built-ins/Map/prototype/values/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Map.prototype.values), false, 'isConstructor(Map.
 
 assert.throws(TypeError, () => {
   let m = new Map(); new m.values();
-}, '`let m = new Map(); new m.values()` throws TypeError');
+});
 

--- a/test/built-ins/Math/abs/not-a-constructor.js
+++ b/test/built-ins/Math/abs/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.abs), false, 'isConstructor(Math.abs) must r
 
 assert.throws(TypeError, () => {
   new Math.abs();
-}, '`new Math.abs()` throws TypeError');
+});
 

--- a/test/built-ins/Math/acos/not-a-constructor.js
+++ b/test/built-ins/Math/acos/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.acos), false, 'isConstructor(Math.acos) must
 
 assert.throws(TypeError, () => {
   new Math.acos();
-}, '`new Math.acos()` throws TypeError');
+});
 

--- a/test/built-ins/Math/acosh/not-a-constructor.js
+++ b/test/built-ins/Math/acosh/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.acosh), false, 'isConstructor(Math.acosh) mu
 
 assert.throws(TypeError, () => {
   new Math.acosh();
-}, '`new Math.acosh()` throws TypeError');
+});
 

--- a/test/built-ins/Math/asin/not-a-constructor.js
+++ b/test/built-ins/Math/asin/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.asin), false, 'isConstructor(Math.asin) must
 
 assert.throws(TypeError, () => {
   new Math.asin();
-}, '`new Math.asin()` throws TypeError');
+});
 

--- a/test/built-ins/Math/asinh/not-a-constructor.js
+++ b/test/built-ins/Math/asinh/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.asinh), false, 'isConstructor(Math.asinh) mu
 
 assert.throws(TypeError, () => {
   new Math.asinh();
-}, '`new Math.asinh()` throws TypeError');
+});
 

--- a/test/built-ins/Math/atan/not-a-constructor.js
+++ b/test/built-ins/Math/atan/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.atan), false, 'isConstructor(Math.atan) must
 
 assert.throws(TypeError, () => {
   new Math.atan();
-}, '`new Math.atan()` throws TypeError');
+});
 

--- a/test/built-ins/Math/atan2/not-a-constructor.js
+++ b/test/built-ins/Math/atan2/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.atan2), false, 'isConstructor(Math.atan2) mu
 
 assert.throws(TypeError, () => {
   new Math.atan2();
-}, '`new Math.atan2()` throws TypeError');
+});
 

--- a/test/built-ins/Math/atanh/not-a-constructor.js
+++ b/test/built-ins/Math/atanh/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.atanh), false, 'isConstructor(Math.atanh) mu
 
 assert.throws(TypeError, () => {
   new Math.atanh();
-}, '`new Math.atanh()` throws TypeError');
+});
 

--- a/test/built-ins/Math/cbrt/not-a-constructor.js
+++ b/test/built-ins/Math/cbrt/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.cbrt), false, 'isConstructor(Math.cbrt) must
 
 assert.throws(TypeError, () => {
   new Math.cbrt();
-}, '`new Math.cbrt()` throws TypeError');
+});
 

--- a/test/built-ins/Math/ceil/not-a-constructor.js
+++ b/test/built-ins/Math/ceil/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.ceil), false, 'isConstructor(Math.ceil) must
 
 assert.throws(TypeError, () => {
   new Math.ceil();
-}, '`new Math.ceil()` throws TypeError');
+});
 

--- a/test/built-ins/Math/clz32/not-a-constructor.js
+++ b/test/built-ins/Math/clz32/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.clz32), false, 'isConstructor(Math.clz32) mu
 
 assert.throws(TypeError, () => {
   new Math.clz32();
-}, '`new Math.clz32()` throws TypeError');
+});
 

--- a/test/built-ins/Math/cos/not-a-constructor.js
+++ b/test/built-ins/Math/cos/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.cos), false, 'isConstructor(Math.cos) must r
 
 assert.throws(TypeError, () => {
   new Math.cos();
-}, '`new Math.cos()` throws TypeError');
+});
 

--- a/test/built-ins/Math/cosh/not-a-constructor.js
+++ b/test/built-ins/Math/cosh/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.cosh), false, 'isConstructor(Math.cosh) must
 
 assert.throws(TypeError, () => {
   new Math.cosh();
-}, '`new Math.cosh()` throws TypeError');
+});
 

--- a/test/built-ins/Math/exp/not-a-constructor.js
+++ b/test/built-ins/Math/exp/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.exp), false, 'isConstructor(Math.exp) must r
 
 assert.throws(TypeError, () => {
   new Math.exp();
-}, '`new Math.exp()` throws TypeError');
+});
 

--- a/test/built-ins/Math/expm1/not-a-constructor.js
+++ b/test/built-ins/Math/expm1/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.expm1), false, 'isConstructor(Math.expm1) mu
 
 assert.throws(TypeError, () => {
   new Math.expm1();
-}, '`new Math.expm1()` throws TypeError');
+});
 

--- a/test/built-ins/Math/floor/not-a-constructor.js
+++ b/test/built-ins/Math/floor/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.floor), false, 'isConstructor(Math.floor) mu
 
 assert.throws(TypeError, () => {
   new Math.floor();
-}, '`new Math.floor()` throws TypeError');
+});
 

--- a/test/built-ins/Math/fround/not-a-constructor.js
+++ b/test/built-ins/Math/fround/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.fround), false, 'isConstructor(Math.fround) 
 
 assert.throws(TypeError, () => {
   new Math.fround();
-}, '`new Math.fround()` throws TypeError');
+});
 

--- a/test/built-ins/Math/hypot/not-a-constructor.js
+++ b/test/built-ins/Math/hypot/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.hypot), false, 'isConstructor(Math.hypot) mu
 
 assert.throws(TypeError, () => {
   new Math.hypot();
-}, '`new Math.hypot()` throws TypeError');
+});
 

--- a/test/built-ins/Math/imul/not-a-constructor.js
+++ b/test/built-ins/Math/imul/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.imul), false, 'isConstructor(Math.imul) must
 
 assert.throws(TypeError, () => {
   new Math.imul();
-}, '`new Math.imul()` throws TypeError');
+});
 

--- a/test/built-ins/Math/log/not-a-constructor.js
+++ b/test/built-ins/Math/log/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.log), false, 'isConstructor(Math.log) must r
 
 assert.throws(TypeError, () => {
   new Math.log();
-}, '`new Math.log()` throws TypeError');
+});
 

--- a/test/built-ins/Math/log10/not-a-constructor.js
+++ b/test/built-ins/Math/log10/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.log10), false, 'isConstructor(Math.log10) mu
 
 assert.throws(TypeError, () => {
   new Math.log10();
-}, '`new Math.log10()` throws TypeError');
+});
 

--- a/test/built-ins/Math/log1p/not-a-constructor.js
+++ b/test/built-ins/Math/log1p/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.log1p), false, 'isConstructor(Math.log1p) mu
 
 assert.throws(TypeError, () => {
   new Math.log1p();
-}, '`new Math.log1p()` throws TypeError');
+});
 

--- a/test/built-ins/Math/log2/not-a-constructor.js
+++ b/test/built-ins/Math/log2/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.log2), false, 'isConstructor(Math.log2) must
 
 assert.throws(TypeError, () => {
   new Math.log2();
-}, '`new Math.log2()` throws TypeError');
+});
 

--- a/test/built-ins/Math/max/not-a-constructor.js
+++ b/test/built-ins/Math/max/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.max), false, 'isConstructor(Math.max) must r
 
 assert.throws(TypeError, () => {
   new Math.max();
-}, '`new Math.max()` throws TypeError');
+});
 

--- a/test/built-ins/Math/min/not-a-constructor.js
+++ b/test/built-ins/Math/min/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.min), false, 'isConstructor(Math.min) must r
 
 assert.throws(TypeError, () => {
   new Math.min();
-}, '`new Math.min()` throws TypeError');
+});
 

--- a/test/built-ins/Math/pow/not-a-constructor.js
+++ b/test/built-ins/Math/pow/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.pow), false, 'isConstructor(Math.pow) must r
 
 assert.throws(TypeError, () => {
   new Math.pow();
-}, '`new Math.pow()` throws TypeError');
+});
 

--- a/test/built-ins/Math/random/not-a-constructor.js
+++ b/test/built-ins/Math/random/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.random), false, 'isConstructor(Math.random) 
 
 assert.throws(TypeError, () => {
   new Math.random();
-}, '`new Math.random()` throws TypeError');
+});
 

--- a/test/built-ins/Math/round/not-a-constructor.js
+++ b/test/built-ins/Math/round/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.round), false, 'isConstructor(Math.round) mu
 
 assert.throws(TypeError, () => {
   new Math.round();
-}, '`new Math.round()` throws TypeError');
+});
 

--- a/test/built-ins/Math/sign/not-a-constructor.js
+++ b/test/built-ins/Math/sign/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.sign), false, 'isConstructor(Math.sign) must
 
 assert.throws(TypeError, () => {
   new Math.sign();
-}, '`new Math.sign()` throws TypeError');
+});
 

--- a/test/built-ins/Math/sin/not-a-constructor.js
+++ b/test/built-ins/Math/sin/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.sin), false, 'isConstructor(Math.sin) must r
 
 assert.throws(TypeError, () => {
   new Math.sin();
-}, '`new Math.sin()` throws TypeError');
+});
 

--- a/test/built-ins/Math/sinh/not-a-constructor.js
+++ b/test/built-ins/Math/sinh/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.sinh), false, 'isConstructor(Math.sinh) must
 
 assert.throws(TypeError, () => {
   new Math.sinh();
-}, '`new Math.sinh()` throws TypeError');
+});
 

--- a/test/built-ins/Math/sqrt/not-a-constructor.js
+++ b/test/built-ins/Math/sqrt/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.sqrt), false, 'isConstructor(Math.sqrt) must
 
 assert.throws(TypeError, () => {
   new Math.sqrt();
-}, '`new Math.sqrt()` throws TypeError');
+});
 

--- a/test/built-ins/Math/tan/not-a-constructor.js
+++ b/test/built-ins/Math/tan/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.tan), false, 'isConstructor(Math.tan) must r
 
 assert.throws(TypeError, () => {
   new Math.tan();
-}, '`new Math.tan()` throws TypeError');
+});
 

--- a/test/built-ins/Math/tanh/not-a-constructor.js
+++ b/test/built-ins/Math/tanh/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.tanh), false, 'isConstructor(Math.tanh) must
 
 assert.throws(TypeError, () => {
   new Math.tanh();
-}, '`new Math.tanh()` throws TypeError');
+});
 

--- a/test/built-ins/Math/trunc/not-a-constructor.js
+++ b/test/built-ins/Math/trunc/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Math.trunc), false, 'isConstructor(Math.trunc) mu
 
 assert.throws(TypeError, () => {
   new Math.trunc();
-}, '`new Math.trunc()` throws TypeError');
+});
 

--- a/test/built-ins/Number/isFinite/not-a-constructor.js
+++ b/test/built-ins/Number/isFinite/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Number.isFinite), false, 'isConstructor(Number.is
 
 assert.throws(TypeError, () => {
   new Number.isFinite();
-}, '`new Number.isFinite()` throws TypeError');
+});
 

--- a/test/built-ins/Number/isInteger/not-a-constructor.js
+++ b/test/built-ins/Number/isInteger/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Number.isInteger), false, 'isConstructor(Number.i
 
 assert.throws(TypeError, () => {
   new Number.isInteger();
-}, '`new Number.isInteger()` throws TypeError');
+});
 

--- a/test/built-ins/Number/isNaN/not-a-constructor.js
+++ b/test/built-ins/Number/isNaN/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Number.isNaN), false, 'isConstructor(Number.isNaN
 
 assert.throws(TypeError, () => {
   new Number.isNaN();
-}, '`new Number.isNaN()` throws TypeError');
+});
 

--- a/test/built-ins/Number/isSafeInteger/not-a-constructor.js
+++ b/test/built-ins/Number/isSafeInteger/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Number.isSafeInteger), false, 'isConstructor(Numb
 
 assert.throws(TypeError, () => {
   new Number.isSafeInteger();
-}, '`new Number.isSafeInteger()` throws TypeError');
+});
 

--- a/test/built-ins/Number/parseFloat/not-a-constructor.js
+++ b/test/built-ins/Number/parseFloat/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Number.parseFloat), false, 'isConstructor(Number.
 
 assert.throws(TypeError, () => {
   new Number.parseFloat();
-}, '`new Number.parseFloat()` throws TypeError');
+});
 

--- a/test/built-ins/Number/parseInt/not-a-constructor.js
+++ b/test/built-ins/Number/parseInt/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Number.parseInt), false, 'isConstructor(Number.pa
 
 assert.throws(TypeError, () => {
   new Number.parseInt();
-}, '`new Number.parseInt()` throws TypeError');
+});
 

--- a/test/built-ins/Number/prototype/toExponential/not-a-constructor.js
+++ b/test/built-ins/Number/prototype/toExponential/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Number.prototype.toExponential();
-}, '`new Number.prototype.toExponential()` throws TypeError');
+});
 

--- a/test/built-ins/Number/prototype/toFixed/not-a-constructor.js
+++ b/test/built-ins/Number/prototype/toFixed/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Number.prototype.toFixed();
-}, '`new Number.prototype.toFixed()` throws TypeError');
+});
 

--- a/test/built-ins/Number/prototype/toLocaleString/not-a-constructor.js
+++ b/test/built-ins/Number/prototype/toLocaleString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Number.prototype.toLocaleString();
-}, '`new Number.prototype.toLocaleString()` throws TypeError');
+});
 

--- a/test/built-ins/Number/prototype/toPrecision/not-a-constructor.js
+++ b/test/built-ins/Number/prototype/toPrecision/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Number.prototype.toPrecision();
-}, '`new Number.prototype.toPrecision()` throws TypeError');
+});
 

--- a/test/built-ins/Number/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/Number/prototype/toString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Number.prototype.toString();
-}, '`new Number.prototype.toString()` throws TypeError');
+});
 

--- a/test/built-ins/Number/prototype/valueOf/not-a-constructor.js
+++ b/test/built-ins/Number/prototype/valueOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Number.prototype.valueOf();
-}, '`new Number.prototype.valueOf()` throws TypeError');
+});
 

--- a/test/built-ins/Object/assign/not-a-constructor.js
+++ b/test/built-ins/Object/assign/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.assign), false, 'isConstructor(Object.assi
 
 assert.throws(TypeError, () => {
   new Object.assign({});
-}, '`new Object.assign({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/create/not-a-constructor.js
+++ b/test/built-ins/Object/create/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.create), false, 'isConstructor(Object.crea
 
 assert.throws(TypeError, () => {
   new Object.create(null);
-}, '`new Object.create(null)` throws TypeError');
+});
 

--- a/test/built-ins/Object/defineProperties/not-a-constructor.js
+++ b/test/built-ins/Object/defineProperties/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.defineProperties({}, {});
-}, '`new Object.defineProperties({}, {})` throws TypeError');
+});
 

--- a/test/built-ins/Object/defineProperty/not-a-constructor.js
+++ b/test/built-ins/Object/defineProperty/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.defineProperty({}, '', {});
-}, '`new Object.defineProperty({}, \'\', {})` throws TypeError');
+});
 

--- a/test/built-ins/Object/entries/not-a-constructor.js
+++ b/test/built-ins/Object/entries/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.entries), false, 'isConstructor(Object.ent
 
 assert.throws(TypeError, () => {
   new Object.entries({});
-}, '`new Object.entries({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/freeze/not-a-constructor.js
+++ b/test/built-ins/Object/freeze/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.freeze), false, 'isConstructor(Object.free
 
 assert.throws(TypeError, () => {
   new Object.freeze({});
-}, '`new Object.freeze({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/fromEntries/not-a-constructor.js
+++ b/test/built-ins/Object/fromEntries/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.fromEntries), false, 'isConstructor(Object
 
 assert.throws(TypeError, () => {
   new Object.fromEntries([]);
-}, '`new Object.fromEntries([])` throws TypeError');
+});
 

--- a/test/built-ins/Object/getOwnPropertyDescriptor/not-a-constructor.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.getOwnPropertyDescriptor({}, '');
-}, '`new Object.getOwnPropertyDescriptor({}, \'\')` throws TypeError');
+});
 

--- a/test/built-ins/Object/getOwnPropertyDescriptors/not-a-constructor.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptors/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.getOwnPropertyDescriptors({});
-}, '`new Object.getOwnPropertyDescriptors({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/getOwnPropertyNames/not-a-constructor.js
+++ b/test/built-ins/Object/getOwnPropertyNames/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.getOwnPropertyNames({});
-}, '`new Object.getOwnPropertyNames({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/getOwnPropertySymbols/not-a-constructor.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.getOwnPropertySymbols({});
-}, '`new Object.getOwnPropertySymbols({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/getPrototypeOf/not-a-constructor.js
+++ b/test/built-ins/Object/getPrototypeOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.getPrototypeOf({});
-}, '`new Object.getPrototypeOf({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/hasOwn/not-a-constructor.js
+++ b/test/built-ins/Object/hasOwn/not-a-constructor.js
@@ -30,4 +30,4 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.hasOwn('');
-}, '`new Object.hasOwn(\'\')` throws TypeError');
+});

--- a/test/built-ins/Object/is/not-a-constructor.js
+++ b/test/built-ins/Object/is/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.is), false, 'isConstructor(Object.is) must
 
 assert.throws(TypeError, () => {
   new Object.is(0, 0);
-}, '`new Object.is(0, 0)` throws TypeError');
+});
 

--- a/test/built-ins/Object/isExtensible/not-a-constructor.js
+++ b/test/built-ins/Object/isExtensible/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.isExtensible), false, 'isConstructor(Objec
 
 assert.throws(TypeError, () => {
   new Object.isExtensible({});
-}, '`new Object.isExtensible({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/isFrozen/not-a-constructor.js
+++ b/test/built-ins/Object/isFrozen/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.isFrozen), false, 'isConstructor(Object.is
 
 assert.throws(TypeError, () => {
   new Object.isFrozen({});
-}, '`new Object.isFrozen({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/isSealed/not-a-constructor.js
+++ b/test/built-ins/Object/isSealed/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.isSealed), false, 'isConstructor(Object.is
 
 assert.throws(TypeError, () => {
   new Object.isSealed({});
-}, '`new Object.isSealed({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/keys/not-a-constructor.js
+++ b/test/built-ins/Object/keys/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.keys), false, 'isConstructor(Object.keys) 
 
 assert.throws(TypeError, () => {
   new Object.keys({});
-}, '`new Object.keys({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/preventExtensions/not-a-constructor.js
+++ b/test/built-ins/Object/preventExtensions/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.preventExtensions({});
-}, '`new Object.preventExtensions({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/prototype/hasOwnProperty/not-a-constructor.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.prototype.hasOwnProperty('');
-}, '`new Object.prototype.hasOwnProperty(\'\')` throws TypeError');
+});
 

--- a/test/built-ins/Object/prototype/isPrototypeOf/not-a-constructor.js
+++ b/test/built-ins/Object/prototype/isPrototypeOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.prototype.isPrototypeOf({});
-}, '`new Object.prototype.isPrototypeOf({})` throws TypeError');
+});
 

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/not-a-constructor.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.prototype.propertyIsEnumerable('');
-}, '`new Object.prototype.propertyIsEnumerable(\'\')` throws TypeError');
+});
 

--- a/test/built-ins/Object/prototype/toLocaleString/not-a-constructor.js
+++ b/test/built-ins/Object/prototype/toLocaleString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.prototype.toLocaleString('');
-}, '`new Object.prototype.toLocaleString(\'\')` throws TypeError');
+});
 

--- a/test/built-ins/Object/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/Object/prototype/toString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.prototype.toString();
-}, '`new Object.prototype.toString()` throws TypeError');
+});
 

--- a/test/built-ins/Object/prototype/valueOf/not-a-constructor.js
+++ b/test/built-ins/Object/prototype/valueOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.prototype.valueOf();
-}, '`new Object.prototype.valueOf()` throws TypeError');
+});
 

--- a/test/built-ins/Object/seal/not-a-constructor.js
+++ b/test/built-ins/Object/seal/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.seal), false, 'isConstructor(Object.seal) 
 
 assert.throws(TypeError, () => {
   new Object.seal();
-}, '`new Object.seal()` throws TypeError');
+});
 

--- a/test/built-ins/Object/setPrototypeOf/not-a-constructor.js
+++ b/test/built-ins/Object/setPrototypeOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Object.setPrototypeOf({}, {});
-}, '`new Object.setPrototypeOf({}, {})` throws TypeError');
+});
 

--- a/test/built-ins/Object/values/not-a-constructor.js
+++ b/test/built-ins/Object/values/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Object.values), false, 'isConstructor(Object.valu
 
 assert.throws(TypeError, () => {
   new Object.values({});
-}, '`new Object.values({})` throws TypeError');
+});
 

--- a/test/built-ins/Promise/all/not-a-constructor.js
+++ b/test/built-ins/Promise/all/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Promise.all), false, 'isConstructor(Promise.all) 
 
 assert.throws(TypeError, () => {
   new Promise.all([]);
-}, '`new Promise.all([])` throws TypeError');
+});
 

--- a/test/built-ins/Promise/allSettled/not-a-constructor.js
+++ b/test/built-ins/Promise/allSettled/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Promise.allSettled), false, 'isConstructor(Promis
 
 assert.throws(TypeError, () => {
   new Promise.allSettled();
-}, '`new Promise.allSettled()` throws TypeError');
+});
 

--- a/test/built-ins/Promise/any/not-a-constructor.js
+++ b/test/built-ins/Promise/any/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Promise.any), false, 'isConstructor(Promise.any) 
 
 assert.throws(TypeError, () => {
   new Promise.any([1]);
-}, '`new Promise.any([1])` throws TypeError');
+});
 

--- a/test/built-ins/Promise/create-resolving-functions-reject.js
+++ b/test/built-ins/Promise/create-resolving-functions-reject.js
@@ -23,7 +23,7 @@ Promise.prototype.then = function(resolve, reject) {
   assert.sameValue(isConstructor(reject), false, 'isConstructor(reject) must return false');
   assert.throws(TypeError, () => {
     new reject();
-  }, '`new reject()` throws TypeError');
+  });
 
   assert.sameValue(reject.length, 1, 'The value of reject.length is 1');
   assert.sameValue(reject.name, '', 'The value of reject.name is ""');

--- a/test/built-ins/Promise/create-resolving-functions-resolve.js
+++ b/test/built-ins/Promise/create-resolving-functions-resolve.js
@@ -23,7 +23,7 @@ Promise.prototype.then = function(resolve, reject) {
   assert.sameValue(isConstructor(resolve), false, 'isConstructor(resolve) must return false');
   assert.throws(TypeError, () => {
     new resolve();
-  }, '`new resolve()` throws TypeError');
+  });
 
   assert.sameValue(resolve.length, 1, 'The value of resolve.length is 1');
   assert.sameValue(resolve.name, '', 'The value of resolve.name is ""');

--- a/test/built-ins/Promise/executor-function-not-a-constructor.js
+++ b/test/built-ins/Promise/executor-function-not-a-constructor.js
@@ -30,5 +30,5 @@ assert.sameValue(isConstructor(executorFunction), false, 'isConstructor(executor
 
 assert.throws(TypeError, () => {
   new executorFunction();
-}, '`new executorFunction()` throws TypeError');
+});
 

--- a/test/built-ins/Promise/prototype/catch/not-a-constructor.js
+++ b/test/built-ins/Promise/prototype/catch/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let p = new Promise(() => {}); new p.catch();
-}, '`let p = new Promise(() => {}); new p.catch()` throws TypeError');
+});
 

--- a/test/built-ins/Promise/prototype/finally/invokes-then-with-function.js
+++ b/test/built-ins/Promise/prototype/finally/invokes-then-with-function.js
@@ -48,7 +48,7 @@ assert.sameValue(resolve.name, '', 'The value of resolve.name is ""');
 assert.sameValue(isConstructor(resolve), false, 'isConstructor(resolve) must return false');
 assert.throws(TypeError, () => {
   new resolve();
-}, '`new resolve()` throws TypeError');
+});
 
 
 assert.sameValue(
@@ -62,6 +62,6 @@ assert.sameValue(reject.name, '', 'The value of reject.name is ""');
 assert.sameValue(isConstructor(reject), false, 'isConstructor(reject) must return false');
 assert.throws(TypeError, () => {
   new reject();
-}, '`new reject()` throws TypeError');
+});
 
 assert.sameValue(result, returnValue, 'The value of `result` is expected to equal the value of returnValue');

--- a/test/built-ins/Promise/prototype/finally/not-a-constructor.js
+++ b/test/built-ins/Promise/prototype/finally/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let p = new Promise(() => {}); new p.finally();
-}, '`let p = new Promise(() => {}); new p.finally()` throws TypeError');
+});
 

--- a/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls-argument.js
+++ b/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls-argument.js
@@ -58,7 +58,7 @@ Promise.prototype.then = function(resolve, reject) {
     assert.sameValue(isConstructor(reject), false, 'isConstructor(reject) must return false');
     assert.throws(TypeError, () => {
       new reject();
-    }, '`new reject()` throws TypeError');
+    });
     assert.sameValue(arguments.length, 2, '`then` invoked with two arguments');
   }
 

--- a/test/built-ins/Promise/prototype/finally/resolved-observable-then-calls-argument.js
+++ b/test/built-ins/Promise/prototype/finally/resolved-observable-then-calls-argument.js
@@ -34,7 +34,7 @@ Promise.prototype.then = function(resolve) {
   assert.sameValue(isConstructor(resolve), false, 'isConstructor(resolve) must return false');
   assert.throws(TypeError, () => {
     new resolve();
-  }, '`new resolve()` throws TypeError');
+  });
 
   assert.sameValue(
     resolve.length,

--- a/test/built-ins/Promise/prototype/then/not-a-constructor.js
+++ b/test/built-ins/Promise/prototype/then/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let p = new Promise(() => {}); new p.then();
-}, '`let p = new Promise(() => {}); new p.then()` throws TypeError');
+});
 

--- a/test/built-ins/Promise/race/not-a-constructor.js
+++ b/test/built-ins/Promise/race/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Promise.race), false, 'isConstructor(Promise.race
 
 assert.throws(TypeError, () => {
   new Promise.race([]);
-}, '`new Promise.race([])` throws TypeError');
+});
 

--- a/test/built-ins/Promise/reject/not-a-constructor.js
+++ b/test/built-ins/Promise/reject/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Promise.reject), false, 'isConstructor(Promise.re
 
 assert.throws(TypeError, () => {
   new Promise.reject();
-}, '`new Promise.reject()` throws TypeError');
+});
 

--- a/test/built-ins/Promise/resolve/not-a-constructor.js
+++ b/test/built-ins/Promise/resolve/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Promise.resolve), false, 'isConstructor(Promise.r
 
 assert.throws(TypeError, () => {
   new Promise.resolve();
-}, '`new Promise.resolve()` throws TypeError');
+});
 

--- a/test/built-ins/Proxy/create-target-is-not-a-constructor.js
+++ b/test/built-ins/Proxy/create-target-is-not-a-constructor.js
@@ -28,4 +28,4 @@ proxy(); // the Proxy object is callable
 assert.sameValue(isConstructor(proxy), false, 'isConstructor(proxy) must return false');
 assert.throws(TypeError, () => {
   new proxy();
-}, '`new proxy()` throws TypeError');
+});

--- a/test/built-ins/Proxy/revocable/not-a-constructor.js
+++ b/test/built-ins/Proxy/revocable/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Proxy.revocable), false, 'isConstructor(Proxy.rev
 
 assert.throws(TypeError, () => {
   new Proxy.revocable({}, {});
-}, '`new Proxy.revocable({}, {})` throws TypeError');
+});
 

--- a/test/built-ins/Proxy/revocable/revocation-function-not-a-constructor.js
+++ b/test/built-ins/Proxy/revocable/revocation-function-not-a-constructor.js
@@ -23,6 +23,6 @@ assert.sameValue(
 assert.sameValue(isConstructor(revocationFunction), false, 'isConstructor(revocationFunction) must return false');
 assert.throws(TypeError, () => {
   new revocationFunction();
-}, '`new revocationFunction()` throws TypeError');
+});
 
 

--- a/test/built-ins/Reflect/apply/not-a-constructor.js
+++ b/test/built-ins/Reflect/apply/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Reflect.apply), false, 'isConstructor(Reflect.app
 
 assert.throws(TypeError, () => {
   new Reflect.apply(() => {}, undefined, []);
-}, '`new Reflect.apply(() => {}, undefined, [])` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/construct/not-a-constructor.js
+++ b/test/built-ins/Reflect/construct/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Reflect.construct), false, 'isConstructor(Reflect
 
 assert.throws(TypeError, () => {
   new Reflect.construct(Function, [], Function);
-}, '`new Reflect.construct(Function, [], Function)` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/defineProperty/not-a-constructor.js
+++ b/test/built-ins/Reflect/defineProperty/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Reflect.defineProperty({}, '');
-}, '`new Reflect.defineProperty({}, \'\')` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/deleteProperty/not-a-constructor.js
+++ b/test/built-ins/Reflect/deleteProperty/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Reflect.deleteProperty({}, '');
-}, '`new Reflect.deleteProperty({}, \'\')` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/get/not-a-constructor.js
+++ b/test/built-ins/Reflect/get/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Reflect.get), false, 'isConstructor(Reflect.get) 
 
 assert.throws(TypeError, () => {
   new Reflect.get({}, '');
-}, '`new Reflect.get({}, \'\')` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/not-a-constructor.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Reflect.getOwnPropertyDescriptor({}, '');
-}, '`new Reflect.getOwnPropertyDescriptor({}, \'\')` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/getPrototypeOf/not-a-constructor.js
+++ b/test/built-ins/Reflect/getPrototypeOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Reflect.getPrototypeOf({});
-}, '`new Reflect.getPrototypeOf({})` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/has/not-a-constructor.js
+++ b/test/built-ins/Reflect/has/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Reflect.has), false, 'isConstructor(Reflect.has) 
 
 assert.throws(TypeError, () => {
   new Reflect.has();
-}, '`new Reflect.has()` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/isExtensible/not-a-constructor.js
+++ b/test/built-ins/Reflect/isExtensible/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Reflect.isExtensible), false, 'isConstructor(Refl
 
 assert.throws(TypeError, () => {
   new Reflect.isExtensible({});
-}, '`new Reflect.isExtensible({})` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/ownKeys/not-a-constructor.js
+++ b/test/built-ins/Reflect/ownKeys/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Reflect.ownKeys), false, 'isConstructor(Reflect.o
 
 assert.throws(TypeError, () => {
   new Reflect.ownKeys({});
-}, '`new Reflect.ownKeys({})` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/preventExtensions/not-a-constructor.js
+++ b/test/built-ins/Reflect/preventExtensions/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Reflect.preventExtensions({});
-}, '`new Reflect.preventExtensions({})` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/set/not-a-constructor.js
+++ b/test/built-ins/Reflect/set/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Reflect.set), false, 'isConstructor(Reflect.set) 
 
 assert.throws(TypeError, () => {
   new Reflect.set({});
-}, '`new Reflect.set({})` throws TypeError');
+});
 

--- a/test/built-ins/Reflect/setPrototypeOf/not-a-constructor.js
+++ b/test/built-ins/Reflect/setPrototypeOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new Reflect.setPrototypeOf({}, {});
-}, '`new Reflect.setPrototypeOf({}, {})` throws TypeError');
+});
 

--- a/test/built-ins/RegExp/prototype/Symbol.match/not-a-constructor.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let re = new RegExp(''); new re[Symbol.match]();
-}, '`let re = new RegExp(\'\'); new re[Symbol.match]()` throws TypeError');
+});
 

--- a/test/built-ins/RegExp/prototype/Symbol.matchAll/not-a-constructor.js
+++ b/test/built-ins/RegExp/prototype/Symbol.matchAll/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let re = new RegExp(''); new re[Symbol.matchAll]();
-}, '`let re = new RegExp(\'\'); new re[Symbol.matchAll]()` throws TypeError');
+});
 

--- a/test/built-ins/RegExp/prototype/Symbol.replace/not-a-constructor.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let re = new RegExp(''); new re[Symbol.replace]();
-}, '`let re = new RegExp(\'\'); new re[Symbol.replace]()` throws TypeError');
+});
 

--- a/test/built-ins/RegExp/prototype/Symbol.search/not-a-constructor.js
+++ b/test/built-ins/RegExp/prototype/Symbol.search/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let re = new RegExp(''); new re[Symbol.search]();
-}, '`let re = new RegExp(\'\'); new re[Symbol.search]()` throws TypeError');
+});
 

--- a/test/built-ins/RegExp/prototype/Symbol.split/not-a-constructor.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let re = new RegExp(''); new re[Symbol.split]();
-}, '`let re = new RegExp(\'\'); new re[Symbol.split]()` throws TypeError');
+});
 

--- a/test/built-ins/RegExp/prototype/exec/not-a-constructor.js
+++ b/test/built-ins/RegExp/prototype/exec/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let re = new RegExp(''); new re.exec();
-}, '`let re = new RegExp(\'\'); new re.exec()` throws TypeError');
+});
 

--- a/test/built-ins/RegExp/prototype/test/not-a-constructor.js
+++ b/test/built-ins/RegExp/prototype/test/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let re = new RegExp(''); new re.test();
-}, '`let re = new RegExp(\'\'); new re.test()` throws TypeError');
+});
 

--- a/test/built-ins/RegExp/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/RegExp/prototype/toString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let re = new RegExp(''); new re.toString();
-}, '`let re = new RegExp(\'\'); new re.toString()` throws TypeError');
+});
 

--- a/test/built-ins/Set/prototype/Symbol.iterator/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/Symbol.iterator/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let s = new Set([]); new s[Symbol.iterator]();
-}, '`let s = new Set([]); new s[Symbol.iterator]()` throws TypeError');
+});
 

--- a/test/built-ins/Set/prototype/add/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/add/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Set.prototype.add), false, 'isConstructor(Set.pro
 
 assert.throws(TypeError, () => {
   let s = new Set([]); new s.add();
-}, '`let s = new Set([]); new s.add()` throws TypeError');
+});
 

--- a/test/built-ins/Set/prototype/clear/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/clear/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Set.prototype.clear), false, 'isConstructor(Set.p
 
 assert.throws(TypeError, () => {
   let s = new Set([]); new s.clear();
-}, '`let s = new Set([]); new s.clear()` throws TypeError');
+});
 

--- a/test/built-ins/Set/prototype/delete/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/delete/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Set.prototype.delete), false, 'isConstructor(Set.
 
 assert.throws(TypeError, () => {
   let s = new Set([]); new s.delete();
-}, '`let s = new Set([]); new s.delete()` throws TypeError');
+});
 

--- a/test/built-ins/Set/prototype/difference/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/difference/not-a-constructor.js
@@ -17,6 +17,4 @@ assert.throws(
   TypeError,
   () => {
     new Set.prototype.difference();
-  },
-  "`new Set.prototype.difference()` throws TypeError"
-);
+  });

--- a/test/built-ins/Set/prototype/entries/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/entries/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let s = new Set([]); new s.entries();
-}, '`let s = new Set([]); new s.entries()` throws TypeError');
+});
 

--- a/test/built-ins/Set/prototype/forEach/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/forEach/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let s = new Set([]); new s.forEach(() => {});
-}, '`let s = new Set([]); new s.forEach(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/Set/prototype/has/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/has/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Set.prototype.has), false, 'isConstructor(Set.pro
 
 assert.throws(TypeError, () => {
   let s = new Set([]); new s.has();
-}, '`let s = new Set([]); new s.has()` throws TypeError');
+});
 

--- a/test/built-ins/Set/prototype/intersection/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/intersection/not-a-constructor.js
@@ -17,6 +17,4 @@ assert.throws(
   TypeError,
   () => {
     new Set.prototype.intersection();
-  },
-  "`new Set.prototype.intersection()` throws TypeError"
-);
+  });

--- a/test/built-ins/Set/prototype/isDisjointFrom/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/isDisjointFrom/not-a-constructor.js
@@ -17,6 +17,4 @@ assert.throws(
   TypeError,
   () => {
     new Set.prototype.isDisjointFrom();
-  },
-  "`new Set.prototype.isDisjointFrom()` throws TypeError"
-);
+  });

--- a/test/built-ins/Set/prototype/isSubsetOf/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/isSubsetOf/not-a-constructor.js
@@ -17,6 +17,4 @@ assert.throws(
   TypeError,
   () => {
     new Set.prototype.isSubsetOf();
-  },
-  "`new Set.prototype.isSubsetOf()` throws TypeError"
-);
+  });

--- a/test/built-ins/Set/prototype/isSupersetOf/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/isSupersetOf/not-a-constructor.js
@@ -17,6 +17,4 @@ assert.throws(
   TypeError,
   () => {
     new Set.prototype.isSupersetOf();
-  },
-  "`new Set.prototype.isSupersetOf()` throws TypeError"
-);
+  });

--- a/test/built-ins/Set/prototype/symmetricDifference/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/symmetricDifference/not-a-constructor.js
@@ -17,6 +17,4 @@ assert.throws(
   TypeError,
   () => {
     new Set.prototype.symmetricDifference();
-  },
-  "`new Set.prototype.symmetricDifference()` throws TypeError"
-);
+  });

--- a/test/built-ins/Set/prototype/union/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/union/not-a-constructor.js
@@ -17,6 +17,4 @@ assert.throws(
   TypeError,
   () => {
     new Set.prototype.union();
-  },
-  "`new Set.prototype.union()` throws TypeError"
-);
+  });

--- a/test/built-ins/Set/prototype/values/not-a-constructor.js
+++ b/test/built-ins/Set/prototype/values/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Set.prototype.values), false, 'isConstructor(Set.
 
 assert.throws(TypeError, () => {
   let s = new Set([]); new s.values();
-}, '`let s = new Set([]); new s.values()` throws TypeError');
+});
 

--- a/test/built-ins/ShadowRealm/prototype/evaluate/not-constructor.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/not-constructor.js
@@ -22,7 +22,7 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new ShadowRealm.prototype.evaluate("");
-}, '`new ShadowRealm.prototype.evaluate("")` throws TypeError');
+});
 
 const r = new ShadowRealm();
 r.evaluate('globalThis.x = 0');

--- a/test/built-ins/SharedArrayBuffer/prototype/slice/not-a-constructor.js
+++ b/test/built-ins/SharedArrayBuffer/prototype/slice/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let sab = new SharedArrayBuffer(1); new sab.slice();
-}, '`let sab = new SharedArrayBuffer(1); new sab.slice()` throws TypeError');
+});
 

--- a/test/built-ins/String/fromCharCode/not-a-constructor.js
+++ b/test/built-ins/String/fromCharCode/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(String.fromCharCode), false, 'isConstructor(Strin
 
 assert.throws(TypeError, () => {
   new String.fromCharCode();
-}, '`new String.fromCharCode()` throws TypeError');
+});
 

--- a/test/built-ins/String/fromCodePoint/not-a-constructor.js
+++ b/test/built-ins/String/fromCodePoint/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(String.fromCodePoint), false, 'isConstructor(Stri
 
 assert.throws(TypeError, () => {
   new String.fromCodePoint();
-}, '`new String.fromCodePoint()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/Symbol.iterator/not-a-constructor.js
+++ b/test/built-ins/String/prototype/Symbol.iterator/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype[Symbol.iterator]();
-}, '`new String.prototype[Symbol.iterator]()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/at/index-non-numeric-argument-tointeger-invalid.js
+++ b/test/built-ins/String/prototype/at/index-non-numeric-argument-tointeger-invalid.js
@@ -17,4 +17,4 @@ let s = "01";
 
 assert.throws(TypeError, () => {
   s.at(Symbol());
-}, '`s.at(Symbol())` throws TypeError');
+});

--- a/test/built-ins/String/prototype/at/return-abrupt-from-this.js
+++ b/test/built-ins/String/prototype/at/return-abrupt-from-this.js
@@ -15,8 +15,8 @@ assert.sameValue(typeof String.prototype.at, 'function');
 
 assert.throws(TypeError, () => {
   String.prototype.at.call(undefined);
-}, '`String.prototype.at.call(undefined)` throws TypeError');
+});
 
 assert.throws(TypeError, () => {
   String.prototype.at.call(null);
-}, '`String.prototype.at.call(null)` throws TypeError');
+});

--- a/test/built-ins/String/prototype/charAt/not-a-constructor.js
+++ b/test/built-ins/String/prototype/charAt/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.charAt();
-}, '`new String.prototype.charAt()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/charCodeAt/not-a-constructor.js
+++ b/test/built-ins/String/prototype/charCodeAt/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.charCodeAt();
-}, '`new String.prototype.charCodeAt()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/codePointAt/not-a-constructor.js
+++ b/test/built-ins/String/prototype/codePointAt/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.codePointAt();
-}, '`new String.prototype.codePointAt()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/concat/not-a-constructor.js
+++ b/test/built-ins/String/prototype/concat/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.concat();
-}, '`new String.prototype.concat()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/endsWith/not-a-constructor.js
+++ b/test/built-ins/String/prototype/endsWith/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.endsWith();
-}, '`new String.prototype.endsWith()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/includes/not-a-constructor.js
+++ b/test/built-ins/String/prototype/includes/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.includes(1);
-}, '`new String.prototype.includes(1)` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/indexOf/not-a-constructor.js
+++ b/test/built-ins/String/prototype/indexOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.indexOf();
-}, '`new String.prototype.indexOf()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/isWellFormed/not-a-constructor.js
+++ b/test/built-ins/String/prototype/isWellFormed/not-a-constructor.js
@@ -29,4 +29,4 @@ assert.sameValue(
 
 assert.throws(TypeError, function () {
   new String.prototype.isWellFormed();
-}, '`new String.prototype.isWellFormed()` throws TypeError');
+});

--- a/test/built-ins/String/prototype/isWellFormed/return-abrupt-from-this.js
+++ b/test/built-ins/String/prototype/isWellFormed/return-abrupt-from-this.js
@@ -15,8 +15,8 @@ assert.sameValue(typeof String.prototype.isWellFormed, 'function');
 
 assert.throws(TypeError, function () {
   String.prototype.isWellFormed.call(undefined);
-}, '`String.prototype.isWellFormed.call(undefined)` throws TypeError');
+});
 
 assert.throws(TypeError, function () {
   String.prototype.isWellFormed.call(null);
-}, '`String.prototype.isWellFormed.call(null)` throws TypeError');
+});

--- a/test/built-ins/String/prototype/lastIndexOf/not-a-constructor.js
+++ b/test/built-ins/String/prototype/lastIndexOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.lastIndexOf();
-}, '`new String.prototype.lastIndexOf()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/localeCompare/not-a-constructor.js
+++ b/test/built-ins/String/prototype/localeCompare/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.localeCompare();
-}, '`new String.prototype.localeCompare()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/match/not-a-constructor.js
+++ b/test/built-ins/String/prototype/match/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.match();
-}, '`new String.prototype.match()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/matchAll/not-a-constructor.js
+++ b/test/built-ins/String/prototype/matchAll/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.matchAll();
-}, '`new String.prototype.matchAll()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/normalize/not-a-constructor.js
+++ b/test/built-ins/String/prototype/normalize/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.normalize();
-}, '`new String.prototype.normalize()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/padEnd/not-a-constructor.js
+++ b/test/built-ins/String/prototype/padEnd/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.padEnd();
-}, '`new String.prototype.padEnd()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/padStart/not-a-constructor.js
+++ b/test/built-ins/String/prototype/padStart/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.padStart();
-}, '`new String.prototype.padStart()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/repeat/not-a-constructor.js
+++ b/test/built-ins/String/prototype/repeat/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.repeat();
-}, '`new String.prototype.repeat()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/replace/not-a-constructor.js
+++ b/test/built-ins/String/prototype/replace/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.replace();
-}, '`new String.prototype.replace()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/replaceAll/not-a-constructor.js
+++ b/test/built-ins/String/prototype/replaceAll/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.replaceAll();
-}, '`new String.prototype.replaceAll()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/search/not-a-constructor.js
+++ b/test/built-ins/String/prototype/search/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.search();
-}, '`new String.prototype.search()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/slice/not-a-constructor.js
+++ b/test/built-ins/String/prototype/slice/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.slice();
-}, '`new String.prototype.slice()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/split/not-a-constructor.js
+++ b/test/built-ins/String/prototype/split/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.split();
-}, '`new String.prototype.split()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/startsWith/not-a-constructor.js
+++ b/test/built-ins/String/prototype/startsWith/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.startsWith();
-}, '`new String.prototype.startsWith()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/substring/not-a-constructor.js
+++ b/test/built-ins/String/prototype/substring/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.substring();
-}, '`new String.prototype.substring()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/toLocaleLowerCase/not-a-constructor.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.toLocaleLowerCase();
-}, '`new String.prototype.toLocaleLowerCase()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/toLocaleUpperCase/not-a-constructor.js
+++ b/test/built-ins/String/prototype/toLocaleUpperCase/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.toLocaleUpperCase();
-}, '`new String.prototype.toLocaleUpperCase()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/toLowerCase/not-a-constructor.js
+++ b/test/built-ins/String/prototype/toLowerCase/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.toLowerCase();
-}, '`new String.prototype.toLowerCase()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/String/prototype/toString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.toString();
-}, '`new String.prototype.toString()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/toUpperCase/not-a-constructor.js
+++ b/test/built-ins/String/prototype/toUpperCase/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.toUpperCase();
-}, '`new String.prototype.toUpperCase()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/toWellFormed/not-a-constructor.js
+++ b/test/built-ins/String/prototype/toWellFormed/not-a-constructor.js
@@ -29,4 +29,4 @@ assert.sameValue(
 
 assert.throws(TypeError, function () {
   new String.prototype.toWellFormed();
-}, '`new String.prototype.toWellFormed()` throws TypeError');
+});

--- a/test/built-ins/String/prototype/toWellFormed/return-abrupt-from-this.js
+++ b/test/built-ins/String/prototype/toWellFormed/return-abrupt-from-this.js
@@ -15,8 +15,8 @@ assert.sameValue(typeof String.prototype.toWellFormed, 'function');
 
 assert.throws(TypeError, function () {
   String.prototype.toWellFormed.call(undefined);
-}, '`String.prototype.toWellFormed.call(undefined)` throws TypeError');
+});
 
 assert.throws(TypeError, function () {
   String.prototype.toWellFormed.call(null);
-}, '`String.prototype.toWellFormed.call(null)` throws TypeError');
+});

--- a/test/built-ins/String/prototype/trim/not-a-constructor.js
+++ b/test/built-ins/String/prototype/trim/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.trim();
-}, '`new String.prototype.trim()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/trimEnd/not-a-constructor.js
+++ b/test/built-ins/String/prototype/trimEnd/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.trimEnd();
-}, '`new String.prototype.trimEnd()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/trimStart/not-a-constructor.js
+++ b/test/built-ins/String/prototype/trimStart/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.trimStart();
-}, '`new String.prototype.trimStart()` throws TypeError');
+});
 

--- a/test/built-ins/String/prototype/valueOf/not-a-constructor.js
+++ b/test/built-ins/String/prototype/valueOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new String.prototype.valueOf();
-}, '`new String.prototype.valueOf()` throws TypeError');
+});
 

--- a/test/built-ins/String/raw/not-a-constructor.js
+++ b/test/built-ins/String/raw/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(String.raw), false, 'isConstructor(String.raw) mu
 
 assert.throws(TypeError, () => {
   new String.raw({raw: []}, []);
-}, '`new String.raw({raw: []}, [])` throws TypeError');
+});
 

--- a/test/built-ins/Symbol/for/not-a-constructor.js
+++ b/test/built-ins/Symbol/for/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Symbol.for), false, 'isConstructor(Symbol.for) mu
 
 assert.throws(TypeError, () => {
   new Symbol.for();
-}, '`new Symbol.for()` throws TypeError');
+});
 

--- a/test/built-ins/Symbol/keyFor/not-a-constructor.js
+++ b/test/built-ins/Symbol/keyFor/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(Symbol.keyFor), false, 'isConstructor(Symbol.keyF
 
 assert.throws(TypeError, () => {
   new Symbol.keyFor(Symbol());
-}, '`new Symbol.keyFor(Symbol())` throws TypeError');
+});
 

--- a/test/built-ins/Symbol/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/Symbol/prototype/toString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let symbol = Symbol(); new symbol.toString();
-}, '`let symbol = Symbol(); new symbol.toString()` throws TypeError');
+});
 

--- a/test/built-ins/Symbol/prototype/valueOf/not-a-constructor.js
+++ b/test/built-ins/Symbol/prototype/valueOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let symbol = Symbol(); new symbol.valueOf();
-}, '`let symbol = Symbol(); new symbol.valueOf()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/from/not-a-constructor.js
+++ b/test/built-ins/TypedArray/from/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(TypedArray.from), false, 'isConstructor(TypedArra
 
 assert.throws(TypeError, () => {
   new TypedArray.from([]);
-}, '`new TypedArray.from([])` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/of/not-a-constructor.js
+++ b/test/built-ins/TypedArray/of/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(TypedArray.of), false, 'isConstructor(TypedArray.
 
 assert.throws(TypeError, () => {
   new TypedArray.of(1, 2, 3, 4);
-}, '`new TypedArray.of(1, 2, 3, 4)` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/Symbol.iterator/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/Symbol.iterator/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8[Symbol.iterator]();
-}, '`let u8 = new Uint8Array(1); new u8[Symbol.iterator]()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/at/index-non-numeric-argument-tointeger-invalid.js
+++ b/test/built-ins/TypedArray/prototype/at/index-non-numeric-argument-tointeger-invalid.js
@@ -24,5 +24,5 @@ testWithTypedArrayConstructors(TA => {
 
   assert.throws(TypeError, () => {
     a.at(Symbol());
-  }, '`a.at(Symbol())` throws TypeError');
+  });
 });

--- a/test/built-ins/TypedArray/prototype/at/return-abrupt-from-this.js
+++ b/test/built-ins/TypedArray/prototype/at/return-abrupt-from-this.js
@@ -21,20 +21,20 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   TypedArray.prototype.at.call(undefined);
-}, '`TypedArray.prototype.at.call(undefined)` throws TypeError');
+});
 
 assert.throws(TypeError, () => {
   TypedArray.prototype.at.call(null);
-}, '`TypedArray.prototype.at.call(null)` throws TypeError');
+});
 
 testWithTypedArrayConstructors(TA => {
   assert.sameValue(typeof TA.prototype.at, 'function', 'The value of `typeof TA.prototype.at` is "function"');
 
   assert.throws(TypeError, () => {
     TA.prototype.at.call(undefined);
-  }, '`TA.prototype.at.call(undefined)` throws TypeError');
+  });
 
   assert.throws(TypeError, () => {
     TA.prototype.at.call(null);
-  }, '`TA.prototype.at.call(null)` throws TypeError');
+  });
 });

--- a/test/built-ins/TypedArray/prototype/copyWithin/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.copyWithin();
-}, '`let u8 = new Uint8Array(1); new u8.copyWithin()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/entries/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/entries/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.entries();
-}, '`let u8 = new Uint8Array(1); new u8.entries()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/every/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/every/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.every(() => {});
-}, '`let u8 = new Uint8Array(1); new u8.every(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/fill/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/fill/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.fill();
-}, '`let u8 = new Uint8Array(1); new u8.fill()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/filter/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/filter/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.filter(() => {});
-}, '`let u8 = new Uint8Array(1); new u8.filter(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/find/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/find/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.find(() => {});
-}, '`let u8 = new Uint8Array(1); new u8.find(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/findIndex/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.findIndex(() => {});
-}, '`let u8 = new Uint8Array(1); new u8.findIndex(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/findLast/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/findLast/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.findLast(() => {});
-}, '`let u8 = new Uint8Array(1); new u8.findLast(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/findLastIndex/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.findLastIndex(() => {});
-}, '`let u8 = new Uint8Array(1); new u8.findLastIndex(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/forEach/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/forEach/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.forEach(() => {});
-}, '`let u8 = new Uint8Array(1); new u8.forEach(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/includes/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/includes/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.includes(1);
-}, '`let u8 = new Uint8Array(1); new u8.includes(1)` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/indexOf/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.indexOf();
-}, '`let u8 = new Uint8Array(1); new u8.indexOf()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/join/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/join/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.join();
-}, '`let u8 = new Uint8Array(1); new u8.join()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/keys/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/keys/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.keys();
-}, '`let u8 = new Uint8Array(1); new u8.keys()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.lastIndexOf();
-}, '`let u8 = new Uint8Array(1); new u8.lastIndexOf()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/map/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/map/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.map(() => {});
-}, '`let u8 = new Uint8Array(1); new u8.map(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/reduce/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/reduce/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.reduce(() => {}, []);
-}, '`let u8 = new Uint8Array(1); new u8.reduce(() => {}, [])` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/reduceRight/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.reduceRight(() => {}, []);
-}, '`let u8 = new Uint8Array(1); new u8.reduceRight(() => {}, [])` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/reverse/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/reverse/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.reverse();
-}, '`let u8 = new Uint8Array(1); new u8.reverse()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/set/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/set/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.set([0], 0);
-}, '`let u8 = new Uint8Array(1); new u8.set([0], 0)` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/slice/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/slice/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.slice();
-}, '`let u8 = new Uint8Array(1); new u8.slice()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/some/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/some/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.some(() => {});
-}, '`let u8 = new Uint8Array(1); new u8.some(() => {})` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/sort/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/sort/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.sort();
-}, '`let u8 = new Uint8Array(1); new u8.sort()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/subarray/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/subarray/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.subarray();
-}, '`let u8 = new Uint8Array(1); new u8.subarray()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/toLocaleString/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.toLocaleString();
-}, '`let u8 = new Uint8Array(1); new u8.toLocaleString()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/toReversed/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/toReversed/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new TypedArray.prototype.toReversed();
-}, '`new TypedArray.prototype.toReversed()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/toSorted/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/toSorted/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   new TypedArray.prototype.toSorted();
-}, '`new TypedArray.prototype.toSorted()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/toString/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/toString/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.toString();
-}, '`let u8 = new Uint8Array(1); new u8.toString()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArray/prototype/values/not-a-constructor.js
+++ b/test/built-ins/TypedArray/prototype/values/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let u8 = new Uint8Array(1); new u8.values();
-}, '`let u8 = new Uint8Array(1); new u8.values()` throws TypeError');
+});
 

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/indexed-value-ab-strict.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/indexed-value-ab-strict.js
@@ -39,14 +39,14 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, () => {
     delete sample["0"];
-  }, '`delete sample["0"]` throws TypeError');
+  });
   assert.throws(TypeError, () => {
     delete sample["1"];
-  }, '`delete sample["1"]` throws TypeError');
+  });
   assert.throws(TypeError, () => {
     delete sample[0];
-  }, '`delete sample[0]` throws TypeError');
+  });
   assert.throws(TypeError, () => {
     delete sample[0];
-  }, '`delete sample[0]` throws TypeError');
+  });
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-not-canonical-index-strict.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-not-canonical-index-strict.js
@@ -59,7 +59,7 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
     assert.throws(TypeError, () => {
       delete sample[key];
-    }, '`delete sample[key]` throws TypeError');
+    });
 
     delete TypedArray.prototype[key];
   });

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-not-minus-zero-strict.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-not-minus-zero-strict.js
@@ -42,5 +42,5 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.sameValue(delete sample["-0"], true, 'The value of `delete sample["-0"]` is true');
   assert.throws(TypeError, () => {
     delete sample[-0];
-  }, '`delete sample[-0]` throws TypeError');
+  });
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-not-numeric-index-get-throws.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-not-numeric-index-get-throws.js
@@ -34,5 +34,5 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(Test262Error, () => {
     sample.foo;
-  }, '`sample.foo` throws Test262Error');
+  });
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-not-numeric-index-strict.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-not-numeric-index-strict.js
@@ -41,7 +41,7 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, () => {
     delete sample.bar;
-  }, '`delete sample.bar` throws TypeError');
+  });
 
   assert.sameValue(delete sample.baz, true, 'The value of `delete sample.baz` is true');
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-out-of-bounds-strict.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-out-of-bounds-strict.js
@@ -43,11 +43,11 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, () => {
     delete sample["0"];
-  }, '`delete sample["0"]` throws TypeError');
+  });
 
   assert.throws(TypeError, () => {
     delete sample[0];
-  }, '`delete sample[0]` throws TypeError');
+  });
 
   assert.sameValue(delete sample["1"], true, 'The value of `delete sample["1"]` is true');
   assert.sameValue(delete sample[1], true, 'The value of `delete sample[1]` is true');

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/indexed-value-ab-strict.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/indexed-value-ab-strict.js
@@ -39,14 +39,14 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, () => {
     delete sample["0"];
-  }, '`delete sample["0"]` throws TypeError');
+  });
   assert.throws(TypeError, () => {
     delete sample["1"];
-  }, '`delete sample["1"]` throws TypeError');
+  });
   assert.throws(TypeError, () => {
     delete sample[0];
-  }, '`delete sample[0]` throws TypeError');
+  });
   assert.throws(TypeError, () => {
     delete sample[0];
-  }, '`delete sample[0]` throws TypeError');
+  });
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/key-is-not-canonical-index-strict.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/key-is-not-canonical-index-strict.js
@@ -59,7 +59,7 @@ testWithTypedArrayConstructors(function(TA) {
 
     assert.throws(TypeError, () => {
       delete sample[key];
-    }, '`delete sample[key]` throws TypeError');
+    });
 
     delete TypedArray.prototype[key];
   });

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/key-is-not-minus-zero-strict.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/key-is-not-minus-zero-strict.js
@@ -42,5 +42,5 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(delete sample["-0"], true, 'The value of `delete sample["-0"]` is true');
   assert.throws(TypeError, () => {
     delete sample[-0];
-  }, '`delete sample[-0]` throws TypeError');
+  });
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/key-is-not-numeric-index-get-throws.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/key-is-not-numeric-index-get-throws.js
@@ -34,5 +34,5 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(Test262Error, () => {
     sample.foo;
-  }, '`sample.foo` throws Test262Error');
+  });
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/key-is-not-numeric-index-strict.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/key-is-not-numeric-index-strict.js
@@ -41,7 +41,7 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, () => {
     delete sample.bar;
-  }, '`delete sample.bar` throws TypeError');
+  });
 
   assert.sameValue(delete sample.baz, true, 'The value of `delete sample.baz` is true');
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Delete/key-is-out-of-bounds-strict.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Delete/key-is-out-of-bounds-strict.js
@@ -43,11 +43,11 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, () => {
     delete sample["0"];
-  }, '`delete sample["0"]` throws TypeError');
+  });
 
   assert.throws(TypeError, () => {
     delete sample[0];
-  }, '`delete sample[0]` throws TypeError');
+  });
 
   assert.sameValue(delete sample["1"], true, 'The value of `delete sample["1"]` is true');
   assert.sameValue(delete sample[1], true, 'The value of `delete sample[1]` is true');

--- a/test/built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/abrupt-from-ordinary-has-parent-hasproperty.js
+++ b/test/built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/abrupt-from-ordinary-has-parent-hasproperty.js
@@ -51,7 +51,7 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(Test262Error, function() {
     Reflect.has(sample, "foo");
-  }, '`Reflect.has(sample, "foo")` throws Test262Error');
+  });
 
   Object.defineProperty(sample, "foo", { value: 42 });
 

--- a/test/built-ins/TypedArrayConstructors/internals/HasProperty/abrupt-from-ordinary-has-parent-hasproperty.js
+++ b/test/built-ins/TypedArrayConstructors/internals/HasProperty/abrupt-from-ordinary-has-parent-hasproperty.js
@@ -51,7 +51,7 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(Test262Error, function() {
     Reflect.has(sample, "foo");
-  }, '`Reflect.has(sample, "foo")` throws Test262Error');
+  });
 
   Object.defineProperty(sample, "foo", { value: 42 });
 

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-not-numeric-index-set-throws.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-not-numeric-index-set-throws.js
@@ -34,7 +34,7 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(Test262Error, function() {
     sample.test262 = 1;
-  }, '`sample.test262 = 1` throws Test262Error');
+  });
 
   assert.sameValue(sample.test262, undefined, 'The value of sample.test262 is expected to equal `undefined`');
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/null-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/null-tobigint.js
@@ -56,6 +56,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, function() {
     typedArray[0] = null;
-  }, '`typedArray[0] = null` throws TypeError');
+  });
 
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/number-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/number-tobigint.js
@@ -56,30 +56,30 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, function() {
     typedArray[0] = 1;
-  }, '`typedArray[0] = 1` throws TypeError');
+  });
 
   assert.throws(TypeError, function() {
     typedArray[0] = Math.pow(2, 63);
-  }, '`typedArray[0] = Math.pow(2, 63)` throws TypeError');
+  });
 
   assert.throws(TypeError, function() {
     typedArray[0] = +0;
-  }, '`typedArray[0] = +0` throws TypeError');
+  });
 
   assert.throws(TypeError, function() {
     typedArray[0] = -0;
-  }, '`typedArray[0] = -0` throws TypeError');
+  });
 
   assert.throws(TypeError, function() {
     typedArray[0] = Infinity;
-  }, '`typedArray[0] = Infinity` throws TypeError');
+  });
 
   assert.throws(TypeError, function() {
     typedArray[0] = -Infinity;
-  }, '`typedArray[0] = -Infinity` throws TypeError');
+  });
 
   assert.throws(TypeError, function() {
     typedArray[0] = NaN;
-  }, '`typedArray[0] = NaN` throws TypeError');
+  });
 
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/string-nan-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/string-nan-tobigint.js
@@ -60,6 +60,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(SyntaxError, function() {
     typedArray[0] = "definately not a number";
-  }, '`typedArray[0] = "definately not a number"` throws SyntaxError');
+  });
 
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/symbol-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/symbol-tobigint.js
@@ -58,6 +58,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, function() {
     typedArray[0] = s;
-  }, '`typedArray[0] = s` throws TypeError');
+  });
 
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/undefined-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/undefined-tobigint.js
@@ -57,6 +57,6 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, function() {
     typedArray[0] = undefined;
-  }, '`typedArray[0] = undefined` throws TypeError');
+  });
 
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Set/bigint-tonumber.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/bigint-tonumber.js
@@ -55,5 +55,5 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, function() {
     typedArray[0] = 1n;
-  }, '`typedArray[0] = 1n` throws TypeError');
+  });
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Set/detached-buffer.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/detached-buffer.js
@@ -51,5 +51,5 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(Test262Error, function() {
     sample['0'] = obj;
-  }, '`sample[\'0\'] = obj` throws Test262Error');
+  });
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Set/key-is-not-numeric-index-set-throws.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/key-is-not-numeric-index-set-throws.js
@@ -34,7 +34,7 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(Test262Error, function() {
     sample.test262 = 1;
-  }, '`sample.test262 = 1` throws Test262Error');
+  });
 
   assert.sameValue(sample.test262, undefined, 'The value of sample.test262 is expected to equal `undefined`');
 });

--- a/test/built-ins/TypedArrayConstructors/internals/Set/tonumber-value-throws.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/tonumber-value-throws.js
@@ -37,25 +37,25 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(Test262Error, function() {
     sample["0"] = obj;
-  }, '`sample["0"] = obj` throws Test262Error');
+  });
 
   assert.throws(Test262Error, function() {
     sample["1.1"] = obj;
-  }, '`sample["1.1"] = obj` throws Test262Error');
+  });
 
   assert.throws(Test262Error, function() {
     sample["-0"] = obj;
-  }, '`sample["-0"] = obj` throws Test262Error');
+  });
 
   assert.throws(Test262Error, function() {
     sample["-1"] = obj;
-  }, '`sample["-1"] = obj` throws Test262Error');
+  });
 
   assert.throws(Test262Error, function() {
     sample["1"] = obj;
-  }, '`sample["1"] = obj` throws Test262Error');
+  });
 
   assert.throws(Test262Error, function() {
     sample["2"] = obj;
-  }, '`sample["2"] = obj` throws Test262Error');
+  });
 });

--- a/test/built-ins/WeakMap/prototype/delete/not-a-constructor.js
+++ b/test/built-ins/WeakMap/prototype/delete/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let wm = new WeakMap(); new wm.delete();
-}, '`let wm = new WeakMap(); new wm.delete()` throws TypeError');
+});
 

--- a/test/built-ins/WeakMap/prototype/get/not-a-constructor.js
+++ b/test/built-ins/WeakMap/prototype/get/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let wm = new WeakMap(); new wm.get();
-}, '`let wm = new WeakMap(); new wm.get()` throws TypeError');
+});
 

--- a/test/built-ins/WeakMap/prototype/has/not-a-constructor.js
+++ b/test/built-ins/WeakMap/prototype/has/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let wm = new WeakMap(); new wm.has();
-}, '`let wm = new WeakMap(); new wm.has()` throws TypeError');
+});
 

--- a/test/built-ins/WeakMap/prototype/set/not-a-constructor.js
+++ b/test/built-ins/WeakMap/prototype/set/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let wm = new WeakMap(); new wm.set({}, 1);
-}, '`let wm = new WeakMap(); new wm.set({}, 1)` throws TypeError');
+});
 

--- a/test/built-ins/WeakRef/prototype/deref/not-a-constructor.js
+++ b/test/built-ins/WeakRef/prototype/deref/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let wr = new WeakRef({}); new wr.deref();
-}, '`let wr = new WeakRef({}); new wr.deref()` throws TypeError');
+});
 

--- a/test/built-ins/WeakSet/prototype/add/not-a-constructor.js
+++ b/test/built-ins/WeakSet/prototype/add/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let ws = new WeakSet(); new ws.add({});
-}, '`let ws = new WeakSet(); new ws.add({})` throws TypeError');
+});
 

--- a/test/built-ins/WeakSet/prototype/delete/not-a-constructor.js
+++ b/test/built-ins/WeakSet/prototype/delete/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let ws = new WeakSet(); new ws.delete();
-}, '`let ws = new WeakSet(); new ws.delete()` throws TypeError');
+});
 

--- a/test/built-ins/WeakSet/prototype/has/not-a-constructor.js
+++ b/test/built-ins/WeakSet/prototype/has/not-a-constructor.js
@@ -29,5 +29,5 @@ assert.sameValue(
 
 assert.throws(TypeError, () => {
   let ws = new WeakSet(); new ws.has();
-}, '`let ws = new WeakSet(); new ws.has()` throws TypeError');
+});
 

--- a/test/built-ins/decodeURI/not-a-constructor.js
+++ b/test/built-ins/decodeURI/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(decodeURI), false, 'isConstructor(decodeURI) must
 
 assert.throws(TypeError, () => {
   new decodeURI('');
-}, '`new decodeURI(\'\')` throws TypeError');
+});
 

--- a/test/built-ins/decodeURIComponent/not-a-constructor.js
+++ b/test/built-ins/decodeURIComponent/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(decodeURIComponent), false, 'isConstructor(decode
 
 assert.throws(TypeError, () => {
   new decodeURIComponent('');
-}, '`new decodeURIComponent(\'\')` throws TypeError');
+});
 

--- a/test/built-ins/encodeURI/not-a-constructor.js
+++ b/test/built-ins/encodeURI/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(encodeURI), false, 'isConstructor(encodeURI) must
 
 assert.throws(TypeError, () => {
   new encodeURI('');
-}, '`new encodeURI(\'\')` throws TypeError');
+});
 

--- a/test/built-ins/encodeURIComponent/not-a-constructor.js
+++ b/test/built-ins/encodeURIComponent/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(encodeURIComponent), false, 'isConstructor(encode
 
 assert.throws(TypeError, () => {
   new encodeURIComponent('');
-}, '`new encodeURIComponent(\'\')` throws TypeError');
+});
 

--- a/test/built-ins/eval/not-a-constructor.js
+++ b/test/built-ins/eval/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(eval), false, 'isConstructor(eval) must return fa
 
 assert.throws(TypeError, () => {
   new eval('');
-}, '`new eval(\'\')` throws TypeError');
+});
 

--- a/test/built-ins/isFinite/not-a-constructor.js
+++ b/test/built-ins/isFinite/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(isFinite), false, 'isConstructor(isFinite) must r
 
 assert.throws(TypeError, () => {
   new isFinite(1);
-}, '`new isFinite(1)` throws TypeError');
+});
 

--- a/test/built-ins/isNaN/not-a-constructor.js
+++ b/test/built-ins/isNaN/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(isNaN), false, 'isConstructor(isNaN) must return 
 
 assert.throws(TypeError, () => {
   new isNaN(1);
-}, '`new isNaN(1)` throws TypeError');
+});
 

--- a/test/built-ins/parseFloat/not-a-constructor.js
+++ b/test/built-ins/parseFloat/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(parseFloat), false, 'isConstructor(parseFloat) mu
 
 assert.throws(TypeError, () => {
   new parseFloat(1);
-}, '`new parseFloat(1)` throws TypeError');
+});
 

--- a/test/built-ins/parseInt/not-a-constructor.js
+++ b/test/built-ins/parseInt/not-a-constructor.js
@@ -25,5 +25,5 @@ assert.sameValue(isConstructor(parseInt), false, 'isConstructor(parseInt) must r
 
 assert.throws(TypeError, () => {
   new parseInt(1);
-}, '`new parseInt(1)` throws TypeError');
+});
 

--- a/test/intl402/Locale/constructor-options-collation-invalid.js
+++ b/test/intl402/Locale/constructor-options-collation-invalid.js
@@ -30,5 +30,5 @@ const invalidCollationOptions = [
 for (const invalidCollationOption of invalidCollationOptions) {
   assert.throws(RangeError, function() {
     new Intl.Locale("en", {collation: invalidCollationOption});
-  }, '`new Intl.Locale("en", {collation: invalidCollationOption})` throws RangeError');
+  });
 }


### PR DESCRIPTION
Per https://github.com/tc39/test262/pull/4017#discussion_r1524072885, this (automatically) rewrites a bunch of tests to remove auto-generated error messages in various `assert.throws` tests.

There's still a handful left but this deals with most of them.

<details>
<summary>rewrite-test262.mjs</summary>

```js
import fs from 'node:fs';
import path from 'node:path';

if (process.argv.length !== 3) {
  console.log('Usage: node rewrite-test262.mjs path-to-test262');
  process.exit(1);
}

let dir = process.argv[2];

let matches = 0;
let files = [...fs.readdirSync(dir, { recursive: true, withFileTypes: true })];
for (let i = 0; i < files.length; ++i) {
  let file = files[i];
  if (!file.isFile()) continue;
  let fname = path.join(file.parentPath, file.name);
  let content = fs.readFileSync(fname, 'utf8');

  let regexpSrc = String.raw`
(?<main>assert.throws\( (?<kind>[A-Za-z0-9]+), (function \(\)|\(\) =>) \{
  (?<code>[^}]*|.*)
\})\, "\`(?<code2>[^\`]+)\` throws \k<kind>" \);
`
    .trim()
    .replace(/\\`/g, '`')
    .replace(/\s+/g, '\\s*')
    .replace(/"/g, '["\']');
  let regexp = new RegExp(regexpSrc);

  let match = regexp.exec(content);
  if (match) {
    let { groups } = match;
    let { code, code2} = groups;
    code = code.trim().replace(/\s+/g, '');
    code2 = code2.trim().replace(/\\'/g, "'").replace(/\s+/g, '');
    if (code.endsWith(';')) code = code.slice(0, -1);
    if (code2 !== code) continue;

    ++matches;

    let replacement = `${groups.main});`
    content = content.slice(0, match.index) + replacement + content.slice(match.index + match[0].length);

    fs.writeFileSync(fname, content, 'utf8');
    --i; // re-run on this file in case there was more than one
  }
}
console.log(`rewrote ${matches} instances`);
```
</details>