### PR TITLE
Update NumberFormat.prototype.useGrouping test for CLDR 45

### DIFF
--- a/test/intl402/NumberFormat/prototype/format/useGrouping-extended-en-IN.js
+++ b/test/intl402/NumberFormat/prototype/format/useGrouping-extended-en-IN.js
@@ -28,6 +28,6 @@ assert.sameValue(nf.format(100000), '1,00,000', '"min2"');
 nf = new Intl.NumberFormat('en-IN', {notation: 'compact'});
 
 assert.sameValue(nf.format(100), '100', 'notation: "compact"');
-assert.sameValue(nf.format(1000), '1T', 'notation: "compact"');
-assert.sameValue(nf.format(10000), '10T', 'notation: "compact"');
+assert.sameValue(nf.format(1000), '1K', 'notation: "compact"');
+assert.sameValue(nf.format(10000), '10K', 'notation: "compact"');
 assert.sameValue(nf.format(100000), '1L', 'notation: "compact"');


### PR DESCRIPTION
In CLDR 45, in the en-IN locale, the compact thousands symbol changed from 'T' to 'K' after a survey was conducted in India:

https://github.com/unicode-org/cldr/commit/b8d447297556ee01575da2b5b710554af34b3482