### PR TITLE
Correct Intl.DateTimeFormat and Intl.DisplayNames locale metadata

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/format/dayPeriod-long-en.js
+++ b/test/intl402/DateTimeFormat/prototype/format/dayPeriod-long-en.js
@@ -5,7 +5,7 @@
 esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, long format.
 features: [Intl.DateTimeFormat-dayPeriod]
-locale: [en-US]
+locale: [en]
 ---*/
 
 const d0000 = new Date(2017, 11, 12,  0, 0, 0, 0);

--- a/test/intl402/DateTimeFormat/prototype/format/dayPeriod-narrow-en.js
+++ b/test/intl402/DateTimeFormat/prototype/format/dayPeriod-narrow-en.js
@@ -5,7 +5,7 @@
 esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, narrow format.
 features: [Intl.DateTimeFormat-dayPeriod]
-locale: [en-US]
+locale: [en]
 ---*/
 
 const d0000 = new Date(2017, 11, 12,  0, 0, 0, 0);

--- a/test/intl402/DateTimeFormat/prototype/format/dayPeriod-short-en.js
+++ b/test/intl402/DateTimeFormat/prototype/format/dayPeriod-short-en.js
@@ -5,7 +5,7 @@
 esid: sec-initializedatetimeformat
 description: Checks basic handling of dayPeriod, short format.
 features: [Intl.DateTimeFormat-dayPeriod]
-locale: [en-US]
+locale: [en]
 ---*/
 
 const d0000 = new Date(2017, 11, 12,  0, 0, 0, 0);

--- a/test/intl402/DateTimeFormat/prototype/format/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/format/fractionalSecondDigits.js
@@ -5,7 +5,7 @@
 esid: sec-createdatetimeformat
 description: Checks basic handling of fractionalSecondDigits.
 features: [Intl.DateTimeFormat-fractionalSecondDigits]
-locale: [en-US]
+locale: [en]
 ---*/
 
 const d1 = new Date(2019, 7, 10,  1, 2, 3, 234);

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/fractionalSecondDigits.js
@@ -5,7 +5,7 @@
 esid: sec-createdatetimeformat
 description: Checks basic handling of fractionalSecondDigits.
 features: [Intl.DateTimeFormat-fractionalSecondDigits]
-locale: [en-US]
+locale: [en]
 ---*/
 
 const d1 = new Date(2019, 7, 10,  1, 2, 3, 234);


### PR DESCRIPTION
Corrects metadata in `DateTimeFormat` and `DisplayNames` which inappropriately identified tests using 'en' locale as `locale: [en-US]` 