### PR TITLE
DurationFormat: changed metadata for 'en'/'en-US' tests to correctly indicate locale

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/negative-duration-style-default-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-duration-style-default-en.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.format
 description: >
   Test format method with negative duration and default style
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/format/negative-duration-style-short-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-duration-style-short-en.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.format
 description: >
   Test format method with negative duration and "short" style
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/format/negative-durationstyle-digital-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-durationstyle-digital-en.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.format
 description: >
   Test format method with negative duration and "digital" style
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/format/negative-durationstyle-long-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-durationstyle-long-en.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.format
 description: >
   Test format method with negative duration and "long" style
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/format/negative-durationstyle-narrow-en.js
+++ b/test/intl402/DurationFormat/prototype/format/negative-durationstyle-narrow-en.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.format
 description: >
   Test format method with negative duration and "narrow" style
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds.js
+++ b/test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.format
 description: >
   Minutes with numeric or 2-digit style are included in the output when between displayed hours and seconds, even when the minutes value is zero.
-locale: [en-US]
+locale: [en]
 features: [Intl.DurationFormat]
 ---*/
 

--- a/test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js
+++ b/test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js
@@ -24,7 +24,7 @@ info: |
         7. Let parts be ! PartitionNumberPattern(nf, value).
         ...
 
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/format/style-default-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-default-en.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-Intl.DurationFormat.prototype.format
 description: Test if format method formats duration correctly with different "style" arguments
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/format/style-digital-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-en.js
@@ -5,7 +5,7 @@
 /*---
 esid: sec-Intl.DurationFormat.prototype.format
 description: Test if format method formats duration correctly with different "style" arguments
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-en.js
@@ -13,7 +13,7 @@ info: |
   5. Else,
     a. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", durationFormat.[[FractionalDigits]]).
     b. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", durationFormat.[[FractionalDigits]]).
-locale: [en-US]
+locale: [en]
 features: [Intl.DurationFormat]
 ---*/
 

--- a/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined-en.js
@@ -13,7 +13,7 @@ info: |
   5. Else,
     a. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", durationFormat.[[FractionalDigits]]).
     b. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", durationFormat.[[FractionalDigits]]).
-locale: [en-US]
+locale: [en]
 features: [Intl.DurationFormat]
 ---*/
 

--- a/test/intl402/DurationFormat/prototype/format/style-long-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-long-en.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-Intl.DurationFormat.prototype.format
 description: Test if format method formats duration correctly with different "style" arguments
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/format/style-narrow-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-narrow-en.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-Intl.DurationFormat.prototype.format
 description: Test if format method formats duration correctly with different "style" arguments
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/format/style-short-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-short-en.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-Intl.DurationFormat.prototype.format
 description: Test if format method formats duration correctly with different "style" arguments
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-default-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-default-en.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.formatToParts
 description: >
   Test formatToParts method with negative duration and default style
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-digital-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-digital-en.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.formatToParts
 description: >
   Test formatToParts method with negative duration and "digital" style
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-long-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-long-en.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.formatToParts
 description: >
   Test formatToParts method with negative duration and "long" style
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-narrow-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-narrow-en.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.formatToParts
 description: >
   Test formatToParts method with negative duration and "narrow" style
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/

--- a/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-short-en.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-short-en.js
@@ -5,7 +5,7 @@
 esid: sec-Intl.DurationFormat.prototype.formatToParts
 description: >
   Test formatToParts method with negative duration and "short" style
-locale: [en-US]
+locale: [en]
 includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/


### PR DESCRIPTION
The metadata for several Intl.DurationFormat tests list give "en-US" as the locale when the actual locale used for the tests is just "en". This PR changes the metadata to match the tests.