### PR TITLE
RAB: Integrate staging tests for the .every method

### DIFF
--- a/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -21,16 +21,12 @@ const ArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
 //                    [4, 6] << fixedLengthWithOffset
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
-let values;
-let rab;
-let resizeAfter;
-let resizeTo;
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  values = [];
-  resizeAfter = 2;
-  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 2;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
   assert(ArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     0,

--- a/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -10,11 +10,19 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-const ArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
-  return Array.prototype.every.call(
-    ta,
-    (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
-};
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer "rab" into "values", with an
+// iteration during which, after "resizeAfter" steps, "rab" is resized to length
+// "resizeTo". To be called by a method of the view being collected.
+// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
+// before calling this.
+function ResizeBufferMidIteration(n) {
+  // Returns true by default.
+  return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+}
 
 // Orig. array: [0, 2, 4, 6]
 //              [0, 2, 4, 6] << fixedLength
@@ -22,12 +30,12 @@ const ArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  const values = [];
-  const resizeAfter = 2;
-  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(ArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(Array.prototype.every.call(fixedLength, ResizeBufferMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -36,24 +44,24 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  const values = [];
-  const resizeAfter = 1;
-  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(ArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(Array.prototype.every.call(fixedLengthWithOffset, ResizeBufferMidIteration));
   assert.compareArray(values, [
     4,
     6
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  const values = [];
-  const resizeAfter = 2;
-  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(ArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(Array.prototype.every.call(lengthTracking, ResizeBufferMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -62,12 +70,12 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  const values = [];
-  const resizeAfter = 1;
-  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(ArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(Array.prototype.every.call(lengthTrackingWithOffset, ResizeBufferMidIteration));
   assert.compareArray(values, [
     4,
     6

--- a/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,83 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.every
+description: >
+  Array.p.every behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+const ArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
+  return Array.prototype.every.call(
+    ta,
+    (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
+};
+
+function EveryGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(ArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(ArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(ArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(ArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+EveryGrowMidIteration();

--- a/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -36,11 +36,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
-  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  values = [];
-  resizeAfter = 1;
-  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  const rab = CreateRabForTest(ctor);
+  const const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const values = [];
+  const resizeAfter = 1;
+  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
   assert(ArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     4,
@@ -48,11 +48,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
-  const lengthTracking = new ctor(rab, 0);
-  values = [];
-  resizeAfter = 2;
-  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  const rab = CreateRabForTest(ctor);
+  const const lengthTracking = new ctor(rab, 0);
+  const values = [];
+  const resizeAfter = 2;
+  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
   assert(ArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     0,
@@ -62,11 +62,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
-  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  values = [];
-  resizeAfter = 1;
-  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  const rab = CreateRabForTest(ctor);
+  const const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  const values = [];
+  const resizeAfter = 1;
+  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
   assert(ArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     4,

--- a/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -14,10 +14,10 @@ let values;
 let rab;
 let resizeAfter;
 let resizeTo;
-// Collects the view of the resizable array buffer "rab" into "values", with an
-// iteration during which, after "resizeAfter" steps, "rab" is resized to length
-// "resizeTo". To be called by a method of the view being collected.
-// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
 function ResizeBufferMidIteration(n) {
   // Returns true by default.

--- a/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.every
 description: >
   Array.p.every behaves correctly when receiver is backed by resizable
   buffer that is grown mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 

--- a/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -37,7 +37,7 @@ for (let ctor of ctors) {
 }
 for (let ctor of ctors) {
   const rab = CreateRabForTest(ctor);
-  const const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
   const values = [];
   const resizeAfter = 1;
   const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
 }
 for (let ctor of ctors) {
   const rab = CreateRabForTest(ctor);
-  const const lengthTracking = new ctor(rab, 0);
+  const lengthTracking = new ctor(rab, 0);
   const values = [];
   const resizeAfter = 2;
   const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
@@ -63,7 +63,7 @@ for (let ctor of ctors) {
 }
 for (let ctor of ctors) {
   const rab = CreateRabForTest(ctor);
-  const const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
   const values = [];
   const resizeAfter = 1;
   const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;

--- a/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -16,68 +16,64 @@ const ArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
     (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
 };
 
-function EveryGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert(ArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert(ArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert(ArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert(ArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(ArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-EveryGrowMidIteration();
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(ArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(ArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(ArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
+}

--- a/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -16,59 +16,55 @@ const ArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
     (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
 };
 
-function EveryShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert(ArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      0,
-      2
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert(ArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [4]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert(ArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      0,
-      2,
-      4
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert(ArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [4]);
-  }
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(ArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    0,
+    2
+  ]);
 }
-
-EveryShrinkMidIteration();
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(ArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [4]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(ArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(ArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [4]);
+}

--- a/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -10,11 +10,19 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-const ArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
-  return Array.prototype.every.call(
-    ta,
-    (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
-};
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer "rab" into "values", with an
+// iteration during which, after "resizeAfter" steps, "rab" is resized to length
+// "resizeTo". To be called by a method of the view being collected.
+// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
+// before calling this.
+function ResizeBufferMidIteration(n) {
+  // Returns true by default.
+  return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+}
 
 // Orig. array: [0, 2, 4, 6]
 //              [0, 2, 4, 6] << fixedLength
@@ -22,33 +30,33 @@ const ArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  const values = [];
-  const resizeAfter = 2;
-  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(ArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(Array.prototype.every.call(fixedLength, ResizeBufferMidIteration));
   assert.compareArray(values, [
     0,
     2
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  const values = [];
-  const resizeAfter = 1;
-  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(ArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(Array.prototype.every.call(fixedLengthWithOffset, ResizeBufferMidIteration));
   assert.compareArray(values, [4]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  const values = [];
-  const resizeAfter = 2;
-  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(ArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(Array.prototype.every.call(lengthTracking, ResizeBufferMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -56,11 +64,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  const values = [];
-  const resizeAfter = 1;
-  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(ArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(Array.prototype.every.call(lengthTrackingWithOffset, ResizeBufferMidIteration));
   assert.compareArray(values, [4]);
 }

--- a/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,74 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.every
+description: >
+  Array.p.every behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+const ArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
+  return Array.prototype.every.call(
+    ta,
+    (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
+};
+
+function EveryShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(ArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      0,
+      2
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(ArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [4]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(ArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      0,
+      2,
+      4
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(ArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [4]);
+  }
+}
+
+EveryShrinkMidIteration();

--- a/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.every
 description: >
   Array.p.every behaves correctly when receiver is backed by resizable
   buffer that is shrunk mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 

--- a/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -14,10 +14,10 @@ let values;
 let rab;
 let resizeAfter;
 let resizeTo;
-// Collects the view of the resizable array buffer "rab" into "values", with an
-// iteration during which, after "resizeAfter" steps, "rab" is resized to length
-// "resizeTo". To be called by a method of the view being collected.
-// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
 function ResizeBufferMidIteration(n) {
   // Returns true by default.

--- a/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -21,16 +21,12 @@ const ArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
 //                    [4, 6] << fixedLengthWithOffset
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
-let values;
-let rab;
-let resizeAfter;
-let resizeTo;
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  values = [];
-  resizeAfter = 2;
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 2;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
   assert(ArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     0,
@@ -38,20 +34,20 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  values = [];
-  resizeAfter = 1;
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 1;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
   assert(ArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [4]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  values = [];
-  resizeAfter = 2;
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 2;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
   assert(ArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     0,
@@ -60,11 +56,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  values = [];
-  resizeAfter = 1;
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 1;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
   assert(ArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [4]);
 }

--- a/test/built-ins/Array/prototype/every/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer.js
@@ -1,0 +1,110 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.every
+description: >
+  Array.p.every behaves correctly when the receiver is backed by
+  resizable buffer
+includes: [resizableArrayBufferUtils.js ]
+features: [resizable-arraybuffer]
+---*/
+
+const ArrayEveryHelper = (ta, ...rest) => {
+  return Array.prototype.every.call(ta, ...rest);
+};
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  function div3(n) {
+    return Number(n) % 3 == 0;
+  }
+  function even(n) {
+    return Number(n) % 2 == 0;
+  }
+  function over10(n) {
+    return Number(n) > 10;
+  }
+  assert(!everyHelper(fixedLength, div3));
+  assert(everyHelper(fixedLength, even));
+  assert(!everyHelper(fixedLengthWithOffset, div3));
+  assert(everyHelper(fixedLengthWithOffset, even));
+  assert(!everyHelper(lengthTracking, div3));
+  assert(everyHelper(lengthTracking, even));
+  assert(!everyHelper(lengthTrackingWithOffset, div3));
+  assert(everyHelper(lengthTrackingWithOffset, even));
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  // Calling .every on an out of bounds TA doesn't throw.
+  assert(everyHelper(fixedLength, div3));
+  assert(everyHelper(fixedLengthWithOffset, div3));
+
+  assert(!everyHelper(lengthTracking, div3));
+  assert(everyHelper(lengthTracking, even));
+  assert(!everyHelper(lengthTrackingWithOffset, div3));
+  assert(everyHelper(lengthTrackingWithOffset, even));
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  // Calling .every on an out of bounds TA doesn't throw.
+  assert(everyHelper(fixedLength, div3));
+  assert(everyHelper(fixedLengthWithOffset, div3));
+  assert(everyHelper(lengthTrackingWithOffset, div3));
+
+  assert(everyHelper(lengthTracking, div3));
+  assert(everyHelper(lengthTracking, even));
+
+  // Shrink to zero.
+  rab.resize(0);
+  // Calling .every on an out of bounds TA doesn't throw.
+  assert(everyHelper(fixedLength, div3));
+  assert(everyHelper(fixedLengthWithOffset, div3));
+  assert(everyHelper(lengthTrackingWithOffset, div3));
+
+  assert(everyHelper(lengthTracking, div3));
+  assert(everyHelper(lengthTracking, even));
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert(!everyHelper(fixedLength, div3));
+  assert(everyHelper(fixedLength, even));
+  assert(!everyHelper(fixedLengthWithOffset, div3));
+  assert(everyHelper(fixedLengthWithOffset, even));
+  assert(!everyHelper(lengthTracking, div3));
+  assert(everyHelper(lengthTracking, even));
+  assert(!everyHelper(lengthTrackingWithOffset, div3));
+  assert(everyHelper(lengthTrackingWithOffset, even));
+}

--- a/test/built-ins/Array/prototype/every/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer.js
@@ -42,14 +42,14 @@ for (let ctor of ctors) {
   function over10(n) {
     return Number(n) > 10;
   }
-  assert(!everyHelper(fixedLength, div3));
-  assert(everyHelper(fixedLength, even));
-  assert(!everyHelper(fixedLengthWithOffset, div3));
-  assert(everyHelper(fixedLengthWithOffset, even));
-  assert(!everyHelper(lengthTracking, div3));
-  assert(everyHelper(lengthTracking, even));
-  assert(!everyHelper(lengthTrackingWithOffset, div3));
-  assert(everyHelper(lengthTrackingWithOffset, even));
+  assert(!ArrayEveryHelper(fixedLength, div3));
+  assert(ArrayEveryHelper(fixedLength, even));
+  assert(!ArrayEveryHelper(fixedLengthWithOffset, div3));
+  assert(ArrayEveryHelper(fixedLengthWithOffset, even));
+  assert(!ArrayEveryHelper(lengthTracking, div3));
+  assert(ArrayEveryHelper(lengthTracking, even));
+  assert(!ArrayEveryHelper(lengthTrackingWithOffset, div3));
+  assert(ArrayEveryHelper(lengthTrackingWithOffset, even));
 
   // Shrink so that fixed length TAs go out of bounds.
   rab.resize(3 * ctor.BYTES_PER_ELEMENT);
@@ -59,33 +59,33 @@ for (let ctor of ctors) {
   //                    [4, ...] << lengthTrackingWithOffset
 
   // Calling .every on an out of bounds TA doesn't throw.
-  assert(everyHelper(fixedLength, div3));
-  assert(everyHelper(fixedLengthWithOffset, div3));
+  assert(ArrayEveryHelper(fixedLength, div3));
+  assert(ArrayEveryHelper(fixedLengthWithOffset, div3));
 
-  assert(!everyHelper(lengthTracking, div3));
-  assert(everyHelper(lengthTracking, even));
-  assert(!everyHelper(lengthTrackingWithOffset, div3));
-  assert(everyHelper(lengthTrackingWithOffset, even));
+  assert(!ArrayEveryHelper(lengthTracking, div3));
+  assert(ArrayEveryHelper(lengthTracking, even));
+  assert(!ArrayEveryHelper(lengthTrackingWithOffset, div3));
+  assert(ArrayEveryHelper(lengthTrackingWithOffset, even));
 
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
   // Calling .every on an out of bounds TA doesn't throw.
-  assert(everyHelper(fixedLength, div3));
-  assert(everyHelper(fixedLengthWithOffset, div3));
-  assert(everyHelper(lengthTrackingWithOffset, div3));
+  assert(ArrayEveryHelper(fixedLength, div3));
+  assert(ArrayEveryHelper(fixedLengthWithOffset, div3));
+  assert(ArrayEveryHelper(lengthTrackingWithOffset, div3));
 
-  assert(everyHelper(lengthTracking, div3));
-  assert(everyHelper(lengthTracking, even));
+  assert(ArrayEveryHelper(lengthTracking, div3));
+  assert(ArrayEveryHelper(lengthTracking, even));
 
   // Shrink to zero.
   rab.resize(0);
   // Calling .every on an out of bounds TA doesn't throw.
-  assert(everyHelper(fixedLength, div3));
-  assert(everyHelper(fixedLengthWithOffset, div3));
-  assert(everyHelper(lengthTrackingWithOffset, div3));
+  assert(ArrayEveryHelper(fixedLength, div3));
+  assert(ArrayEveryHelper(fixedLengthWithOffset, div3));
+  assert(ArrayEveryHelper(lengthTrackingWithOffset, div3));
 
-  assert(everyHelper(lengthTracking, div3));
-  assert(everyHelper(lengthTracking, even));
+  assert(ArrayEveryHelper(lengthTracking, div3));
+  assert(ArrayEveryHelper(lengthTracking, even));
 
   // Grow so that all TAs are back in-bounds.
   rab.resize(6 * ctor.BYTES_PER_ELEMENT);
@@ -99,12 +99,12 @@ for (let ctor of ctors) {
   //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
   //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
 
-  assert(!everyHelper(fixedLength, div3));
-  assert(everyHelper(fixedLength, even));
-  assert(!everyHelper(fixedLengthWithOffset, div3));
-  assert(everyHelper(fixedLengthWithOffset, even));
-  assert(!everyHelper(lengthTracking, div3));
-  assert(everyHelper(lengthTracking, even));
-  assert(!everyHelper(lengthTrackingWithOffset, div3));
-  assert(everyHelper(lengthTrackingWithOffset, even));
+  assert(!ArrayEveryHelper(fixedLength, div3));
+  assert(ArrayEveryHelper(fixedLength, even));
+  assert(!ArrayEveryHelper(fixedLengthWithOffset, div3));
+  assert(ArrayEveryHelper(fixedLengthWithOffset, even));
+  assert(!ArrayEveryHelper(lengthTracking, div3));
+  assert(ArrayEveryHelper(lengthTracking, even));
+  assert(!ArrayEveryHelper(lengthTrackingWithOffset, div3));
+  assert(ArrayEveryHelper(lengthTrackingWithOffset, even));
 }

--- a/test/built-ins/Array/prototype/every/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer.js
@@ -10,9 +10,19 @@ includes: [resizableArrayBufferUtils.js ]
 features: [resizable-arraybuffer]
 ---*/
 
-const ArrayEveryHelper = (ta, ...rest) => {
-  return Array.prototype.every.call(ta, ...rest);
-};
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer "rab" into "values", with an
+// iteration during which, after "resizeAfter" steps, "rab" is resized to length
+// "resizeTo". To be called by a method of the view being collected.
+// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
+// before calling this.
+function ResizeBufferMidIteration(n) {
+  // Returns true by default.
+  return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+}
 
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -42,14 +52,14 @@ for (let ctor of ctors) {
   function over10(n) {
     return Number(n) > 10;
   }
-  assert(!ArrayEveryHelper(fixedLength, div3));
-  assert(ArrayEveryHelper(fixedLength, even));
-  assert(!ArrayEveryHelper(fixedLengthWithOffset, div3));
-  assert(ArrayEveryHelper(fixedLengthWithOffset, even));
-  assert(!ArrayEveryHelper(lengthTracking, div3));
-  assert(ArrayEveryHelper(lengthTracking, even));
-  assert(!ArrayEveryHelper(lengthTrackingWithOffset, div3));
-  assert(ArrayEveryHelper(lengthTrackingWithOffset, even));
+  assert(!Array.prototype.every.call(fixedLength, div3));
+  assert(Array.prototype.every.call(fixedLength, even));
+  assert(!Array.prototype.every.call(fixedLengthWithOffset, div3));
+  assert(Array.prototype.every.call(fixedLengthWithOffset, even));
+  assert(!Array.prototype.every.call(lengthTracking, div3));
+  assert(Array.prototype.every.call(lengthTracking, even));
+  assert(!Array.prototype.every.call(lengthTrackingWithOffset, div3));
+  assert(Array.prototype.every.call(lengthTrackingWithOffset, even));
 
   // Shrink so that fixed length TAs go out of bounds.
   rab.resize(3 * ctor.BYTES_PER_ELEMENT);
@@ -59,33 +69,33 @@ for (let ctor of ctors) {
   //                    [4, ...] << lengthTrackingWithOffset
 
   // Calling .every on an out of bounds TA doesn't throw.
-  assert(ArrayEveryHelper(fixedLength, div3));
-  assert(ArrayEveryHelper(fixedLengthWithOffset, div3));
+  assert(Array.prototype.every.call(fixedLength, div3));
+  assert(Array.prototype.every.call(fixedLengthWithOffset, div3));
 
-  assert(!ArrayEveryHelper(lengthTracking, div3));
-  assert(ArrayEveryHelper(lengthTracking, even));
-  assert(!ArrayEveryHelper(lengthTrackingWithOffset, div3));
-  assert(ArrayEveryHelper(lengthTrackingWithOffset, even));
+  assert(!Array.prototype.every.call(lengthTracking, div3));
+  assert(Array.prototype.every.call(lengthTracking, even));
+  assert(!Array.prototype.every.call(lengthTrackingWithOffset, div3));
+  assert(Array.prototype.every.call(lengthTrackingWithOffset, even));
 
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
   // Calling .every on an out of bounds TA doesn't throw.
-  assert(ArrayEveryHelper(fixedLength, div3));
-  assert(ArrayEveryHelper(fixedLengthWithOffset, div3));
-  assert(ArrayEveryHelper(lengthTrackingWithOffset, div3));
+  assert(Array.prototype.every.call(fixedLength, div3));
+  assert(Array.prototype.every.call(fixedLengthWithOffset, div3));
+  assert(Array.prototype.every.call(lengthTrackingWithOffset, div3));
 
-  assert(ArrayEveryHelper(lengthTracking, div3));
-  assert(ArrayEveryHelper(lengthTracking, even));
+  assert(Array.prototype.every.call(lengthTracking, div3));
+  assert(Array.prototype.every.call(lengthTracking, even));
 
   // Shrink to zero.
   rab.resize(0);
   // Calling .every on an out of bounds TA doesn't throw.
-  assert(ArrayEveryHelper(fixedLength, div3));
-  assert(ArrayEveryHelper(fixedLengthWithOffset, div3));
-  assert(ArrayEveryHelper(lengthTrackingWithOffset, div3));
+  assert(Array.prototype.every.call(fixedLength, div3));
+  assert(Array.prototype.every.call(fixedLengthWithOffset, div3));
+  assert(Array.prototype.every.call(lengthTrackingWithOffset, div3));
 
-  assert(ArrayEveryHelper(lengthTracking, div3));
-  assert(ArrayEveryHelper(lengthTracking, even));
+  assert(Array.prototype.every.call(lengthTracking, div3));
+  assert(Array.prototype.every.call(lengthTracking, even));
 
   // Grow so that all TAs are back in-bounds.
   rab.resize(6 * ctor.BYTES_PER_ELEMENT);
@@ -99,12 +109,12 @@ for (let ctor of ctors) {
   //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
   //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
 
-  assert(!ArrayEveryHelper(fixedLength, div3));
-  assert(ArrayEveryHelper(fixedLength, even));
-  assert(!ArrayEveryHelper(fixedLengthWithOffset, div3));
-  assert(ArrayEveryHelper(fixedLengthWithOffset, even));
-  assert(!ArrayEveryHelper(lengthTracking, div3));
-  assert(ArrayEveryHelper(lengthTracking, even));
-  assert(!ArrayEveryHelper(lengthTrackingWithOffset, div3));
-  assert(ArrayEveryHelper(lengthTrackingWithOffset, even));
+  assert(!Array.prototype.every.call(fixedLength, div3));
+  assert(Array.prototype.every.call(fixedLength, even));
+  assert(!Array.prototype.every.call(fixedLengthWithOffset, div3));
+  assert(Array.prototype.every.call(fixedLengthWithOffset, even));
+  assert(!Array.prototype.every.call(lengthTracking, div3));
+  assert(Array.prototype.every.call(lengthTracking, even));
+  assert(!Array.prototype.every.call(lengthTrackingWithOffset, div3));
+  assert(Array.prototype.every.call(lengthTrackingWithOffset, even));
 }

--- a/test/built-ins/Array/prototype/every/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer.js
@@ -10,20 +10,6 @@ includes: [resizableArrayBufferUtils.js ]
 features: [resizable-arraybuffer]
 ---*/
 
-let values;
-let rab;
-let resizeAfter;
-let resizeTo;
-// Collects the view of the resizable array buffer "rab" into "values", with an
-// iteration during which, after "resizeAfter" steps, "rab" is resized to length
-// "resizeTo". To be called by a method of the view being collected.
-// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
-// before calling this.
-function ResizeBufferMidIteration(n) {
-  // Returns true by default.
-  return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
-}
-
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
   const fixedLength = new ctor(rab, 0, 4);

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -20,16 +20,12 @@ const TypedArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
 //                    [4, 6] << fixedLengthWithOffset
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
-let values;
-let rab;
-let resizeAfter;
-let resizeTo;
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  values = [];
-  resizeAfter = 2;
-  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 2;
+  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
   assert(TypedArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     0,
@@ -39,11 +35,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  values = [];
-  resizeAfter = 1;
-  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 1;
+  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
   assert(TypedArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     4,
@@ -51,11 +47,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  values = [];
-  resizeAfter = 2;
-  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 2;
+  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
   assert(TypedArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     0,
@@ -65,11 +61,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  values = [];
-  resizeAfter = 1;
-  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 1;
+  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
   assert(TypedArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     4,

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -15,68 +15,64 @@ const TypedArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
     (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
 };
 
-function EveryGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert(TypedArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert(TypedArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert(TypedArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert(TypedArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(TypedArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-EveryGrowMidIteration();
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(TypedArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(TypedArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(TypedArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -6,7 +6,7 @@ esid: sec-%typedarray%.prototype.every
 description: >
   TypedArray.p.every behaves correctly when receiver is backed by resizable
   buffer that is grown mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -10,10 +10,19 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-const TypedArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
-  return ta.every(
-    (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
-};
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer "rab" into "values", with an
+// iteration during which, after "resizeAfter" steps, "rab" is resized to length
+// "resizeTo". To be called by a method of the view being collected.
+// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
+// before calling this.
+function ResizeBufferMidIteration(n) {
+  // Returns true by default.
+  return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+}
 
 // Orig. array: [0, 2, 4, 6]
 //              [0, 2, 4, 6] << fixedLength
@@ -21,12 +30,12 @@ const TypedArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  const values = [];
-  const resizeAfter = 2;
-  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(TypedArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(fixedLength.every(ResizeBufferMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -35,24 +44,24 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  const values = [];
-  const resizeAfter = 1;
-  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(TypedArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(fixedLengthWithOffset.every(ResizeBufferMidIteration));
   assert.compareArray(values, [
     4,
     6
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  const values = [];
-  const resizeAfter = 2;
-  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(TypedArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(lengthTracking.every(ResizeBufferMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -61,12 +70,12 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  const values = [];
-  const resizeAfter = 1;
-  const resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(TypedArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert(lengthTrackingWithOffset.every(ResizeBufferMidIteration));
   assert.compareArray(values, [
     4,
     6

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,82 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.every
+description: >
+  TypedArray.p.every behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+const TypedArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
+  return ta.every(
+    (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
+};
+
+function EveryGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(TypedArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(TypedArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(TypedArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(TypedArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+EveryGrowMidIteration();

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -14,10 +14,10 @@ let values;
 let rab;
 let resizeAfter;
 let resizeTo;
-// Collects the view of the resizable array buffer "rab" into "values", with an
-// iteration during which, after "resizeAfter" steps, "rab" is resized to length
-// "resizeTo". To be called by a method of the view being collected.
-// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
 function ResizeBufferMidIteration(n) {
   // Returns true by default.

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -15,68 +15,64 @@ const TypedArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
     (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
 };
 
-function EveryShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert(TypedArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      0,
-      2,
-      undefined,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert(TypedArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert(TypedArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert(TypedArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
-    assert.compareArray(values, [
-      4,
-      undefined
-    ]);
-  }
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(TypedArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    0,
+    2,
+    undefined,
+    undefined
+  ]);
 }
-
-EveryShrinkMidIteration();
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(TypedArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(TypedArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(TypedArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,82 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.every
+description: >
+  TypedArray.p.every behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+const TypedArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
+  return ta.every(
+    (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
+};
+
+function EveryShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(TypedArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      0,
+      2,
+      undefined,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(TypedArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(TypedArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(TypedArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+}
+
+EveryShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -10,24 +10,32 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-const TypedArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
-  return ta.every(
-    (n) => CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo));
-};
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer "rab" into "values", with an
+// iteration during which, after "resizeAfter" steps, "rab" is resized to length
+// "resizeTo". To be called by a method of the view being collected.
+// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
+// before calling this.
+function ResizeBufferMidIteration(n) {
+  // Returns true by default.
+  return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+}
 
 // Orig. array: [0, 2, 4, 6]
 //              [0, 2, 4, 6] << fixedLength
 //                    [4, 6] << fixedLengthWithOffset
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
-
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  const values = [];
-  const resizeAfter = 2;
-  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(TypedArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(fixedLength.every(ResizeBufferMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -36,24 +44,24 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  const values = [];
-  const resizeAfter = 1;
-  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(TypedArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(fixedLengthWithOffset.every(ResizeBufferMidIteration));
   assert.compareArray(values, [
     4,
     undefined
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  const values = [];
-  const resizeAfter = 2;
-  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(TypedArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(lengthTracking.every(ResizeBufferMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -62,12 +70,12 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  const rab = CreateRabForTest(ctor);
+  rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  const values = [];
-  const resizeAfter = 1;
-  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(TypedArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert(lengthTrackingWithOffset.every(ResizeBufferMidIteration));
   assert.compareArray(values, [
     4,
     undefined

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -20,16 +20,13 @@ const TypedArrayEveryHelper = (ta, values, rab, resizeAfter, resizeTo) => {
 //                    [4, 6] << fixedLengthWithOffset
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
-let values;
-let rab;
-let resizeAfter;
-let resizeTo;
+
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  values = [];
-  resizeAfter = 2;
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 2;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
   assert(TypedArrayEveryHelper(fixedLength, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     0,
@@ -39,11 +36,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  values = [];
-  resizeAfter = 1;
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 1;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
   assert(TypedArrayEveryHelper(fixedLengthWithOffset, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     4,
@@ -51,11 +48,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  values = [];
-  resizeAfter = 2;
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 2;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
   assert(TypedArrayEveryHelper(lengthTracking, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     0,
@@ -65,11 +62,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  values = [];
-  resizeAfter = 1;
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  const values = [];
+  const resizeAfter = 1;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
   assert(TypedArrayEveryHelper(lengthTrackingWithOffset, values, rab, resizeAfter, resizeTo));
   assert.compareArray(values, [
     4,

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -14,10 +14,10 @@ let values;
 let rab;
 let resizeAfter;
 let resizeTo;
-// Collects the view of the resizable array buffer "rab" into "values", with an
-// iteration during which, after "resizeAfter" steps, "rab" is resized to length
-// "resizeTo". To be called by a method of the view being collected.
-// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
 function ResizeBufferMidIteration(n) {
   // Returns true by default.

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -6,7 +6,7 @@ esid: sec-%typedarray%.prototype.every
 description: >
   TypedArray.p.every behaves correctly when receiver is backed by resizable
   buffer that is shrunk mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer.js
@@ -1,0 +1,122 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.every
+description: >
+  TypedArray.p.every behaves correctly when the receiver is backed by
+  resizable buffer
+includes: [resizableArrayBufferUtils.js]
+features: [resizable-arraybuffer]
+---*/
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  function div3(n) {
+    return Number(n) % 3 == 0;
+  }
+  function even(n) {
+    return Number(n) % 2 == 0;
+  }
+  function over10(n) {
+    return Number(n) > 10;
+  }
+  assert(!fixedLength.every(div3));
+  assert(fixedLength.every(even));
+  assert(!fixedLengthWithOffset.every(div3));
+  assert(fixedLengthWithOffset.every(even));
+  assert(!lengthTracking.every(div3));
+  assert(lengthTracking.every(even));
+  assert(!lengthTrackingWithOffset.every(div3));
+  assert(lengthTrackingWithOffset.every(even));
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  // Calling .every on an out of bounds TA throws.
+  assert.throws(TypeError, () => {
+    fixedLength.every(div3);
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.every(div3);
+  });
+
+  assert(!lengthTracking.every(div3));
+  assert(lengthTracking.every(even));
+  assert(!lengthTrackingWithOffset.every(div3));
+  assert(lengthTrackingWithOffset.every(even));
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  // Calling .every on an out of bounds TA throws.
+  assert.throws(TypeError, () => {
+    fixedLength.every(div3);
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.every(div3);
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.every(div3);
+  });
+
+  assert(lengthTracking.every(div3));
+  assert(lengthTracking.every(even));
+
+  // Shrink to zero.
+  rab.resize(0);
+  // Calling .every on an out of bounds TA throws.
+  assert.throws(TypeError, () => {
+    fixedLength.every(div3);
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.every(div3);
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.every(div3);
+  });
+
+  assert(lengthTracking.every(div3));
+  assert(lengthTracking.every(even));
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert(!fixedLength.every(div3));
+  assert(fixedLength.every(even));
+  assert(!fixedLengthWithOffset.every(div3));
+  assert(fixedLengthWithOffset.every(even));
+  assert(!lengthTracking.every(div3));
+  assert(lengthTracking.every(even));
+  assert(!lengthTrackingWithOffset.every(div3));
+  assert(lengthTrackingWithOffset.every(even));
+}

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer.js
@@ -10,6 +10,20 @@ includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer "rab" into "values", with an
+// iteration during which, after "resizeAfter" steps, "rab" is resized to length
+// "resizeTo". To be called by a method of the view being collected.
+// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
+// before calling this.
+function ResizeBufferMidIteration(n) {
+  // Returns true by default.
+  return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+}
+
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
   const fixedLength = new ctor(rab, 0, 4);

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer.js
@@ -10,20 +10,6 @@ includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-let values;
-let rab;
-let resizeAfter;
-let resizeTo;
-// Collects the view of the resizable array buffer "rab" into "values", with an
-// iteration during which, after "resizeAfter" steps, "rab" is resized to length
-// "resizeTo". To be called by a method of the view being collected.
-// Note that "rab", "values", "resizeAfter", and "resizeTo" may need to be reset
-// before calling this.
-function ResizeBufferMidIteration(n) {
-  // Returns true by default.
-  return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
-}
-
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
   const fixedLength = new ctor(rab, 0, 4);


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR #3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js