### PR TITLE
Fix mixed-short-and-numeric.js

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/mixed-short-and-numeric.js
+++ b/test/intl402/DurationFormat/prototype/format/mixed-short-and-numeric.js
@@ -7,6 +7,7 @@ description: Checks that durations containing a mixture of numericlike and non-n
 info: |
     PartitionDurationFormatPattern ( durationFormat, duration )
 
+      11. Perform ! CreateDataPropertyOrThrow(lfOpts, "type", "unit").
       12. Let listStyle be durationFormat.[[Style]].
       (...)
       14. Perform ! CreateDataPropertyOrThrow(lfOpts, "style", listStyle).
@@ -27,7 +28,7 @@ expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "day", uni
 expectedList.push(new Intl.NumberFormat(locale, {style: "unit", unit: "hour", unitDisplay: "short"}).format(d.hours));
 expectedList.push(new Intl.NumberFormat(locale).format(d.minutes) + timeSeparator + new Intl.NumberFormat(locale, {minimumIntegerDigits: 2}).format(d.seconds));
 
-let expected = new Intl.ListFormat(locale, {style: "short"}).format(expectedList);
+let expected = new Intl.ListFormat(locale, {type: "unit", style: "short"}).format(expectedList);
 let actual = new Intl.DurationFormat(locale, dfOpts).format(d);
 
 assert.sameValue(actual, expected);


### PR DESCRIPTION
The option for the listFormat need to include {type: "unit"}

see https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern 

@ben-allen @anba @ryzokuken @Ms2ger 