### PR TITLE
RAB: Integrate staging tests for the .entries method

### DIFF
--- a/test/built-ins/Array/prototype/entries/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/entries/resizable-buffer-grow-mid-iteration.js
@@ -6,8 +6,8 @@ esid: sec-array.prototype.entries
 description: >
   Array.p.entries behaves correctly when receiver is backed by a resizable
   buffer and resized mid-iteration
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
 ---*/
 
 function ArrayEntriesHelper(ta) {

--- a/test/built-ins/Array/prototype/entries/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/entries/resizable-buffer-grow-mid-iteration.js
@@ -14,105 +14,100 @@ function ArrayEntriesHelper(ta) {
   return Array.prototype.entries.call(ta);
 }
 
-function EntriesGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
 
-  // Iterating with entries() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(ArrayEntriesHelper(fixedLength), [
-      [
-        0,
-        0
-      ],
-      [
-        1,
-        2
-      ],
-      [
-        2,
-        4
-      ],
-      [
-        3,
-        6
-      ]
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(ArrayEntriesHelper(fixedLengthWithOffset), [
-      [
-        0,
-        4
-      ],
-      [
-        1,
-        6
-      ]
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(ArrayEntriesHelper(lengthTracking), [
-      [
-        0,
-        0
-      ],
-      [
-        1,
-        2
-      ],
-      [
-        2,
-        4
-      ],
-      [
-        3,
-        6
-      ],
-      [
-        4,
-        0
-      ],
-      [
-        5,
-        0
-      ]
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    TestIterationAndResize(ArrayEntriesHelper(lengthTrackingWithOffset), [
-      [
-        0,
-        4
-      ],
-      [
-        1,
-        6
-      ],
-      [
-        2,
-        0
-      ],
-      [
-        3,
-        0
-      ]
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
+// Iterating with entries() (the 4 loops below).
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(ArrayEntriesHelper(fixedLength), [
+    [
+      0,
+      0
+    ],
+    [
+      1,
+      2
+    ],
+    [
+      2,
+      4
+    ],
+    [
+      3,
+      6
+    ]
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-EntriesGrowMidIteration();
-
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(ArrayEntriesHelper(fixedLengthWithOffset), [
+    [
+      0,
+      4
+    ],
+    [
+      1,
+      6
+    ]
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(ArrayEntriesHelper(lengthTracking), [
+    [
+      0,
+      0
+    ],
+    [
+      1,
+      2
+    ],
+    [
+      2,
+      4
+    ],
+    [
+      3,
+      6
+    ],
+    [
+      4,
+      0
+    ],
+    [
+      5,
+      0
+    ]
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  TestIterationAndResize(ArrayEntriesHelper(lengthTrackingWithOffset), [
+    [
+      0,
+      4
+    ],
+    [
+      1,
+      6
+    ],
+    [
+      2,
+      0
+    ],
+    [
+      3,
+      0
+    ]
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+}

--- a/test/built-ins/Array/prototype/entries/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/entries/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,118 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.entries
+description: >
+  Array.p.entries behaves correctly when receiver is backed by a resizable
+  buffer and resized mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+function ArrayEntriesHelper(ta) {
+  return Array.prototype.entries.call(ta);
+}
+
+function EntriesGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  // Iterating with entries() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(ArrayEntriesHelper(fixedLength), [
+      [
+        0,
+        0
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        4
+      ],
+      [
+        3,
+        6
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(ArrayEntriesHelper(fixedLengthWithOffset), [
+      [
+        0,
+        4
+      ],
+      [
+        1,
+        6
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(ArrayEntriesHelper(lengthTracking), [
+      [
+        0,
+        0
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        4
+      ],
+      [
+        3,
+        6
+      ],
+      [
+        4,
+        0
+      ],
+      [
+        5,
+        0
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(ArrayEntriesHelper(lengthTrackingWithOffset), [
+      [
+        0,
+        4
+      ],
+      [
+        1,
+        6
+      ],
+      [
+        2,
+        0
+      ],
+      [
+        3,
+        0
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+EntriesGrowMidIteration();
+

--- a/test/built-ins/Array/prototype/entries/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/entries/resizable-buffer-shrink-mid-iteration.js
@@ -14,63 +14,59 @@ function ArrayEntriesHelper(ta) {
   return Array.prototype.entries.call(ta);
 }
 
-function EntriesShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  // Iterating with entries() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+// Iterating with entries() (the 4 loops below).
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
 
-    // The fixed length array goes out of bounds when the RAB is resized.
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(ArrayEntriesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-
-    // The fixed length array goes out of bounds when the RAB is resized.
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(ArrayEntriesHelper(fixedLengthWithOffset), null, rab, 1, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(ArrayEntriesHelper(lengthTracking), [
-      [
-        0,
-        0
-      ],
-      [
-        1,
-        2
-      ],
-      [
-        2,
-        4
-      ]
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    TestIterationAndResize(ArrayEntriesHelper(lengthTrackingWithOffset), [
-      [
-        0,
-        4
-      ],
-      [
-        1,
-        6
-      ]
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
+  // The fixed length array goes out of bounds when the RAB is resized.
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(ArrayEntriesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  });
 }
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
 
-EntriesShrinkMidIteration();
+  // The fixed length array goes out of bounds when the RAB is resized.
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(ArrayEntriesHelper(fixedLengthWithOffset), null, rab, 1, 3 * ctor.BYTES_PER_ELEMENT);
+  });
+}
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(ArrayEntriesHelper(lengthTracking), [
+    [
+      0,
+      0
+    ],
+    [
+      1,
+      2
+    ],
+    [
+      2,
+      4
+    ]
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  TestIterationAndResize(ArrayEntriesHelper(lengthTrackingWithOffset), [
+    [
+      0,
+      4
+    ],
+    [
+      1,
+      6
+    ]
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+}

--- a/test/built-ins/Array/prototype/entries/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/entries/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,76 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.entries
+description: >
+  Array.p.entries behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+function ArrayEntriesHelper(ta) {
+  return Array.prototype.entries.call(ta);
+}
+
+function EntriesShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  // Iterating with entries() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(ArrayEntriesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(ArrayEntriesHelper(fixedLengthWithOffset), null, rab, 1, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(ArrayEntriesHelper(lengthTracking), [
+      [
+        0,
+        0
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        4
+      ]
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(ArrayEntriesHelper(lengthTrackingWithOffset), [
+      [
+        0,
+        4
+      ],
+      [
+        1,
+        6
+      ]
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+EntriesShrinkMidIteration();

--- a/test/built-ins/Array/prototype/entries/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/entries/resizable-buffer-shrink-mid-iteration.js
@@ -6,8 +6,8 @@ esid: sec-array.prototype.entries
 description: >
   Array.p.entries behaves correctly when receiver is backed by resizable
   buffer that is shrunk mid-iteration
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
 ---*/
 
 function ArrayEntriesHelper(ta) {

--- a/test/built-ins/Array/prototype/entries/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/entries/resizable-buffer.js
@@ -18,7 +18,7 @@ function ValuesFromArrayEntries(ta) {
   let result = [];
   let expectedKey = 0;
   for (let [key, value] of Array.prototype.entries.call(ta)) {
-    assert.sameValue(key, expectedKey);
+    assert.sameValue(key, expectedKey, 'TypedArray method .entries should return `expectedKey`.');
     ++expectedKey;
     result.push(Number(value));
   }

--- a/test/built-ins/Array/prototype/entries/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/entries/resizable-buffer.js
@@ -1,0 +1,168 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.entries
+description: >
+  Array.p.entries behaves correctly when receiver is backed by resizable
+  buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+function ArrayEntriesHelper(ta) {
+  return Array.prototype.entries.call(ta);
+}
+
+function ValuesFromArrayEntries(ta) {
+  let result = [];
+  let expectedKey = 0;
+  for (let [key, value] of Array.prototype.entries.call(ta)) {
+    assert.sameValue(key, expectedKey);
+    ++expectedKey;
+    result.push(Number(value));
+  }
+  return result;
+}
+
+function TestEntries() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ValuesFromArrayEntries(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromArrayEntries(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromArrayEntries(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromArrayEntries(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    // TypedArray.prototype.{entries, keys, values} throw right away when
+    // called. Array.prototype.{entries, keys, values} don't throw, but when
+    // we try to iterate the returned ArrayIterator, that throws.
+    ArrayEntriesHelper(fixedLength);
+    ArrayEntriesHelper(fixedLengthWithOffset);
+
+    assert.throws(TypeError, () => {
+      Array.from(ArrayEntriesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayEntriesHelper(fixedLengthWithOffset));
+    });
+    assert.compareArray(ValuesFromArrayEntries(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(ValuesFromArrayEntries(lengthTrackingWithOffset), [4]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    ArrayEntriesHelper(fixedLength);
+    ArrayEntriesHelper(fixedLengthWithOffset);
+    ArrayEntriesHelper(lengthTrackingWithOffset);
+
+    assert.throws(TypeError, () => {
+      Array.from(ArrayEntriesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayEntriesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayEntriesHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(ValuesFromArrayEntries(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    ArrayEntriesHelper(fixedLength);
+    ArrayEntriesHelper(fixedLengthWithOffset);
+    ArrayEntriesHelper(lengthTrackingWithOffset);
+
+    assert.throws(TypeError, () => {
+      Array.from(ArrayEntriesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayEntriesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayEntriesHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(ValuesFromArrayEntries(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ValuesFromArrayEntries(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromArrayEntries(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromArrayEntries(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(ValuesFromArrayEntries(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+  }
+}
+
+TestEntries();

--- a/test/built-ins/Array/prototype/entries/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/entries/resizable-buffer.js
@@ -25,144 +25,140 @@ function ValuesFromArrayEntries(ta) {
   return result;
 }
 
-function TestEntries() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(ValuesFromArrayEntries(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromArrayEntries(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromArrayEntries(lengthTracking), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromArrayEntries(lengthTrackingWithOffset), [
-      4,
-      6
-    ]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    // TypedArray.prototype.{entries, keys, values} throw right away when
-    // called. Array.prototype.{entries, keys, values} don't throw, but when
-    // we try to iterate the returned ArrayIterator, that throws.
-    ArrayEntriesHelper(fixedLength);
-    ArrayEntriesHelper(fixedLengthWithOffset);
-
-    assert.throws(TypeError, () => {
-      Array.from(ArrayEntriesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayEntriesHelper(fixedLengthWithOffset));
-    });
-    assert.compareArray(ValuesFromArrayEntries(lengthTracking), [
-      0,
-      2,
-      4
-    ]);
-    assert.compareArray(ValuesFromArrayEntries(lengthTrackingWithOffset), [4]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    ArrayEntriesHelper(fixedLength);
-    ArrayEntriesHelper(fixedLengthWithOffset);
-    ArrayEntriesHelper(lengthTrackingWithOffset);
-
-    assert.throws(TypeError, () => {
-      Array.from(ArrayEntriesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayEntriesHelper(fixedLengthWithOffset));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayEntriesHelper(lengthTrackingWithOffset));
-    });
-    assert.compareArray(ValuesFromArrayEntries(lengthTracking), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    ArrayEntriesHelper(fixedLength);
-    ArrayEntriesHelper(fixedLengthWithOffset);
-    ArrayEntriesHelper(lengthTrackingWithOffset);
-
-    assert.throws(TypeError, () => {
-      Array.from(ArrayEntriesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayEntriesHelper(fixedLengthWithOffset));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayEntriesHelper(lengthTrackingWithOffset));
-    });
-    assert.compareArray(ValuesFromArrayEntries(lengthTracking), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(ValuesFromArrayEntries(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromArrayEntries(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromArrayEntries(lengthTracking), [
-      0,
-      2,
-      4,
-      6,
-      8,
-      10
-    ]);
-    assert.compareArray(ValuesFromArrayEntries(lengthTrackingWithOffset), [
-      4,
-      6,
-      8,
-      10
-    ]);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-TestEntries();
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ValuesFromArrayEntries(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ValuesFromArrayEntries(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(ValuesFromArrayEntries(lengthTracking), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ValuesFromArrayEntries(lengthTrackingWithOffset), [
+    4,
+    6
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  // TypedArray.prototype.{entries, keys, values} throw right away when
+  // called. Array.prototype.{entries, keys, values} don't throw, but when
+  // we try to iterate the returned ArrayIterator, that throws.
+  ArrayEntriesHelper(fixedLength);
+  ArrayEntriesHelper(fixedLengthWithOffset);
+
+  assert.throws(TypeError, () => {
+    Array.from(ArrayEntriesHelper(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(ArrayEntriesHelper(fixedLengthWithOffset));
+  });
+  assert.compareArray(ValuesFromArrayEntries(lengthTracking), [
+    0,
+    2,
+    4
+  ]);
+  assert.compareArray(ValuesFromArrayEntries(lengthTrackingWithOffset), [4]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  ArrayEntriesHelper(fixedLength);
+  ArrayEntriesHelper(fixedLengthWithOffset);
+  ArrayEntriesHelper(lengthTrackingWithOffset);
+
+  assert.throws(TypeError, () => {
+    Array.from(ArrayEntriesHelper(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(ArrayEntriesHelper(fixedLengthWithOffset));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(ArrayEntriesHelper(lengthTrackingWithOffset));
+  });
+  assert.compareArray(ValuesFromArrayEntries(lengthTracking), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  ArrayEntriesHelper(fixedLength);
+  ArrayEntriesHelper(fixedLengthWithOffset);
+  ArrayEntriesHelper(lengthTrackingWithOffset);
+
+  assert.throws(TypeError, () => {
+    Array.from(ArrayEntriesHelper(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(ArrayEntriesHelper(fixedLengthWithOffset));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(ArrayEntriesHelper(lengthTrackingWithOffset));
+  });
+  assert.compareArray(ValuesFromArrayEntries(lengthTracking), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ValuesFromArrayEntries(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ValuesFromArrayEntries(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(ValuesFromArrayEntries(lengthTracking), [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10
+  ]);
+  assert.compareArray(ValuesFromArrayEntries(lengthTrackingWithOffset), [
+    4,
+    6,
+    8,
+    10
+  ]);
+}

--- a/test/built-ins/Array/prototype/entries/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/entries/resizable-buffer.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.entries
 description: >
   Array.p.entries behaves correctly when receiver is backed by resizable
   buffer
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer-grow-mid-iteration.js
@@ -10,104 +10,100 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function EntriesGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
 
-  // Iterating with entries() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(fixedLength.entries(), [
-      [
-        0,
-        0
-      ],
-      [
-        1,
-        2
-      ],
-      [
-        2,
-        4
-      ],
-      [
-        3,
-        6
-      ]
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(fixedLengthWithOffset.entries(), [
-      [
-        0,
-        4
-      ],
-      [
-        1,
-        6
-      ]
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(lengthTracking.entries(), [
-      [
-        0,
-        0
-      ],
-      [
-        1,
-        2
-      ],
-      [
-        2,
-        4
-      ],
-      [
-        3,
-        6
-      ],
-      [
-        4,
-        0
-      ],
-      [
-        5,
-        0
-      ]
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    TestIterationAndResize(lengthTrackingWithOffset.entries(), [
-      [
-        0,
-        4
-      ],
-      [
-        1,
-        6
-      ],
-      [
-        2,
-        0
-      ],
-      [
-        3,
-        0
-      ]
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
+// Iterating with entries() (the 4 loops below).
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(fixedLength.entries(), [
+    [
+      0,
+      0
+    ],
+    [
+      1,
+      2
+    ],
+    [
+      2,
+      4
+    ],
+    [
+      3,
+      6
+    ]
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-EntriesGrowMidIteration();
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(fixedLengthWithOffset.entries(), [
+    [
+      0,
+      4
+    ],
+    [
+      1,
+      6
+    ]
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(lengthTracking.entries(), [
+    [
+      0,
+      0
+    ],
+    [
+      1,
+      2
+    ],
+    [
+      2,
+      4
+    ],
+    [
+      3,
+      6
+    ],
+    [
+      4,
+      0
+    ],
+    [
+      5,
+      0
+    ]
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  TestIterationAndResize(lengthTrackingWithOffset.entries(), [
+    [
+      0,
+      4
+    ],
+    [
+      1,
+      6
+    ],
+    [
+      2,
+      0
+    ],
+    [
+      3,
+      0
+    ]
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+}

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer-grow-mid-iteration.js
@@ -6,8 +6,8 @@ esid: sec-%typedarray%.prototype.entries
 description: >
   TypedArray.p.entries behaves correctly when receiver is backed by a resizable
   buffer and resized mid-iteration
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
 ---*/
 
 function EntriesGrowMidIteration() {

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,113 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.entries
+description: >
+  TypedArray.p.entries behaves correctly when receiver is backed by a resizable
+  buffer and resized mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+function EntriesGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  // Iterating with entries() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(fixedLength.entries(), [
+      [
+        0,
+        0
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        4
+      ],
+      [
+        3,
+        6
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(fixedLengthWithOffset.entries(), [
+      [
+        0,
+        4
+      ],
+      [
+        1,
+        6
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(lengthTracking.entries(), [
+      [
+        0,
+        0
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        4
+      ],
+      [
+        3,
+        6
+      ],
+      [
+        4,
+        0
+      ],
+      [
+        5,
+        0
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(lengthTrackingWithOffset.entries(), [
+      [
+        0,
+        4
+      ],
+      [
+        1,
+        6
+      ],
+      [
+        2,
+        0
+      ],
+      [
+        3,
+        0
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+EntriesGrowMidIteration();

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,76 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.entries
+description: >
+  TypedArray.p.entries behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+function TypedArrayEntriesHelper(ta) {
+  return ta.entries();
+}
+
+function EntriesShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  // Iterating with entries() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(TypedArrayEntriesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(TypedArrayEntriesHelper(fixedLengthWithOffset), null, rab, 1, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(TypedArrayEntriesHelper(lengthTracking), [
+      [
+        0,
+        0
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        4
+      ]
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(TypedArrayEntriesHelper(lengthTrackingWithOffset), [
+      [
+        0,
+        4
+      ],
+      [
+        1,
+        6
+      ]
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+EntriesShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer-shrink-mid-iteration.js
@@ -6,8 +6,8 @@ esid: sec-%typedarray%.prototype.entries
 description: >
   TypedArray.p.entries behaves correctly when receiver is backed by resizable
   buffer that is shrunk mid-iteration
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
 ---*/
 
 function TypedArrayEntriesHelper(ta) {

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer-shrink-mid-iteration.js
@@ -10,10 +10,6 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function TypedArrayEntriesHelper(ta) {
-  return ta.entries();
-}
-
 // Orig. array: [0, 2, 4, 6]
 //              [0, 2, 4, 6] << fixedLength
 //                    [4, 6] << fixedLengthWithOffset
@@ -26,7 +22,7 @@ for (let ctor of ctors) {
 
   // The fixed length array goes out of bounds when the RAB is resized.
   assert.throws(TypeError, () => {
-    TestIterationAndResize(TypedArrayEntriesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(fixedLength.entries(), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
   });
 }
 for (let ctor of ctors) {
@@ -35,13 +31,13 @@ for (let ctor of ctors) {
 
   // The fixed length array goes out of bounds when the RAB is resized.
   assert.throws(TypeError, () => {
-    TestIterationAndResize(TypedArrayEntriesHelper(fixedLengthWithOffset), null, rab, 1, 3 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(fixedLengthWithOffset.entries(), null, rab, 1, 3 * ctor.BYTES_PER_ELEMENT);
   });
 }
 for (let ctor of ctors) {
   const rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  TestIterationAndResize(TypedArrayEntriesHelper(lengthTracking), [
+  TestIterationAndResize(lengthTracking.entries(), [
     [
       0,
       0
@@ -59,7 +55,7 @@ for (let ctor of ctors) {
 for (let ctor of ctors) {
   const rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  TestIterationAndResize(TypedArrayEntriesHelper(lengthTrackingWithOffset), [
+  TestIterationAndResize(lengthTrackingWithOffset.entries(), [
     [
       0,
       4

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer-shrink-mid-iteration.js
@@ -14,63 +14,59 @@ function TypedArrayEntriesHelper(ta) {
   return ta.entries();
 }
 
-function EntriesShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  // Iterating with entries() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+// Iterating with entries() (the 4 loops below).
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
 
-    // The fixed length array goes out of bounds when the RAB is resized.
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(TypedArrayEntriesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-
-    // The fixed length array goes out of bounds when the RAB is resized.
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(TypedArrayEntriesHelper(fixedLengthWithOffset), null, rab, 1, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(TypedArrayEntriesHelper(lengthTracking), [
-      [
-        0,
-        0
-      ],
-      [
-        1,
-        2
-      ],
-      [
-        2,
-        4
-      ]
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    TestIterationAndResize(TypedArrayEntriesHelper(lengthTrackingWithOffset), [
-      [
-        0,
-        4
-      ],
-      [
-        1,
-        6
-      ]
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
+  // The fixed length array goes out of bounds when the RAB is resized.
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(TypedArrayEntriesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  });
 }
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
 
-EntriesShrinkMidIteration();
+  // The fixed length array goes out of bounds when the RAB is resized.
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(TypedArrayEntriesHelper(fixedLengthWithOffset), null, rab, 1, 3 * ctor.BYTES_PER_ELEMENT);
+  });
+}
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(TypedArrayEntriesHelper(lengthTracking), [
+    [
+      0,
+      0
+    ],
+    [
+      1,
+      2
+    ],
+    [
+      2,
+      4
+    ]
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  TestIterationAndResize(TypedArrayEntriesHelper(lengthTrackingWithOffset), [
+    [
+      0,
+      4
+    ],
+    [
+      1,
+      6
+    ]
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+}

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer.js
@@ -1,0 +1,184 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.values
+description: >
+  TypedArray.p.values behaves correctly when receiver is backed by resizable
+  buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+function TypedArrayEntriesHelper(ta) {
+  return ta.entries();
+}
+
+function ValuesFromTypedArrayEntries(ta) {
+  let result = [];
+  let expectedKey = 0;
+  for (let [key, value] of ta.entries()) {
+    assert.sameValue(key, expectedKey);
+    ++expectedKey;
+    result.push(Number(value));
+  }
+  return result;
+}
+
+function TestEntries() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ValuesFromTypedArrayEntries(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromTypedArrayEntries(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromTypedArrayEntries(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    // TypedArray.prototype.{entries, keys, values} throw right away when
+    // called. Array.prototype.{entries, keys, values} don't throw, but when
+    // we try to iterate the returned ArrayIterator, that throws.
+    assert.throws(TypeError, () => {
+      TypedArrayEntriesHelper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayEntriesHelper(fixedLengthWithOffset);
+    });
+
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayEntriesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
+    });
+    assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(ValuesFromTypedArrayEntries(lengthTrackingWithOffset), [4]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      TypedArrayEntriesHelper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayEntriesHelper(fixedLengthWithOffset);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayEntriesHelper(lengthTrackingWithOffset);
+    });
+
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayEntriesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayEntriesHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      TypedArrayEntriesHelper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayEntriesHelper(fixedLengthWithOffset);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayEntriesHelper(lengthTrackingWithOffset);
+    });
+
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayEntriesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayEntriesHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ValuesFromTypedArrayEntries(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromTypedArrayEntries(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(ValuesFromTypedArrayEntries(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+  }
+}
+
+TestEntries();

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer.js
@@ -10,15 +10,11 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function TypedArrayEntriesHelper(ta) {
-  return ta.entries();
-}
-
 function ValuesFromTypedArrayEntries(ta) {
   let result = [];
   let expectedKey = 0;
   for (let [key, value] of ta.entries()) {
-    assert.sameValue(key, expectedKey);
+    assert.sameValue(key, expectedKey, 'TypedArray method .entries should return `expectedKey`.');
     ++expectedKey;
     result.push(Number(value));
   }
@@ -76,17 +72,17 @@ for (let ctor of ctors) {
   // called. Array.prototype.{entries, keys, values} don't throw, but when
   // we try to iterate the returned ArrayIterator, that throws.
   assert.throws(TypeError, () => {
-    TypedArrayEntriesHelper(fixedLength);
+    fixedLength.entries();
   });
   assert.throws(TypeError, () => {
-    TypedArrayEntriesHelper(fixedLengthWithOffset);
+    fixedLengthWithOffset.entries();
   });
 
   assert.throws(TypeError, () => {
-    Array.from(TypedArrayEntriesHelper(fixedLength));
+    Array.from(fixedLength.entries());
   });
   assert.throws(TypeError, () => {
-    Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
+    Array.from(fixedLengthWithOffset.entries());
   });
   assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [
     0,
@@ -98,46 +94,46 @@ for (let ctor of ctors) {
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
   assert.throws(TypeError, () => {
-    TypedArrayEntriesHelper(fixedLength);
+    fixedLength.entries();
   });
   assert.throws(TypeError, () => {
-    TypedArrayEntriesHelper(fixedLengthWithOffset);
+    fixedLengthWithOffset.entries();
   });
   assert.throws(TypeError, () => {
-    TypedArrayEntriesHelper(lengthTrackingWithOffset);
+    lengthTrackingWithOffset.entries();
   });
 
   assert.throws(TypeError, () => {
-    Array.from(TypedArrayEntriesHelper(fixedLength));
+    Array.from(fixedLength.entries());
   });
   assert.throws(TypeError, () => {
-    Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
+    Array.from(fixedLengthWithOffset.entries());
   });
   assert.throws(TypeError, () => {
-    Array.from(TypedArrayEntriesHelper(lengthTrackingWithOffset));
+    Array.from(lengthTrackingWithOffset.entries());
   });
   assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [0]);
 
   // Shrink to zero.
   rab.resize(0);
   assert.throws(TypeError, () => {
-    TypedArrayEntriesHelper(fixedLength);
+    fixedLength.entries();
   });
   assert.throws(TypeError, () => {
-    TypedArrayEntriesHelper(fixedLengthWithOffset);
+    fixedLengthWithOffset.entries();
   });
   assert.throws(TypeError, () => {
-    TypedArrayEntriesHelper(lengthTrackingWithOffset);
+    lengthTrackingWithOffset.entries();
   });
 
   assert.throws(TypeError, () => {
-    Array.from(TypedArrayEntriesHelper(fixedLength));
+    Array.from(fixedLength.entries());
   });
   assert.throws(TypeError, () => {
-    Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
+    Array.from(fixedLengthWithOffset.entries());
   });
   assert.throws(TypeError, () => {
-    Array.from(TypedArrayEntriesHelper(lengthTrackingWithOffset));
+    Array.from(lengthTrackingWithOffset.entries());
   });
   assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), []);
 

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer.js
@@ -6,7 +6,7 @@ esid: sec-%typedarray%.prototype.values
 description: >
   TypedArray.p.values behaves correctly when receiver is backed by resizable
   buffer
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/entries/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/entries/resizable-buffer.js
@@ -25,160 +25,156 @@ function ValuesFromTypedArrayEntries(ta) {
   return result;
 }
 
-function TestEntries() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(ValuesFromTypedArrayEntries(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromTypedArrayEntries(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromTypedArrayEntries(lengthTrackingWithOffset), [
-      4,
-      6
-    ]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    // TypedArray.prototype.{entries, keys, values} throw right away when
-    // called. Array.prototype.{entries, keys, values} don't throw, but when
-    // we try to iterate the returned ArrayIterator, that throws.
-    assert.throws(TypeError, () => {
-      TypedArrayEntriesHelper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayEntriesHelper(fixedLengthWithOffset);
-    });
-
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayEntriesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
-    });
-    assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [
-      0,
-      2,
-      4
-    ]);
-    assert.compareArray(ValuesFromTypedArrayEntries(lengthTrackingWithOffset), [4]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      TypedArrayEntriesHelper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayEntriesHelper(fixedLengthWithOffset);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayEntriesHelper(lengthTrackingWithOffset);
-    });
-
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayEntriesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayEntriesHelper(lengthTrackingWithOffset));
-    });
-    assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      TypedArrayEntriesHelper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayEntriesHelper(fixedLengthWithOffset);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayEntriesHelper(lengthTrackingWithOffset);
-    });
-
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayEntriesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayEntriesHelper(lengthTrackingWithOffset));
-    });
-    assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(ValuesFromTypedArrayEntries(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromTypedArrayEntries(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [
-      0,
-      2,
-      4,
-      6,
-      8,
-      10
-    ]);
-    assert.compareArray(ValuesFromTypedArrayEntries(lengthTrackingWithOffset), [
-      4,
-      6,
-      8,
-      10
-    ]);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-TestEntries();
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ValuesFromTypedArrayEntries(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ValuesFromTypedArrayEntries(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ValuesFromTypedArrayEntries(lengthTrackingWithOffset), [
+    4,
+    6
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  // TypedArray.prototype.{entries, keys, values} throw right away when
+  // called. Array.prototype.{entries, keys, values} don't throw, but when
+  // we try to iterate the returned ArrayIterator, that throws.
+  assert.throws(TypeError, () => {
+    TypedArrayEntriesHelper(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayEntriesHelper(fixedLengthWithOffset);
+  });
+
+  assert.throws(TypeError, () => {
+    Array.from(TypedArrayEntriesHelper(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
+  });
+  assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [
+    0,
+    2,
+    4
+  ]);
+  assert.compareArray(ValuesFromTypedArrayEntries(lengthTrackingWithOffset), [4]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    TypedArrayEntriesHelper(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayEntriesHelper(fixedLengthWithOffset);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayEntriesHelper(lengthTrackingWithOffset);
+  });
+
+  assert.throws(TypeError, () => {
+    Array.from(TypedArrayEntriesHelper(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(TypedArrayEntriesHelper(lengthTrackingWithOffset));
+  });
+  assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    TypedArrayEntriesHelper(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayEntriesHelper(fixedLengthWithOffset);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayEntriesHelper(lengthTrackingWithOffset);
+  });
+
+  assert.throws(TypeError, () => {
+    Array.from(TypedArrayEntriesHelper(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(TypedArrayEntriesHelper(fixedLengthWithOffset));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(TypedArrayEntriesHelper(lengthTrackingWithOffset));
+  });
+  assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ValuesFromTypedArrayEntries(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ValuesFromTypedArrayEntries(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(ValuesFromTypedArrayEntries(lengthTracking), [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10
+  ]);
+  assert.compareArray(ValuesFromTypedArrayEntries(lengthTrackingWithOffset), [
+    4,
+    6,
+    8,
+    10
+  ]);
+}


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR #3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js