### PR TITLE
DurationFormat: added tests for default styles for units following numeric-styled units

### DIFF
--- a/test/intl402/DurationFormat/constructor-unit-style-defaults.js
+++ b/test/intl402/DurationFormat/constructor-unit-style-defaults.js
@@ -25,9 +25,7 @@ for (const numericLikeStyle of ["numeric", "2-digit"]){
 
   assert.sameValue(opts.minutes, "2-digit", `minutes default value should be '2-digit' when following any ${numericLikeStyle}-styled unit`);
   assert.sameValue(opts.seconds, "2-digit", `seconds default value should be '2-digit' when following any ${numericLikeStyle}-styled unit`);
-  for (const subsecondUnit in ["milliseconds", "microseconds", "nanoseconds"]){
-    assert.sameValue(opts.milliseconds, "numeric", `milliseconds default value should be 'numeric' when following any ${numericLikeStyle}-styled unit`);
-    assert.sameValue(opts.microseconds, "numeric", `microseconds default value should be 'numeric' when following any ${numericLikeStyle}-styled unit`);
-    assert.sameValue(opts.nanoseconds, "numeric", `nanoseconds default value should be 'numeric' when following any ${numericLikeStyle}-styled unit`);
-  }
+  assert.sameValue(opts.milliseconds, "numeric", `milliseconds default value should be 'numeric' when following any ${numericLikeStyle}-styled unit`);
+  assert.sameValue(opts.microseconds, "numeric", `microseconds default value should be 'numeric' when following any ${numericLikeStyle}-styled unit`);
+  assert.sameValue(opts.nanoseconds, "numeric", `nanoseconds default value should be 'numeric' when following any ${numericLikeStyle}-styled unit`);
 }

--- a/test/intl402/DurationFormat/constructor-unit-style-defaults.js
+++ b/test/intl402/DurationFormat/constructor-unit-style-defaults.js
@@ -1,0 +1,33 @@
+// Copyright 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat
+description: Verifies that default style settings for units following units with "numeric" or "2-digit" style are honored.
+info: |
+    GetDurationUnitOptions (unit, options, baseStyle, stylesList, digitalBase, prevStyle)
+      (...)
+      3. If style is undefined, then
+        (...)
+        i. If prevStyle is "fractional", "numeric" or "2-digit", then
+          (...)
+          2. Set style to "numeric".
+      (...)
+      9. If prevStyle is "numeric" or "2-digit", then
+        (...)
+        b. If unit is "minutes" or "seconds", then
+                i. Set style to "2-digit".
+features: [Intl.DurationFormat]
+---*/
+
+for (const numericLikeStyle of ["numeric", "2-digit"]){
+  var opts = new Intl.DurationFormat([], {hours: numericLikeStyle}).resolvedOptions();
+
+  assert.sameValue(opts.minutes, "2-digit", `minutes default value should be '2-digit' when following any ${numericLikeStyle}-styled unit`);
+  assert.sameValue(opts.seconds, "2-digit", `seconds default value should be '2-digit' when following any ${numericLikeStyle}-styled unit`);
+  for (const subsecondUnit in ["milliseconds", "microseconds", "nanoseconds"]){
+    assert.sameValue(opts.milliseconds, "numeric", `milliseconds default value should be 'numeric' when following any ${numericLikeStyle}-styled unit`);
+    assert.sameValue(opts.microseconds, "numeric", `microseconds default value should be 'numeric' when following any ${numericLikeStyle}-styled unit`);
+    assert.sameValue(opts.nanoseconds, "numeric", `nanoseconds default value should be 'numeric' when following any ${numericLikeStyle}-styled unit`);
+  }
+}


### PR DESCRIPTION
The `DurationFormat` constructor sets different default styles for units that follow units that use either `"numeric"` or `"2-digit"` style:
* `minutes` and `seconds` default to `"2-digit"`
* subsecond units default to `"numeric"`.

These tests verify that this is done correctly.