### PR TITLE
RAB: Integrate staging tests for .copyWithin method

### DIFF
--- a/test/built-ins/Array/prototype/copyWithin/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/copyWithin/resizable-buffer.js
@@ -1,0 +1,175 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.copywithin
+description: >
+  Array.p.copyWithin behaves correctly when the receiver is backed by
+  resizable buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+const ArrayCopyWithinHelper = (ta, ...rest) => {
+  Array.prototype.copyWithin.call(ta, ...rest);
+};
+
+function TestCopyWithin() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, ...] << lengthTracking
+    //                    [2, 3, ...] << lengthTrackingWithOffset
+
+    ArrayCopyWithinHelper(fixedLength, 0, 2);
+    assert.compareArray(ToNumbers(fixedLength), [
+      2,
+      3,
+      2,
+      3
+    ]);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+    ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+      3,
+      3
+    ]);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+    ArrayCopyWithinHelper(lengthTracking, 0, 2);
+    assert.compareArray(ToNumbers(lengthTracking), [
+      2,
+      3,
+      2,
+      3
+    ]);
+    ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+      3,
+      3
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 3; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2]
+    //              [0, 1, 2, ...] << lengthTracking
+    //                    [2, ...] << lengthTrackingWithOffset
+
+    ArrayCopyWithinHelper(fixedLength, 0, 1);
+    ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+    // We'll check below that these were no-op.
+
+    assert.compareArray(ToNumbers(lengthTracking), [
+      0,
+      1,
+      2
+    ]);
+    ArrayCopyWithinHelper(lengthTracking, 0, 1);
+    assert.compareArray(ToNumbers(lengthTracking), [
+      1,
+      2,
+      2
+    ]);
+    ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [2]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    WriteToTypedArray(taWrite, 0, 0);
+    ArrayCopyWithinHelper(fixedLength, 0, 1, 1);
+    ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
+    ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
+
+    assert.compareArray(ToNumbers(lengthTracking), [0]);
+    ArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
+    assert.compareArray(ToNumbers(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    ArrayCopyWithinHelper(fixedLength, 0, 1, 1);
+    ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
+    ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
+
+    assert.compareArray(ToNumbers(lengthTracking), []);
+    ArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
+    assert.compareArray(ToNumbers(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3, 4, 5]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+
+    ArrayCopyWithinHelper(fixedLength, 0, 2);
+    assert.compareArray(ToNumbers(fixedLength), [
+      2,
+      3,
+      2,
+      3
+    ]);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+    ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+      3,
+      3
+    ]);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+    //        target ^     ^ start
+    ArrayCopyWithinHelper(lengthTracking, 0, 2);
+    assert.compareArray(ToNumbers(lengthTracking), [
+      2,
+      3,
+      4,
+      5,
+      4,
+      5
+    ]);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+    //              target ^  ^ start
+    ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+      3,
+      4,
+      5,
+      5
+    ]);
+  }
+}
+
+TestCopyWithin();

--- a/test/built-ins/Array/prototype/copyWithin/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/copyWithin/resizable-buffer.js
@@ -14,162 +14,158 @@ const ArrayCopyWithinHelper = (ta, ...rest) => {
   Array.prototype.copyWithin.call(ta, ...rest);
 };
 
-function TestCopyWithin() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    // Orig. array: [0, 1, 2, 3]
-    //              [0, 1, 2, 3] << fixedLength
-    //                    [2, 3] << fixedLengthWithOffset
-    //              [0, 1, 2, 3, ...] << lengthTracking
-    //                    [2, 3, ...] << lengthTrackingWithOffset
-
-    ArrayCopyWithinHelper(fixedLength, 0, 2);
-    assert.compareArray(ToNumbers(fixedLength), [
-      2,
-      3,
-      2,
-      3
-    ]);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-    ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
-    assert.compareArray(ToNumbers(fixedLengthWithOffset), [
-      3,
-      3
-    ]);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-    ArrayCopyWithinHelper(lengthTracking, 0, 2);
-    assert.compareArray(ToNumbers(lengthTracking), [
-      2,
-      3,
-      2,
-      3
-    ]);
-    ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
-    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
-      3,
-      3
-    ]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 3; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    // Orig. array: [0, 1, 2]
-    //              [0, 1, 2, ...] << lengthTracking
-    //                    [2, ...] << lengthTrackingWithOffset
-
-    ArrayCopyWithinHelper(fixedLength, 0, 1);
-    ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
-    // We'll check below that these were no-op.
-
-    assert.compareArray(ToNumbers(lengthTracking), [
-      0,
-      1,
-      2
-    ]);
-    ArrayCopyWithinHelper(lengthTracking, 0, 1);
-    assert.compareArray(ToNumbers(lengthTracking), [
-      1,
-      2,
-      2
-    ]);
-    ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
-    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [2]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    WriteToTypedArray(taWrite, 0, 0);
-    ArrayCopyWithinHelper(fixedLength, 0, 1, 1);
-    ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
-    ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
-
-    assert.compareArray(ToNumbers(lengthTracking), [0]);
-    ArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
-    assert.compareArray(ToNumbers(lengthTracking), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    ArrayCopyWithinHelper(fixedLength, 0, 1, 1);
-    ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
-    ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
-
-    assert.compareArray(ToNumbers(lengthTracking), []);
-    ArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
-    assert.compareArray(ToNumbers(lengthTracking), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    // Orig. array: [0, 1, 2, 3, 4, 5]
-    //              [0, 1, 2, 3] << fixedLength
-    //                    [2, 3] << fixedLengthWithOffset
-    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
-    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
-
-    ArrayCopyWithinHelper(fixedLength, 0, 2);
-    assert.compareArray(ToNumbers(fixedLength), [
-      2,
-      3,
-      2,
-      3
-    ]);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-    ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
-    assert.compareArray(ToNumbers(fixedLengthWithOffset), [
-      3,
-      3
-    ]);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
-    //        target ^     ^ start
-    ArrayCopyWithinHelper(lengthTracking, 0, 2);
-    assert.compareArray(ToNumbers(lengthTracking), [
-      2,
-      3,
-      4,
-      5,
-      4,
-      5
-    ]);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
-    //              target ^  ^ start
-    ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
-    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
-      3,
-      4,
-      5,
-      5
-    ]);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
   }
-}
 
-TestCopyWithin();
+  // Orig. array: [0, 1, 2, 3]
+  //              [0, 1, 2, 3] << fixedLength
+  //                    [2, 3] << fixedLengthWithOffset
+  //              [0, 1, 2, 3, ...] << lengthTracking
+  //                    [2, 3, ...] << lengthTrackingWithOffset
+
+  ArrayCopyWithinHelper(fixedLength, 0, 2);
+  assert.compareArray(ToNumbers(fixedLength), [
+    2,
+    3,
+    2,
+    3
+  ]);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+    3,
+    3
+  ]);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  ArrayCopyWithinHelper(lengthTracking, 0, 2);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    2,
+    3,
+    2,
+    3
+  ]);
+  ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+    3,
+    3
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 3; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+
+  // Orig. array: [0, 1, 2]
+  //              [0, 1, 2, ...] << lengthTracking
+  //                    [2, ...] << lengthTrackingWithOffset
+
+  ArrayCopyWithinHelper(fixedLength, 0, 1);
+  ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+  // We'll check below that these were no-op.
+
+  assert.compareArray(ToNumbers(lengthTracking), [
+    0,
+    1,
+    2
+  ]);
+  ArrayCopyWithinHelper(lengthTracking, 0, 1);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    1,
+    2,
+    2
+  ]);
+  ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [2]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  WriteToTypedArray(taWrite, 0, 0);
+  ArrayCopyWithinHelper(fixedLength, 0, 1, 1);
+  ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
+  ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
+
+  assert.compareArray(ToNumbers(lengthTracking), [0]);
+  ArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
+  assert.compareArray(ToNumbers(lengthTracking), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  ArrayCopyWithinHelper(fixedLength, 0, 1, 1);
+  ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
+  ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
+
+  assert.compareArray(ToNumbers(lengthTracking), []);
+  ArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
+  assert.compareArray(ToNumbers(lengthTracking), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+
+  // Orig. array: [0, 1, 2, 3, 4, 5]
+  //              [0, 1, 2, 3] << fixedLength
+  //                    [2, 3] << fixedLengthWithOffset
+  //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+  //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+
+  ArrayCopyWithinHelper(fixedLength, 0, 2);
+  assert.compareArray(ToNumbers(fixedLength), [
+    2,
+    3,
+    2,
+    3
+  ]);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+    3,
+    3
+  ]);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+
+  //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+  //        target ^     ^ start
+  ArrayCopyWithinHelper(lengthTracking, 0, 2);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    2,
+    3,
+    4,
+    5,
+    4,
+    5
+  ]);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+
+  //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+  //              target ^  ^ start
+  ArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+    3,
+    4,
+    5,
+    5
+  ]);
+}

--- a/test/built-ins/Array/prototype/copyWithin/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/copyWithin/resizable-buffer.js
@@ -74,9 +74,14 @@ for (let ctor of ctors) {
   //              [0, 1, 2, ...] << lengthTracking
   //                    [2, ...] << lengthTrackingWithOffset
 
+  assert.compareArray(ToNumbers(fixedLength), []);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset), []);
+
   ArrayCopyWithinHelper(fixedLength, 0, 1);
   ArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
   // We'll check below that these were no-op.
+  assert.compareArray(ToNumbers(fixedLength), []);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset), []);
 
   assert.compareArray(ToNumbers(lengthTracking), [
     0,

--- a/test/built-ins/Array/prototype/copyWithin/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/copyWithin/resizable-buffer.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.copywithin
 description: >
   Array.p.copyWithin behaves correctly when the receiver is backed by
   resizable buffer
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-end-shrink.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-end-shrink.js
@@ -1,0 +1,80 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.copywithin
+description: >
+  TypedArray.p.copyWithin behaves correctly when argument coercion shrinks the receiver
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  assert.throws(TypeError, () => {
+    fixedLength.copyWithin(evil, 0, 1);
+  });
+  rab.resize(4 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.copyWithin(0, evil, 3);
+  });
+  rab.resize(4 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.copyWithin(0, 1, evil);
+  });
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+  // [0, 1, 2, 3]
+  //        ^
+  //        target
+  // ^
+  // start
+  const evil = {
+    valueOf: () => {
+      rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  lengthTracking.copyWithin(evil, 0);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    0,
+    1,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+  // [0, 1, 2, 3]
+  //        ^
+  //        start
+  // ^
+  // target
+  const evil = {
+    valueOf: () => {
+      rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  lengthTracking.copyWithin(0, evil);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    2,
+    1,
+    2
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-end-shrink.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-end-shrink.js
@@ -5,7 +5,7 @@
 esid: sec-array.prototype.copywithin
 description: >
   TypedArray.p.copyWithin behaves correctly when argument coercion shrinks the receiver
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-grow.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-grow.js
@@ -4,8 +4,7 @@
 /*---
 esid: sec-array.prototype.copywithin
 description: >
-  Automatically ported from CopyWithinParameterConversionGrows test
-  in V8's mjsunit test typedarray-resizablearraybuffer.js
+  TypedArray.p.copyWithin behaves correctly when argument coercion shrinks the receiver
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-grow.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-grow.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.copywithin
 description: >
   Automatically ported from CopyWithinParameterConversionGrows test
   in V8's mjsunit test typedarray-resizablearraybuffer.js
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-grow.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-grow.js
@@ -1,0 +1,56 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.copywithin
+description: >
+  Automatically ported from CopyWithinParameterConversionGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+  const evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      WriteToTypedArray(lengthTracking, 4, 4);
+      WriteToTypedArray(lengthTracking, 5, 5);
+      return 0;
+    }
+  };
+  // Orig. array: [0, 1, 2, 3]  [4, 5]
+  //               ^     ^       ^ new elements
+  //          target     start
+  lengthTracking.copyWithin(evil, 2);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    2,
+    3,
+    2,
+    3,
+    4,
+    5
+  ]);
+  rab.resize(4 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+
+  // Orig. array: [0, 1, 2, 3]  [4, 5]
+  //               ^     ^       ^ new elements
+  //           start     target
+  lengthTracking.copyWithin(2, evil);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    0,
+    1,
+    0,
+    1,
+    4,
+    5
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/copyWithin/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/resizable-buffer.js
@@ -10,10 +10,6 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-const TypedArrayCopyWithinHelper = (ta, ...rest) => {
-  ta.copyWithin(...rest);
-};
-
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
   const fixedLength = new ctor(rab, 0, 4);
@@ -33,7 +29,7 @@ for (let ctor of ctors) {
   //              [0, 1, 2, 3, ...] << lengthTracking
   //                    [2, 3, ...] << lengthTrackingWithOffset
 
-  TypedArrayCopyWithinHelper(fixedLength, 0, 2);
+  fixedLength.copyWithin(0, 2);
   assert.compareArray(ToNumbers(fixedLength), [
     2,
     3,
@@ -43,7 +39,7 @@ for (let ctor of ctors) {
   for (let i = 0; i < 4; ++i) {
     WriteToTypedArray(taWrite, i, i);
   }
-  TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+  fixedLengthWithOffset.copyWithin(0, 1);
   assert.compareArray(ToNumbers(fixedLengthWithOffset), [
     3,
     3
@@ -51,14 +47,14 @@ for (let ctor of ctors) {
   for (let i = 0; i < 4; ++i) {
     WriteToTypedArray(taWrite, i, i);
   }
-  TypedArrayCopyWithinHelper(lengthTracking, 0, 2);
+  lengthTracking.copyWithin(0, 2);
   assert.compareArray(ToNumbers(lengthTracking), [
     2,
     3,
     2,
     3
   ]);
-  TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+  lengthTrackingWithOffset.copyWithin(0, 1);
   assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
     3,
     3
@@ -75,54 +71,54 @@ for (let ctor of ctors) {
   //                    [2, ...] << lengthTrackingWithOffset
 
   assert.throws(TypeError, () => {
-    TypedArrayCopyWithinHelper(fixedLength, 0, 1);
+    fixedLength.copyWithin(0, 1);
   });
   assert.throws(TypeError, () => {
-    TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+    fixedLengthWithOffset.copyWithin(0, 1);
   });
   assert.compareArray(ToNumbers(lengthTracking), [
     0,
     1,
     2
   ]);
-  TypedArrayCopyWithinHelper(lengthTracking, 0, 1);
+  lengthTracking.copyWithin(0, 1);
   assert.compareArray(ToNumbers(lengthTracking), [
     1,
     2,
     2
   ]);
-  TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+  lengthTrackingWithOffset.copyWithin(0, 1);
   assert.compareArray(ToNumbers(lengthTrackingWithOffset), [2]);
 
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
   WriteToTypedArray(taWrite, 0, 0);
   assert.throws(TypeError, () => {
-    TypedArrayCopyWithinHelper(fixedLength, 0, 1, 1);
+    fixedLength.copyWithin(0, 1, 1);
   });
   assert.throws(TypeError, () => {
-    TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
+    fixedLengthWithOffset.copyWithin(0, 1, 1);
   });
   assert.throws(TypeError, () => {
-    TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
+    lengthTrackingWithOffset.copyWithin(0, 1, 1);
   });
   assert.compareArray(ToNumbers(lengthTracking), [0]);
-  TypedArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
+  lengthTracking.copyWithin(0, 0, 1);
   assert.compareArray(ToNumbers(lengthTracking), [0]);
 
   // Shrink to zero.
   rab.resize(0);
   assert.throws(TypeError, () => {
-    TypedArrayCopyWithinHelper(fixedLength, 0, 1, 1);
+    fixedLength.copyWithin(0, 1, 1);
   });
   assert.throws(TypeError, () => {
-    TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
+    fixedLengthWithOffset.copyWithin(0, 1, 1);
   });
   assert.throws(TypeError, () => {
-    TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
+    lengthTrackingWithOffset.copyWithin(0, 1, 1);
   });
   assert.compareArray(ToNumbers(lengthTracking), []);
-  TypedArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
+  lengthTracking.copyWithin(0, 0, 1);
   assert.compareArray(ToNumbers(lengthTracking), []);
 
   // Grow so that all TAs are back in-bounds.
@@ -137,7 +133,7 @@ for (let ctor of ctors) {
   //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
   //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
 
-  TypedArrayCopyWithinHelper(fixedLength, 0, 2);
+  fixedLength.copyWithin(0, 2);
   assert.compareArray(ToNumbers(fixedLength), [
     2,
     3,
@@ -147,7 +143,7 @@ for (let ctor of ctors) {
   for (let i = 0; i < 6; ++i) {
     WriteToTypedArray(taWrite, i, i);
   }
-  TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+  fixedLengthWithOffset.copyWithin(0, 1);
   assert.compareArray(ToNumbers(fixedLengthWithOffset), [
     3,
     3
@@ -158,7 +154,7 @@ for (let ctor of ctors) {
 
   //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
   //        target ^     ^ start
-  TypedArrayCopyWithinHelper(lengthTracking, 0, 2);
+  lengthTracking.copyWithin(0, 2);
   assert.compareArray(ToNumbers(lengthTracking), [
     2,
     3,
@@ -173,7 +169,7 @@ for (let ctor of ctors) {
 
   //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
   //              target ^  ^ start
-  TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+  lengthTrackingWithOffset.copyWithin(0, 1);
   assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
     3,
     4,

--- a/test/built-ins/TypedArray/prototype/copyWithin/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/resizable-buffer.js
@@ -6,7 +6,7 @@ esid: sec-%typedarray%.prototype.copywithin
 description: >
   TypedArray.p.copyWithin behaves correctly when the receiver is backed by
   resizable buffer
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/resizable-buffer.js
@@ -14,174 +14,170 @@ const TypedArrayCopyWithinHelper = (ta, ...rest) => {
   ta.copyWithin(...rest);
 };
 
-function TestCopyWithin() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    // Orig. array: [0, 1, 2, 3]
-    //              [0, 1, 2, 3] << fixedLength
-    //                    [2, 3] << fixedLengthWithOffset
-    //              [0, 1, 2, 3, ...] << lengthTracking
-    //                    [2, 3, ...] << lengthTrackingWithOffset
-
-    TypedArrayCopyWithinHelper(fixedLength, 0, 2);
-    assert.compareArray(ToNumbers(fixedLength), [
-      2,
-      3,
-      2,
-      3
-    ]);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-    TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
-    assert.compareArray(ToNumbers(fixedLengthWithOffset), [
-      3,
-      3
-    ]);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-    TypedArrayCopyWithinHelper(lengthTracking, 0, 2);
-    assert.compareArray(ToNumbers(lengthTracking), [
-      2,
-      3,
-      2,
-      3
-    ]);
-    TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
-    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
-      3,
-      3
-    ]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 3; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    // Orig. array: [0, 1, 2]
-    //              [0, 1, 2, ...] << lengthTracking
-    //                    [2, ...] << lengthTrackingWithOffset
-
-    assert.throws(TypeError, () => {
-      TypedArrayCopyWithinHelper(fixedLength, 0, 1);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
-    });
-    assert.compareArray(ToNumbers(lengthTracking), [
-      0,
-      1,
-      2
-    ]);
-    TypedArrayCopyWithinHelper(lengthTracking, 0, 1);
-    assert.compareArray(ToNumbers(lengthTracking), [
-      1,
-      2,
-      2
-    ]);
-    TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
-    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [2]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    WriteToTypedArray(taWrite, 0, 0);
-    assert.throws(TypeError, () => {
-      TypedArrayCopyWithinHelper(fixedLength, 0, 1, 1);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
-    });
-    assert.compareArray(ToNumbers(lengthTracking), [0]);
-    TypedArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
-    assert.compareArray(ToNumbers(lengthTracking), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      TypedArrayCopyWithinHelper(fixedLength, 0, 1, 1);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
-    });
-    assert.compareArray(ToNumbers(lengthTracking), []);
-    TypedArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
-    assert.compareArray(ToNumbers(lengthTracking), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    // Orig. array: [0, 1, 2, 3, 4, 5]
-    //              [0, 1, 2, 3] << fixedLength
-    //                    [2, 3] << fixedLengthWithOffset
-    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
-    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
-
-    TypedArrayCopyWithinHelper(fixedLength, 0, 2);
-    assert.compareArray(ToNumbers(fixedLength), [
-      2,
-      3,
-      2,
-      3
-    ]);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-    TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
-    assert.compareArray(ToNumbers(fixedLengthWithOffset), [
-      3,
-      3
-    ]);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
-    //        target ^     ^ start
-    TypedArrayCopyWithinHelper(lengthTracking, 0, 2);
-    assert.compareArray(ToNumbers(lengthTracking), [
-      2,
-      3,
-      4,
-      5,
-      4,
-      5
-    ]);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
-    //              target ^  ^ start
-    TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
-    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
-      3,
-      4,
-      5,
-      5
-    ]);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
   }
-}
 
-TestCopyWithin();
+  // Orig. array: [0, 1, 2, 3]
+  //              [0, 1, 2, 3] << fixedLength
+  //                    [2, 3] << fixedLengthWithOffset
+  //              [0, 1, 2, 3, ...] << lengthTracking
+  //                    [2, 3, ...] << lengthTrackingWithOffset
+
+  TypedArrayCopyWithinHelper(fixedLength, 0, 2);
+  assert.compareArray(ToNumbers(fixedLength), [
+    2,
+    3,
+    2,
+    3
+  ]);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+    3,
+    3
+  ]);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  TypedArrayCopyWithinHelper(lengthTracking, 0, 2);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    2,
+    3,
+    2,
+    3
+  ]);
+  TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+    3,
+    3
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 3; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+
+  // Orig. array: [0, 1, 2]
+  //              [0, 1, 2, ...] << lengthTracking
+  //                    [2, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    TypedArrayCopyWithinHelper(fixedLength, 0, 1);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+  });
+  assert.compareArray(ToNumbers(lengthTracking), [
+    0,
+    1,
+    2
+  ]);
+  TypedArrayCopyWithinHelper(lengthTracking, 0, 1);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    1,
+    2,
+    2
+  ]);
+  TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [2]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  WriteToTypedArray(taWrite, 0, 0);
+  assert.throws(TypeError, () => {
+    TypedArrayCopyWithinHelper(fixedLength, 0, 1, 1);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
+  });
+  assert.compareArray(ToNumbers(lengthTracking), [0]);
+  TypedArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
+  assert.compareArray(ToNumbers(lengthTracking), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    TypedArrayCopyWithinHelper(fixedLength, 0, 1, 1);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
+  });
+  assert.compareArray(ToNumbers(lengthTracking), []);
+  TypedArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
+  assert.compareArray(ToNumbers(lengthTracking), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+
+  // Orig. array: [0, 1, 2, 3, 4, 5]
+  //              [0, 1, 2, 3] << fixedLength
+  //                    [2, 3] << fixedLengthWithOffset
+  //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+  //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+
+  TypedArrayCopyWithinHelper(fixedLength, 0, 2);
+  assert.compareArray(ToNumbers(fixedLength), [
+    2,
+    3,
+    2,
+    3
+  ]);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+    3,
+    3
+  ]);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+
+  //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+  //        target ^     ^ start
+  TypedArrayCopyWithinHelper(lengthTracking, 0, 2);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    2,
+    3,
+    4,
+    5,
+    4,
+    5
+  ]);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+
+  //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+  //              target ^  ^ start
+  TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+    3,
+    4,
+    5,
+    5
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/copyWithin/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/resizable-buffer.js
@@ -1,0 +1,187 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.copywithin
+description: >
+  TypedArray.p.copyWithin behaves correctly when the receiver is backed by
+  resizable buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+const TypedArrayCopyWithinHelper = (ta, ...rest) => {
+  ta.copyWithin(...rest);
+};
+
+function TestCopyWithin() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, ...] << lengthTracking
+    //                    [2, 3, ...] << lengthTrackingWithOffset
+
+    TypedArrayCopyWithinHelper(fixedLength, 0, 2);
+    assert.compareArray(ToNumbers(fixedLength), [
+      2,
+      3,
+      2,
+      3
+    ]);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+    TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+      3,
+      3
+    ]);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+    TypedArrayCopyWithinHelper(lengthTracking, 0, 2);
+    assert.compareArray(ToNumbers(lengthTracking), [
+      2,
+      3,
+      2,
+      3
+    ]);
+    TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+      3,
+      3
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 3; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2]
+    //              [0, 1, 2, ...] << lengthTracking
+    //                    [2, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      TypedArrayCopyWithinHelper(fixedLength, 0, 1);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+    });
+    assert.compareArray(ToNumbers(lengthTracking), [
+      0,
+      1,
+      2
+    ]);
+    TypedArrayCopyWithinHelper(lengthTracking, 0, 1);
+    assert.compareArray(ToNumbers(lengthTracking), [
+      1,
+      2,
+      2
+    ]);
+    TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [2]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    WriteToTypedArray(taWrite, 0, 0);
+    assert.throws(TypeError, () => {
+      TypedArrayCopyWithinHelper(fixedLength, 0, 1, 1);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
+    });
+    assert.compareArray(ToNumbers(lengthTracking), [0]);
+    TypedArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
+    assert.compareArray(ToNumbers(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      TypedArrayCopyWithinHelper(fixedLength, 0, 1, 1);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1, 1);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1, 1);
+    });
+    assert.compareArray(ToNumbers(lengthTracking), []);
+    TypedArrayCopyWithinHelper(lengthTracking, 0, 0, 1);
+    assert.compareArray(ToNumbers(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3, 4, 5]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+
+    TypedArrayCopyWithinHelper(fixedLength, 0, 2);
+    assert.compareArray(ToNumbers(fixedLength), [
+      2,
+      3,
+      2,
+      3
+    ]);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+    TypedArrayCopyWithinHelper(fixedLengthWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+      3,
+      3
+    ]);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+    //        target ^     ^ start
+    TypedArrayCopyWithinHelper(lengthTracking, 0, 2);
+    assert.compareArray(ToNumbers(lengthTracking), [
+      2,
+      3,
+      4,
+      5,
+      4,
+      5
+    ]);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+    //              target ^  ^ start
+    TypedArrayCopyWithinHelper(lengthTrackingWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+      3,
+      4,
+      5,
+      5
+    ]);
+  }
+}
+
+TestCopyWithin();


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR #3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js