### PR TITLE
Fix `asyncTest` usage for `Promise.try` tests

### DIFF
--- a/test/built-ins/Promise/try/args.js
+++ b/test/built-ins/Promise/try/args.js
@@ -11,12 +11,12 @@ includes: [asyncHelpers.js, compareArray.js]
 
 var sentinel = { sentinel: true };
 
-asyncTest(
-  Promise.try(function () {
+asyncTest(function () {
+  return Promise.try(function () {
     assert.compareArray(
       Array.prototype.slice.call(arguments),
       [1, 2, Test262Error, sentinel]
     );
   }, 1, 2, Test262Error, sentinel)
-);
+});
 

--- a/test/built-ins/Promise/try/return-value.js
+++ b/test/built-ins/Promise/try/return-value.js
@@ -11,11 +11,11 @@ includes: [asyncHelpers.js]
 
 var sentinel = { sentinel: true };
 
-asyncTest(
-  Promise.try(function () {
+asyncTest(function() {
+  return Promise.try(function () {
     return sentinel;
   }).then(function (v) {
     assert.sameValue(v, sentinel);
   })
-);
+});
 


### PR DESCRIPTION
We've updated test262 for WebKit, then following two tests for `Promise.try` failed with an error message `Test262Error: asyncTest called with non-function argument'`[^2]:

- https://github.com/tc39/test262/blob/081808bebd96bc9c755300e8c3eb59d8bef578f1/test/built-ins/Promise/try/args.js
- https://github.com/tc39/test262/blob/081808bebd96bc9c755300e8c3eb59d8bef578f1/test/built-ins/Promise/try/return-value.js

`asyncTest` harness must be called with function type argument[^1] but, current tests call it with the result of `Promise.try` directly.

This PR changes to call it with a function that wraps `Promise.try` call.

[^1]: https://github.com/tc39/test262/blob/081808bebd96bc9c755300e8c3eb59d8bef578f1/harness/asyncHelpers.js#L13-L16
[^2]: https://github.com/WebKit/WebKit/blob/4bae864b01100e8179cc36948b7d15b7dafe2095/JSTests/test262/expectations.yaml#L72-L83