### PR TITLE
added test for formatting mixture of short and numeric styles

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/mixed-short-and-numeric.js
+++ b/test/intl402/DurationFormat/prototype/format/mixed-short-and-numeric.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.format
+description: Checks that durations containing a mixture of numericlike and non-numericlike styles are formatted using the "short" style when DurationFormat base style is *undefined*.
+info: |
+    PartitionDurationFormatPattern ( durationFormat, duration )
+
+      12. Let listStyle be durationFormat.[[Style]].
+      (...)
+      14. Perform ! CreateDataPropertyOrThrow(lfOpts, "style", listStyle).
+
+locale: [en]
+features: [Intl.DurationFormat]
+---*/
+
+const locale = "en";
+const timeSeparator = ":";
+
+
+let d = {days: 5, hours: 1, minutes: 2, seconds: 3};
+let dfOpts = {minutes: "numeric", seconds: "numeric"};
+
+let expectedList = [];
+expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "day", unitDisplay: "short"}).format(d.days));
+expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "hour", unitDisplay: "short"}).format(d.hours));
+expectedList.push(d.minutes + timeSeparator + new Intl.NumberFormat(locale, {minimumIntegerDigits: 2}).format(d.seconds));
+
+let expected = new Intl.ListFormat(locale, {style: "short"}).format(expectedList);
+let actual = new Intl.DurationFormat(locale, dfOpts).format(d);
+
+assert.sameValue(actual, expected);
+

--- a/test/intl402/DurationFormat/prototype/format/mixed-short-and-numeric.js
+++ b/test/intl402/DurationFormat/prototype/format/mixed-short-and-numeric.js
@@ -25,7 +25,7 @@ let dfOpts = {minutes: "numeric", seconds: "numeric"};
 let expectedList = [];
 expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "day", unitDisplay: "short"}).format(d.days));
 expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "hour", unitDisplay: "short"}).format(d.hours));
-expectedList.push(d.minutes + timeSeparator + new Intl.NumberFormat(locale, {minimumIntegerDigits: 2}).format(d.seconds));
+expectedList.push(new Intl.NumberFormat(locale).format(d.minutes) + timeSeparator + new Intl.NumberFormat(locale, {minimumIntegerDigits: 2}).format(d.seconds));
 
 let expected = new Intl.ListFormat(locale, {style: "short"}).format(expectedList);
 let actual = new Intl.DurationFormat(locale, dfOpts).format(d);


### PR DESCRIPTION
Verifies that:

1. `numeric`-style minutes are not padded to 2 digits when the style for `hours` is neither `numeric` nor `2-digit`.
2. The correct `ListFormat` style (`"short"`) is used when no `DurationFormat` base style defined.