### PR TITLE
Use space instead of tab in comments

### DIFF
--- a/test/intl402/DisplayNames/prototype/of/type-region-invalid.js
+++ b/test/intl402/DisplayNames/prototype/of/type-region-invalid.js
@@ -14,7 +14,7 @@ features: [Intl.DisplayNames]
 ---*/
 
 // https://unicode.org/reports/tr35/#unicode_region_subtag
-// unicode_region_subtag	= (alpha{2} | digit{3}) ;
+// unicode_region_subtag = (alpha{2} | digit{3}) ;
 
 var displayNames = new Intl.DisplayNames(undefined, {type: 'region'});
 


### PR DESCRIPTION
If there is no necessity for it to be a tab, then I think we should use spaces for consistency.

context: WebKit style check is failed because of this(https://github.com/WebKit/WebKit/pull/27213).