### PR TITLE
Bug fix for DurationFormat prototype/format/fractions-of-subsecond-units-en.js 

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/fractions-of-subsecond-units-en.js
+++ b/test/intl402/DurationFormat/prototype/format/fractions-of-subsecond-units-en.js
@@ -42,19 +42,19 @@ let dfOpts = {microseconds: "numeric"};
 
 let expectedList = [];
 expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "second", unitDisplay: "short"}).format(d.seconds));
-expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "millisecond", unitDisplay: "short", minimumFractionDigits:0, maximumFractionDigits: 9}).format(d.milliseconds.toString() + decimalSeparator + d.microseconds.toString().padStart(3, '0') + d.nanoseconds.toString().padStart(3, '0')));
+expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "millisecond", unitDisplay: "short", minimumFractionDigits:0, maximumFractionDigits: 9, roundingMode: "trunc"}).format(d.milliseconds.toString() + decimalSeparator + d.microseconds.toString().padStart(3, '0') + d.nanoseconds.toString().padStart(3, '0')));
 
 let expected = new Intl.ListFormat(locale, {style: "short"}).format(expectedList);
 let actual = new Intl.DurationFormat(locale, dfOpts).format(d);
 
-// assert.sameValue(actual, expected, `DurationFormat output when microseconds first "numeric" unit`);
+assert.sameValue(actual, expected, `DurationFormat output when microseconds first "numeric" unit`);
 
 dfOpts = {nanoseconds: "numeric"};
 expectedList = [];
 
 expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "second", unitDisplay: "short"}).format(d.seconds));
 expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "millisecond", unitDisplay: "short"}).format(d.milliseconds));
-expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "microsecond", unitDisplay: "short", minimumFractionDigits:0, maximumFractionDigits: 9}).format(d.microseconds.toString() + decimalSeparator + d.nanoseconds.toString().padStart(3, '0')));
+expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "microsecond", unitDisplay: "short", minimumFractionDigits:0, maximumFractionDigits: 9, roundingMode: "trunc"}).format(d.microseconds.toString() + decimalSeparator + d.nanoseconds.toString().padStart(3, '0')));
 
 expected = new Intl.ListFormat(locale, {style: "short"}).format(expectedList);
 actual = new Intl.DurationFormat(locale, dfOpts).format(d);


### PR DESCRIPTION
Uncommented erroneously commented line, added roundingMode: 'trunc' to NumberFormat options when fractional digits are formatted to match behaviour of DurationFormat -- doesn't make a difference with these test values, but could with others
