### PR TITLE
Update test for o[p] = f()

### DIFF
--- a/test/language/expressions/assignment/S11.13.1_A7_T3.js
+++ b/test/language/expressions/assignment/S11.13.1_A7_T3.js
@@ -1,25 +1,38 @@
 // Copyright (C) 2015 André Bargull. All rights reserved.
+// Copyright (C) 2024 Sony Interactive Entertainment Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 info: Assignment Operator evaluates its operands from left to right.
 description: >
     The left-hand side expression is evaluated before the right-hand side.
-    Left-hand side expression is MemberExpression: base[prop]. Evaluating
-    ToPropertyKey(prop) throws an error.
+    Left-hand side expression is MemberExpression: base[prop].
+    ToPropertyKey(prop) occurs after both sides are evaluated.
 ---*/
 
 function DummyError() { }
 
 assert.throws(DummyError, function() {
   var base = {};
-  var prop = {
-    toString: function() {
-      throw new DummyError();
-    }
+  var prop = function() {
+    throw new DummyError();
   };
   var expr = function() {
     throw new Test262Error("right-hand side expression evaluated");
+  };
+
+  base[prop()] = expr();
+});
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new Test262Error("property key evaluated");
+    }
+  };
+  var expr = function() {
+    throw new DummyError();
   };
 
   base[prop] = expr();

--- a/test/language/expressions/assignment/target-member-computed-reference.js
+++ b/test/language/expressions/assignment/target-member-computed-reference.js
@@ -3,11 +3,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-info: Assignment Operator evaluates its operands from left to right.
-description: >
-    The left-hand side expression is evaluated before the right-hand side.
-    Left-hand side expression is MemberExpression: base[prop].
-    ToPropertyKey(prop) occurs after both sides are evaluated.
+esid: sec-assignment-operators
+description: Assignment Operator evaluates its operands from left to right (formerly S11.13.1_A7_T3)
+info: |
+  The left-hand side expression is evaluated before the right-hand side.
+  Left-hand side expression is MemberExpression: base[prop].
+  ToPropertyKey(prop) occurs after both sides are evaluated.
 ---*/
 
 function DummyError() { }

--- a/test/language/expressions/assignment/target-super-computed-reference.js
+++ b/test/language/expressions/assignment/target-super-computed-reference.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2024 Sony Interactive Entertainment Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-assignment-operators
+description: Assignment Operator evaluates its operands from left to right
+info: |
+  The left-hand side expression is evaluated before the right-hand side.
+  Left-hand side expression is MemberExpression: super[prop].
+  ToPropertyKey(prop) occurs after both sides are evaluated.
+---*/
+
+assert.throws(DummyError, function() {
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    throw new Test262Error("right-hand side expression evaluated");
+  };
+
+  class C extends class {} {
+    m() {
+      super[prop()] = expr();
+    }
+  }
+  
+  (new C()).m();
+});
+
+assert.throws(DummyError, function() {
+  var prop = {
+    toString: function() {
+      throw new Test262Error("property key evaluated");
+    }
+  };
+  var expr = function() {
+    throw new DummyError();
+  };
+
+  class C extends class {} {
+    m() {
+      super[prop] = expr();
+    }
+  }
+  
+  (new C()).m();
+});


### PR DESCRIPTION
Update S11.13.1_A7_T3.js now that consensus has been reached on https://github.com/tc39/ecma262/pull/3307.

This ends up basically the same as [target-member-computed-reference-null.js](https://github.com/tc39/test262/blob/main/test/language/expressions/assignment/target-member-computed-reference-null.js), just with a valid base object.