### PR TITLE
Wrap `assert.throwsAsync` with `asyncTest` in `Promise.try` test

### DIFF
--- a/test/built-ins/Promise/try/throws.js
+++ b/test/built-ins/Promise/try/throws.js
@@ -6,12 +6,15 @@ description: Promise.try returns a Promise that rejects when the function throws
 esid: sec-promise.try
 features: [promise-try]
 flags: [async]
+includes: [asyncHelpers.js]
 ---*/
 
-assert.throwsAsync(
-  Test262Error,
-  function () {
-    Promise.try(function () { throw new Test262Error(); })
-  },
-  "error thrown from callback must become a rejection"
-);
+asyncTest(async function() {
+  await assert.throwsAsync(
+    Test262Error,
+    function () {
+      Promise.try(function () { throw new Test262Error(); })
+    },
+    "error thrown from callback must become a rejection"
+  );
+});


### PR DESCRIPTION
In WebKit test262, `/test/built-ins/Promise/try/throws.js` fails with an error message `assert.throwsAsync is not a function.`[^1].

This PR has following changes:

- Include `asyncHelpers.js` to use `assert.throwAsync`.
- Wrap `assert.throwAsync` call with `asyncTest` according to the [CONTRIBUTING.md](https://github.com/tc39/test262/blob/main/CONTRIBUTING.md#checking-exception-type-in-asynchronous-tests).


[^1]: https://github.com/WebKit/WebKit/blob/4bae864b01100e8179cc36948b7d15b7dafe2095/JSTests/test262/expectations.yaml#L81-L83

