### PR TITLE
Compatibility with Hardened JavaScript

### DIFF
--- a/src/subclass-builtins/Date.case
+++ b/src/subclass-builtins/Date.case
@@ -4,9 +4,11 @@
 /*---
 esid: sec-ecmascript-standard-built-in-objects
 desc: >
-  new SubDate() instanceof Date
+  new SubDate(0) instanceof Date
 template: default
 ---*/
 
 //- builtin
 Date
+//- args
+0

--- a/test/annexB/built-ins/Date/prototype/setYear/year-nan.js
+++ b/test/annexB/built-ins/Date/prototype/setYear/year-nan.js
@@ -15,19 +15,19 @@ features: [Symbol]
 
 var date;
 
-date = new Date();
+date = new Date(1970);
 assert.sameValue(date.setYear(), NaN, 'return value (no argument)');
 assert.sameValue(
   date.valueOf(), NaN, '[[DateValue]] internal slot (no argument)'
 );
 
-date = new Date();
+date = new Date(1970);
 assert.sameValue(date.setYear(NaN), NaN, 'return value (literal NaN)');
 assert.sameValue(
   date.valueOf(), NaN, '[[DateValue]] internal slot (literal NaN)'
 );
 
-date = new Date();
+date = new Date(1970);
 assert.sameValue(
   date.setYear('not a number'), NaN, 'return value (NaN from ToNumber)'
 );

--- a/test/annexB/built-ins/Date/prototype/setYear/year-nan.js
+++ b/test/annexB/built-ins/Date/prototype/setYear/year-nan.js
@@ -15,19 +15,19 @@ features: [Symbol]
 
 var date;
 
-date = new Date(1970);
+date = new Date(0);
 assert.sameValue(date.setYear(), NaN, 'return value (no argument)');
 assert.sameValue(
   date.valueOf(), NaN, '[[DateValue]] internal slot (no argument)'
 );
 
-date = new Date(1970);
+date = new Date(0);
 assert.sameValue(date.setYear(NaN), NaN, 'return value (literal NaN)');
 assert.sameValue(
   date.valueOf(), NaN, '[[DateValue]] internal slot (literal NaN)'
 );
 
-date = new Date(1970);
+date = new Date(0);
 assert.sameValue(
   date.setYear('not a number'), NaN, 'return value (NaN from ToNumber)'
 );

--- a/test/annexB/built-ins/Date/prototype/setYear/year-to-number-err.js
+++ b/test/annexB/built-ins/Date/prototype/setYear/year-to-number-err.js
@@ -12,7 +12,7 @@ info: |
 features: [Symbol]
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var symbol = Symbol('');
 var year = {
   valueOf: function() {

--- a/test/annexB/built-ins/Date/prototype/setYear/year-to-number-err.js
+++ b/test/annexB/built-ins/Date/prototype/setYear/year-to-number-err.js
@@ -12,7 +12,7 @@ info: |
 features: [Symbol]
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var symbol = Symbol('');
 var year = {
   valueOf: function() {

--- a/test/built-ins/Array/isArray/15.4.3.2-1-9.js
+++ b/test/built-ins/Array/isArray/15.4.3.2-1-9.js
@@ -7,4 +7,4 @@ es5id: 15.4.3.2-1-9
 description: Array.isArray applied to Date object
 ---*/
 
-assert.sameValue(Array.isArray(new Date()), false, 'Array.isArray(new Date()) must return false');
+assert.sameValue(Array.isArray(new Date(1970)), false, 'Array.isArray(new Date(1970)) must return false');

--- a/test/built-ins/Array/isArray/15.4.3.2-1-9.js
+++ b/test/built-ins/Array/isArray/15.4.3.2-1-9.js
@@ -7,4 +7,4 @@ es5id: 15.4.3.2-1-9
 description: Array.isArray applied to Date object
 ---*/
 
-assert.sameValue(Array.isArray(new Date(1970)), false, 'Array.isArray(new Date(1970)) must return false');
+assert.sameValue(Array.isArray(new Date(0)), false, 'Array.isArray(new Date(0)) must return false');

--- a/test/built-ins/Array/prototype/every/15.4.4.16-1-11.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-1-11.js
@@ -10,7 +10,7 @@ function callbackfn(val, idx, obj) {
   return !(obj instanceof Date);
 }
 
-var obj = new Date();
+var obj = new Date(1970);
 obj.length = 1;
 obj[0] = 1;
 

--- a/test/built-ins/Array/prototype/every/15.4.4.16-1-11.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-1-11.js
@@ -10,7 +10,7 @@ function callbackfn(val, idx, obj) {
   return !(obj instanceof Date);
 }
 
-var obj = new Date(1970);
+var obj = new Date(0);
 obj.length = 1;
 obj[0] = 1;
 

--- a/test/built-ins/Array/prototype/every/15.4.4.16-3-23.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-3-23.js
@@ -31,10 +31,12 @@ Con.prototype = proto;
 
 var child = new Con();
 
-child.toString = function() {
-  toStringAccessed = true;
-  return '1';
-};
+Object.defineProperty(child, "toString", {
+  value: function() {
+	  toStringAccessed = true;
+	  return '1';
+  }
+});
 
 var obj = {
   0: 12,

--- a/test/built-ins/Array/prototype/every/15.4.4.16-5-15.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-5-15.js
@@ -8,7 +8,7 @@ description: Array.prototype.every - Date Object can be used as thisArg
 ---*/
 
 var accessed = false;
-var objDate = new Date();
+var objDate = new Date(1970);
 
 function callbackfn(val, idx, obj) {
   accessed = true;

--- a/test/built-ins/Array/prototype/every/15.4.4.16-5-15.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-5-15.js
@@ -8,7 +8,7 @@ description: Array.prototype.every - Date Object can be used as thisArg
 ---*/
 
 var accessed = false;
-var objDate = new Date(1970);
+var objDate = new Date(0);
 
 function callbackfn(val, idx, obj) {
   accessed = true;

--- a/test/built-ins/Array/prototype/every/15.4.4.16-7-c-iii-21.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-7-c-iii-21.js
@@ -10,7 +10,7 @@ var accessed = false;
 
 function callbackfn(val, idx, obj) {
   accessed = true;
-  return new Date();
+  return new Date(1970);
 }
 
 assert([11].every(callbackfn), '[11].every(callbackfn) !== true');

--- a/test/built-ins/Array/prototype/every/15.4.4.16-7-c-iii-21.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-7-c-iii-21.js
@@ -10,7 +10,7 @@ var accessed = false;
 
 function callbackfn(val, idx, obj) {
   accessed = true;
-  return new Date(1970);
+  return new Date(0);
 }
 
 assert([11].every(callbackfn), '[11].every(callbackfn) !== true');

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-1-11.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-1-11.js
@@ -10,7 +10,7 @@ function callbackfn(val, idx, obj) {
   return obj instanceof Date;
 }
 
-var obj = new Date(1970);
+var obj = new Date(0);
 obj.length = 1;
 obj[0] = 1;
 

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-1-11.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-1-11.js
@@ -10,7 +10,7 @@ function callbackfn(val, idx, obj) {
   return obj instanceof Date;
 }
 
-var obj = new Date();
+var obj = new Date(1970);
 obj.length = 1;
 obj[0] = 1;
 

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-5-15.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-5-15.js
@@ -8,7 +8,7 @@ description: Array.prototype.filter - Date Object can be used as thisArg
 
 var accessed = false;
 
-var objDate = new Date(1970);
+var objDate = new Date(0);
 
 function callbackfn(val, idx, obj) {
   accessed = true;

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-5-15.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-5-15.js
@@ -8,7 +8,7 @@ description: Array.prototype.filter - Date Object can be used as thisArg
 
 var accessed = false;
 
-var objDate = new Date();
+var objDate = new Date(1970);
 
 function callbackfn(val, idx, obj) {
   accessed = true;

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-22.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-22.js
@@ -9,7 +9,7 @@ description: >
 ---*/
 
 function callbackfn(val, idx, obj) {
-  return new Date();
+  return new Date(1970);
 }
 
 var newArr = [11].filter(callbackfn);

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-22.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-22.js
@@ -9,7 +9,7 @@ description: >
 ---*/
 
 function callbackfn(val, idx, obj) {
-  return new Date(1970);
+  return new Date(0);
 }
 
 var newArr = [11].filter(callbackfn);

--- a/test/built-ins/Array/prototype/forEach/15.4.4.18-1-11.js
+++ b/test/built-ins/Array/prototype/forEach/15.4.4.18-1-11.js
@@ -12,7 +12,7 @@ function callbackfn(val, idx, obj) {
   result = obj instanceof Date;
 }
 
-var obj = new Date(1970);
+var obj = new Date(0);
 obj.length = 1;
 obj[0] = 1;
 

--- a/test/built-ins/Array/prototype/forEach/15.4.4.18-1-11.js
+++ b/test/built-ins/Array/prototype/forEach/15.4.4.18-1-11.js
@@ -12,7 +12,7 @@ function callbackfn(val, idx, obj) {
   result = obj instanceof Date;
 }
 
-var obj = new Date();
+var obj = new Date(1970);
 obj.length = 1;
 obj[0] = 1;
 

--- a/test/built-ins/Array/prototype/forEach/15.4.4.18-5-15.js
+++ b/test/built-ins/Array/prototype/forEach/15.4.4.18-5-15.js
@@ -7,7 +7,7 @@ description: Array.prototype.forEach - Date Object can be used as thisArg
 ---*/
 
 var result = false;
-var objDate = new Date();
+var objDate = new Date(1970);
 
 function callbackfn(val, idx, obj) {
   result = (this === objDate);

--- a/test/built-ins/Array/prototype/forEach/15.4.4.18-5-15.js
+++ b/test/built-ins/Array/prototype/forEach/15.4.4.18-5-15.js
@@ -7,7 +7,7 @@ description: Array.prototype.forEach - Date Object can be used as thisArg
 ---*/
 
 var result = false;
-var objDate = new Date(1970);
+var objDate = new Date(0);
 
 function callbackfn(val, idx, obj) {
   result = (this === objDate);

--- a/test/built-ins/Array/prototype/indexOf/15.4.4.14-1-11.js
+++ b/test/built-ins/Array/prototype/indexOf/15.4.4.14-1-11.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.indexof
 description: Array.prototype.indexOf applied to Date object
 ---*/
 
-var obj = new Date(1970);
+var obj = new Date(0);
 obj.length = 2;
 obj[1] = true;
 

--- a/test/built-ins/Array/prototype/indexOf/15.4.4.14-1-11.js
+++ b/test/built-ins/Array/prototype/indexOf/15.4.4.14-1-11.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.indexof
 description: Array.prototype.indexOf applied to Date object
 ---*/
 
-var obj = new Date();
+var obj = new Date(1970);
 obj.length = 2;
 obj[1] = true;
 

--- a/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-11.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-11.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.lastindexof
 description: Array.prototype.lastIndexOf applied to Date object
 ---*/
 
-var obj = new Date();
+var obj = new Date(1970);
 obj.length = 2;
 obj[1] = true;
 

--- a/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-11.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-11.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.lastindexof
 description: Array.prototype.lastIndexOf applied to Date object
 ---*/
 
-var obj = new Date(1970);
+var obj = new Date(0);
 obj.length = 2;
 obj[1] = true;
 

--- a/test/built-ins/Array/prototype/map/15.4.4.19-1-11.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-1-11.js
@@ -10,7 +10,7 @@ function callbackfn(val, idx, obj) {
   return obj instanceof Date;
 }
 
-var obj = new Date(1970);
+var obj = new Date(0);
 obj.length = 1;
 obj[0] = 1;
 

--- a/test/built-ins/Array/prototype/map/15.4.4.19-1-11.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-1-11.js
@@ -10,7 +10,7 @@ function callbackfn(val, idx, obj) {
   return obj instanceof Date;
 }
 
-var obj = new Date();
+var obj = new Date(1970);
 obj.length = 1;
 obj[0] = 1;
 

--- a/test/built-ins/Array/prototype/map/15.4.4.19-5-15.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-5-15.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.map
 description: Array.prototype.map - Date object can be used as thisArg
 ---*/
 
-var objDate = new Date();
+var objDate = new Date(1970);
 
 function callbackfn(val, idx, obj) {
   return this === objDate;

--- a/test/built-ins/Array/prototype/map/15.4.4.19-5-15.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-5-15.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.map
 description: Array.prototype.map - Date object can be used as thisArg
 ---*/
 
-var objDate = new Date(1970);
+var objDate = new Date(0);
 
 function callbackfn(val, idx, obj) {
   return this === objDate;

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-1-11.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-1-11.js
@@ -10,7 +10,7 @@ function callbackfn(prevVal, curVal, idx, obj) {
   return obj instanceof Date;
 }
 
-var obj = new Date();
+var obj = new Date(1970);
 obj.length = 1;
 obj[0] = 1;
 

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-1-11.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-1-11.js
@@ -10,7 +10,7 @@ function callbackfn(prevVal, curVal, idx, obj) {
   return obj instanceof Date;
 }
 
-var obj = new Date(1970);
+var obj = new Date(0);
 obj.length = 1;
 obj[0] = 1;
 

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-31.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-31.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.reduce
 description: Array.prototype.reduce - Date object can be used as accumulator
 ---*/
 
-var objDate = new Date();
+var objDate = new Date(1970);
 
 var accessed = false;
 

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-31.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-31.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.reduce
 description: Array.prototype.reduce - Date object can be used as accumulator
 ---*/
 
-var objDate = new Date(1970);
+var objDate = new Date(0);
 
 var accessed = false;
 

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-11.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-11.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.reduceright
 description: Array.prototype.reduceRight applied to Date object
 ---*/
 
-var obj = new Date(1970);
+var obj = new Date(0);
 obj.length = 1;
 obj[0] = 1;
 var accessed = false;

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-11.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-11.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.reduceright
 description: Array.prototype.reduceRight applied to Date object
 ---*/
 
-var obj = new Date();
+var obj = new Date(1970);
 obj.length = 1;
 obj[0] = 1;
 var accessed = false;

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-3-23.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-3-23.js
@@ -35,10 +35,12 @@ function callbackfn(prevVal, curVal, idx, obj) {
   return false;
 }
 
-child.toString = function() {
-  toStringAccessed = true;
-  return '1';
-};
+Object.defineProperty(child, "toString", {
+  value: function() {
+	  toStringAccessed = true;
+	  return '1';
+  }
+});
 
 var obj = {
   0: 12,

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-31.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-31.js
@@ -9,7 +9,7 @@ description: >
 ---*/
 
 var accessed = false;
-var objDate = new Date(1970);
+var objDate = new Date(0);
 
 function callbackfn(prevVal, curVal, idx, obj) {
   accessed = true;

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-31.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-31.js
@@ -9,7 +9,7 @@ description: >
 ---*/
 
 var accessed = false;
-var objDate = new Date();
+var objDate = new Date(1970);
 
 function callbackfn(prevVal, curVal, idx, obj) {
   accessed = true;

--- a/test/built-ins/Array/prototype/some/15.4.4.17-1-11.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-1-11.js
@@ -10,7 +10,7 @@ function callbackfn(val, idx, obj) {
   return obj instanceof Date;
 }
 
-var obj = new Date();
+var obj = new Date(1970);
 obj.length = 2;
 obj[0] = 11;
 obj[1] = 9;

--- a/test/built-ins/Array/prototype/some/15.4.4.17-1-11.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-1-11.js
@@ -10,7 +10,7 @@ function callbackfn(val, idx, obj) {
   return obj instanceof Date;
 }
 
-var obj = new Date(1970);
+var obj = new Date(0);
 obj.length = 2;
 obj[0] = 11;
 obj[1] = 9;

--- a/test/built-ins/Array/prototype/some/15.4.4.17-5-15.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-5-15.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.some
 description: Array.prototype.some - Date object can be used as thisArg
 ---*/
 
-var objDate = new Date(1970);
+var objDate = new Date(0);
 
 function callbackfn(val, idx, obj) {
   return this === objDate;

--- a/test/built-ins/Array/prototype/some/15.4.4.17-5-15.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-5-15.js
@@ -6,7 +6,7 @@ esid: sec-array.prototype.some
 description: Array.prototype.some - Date object can be used as thisArg
 ---*/
 
-var objDate = new Date();
+var objDate = new Date(1970);
 
 function callbackfn(val, idx, obj) {
   return this === objDate;

--- a/test/built-ins/Array/prototype/some/15.4.4.17-7-c-iii-21.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-7-c-iii-21.js
@@ -7,7 +7,7 @@ description: Array.prototype.some - return value of callbackfn is a Date object
 ---*/
 
 function callbackfn(val, idx, obj) {
-  return new Date(1970);
+  return new Date(0);
 }
 
 assert([11].some(callbackfn), '[11].some(callbackfn) !== true');

--- a/test/built-ins/Array/prototype/some/15.4.4.17-7-c-iii-21.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-7-c-iii-21.js
@@ -7,7 +7,7 @@ description: Array.prototype.some - return value of callbackfn is a Date object
 ---*/
 
 function callbackfn(val, idx, obj) {
-  return new Date();
+  return new Date(1970);
 }
 
 assert([11].some(callbackfn), '[11].some(callbackfn) !== true');

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js
@@ -12,7 +12,10 @@ description: transferring to the Date objects
 ---*/
 
 var s1 = new Date(1970);
-s1.toString = Boolean.prototype.toString;
+Object.defineProperty(s1, "toString", {
+  value: Boolean.prototype.toString,
+  writable: true
+});
 assert.throws(TypeError, () => {
   s1.toString();
 });

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js
@@ -11,13 +11,13 @@ es5id: 15.6.4.2_A2_T3
 description: transferring to the Date objects
 ---*/
 
-var s1 = new Date(1970);
+var s1 = new Date(0);
 Object.defineProperty(s1, "toString", {value: Boolean.prototype.toString});
 assert.throws(TypeError, () => {
   s1.toString();
 });
 
-var s2 = new Date(1970);
+var s2 = new Date(0);
 s2.myToString = Boolean.prototype.toString;
 assert.throws(TypeError, () => {
   s2.myToString();

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js
@@ -11,14 +11,14 @@ es5id: 15.6.4.2_A2_T3
 description: transferring to the Date objects
 ---*/
 
+var s1 = new Date(1970);
+s1.toString = Boolean.prototype.toString;
 assert.throws(TypeError, () => {
-  var s1 = new Date();
-  s1.toString = Boolean.prototype.toString;
   s1.toString();
 });
 
+var s2 = new Date(1970);
+s2.myToString = Boolean.prototype.toString;
 assert.throws(TypeError, () => {
-  var s2 = new Date();
-  s2.myToString = Boolean.prototype.toString;
   s2.myToString();
 });

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js
@@ -12,10 +12,7 @@ description: transferring to the Date objects
 ---*/
 
 var s1 = new Date(1970);
-Object.defineProperty(s1, "toString", {
-  value: Boolean.prototype.toString,
-  writable: true
-});
+Object.defineProperty(s1, "toString", {value: Boolean.prototype.toString});
 assert.throws(TypeError, () => {
   s1.toString();
 });

--- a/test/built-ins/Date/is-a-constructor.js
+++ b/test/built-ins/Date/is-a-constructor.js
@@ -20,5 +20,5 @@ features: [Reflect.construct]
 ---*/
 
 assert.sameValue(isConstructor(Date), true, 'isConstructor(Date) must return true');
-new Date();
+new Date(1970);
   

--- a/test/built-ins/Date/is-a-constructor.js
+++ b/test/built-ins/Date/is-a-constructor.js
@@ -20,5 +20,5 @@ features: [Reflect.construct]
 ---*/
 
 assert.sameValue(isConstructor(Date), true, 'isConstructor(Date) must return true');
-new Date(1970);
+new Date(0);
   

--- a/test/built-ins/Date/proto-from-ctor-realm-zero.js
+++ b/test/built-ins/Date/proto-from-ctor-realm-zero.js
@@ -25,6 +25,6 @@ var other = $262.createRealm().global;
 var C = new other.Function();
 C.prototype = null;
 
-var o = Reflect.construct(Date, [1970], C);
+var o = Reflect.construct(Date, [0], C);
 
 assert.sameValue(Object.getPrototypeOf(o), other.Date.prototype);

--- a/test/built-ins/Date/proto-from-ctor-realm-zero.js
+++ b/test/built-ins/Date/proto-from-ctor-realm-zero.js
@@ -25,6 +25,6 @@ var other = $262.createRealm().global;
 var C = new other.Function();
 C.prototype = null;
 
-var o = Reflect.construct(Date, [], C);
+var o = Reflect.construct(Date, [1970], C);
 
 assert.sameValue(Object.getPrototypeOf(o), other.Date.prototype);

--- a/test/built-ins/Date/prototype/Symbol.toPrimitive/hint-invalid.js
+++ b/test/built-ins/Date/prototype/Symbol.toPrimitive/hint-invalid.js
@@ -14,7 +14,7 @@ info: |
 features: [Symbol.toPrimitive]
 ---*/
 
-var d = new Date(1970);
+var d = new Date(0);
 
 assert.sameValue(typeof d[Symbol.toPrimitive], 'function');
 

--- a/test/built-ins/Date/prototype/Symbol.toPrimitive/hint-invalid.js
+++ b/test/built-ins/Date/prototype/Symbol.toPrimitive/hint-invalid.js
@@ -14,7 +14,7 @@ info: |
 features: [Symbol.toPrimitive]
 ---*/
 
-var d = new Date();
+var d = new Date(1970);
 
 assert.sameValue(typeof d[Symbol.toPrimitive], 'function');
 

--- a/test/built-ins/Date/prototype/setDate/arg-to-number-err.js
+++ b/test/built-ins/Date/prototype/setDate/arg-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let dt be ? ToNumber(date).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setDate/arg-to-number-err.js
+++ b/test/built-ins/Date/prototype/setDate/arg-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let dt be ? ToNumber(date).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setFullYear/arg-date-to-number-err.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-date-to-number-err.js
@@ -13,7 +13,7 @@ info: |
      ? ToNumber(date).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setFullYear/arg-date-to-number-err.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-date-to-number-err.js
@@ -13,7 +13,7 @@ info: |
      ? ToNumber(date).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setFullYear/arg-month-to-number-err.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-month-to-number-err.js
@@ -11,7 +11,7 @@ info: |
      ? ToNumber(month).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setFullYear/arg-month-to-number-err.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-month-to-number-err.js
@@ -11,7 +11,7 @@ info: |
      ? ToNumber(month).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setFullYear/arg-year-to-number-err.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-year-to-number-err.js
@@ -9,7 +9,7 @@ info: |
   3. Let y be ? ToNumber(year).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setFullYear/arg-year-to-number-err.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-year-to-number-err.js
@@ -9,7 +9,7 @@ info: |
   3. Let y be ? ToNumber(year).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setHours/arg-hour-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-hour-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let dt be ? ToNumber(hour).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setHours/arg-hour-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-hour-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let dt be ? ToNumber(hour).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setHours/arg-min-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-min-to-number-err.js
@@ -10,7 +10,7 @@ info: |
      ToNumber(min).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setHours/arg-min-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-min-to-number-err.js
@@ -10,7 +10,7 @@ info: |
      ToNumber(min).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setHours/arg-ms-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-ms-to-number-err.js
@@ -14,7 +14,7 @@ info: |
      be ? ToNumber(ms).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setHours/arg-ms-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-ms-to-number-err.js
@@ -14,7 +14,7 @@ info: |
      be ? ToNumber(ms).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setHours/arg-sec-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-sec-to-number-err.js
@@ -12,7 +12,7 @@ info: |
      ToNumber(sec).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setHours/arg-sec-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-sec-to-number-err.js
@@ -12,7 +12,7 @@ info: |
      ToNumber(sec).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setMilliseconds/arg-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/arg-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let dt be ? ToNumber(date).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setMilliseconds/arg-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/arg-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let dt be ? ToNumber(date).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setMinutes/arg-min-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-min-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let m be ? ToNumber(min).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setMinutes/arg-min-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-min-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let m be ? ToNumber(min).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setMinutes/arg-ms-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-ms-to-number-err.js
@@ -12,7 +12,7 @@ info: |
      be ? ToNumber(ms).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setMinutes/arg-ms-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-ms-to-number-err.js
@@ -12,7 +12,7 @@ info: |
      be ? ToNumber(ms).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setMinutes/arg-sec-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-sec-to-number-err.js
@@ -10,7 +10,7 @@ info: |
      ToNumber(sec).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setMinutes/arg-sec-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-sec-to-number-err.js
@@ -10,7 +10,7 @@ info: |
      ToNumber(sec).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setMonth/arg-date-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMonth/arg-date-to-number-err.js
@@ -10,7 +10,7 @@ info: |
      ? ToNumber(date).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setMonth/arg-date-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMonth/arg-date-to-number-err.js
@@ -10,7 +10,7 @@ info: |
      ? ToNumber(date).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setMonth/arg-month-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMonth/arg-month-to-number-err.js
@@ -11,7 +11,7 @@ info: |
      ? ToNumber(month).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setMonth/arg-month-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMonth/arg-month-to-number-err.js
@@ -11,7 +11,7 @@ info: |
      ? ToNumber(month).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setSeconds/arg-ms-to-number-err.js
+++ b/test/built-ins/Date/prototype/setSeconds/arg-ms-to-number-err.js
@@ -10,7 +10,7 @@ info: |
      be ? ToNumber(ms).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setSeconds/arg-ms-to-number-err.js
+++ b/test/built-ins/Date/prototype/setSeconds/arg-ms-to-number-err.js
@@ -10,7 +10,7 @@ info: |
      be ? ToNumber(ms).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setSeconds/arg-sec-to-number-err.js
+++ b/test/built-ins/Date/prototype/setSeconds/arg-sec-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let s be ? ToNumber(sec).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setSeconds/arg-sec-to-number-err.js
+++ b/test/built-ins/Date/prototype/setSeconds/arg-sec-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let s be ? ToNumber(sec).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var callCount = 0;
 var originalValue = date.getTime();
 var obj = {

--- a/test/built-ins/Date/prototype/setTime/arg-to-number-err.js
+++ b/test/built-ins/Date/prototype/setTime/arg-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let t be ? ToNumber(time).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setTime/arg-to-number-err.js
+++ b/test/built-ins/Date/prototype/setTime/arg-to-number-err.js
@@ -8,7 +8,7 @@ info: |
   2. Let t be ? ToNumber(time).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 var originalValue = date.getTime();
 var obj = {
   valueOf: function() {

--- a/test/built-ins/Date/prototype/setTime/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setTime/new-value-time-clip.js
@@ -17,7 +17,7 @@ info: |
 ---*/
 
 var maxMs = 8.64e15;
-var date = new Date(1970);
+var date = new Date(0);
 var returnValue;
 
 assert.notSameValue(date.getTime(), NaN);

--- a/test/built-ins/Date/prototype/setTime/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setTime/new-value-time-clip.js
@@ -17,7 +17,7 @@ info: |
 ---*/
 
 var maxMs = 8.64e15;
-var date = new Date();
+var date = new Date(1970);
 var returnValue;
 
 assert.notSameValue(date.getTime(), NaN);

--- a/test/built-ins/Date/prototype/toDateString/format.js
+++ b/test/built-ins/Date/prototype/toDateString/format.js
@@ -11,7 +11,7 @@ info: |
 ---*/
 
 let dateRegExp = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{2} [0-9]{4}$/
-let match = dateRegExp.exec(new Date(1970).toDateString());
+let match = dateRegExp.exec(new Date(0).toDateString());
 assert.notSameValue(null, match);
 
 // Years are padded to the left with zeroes

--- a/test/built-ins/Date/prototype/toDateString/format.js
+++ b/test/built-ins/Date/prototype/toDateString/format.js
@@ -11,7 +11,7 @@ info: |
 ---*/
 
 let dateRegExp = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{2} [0-9]{4}$/
-let match = dateRegExp.exec(new Date().toDateString());
+let match = dateRegExp.exec(new Date(1970).toDateString());
 assert.notSameValue(null, match);
 
 // Years are padded to the left with zeroes

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-10.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-10.js
@@ -9,7 +9,7 @@ description: >
     UTC(0)
 ---*/
 
-var timeZoneMinutes = new Date().getTimezoneOffset() * (-1);
+var timeZoneMinutes = new Date(1970).getTimezoneOffset() * (-1);
 var date, dateStr;
 
 if (timeZoneMinutes > 0) {

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-10.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-10.js
@@ -9,7 +9,7 @@ description: >
     UTC(0)
 ---*/
 
-var timeZoneMinutes = new Date(1970).getTimezoneOffset() * (-1);
+var timeZoneMinutes = new Date(0).getTimezoneOffset() * (-1);
 var date, dateStr;
 
 if (timeZoneMinutes > 0) {

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-11.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-11.js
@@ -9,7 +9,7 @@ description: >
     UTC(0)
 ---*/
 
-var timeZoneMinutes = new Date(1970).getTimezoneOffset() * (-1);
+var timeZoneMinutes = new Date(0).getTimezoneOffset() * (-1);
 var date, dateStr;
 
 date = new Date(1970, 0, 100000001, 0, 0 + timeZoneMinutes - 60, 0, -1);

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-11.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-11.js
@@ -9,7 +9,7 @@ description: >
     UTC(0)
 ---*/
 
-var timeZoneMinutes = new Date().getTimezoneOffset() * (-1);
+var timeZoneMinutes = new Date(1970).getTimezoneOffset() * (-1);
 var date, dateStr;
 
 date = new Date(1970, 0, 100000001, 0, 0 + timeZoneMinutes - 60, 0, -1);

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-12.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-12.js
@@ -9,7 +9,7 @@ description: >
     UTC(0)
 ---*/
 
-var timeZoneMinutes = new Date().getTimezoneOffset() * (-1);
+var timeZoneMinutes = new Date(1970).getTimezoneOffset() * (-1);
 var date, dateStr;
 
 date = new Date(1970, 0, 100000001, 0, 0 + timeZoneMinutes - 60, 0, 0);

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-12.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-12.js
@@ -9,7 +9,7 @@ description: >
     UTC(0)
 ---*/
 
-var timeZoneMinutes = new Date(1970).getTimezoneOffset() * (-1);
+var timeZoneMinutes = new Date(0).getTimezoneOffset() * (-1);
 var date, dateStr;
 
 date = new Date(1970, 0, 100000001, 0, 0 + timeZoneMinutes - 60, 0, 0);

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-5.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-5.js
@@ -8,6 +8,6 @@ description: >
     zone(0)
 ---*/
 
-var dateStr = (new Date()).toISOString();
+var dateStr = (new Date(1970)).toISOString();
 
 assert.sameValue(dateStr[dateStr.length - 1], "Z", 'dateStr[dateStr.length - 1]');

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-5.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-5.js
@@ -8,6 +8,6 @@ description: >
     zone(0)
 ---*/
 
-var dateStr = (new Date(1970)).toISOString();
+var dateStr = (new Date(0)).toISOString();
 
 assert.sameValue(dateStr[dateStr.length - 1], "Z", 'dateStr[dateStr.length - 1]');

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-8.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-8.js
@@ -9,7 +9,7 @@ description: >
     UTC(0)
 ---*/
 
-var timeZoneMinutes = new Date(1970).getTimezoneOffset() * (-1);
+var timeZoneMinutes = new Date(0).getTimezoneOffset() * (-1);
 var date, dateStr;
 assert.throws(RangeError, function() {
   if (timeZoneMinutes > 0) {

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-8.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-8.js
@@ -9,7 +9,7 @@ description: >
     UTC(0)
 ---*/
 
-var timeZoneMinutes = new Date().getTimezoneOffset() * (-1);
+var timeZoneMinutes = new Date(1970).getTimezoneOffset() * (-1);
 var date, dateStr;
 assert.throws(RangeError, function() {
   if (timeZoneMinutes > 0) {

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-9.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-9.js
@@ -9,7 +9,7 @@ description: >
     UTC(0)
 ---*/
 
-var timeZoneMinutes = new Date().getTimezoneOffset() * (-1);
+var timeZoneMinutes = new Date(1970).getTimezoneOffset() * (-1);
 var date, dateStr;
 
 if (timeZoneMinutes > 0) {

--- a/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-9.js
+++ b/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-9.js
@@ -9,7 +9,7 @@ description: >
     UTC(0)
 ---*/
 
-var timeZoneMinutes = new Date(1970).getTimezoneOffset() * (-1);
+var timeZoneMinutes = new Date(0).getTimezoneOffset() * (-1);
 var date, dateStr;
 
 if (timeZoneMinutes > 0) {

--- a/test/built-ins/Date/prototype/toJSON/invoke-result.js
+++ b/test/built-ins/Date/prototype/toJSON/invoke-result.js
@@ -17,7 +17,7 @@ info: |
   4. Return ? Call(func, V, argumentsList).
 ---*/
 
-var date = new Date(1970);
+var date = new Date(0);
 assert.sameValue(date.toJSON(), date.toISOString());
 
 var result = {};

--- a/test/built-ins/Date/prototype/toJSON/invoke-result.js
+++ b/test/built-ins/Date/prototype/toJSON/invoke-result.js
@@ -17,7 +17,7 @@ info: |
   4. Return ? Call(func, V, argumentsList).
 ---*/
 
-var date = new Date();
+var date = new Date(1970);
 assert.sameValue(date.toJSON(), date.toISOString());
 
 var result = {};

--- a/test/built-ins/Date/prototype/toString/format.js
+++ b/test/built-ins/Date/prototype/toString/format.js
@@ -12,7 +12,7 @@ info: |
 ---*/
 
 let stringRegExp = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{2} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT[+-][0-9]{4}( \(.+\))?$/
-let match = stringRegExp.exec(new Date().toString());
+let match = stringRegExp.exec(new Date(1970).toString());
 assert.notSameValue(null, match);
 
 // Years are padded to the left with zeroes

--- a/test/built-ins/Date/prototype/toString/format.js
+++ b/test/built-ins/Date/prototype/toString/format.js
@@ -12,7 +12,7 @@ info: |
 ---*/
 
 let stringRegExp = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{2} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT[+-][0-9]{4}( \(.+\))?$/
-let match = stringRegExp.exec(new Date(1970).toString());
+let match = stringRegExp.exec(new Date(0).toString());
 assert.notSameValue(null, match);
 
 // Years are padded to the left with zeroes

--- a/test/built-ins/Date/prototype/toTimeString/format.js
+++ b/test/built-ins/Date/prototype/toTimeString/format.js
@@ -11,5 +11,5 @@ info: |
 ---*/
 
 let timeRegExp = /^[0-9]{2}:[0-9]{2}:[0-9]{2} GMT[+-][0-9]{4}( \(.+\))?$/
-let match = timeRegExp.exec(new Date(1970).toTimeString());
+let match = timeRegExp.exec(new Date(0).toTimeString());
 assert.notSameValue(null, match);

--- a/test/built-ins/Date/prototype/toTimeString/format.js
+++ b/test/built-ins/Date/prototype/toTimeString/format.js
@@ -11,5 +11,5 @@ info: |
 ---*/
 
 let timeRegExp = /^[0-9]{2}:[0-9]{2}:[0-9]{2} GMT[+-][0-9]{4}( \(.+\))?$/
-let match = timeRegExp.exec(new Date().toTimeString());
+let match = timeRegExp.exec(new Date(1970).toTimeString());
 assert.notSameValue(null, match);

--- a/test/built-ins/Date/prototype/toUTCString/format.js
+++ b/test/built-ins/Date/prototype/toUTCString/format.js
@@ -11,7 +11,7 @@ info: |
 ---*/
 
 let utcRegExp = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), [0-9]{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT$/
-let match = utcRegExp.exec(new Date().toUTCString());
+let match = utcRegExp.exec(new Date(1970).toUTCString());
 assert.notSameValue(null, match);
 
 // Years are padded to the left with zeroes

--- a/test/built-ins/Date/prototype/toUTCString/format.js
+++ b/test/built-ins/Date/prototype/toUTCString/format.js
@@ -11,7 +11,7 @@ info: |
 ---*/
 
 let utcRegExp = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), [0-9]{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT$/
-let match = utcRegExp.exec(new Date(1970).toUTCString());
+let match = utcRegExp.exec(new Date(0).toUTCString());
 assert.notSameValue(null, match);
 
 // Years are padded to the left with zeroes

--- a/test/built-ins/Date/value-to-primitive-get-meth-err.js
+++ b/test/built-ins/Date/value-to-primitive-get-meth-err.js
@@ -14,7 +14,7 @@ features: [Symbol.toPrimitive]
 ---*/
 
 var poisonedObject = {};
-var poisonedDate = new Date(1970);
+var poisonedDate = new Date();
 Object.defineProperty(poisonedObject, Symbol.toPrimitive, {
   get: function() {
     throw new Test262Error();

--- a/test/built-ins/Date/value-to-primitive-get-meth-err.js
+++ b/test/built-ins/Date/value-to-primitive-get-meth-err.js
@@ -14,7 +14,7 @@ features: [Symbol.toPrimitive]
 ---*/
 
 var poisonedObject = {};
-var poisonedDate = new Date();
+var poisonedDate = new Date(1970);
 Object.defineProperty(poisonedObject, Symbol.toPrimitive, {
   get: function() {
     throw new Test262Error();

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A4_T03.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A4_T03.js
@@ -10,9 +10,12 @@ es5id: 15.7.4.2_A4_T03
 description: transferring to the Date objects
 ---*/
 
+var s1 = new Date(1970);
+Object.defineProperty(s1, "toString", {
+  value: Number.prototype.toString,
+  writable: true
+});
 try {
-  var s1 = new Date();
-  s1.toString = Number.prototype.toString;
   var v1 = s1.toString();
   throw new Test262Error('#1: Number.prototype.toString on not a Number object should throw TypeError');
 }
@@ -20,9 +23,9 @@ catch (e) {
   assert(e instanceof TypeError, 'The result of evaluating (e instanceof TypeError) is expected to be true');
 }
 
+var s2 = new Date(1970);
+s2.myToString = Number.prototype.toString;
 try {
-  var s2 = new Date();
-  s2.myToString = Number.prototype.toString;
   var v2 = s2.myToString();
   throw new Test262Error('#2: Number.prototype.toString on not a Number object should throw TypeError');
 }

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A4_T03.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A4_T03.js
@@ -10,7 +10,7 @@ es5id: 15.7.4.2_A4_T03
 description: transferring to the Date objects
 ---*/
 
-var s1 = new Date(1970);
+var s1 = new Date(0);
 Object.defineProperty(s1, "toString", {value: Number.prototype.toString});
 try {
   var v1 = s1.toString();
@@ -20,7 +20,7 @@ catch (e) {
   assert(e instanceof TypeError, 'The result of evaluating (e instanceof TypeError) is expected to be true');
 }
 
-var s2 = new Date(1970);
+var s2 = new Date(0);
 s2.myToString = Number.prototype.toString;
 try {
   var v2 = s2.myToString();

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A4_T03.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A4_T03.js
@@ -11,10 +11,7 @@ description: transferring to the Date objects
 ---*/
 
 var s1 = new Date(1970);
-Object.defineProperty(s1, "toString", {
-  value: Number.prototype.toString,
-  writable: true
-});
+Object.defineProperty(s1, "toString", {value: Number.prototype.toString});
 try {
   var v1 = s1.toString();
   throw new Test262Error('#1: Number.prototype.toString on not a Number object should throw TypeError');

--- a/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A2_T03.js
+++ b/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A2_T03.js
@@ -11,10 +11,7 @@ description: transferring to the Date objects
 ---*/
 
 var s1 = new Date(1970);
-Object.defineProperty(s1, "valueOf", {
-  value: Number.prototype.valueOf,
-  writable: true
-});
+Object.defineProperty(s1, "valueOf", {value: Number.prototype.valueOf});
 try {
   var v1 = s1.valueOf();
   throw new Test262Error('#1: Number.prototype.valueOf on not a Number object should throw TypeError');

--- a/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A2_T03.js
+++ b/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A2_T03.js
@@ -10,7 +10,7 @@ es5id: 15.7.4.4_A2_T03
 description: transferring to the Date objects
 ---*/
 
-var s1 = new Date(1970);
+var s1 = new Date(0);
 Object.defineProperty(s1, "valueOf", {value: Number.prototype.valueOf});
 try {
   var v1 = s1.valueOf();
@@ -20,7 +20,7 @@ catch (e) {
   assert(e instanceof TypeError, 'The result of evaluating (e instanceof TypeError) is expected to be true');
 }
 
-var s2 = new Date(1970);
+var s2 = new Date(0);
 s2.myValueOf = Number.prototype.valueOf;
 try {
   var v2 = s2.myValueOf();

--- a/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A2_T03.js
+++ b/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A2_T03.js
@@ -10,9 +10,12 @@ es5id: 15.7.4.4_A2_T03
 description: transferring to the Date objects
 ---*/
 
+var s1 = new Date(1970);
+Object.defineProperty(s1, "valueOf", {
+  value: Number.prototype.valueOf,
+  writable: true
+});
 try {
-  var s1 = new Date();
-  s1.valueOf = Number.prototype.valueOf;
   var v1 = s1.valueOf();
   throw new Test262Error('#1: Number.prototype.valueOf on not a Number object should throw TypeError');
 }
@@ -20,9 +23,9 @@ catch (e) {
   assert(e instanceof TypeError, 'The result of evaluating (e instanceof TypeError) is expected to be true');
 }
 
+var s2 = new Date(1970);
+s2.myValueOf = Number.prototype.valueOf;
 try {
-  var s2 = new Date();
-  s2.myValueOf = Number.prototype.valueOf;
   var v2 = s2.myValueOf();
   throw new Test262Error('#2: Number.prototype.valueOf on not a Number object should throw TypeError');
 }

--- a/test/built-ins/Object/create/15.2.3.5-4-11.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-11.js
@@ -8,7 +8,7 @@ description: >
     step 2)
 ---*/
 
-var props = new Date();
+var props = new Date(1970);
 var result = false;
 
 Object.defineProperty(props, "prop", {

--- a/test/built-ins/Object/create/15.2.3.5-4-11.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-11.js
@@ -8,7 +8,7 @@ description: >
     step 2)
 ---*/
 
-var props = new Date(1970);
+var props = new Date(0);
 var result = false;
 
 Object.defineProperty(props, "prop", {

--- a/test/built-ins/Object/create/15.2.3.5-4-118.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-118.js
@@ -9,7 +9,7 @@ description: >
     (8.10.5 step 4.a)
 ---*/
 
-var descObj = new Date();
+var descObj = new Date(1970);
 
 descObj.configurable = true;
 

--- a/test/built-ins/Object/create/15.2.3.5-4-118.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-118.js
@@ -9,7 +9,7 @@ description: >
     (8.10.5 step 4.a)
 ---*/
 
-var descObj = new Date(1970);
+var descObj = new Date(0);
 
 descObj.configurable = true;
 

--- a/test/built-ins/Object/create/15.2.3.5-4-143.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-143.js
@@ -10,7 +10,7 @@ description: >
 
 var newObj = Object.create({}, {
   prop: {
-    configurable: new Date()
+    configurable: new Date(1970)
   }
 });
 

--- a/test/built-ins/Object/create/15.2.3.5-4-143.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-143.js
@@ -10,7 +10,7 @@ description: >
 
 var newObj = Object.create({}, {
   prop: {
-    configurable: new Date(1970)
+    configurable: new Date(0)
   }
 });
 

--- a/test/built-ins/Object/create/15.2.3.5-4-171.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-171.js
@@ -9,7 +9,7 @@ description: >
     (8.10.5 step 5.a)
 ---*/
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 
 dateObj.value = "DateValue";
 

--- a/test/built-ins/Object/create/15.2.3.5-4-171.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-171.js
@@ -9,7 +9,7 @@ description: >
     (8.10.5 step 5.a)
 ---*/
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 
 dateObj.value = "DateValue";
 

--- a/test/built-ins/Object/create/15.2.3.5-4-197.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-197.js
@@ -9,7 +9,7 @@ description: >
     (8.10.5 step 6.a)
 ---*/
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 
 dateObj.writable = true;
 

--- a/test/built-ins/Object/create/15.2.3.5-4-197.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-197.js
@@ -9,7 +9,7 @@ description: >
     (8.10.5 step 6.a)
 ---*/
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 
 dateObj.writable = true;
 

--- a/test/built-ins/Object/create/15.2.3.5-4-222.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-222.js
@@ -10,7 +10,7 @@ description: >
 
 var newObj = Object.create({}, {
   prop: {
-    writable: new Date(1970)
+    writable: new Date(0)
   }
 });
 var hasProperty = newObj.hasOwnProperty("prop");

--- a/test/built-ins/Object/create/15.2.3.5-4-222.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-222.js
@@ -10,7 +10,7 @@ description: >
 
 var newObj = Object.create({}, {
   prop: {
-    writable: new Date()
+    writable: new Date(1970)
   }
 });
 var hasProperty = newObj.hasOwnProperty("prop");

--- a/test/built-ins/Object/create/15.2.3.5-4-249.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-249.js
@@ -9,7 +9,7 @@ description: >
     step 7.a)
 ---*/
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 
 dateObj.get = function() {
   return "VerifyDateObject";

--- a/test/built-ins/Object/create/15.2.3.5-4-249.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-249.js
@@ -9,7 +9,7 @@ description: >
     step 7.a)
 ---*/
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 
 dateObj.get = function() {
   return "VerifyDateObject";

--- a/test/built-ins/Object/create/15.2.3.5-4-285.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-285.js
@@ -9,7 +9,7 @@ description: >
     step 8.a)
 ---*/
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 var data = "data";
 dateObj.set = function(value) {
   data = value;

--- a/test/built-ins/Object/create/15.2.3.5-4-285.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-285.js
@@ -9,7 +9,7 @@ description: >
     step 8.a)
 ---*/
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 var data = "data";
 dateObj.set = function(value) {
   data = value;

--- a/test/built-ins/Object/create/15.2.3.5-4-297.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-297.js
@@ -12,7 +12,7 @@ description: >
 assert.throws(TypeError, function() {
   Object.create({}, {
     prop: {
-      set: new Date(1970)
+      set: new Date(0)
     }
   });
 });

--- a/test/built-ins/Object/create/15.2.3.5-4-297.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-297.js
@@ -12,7 +12,7 @@ description: >
 assert.throws(TypeError, function() {
   Object.create({}, {
     prop: {
-      set: new Date()
+      set: new Date(1970)
     }
   });
 });

--- a/test/built-ins/Object/create/15.2.3.5-4-34.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-34.js
@@ -9,7 +9,7 @@ description: >
     5.a)
 ---*/
 
-var props = new Date();
+var props = new Date(1970);
 props.prop = {
   value: 12,
   enumerable: true

--- a/test/built-ins/Object/create/15.2.3.5-4-34.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-34.js
@@ -9,7 +9,7 @@ description: >
     5.a)
 ---*/
 
-var props = new Date(1970);
+var props = new Date(0);
 props.prop = {
   value: 12,
   enumerable: true

--- a/test/built-ins/Object/create/15.2.3.5-4-65.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-65.js
@@ -10,7 +10,7 @@ description: >
 ---*/
 
 var accessed = false;
-var descObj = new Date();
+var descObj = new Date(1970);
 
 descObj.enumerable = true;
 

--- a/test/built-ins/Object/create/15.2.3.5-4-65.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-65.js
@@ -10,7 +10,7 @@ description: >
 ---*/
 
 var accessed = false;
-var descObj = new Date(1970);
+var descObj = new Date(0);
 
 descObj.enumerable = true;
 

--- a/test/built-ins/Object/create/15.2.3.5-4-90.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-90.js
@@ -12,7 +12,7 @@ var accessed = false;
 
 var newObj = Object.create({}, {
   prop: {
-    enumerable: new Date(1970)
+    enumerable: new Date(0)
   }
 });
 for (var property in newObj) {

--- a/test/built-ins/Object/create/15.2.3.5-4-90.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-90.js
@@ -12,7 +12,7 @@ var accessed = false;
 
 var newObj = Object.create({}, {
   prop: {
-    enumerable: new Date()
+    enumerable: new Date(1970)
   }
 });
 for (var property in newObj) {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-2-12.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-2-12.js
@@ -7,7 +7,7 @@ description: Object.defineProperties - argument 'Properties' is a Date object
 ---*/
 
 var obj = {};
-var props = new Date(1970);
+var props = new Date(0);
 var result = false;
 
 Object.defineProperty(props, "prop", {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-2-12.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-2-12.js
@@ -7,7 +7,7 @@ description: Object.defineProperties - argument 'Properties' is a Date object
 ---*/
 
 var obj = {};
-var props = new Date();
+var props = new Date(1970);
 var result = false;
 
 Object.defineProperty(props, "prop", {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-a-13.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-a-13.js
@@ -9,7 +9,7 @@ description: >
 ---*/
 
 var obj = {};
-var props = new Date(1970);
+var props = new Date(0);
 
 Object.defineProperty(props, "prop", {
   value: {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-a-13.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-a-13.js
@@ -9,7 +9,7 @@ description: >
 ---*/
 
 var obj = {};
-var props = new Date();
+var props = new Date(1970);
 
 Object.defineProperty(props, "prop", {
   value: {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-103.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-103.js
@@ -12,7 +12,7 @@ var obj = {};
 
 Object.defineProperties(obj, {
   property: {
-    configurable: new Date()
+    configurable: new Date(1970)
   }
 });
 var preCheck = obj.hasOwnProperty("property");

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-103.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-103.js
@@ -12,7 +12,7 @@ var obj = {};
 
 Object.defineProperties(obj, {
   property: {
-    configurable: new Date(1970)
+    configurable: new Date(0)
   }
 });
 var preCheck = obj.hasOwnProperty("property");

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-131.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-131.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var descObj = new Date(1970);
+var descObj = new Date(0);
 
 descObj.value = "Date";
 

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-131.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-131.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var descObj = new Date();
+var descObj = new Date(1970);
 
 descObj.value = "Date";
 

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-157.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-157.js
@@ -12,7 +12,7 @@ includes: [propertyHelper.js]
 
 var obj = {};
 
-var descObj = new Date(1970);
+var descObj = new Date(0);
 
 descObj.writable = false;
 

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-157.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-157.js
@@ -12,7 +12,7 @@ includes: [propertyHelper.js]
 
 var obj = {};
 
-var descObj = new Date();
+var descObj = new Date(1970);
 
 descObj.writable = false;
 

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-182.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-182.js
@@ -12,7 +12,7 @@ var obj = {};
 
 Object.defineProperties(obj, {
   property: {
-    writable: new Date(1970)
+    writable: new Date(0)
   }
 });
 

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-182.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-182.js
@@ -12,7 +12,7 @@ var obj = {};
 
 Object.defineProperties(obj, {
   property: {
-    writable: new Date()
+    writable: new Date(1970)
   }
 });
 

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-210.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-210.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var descObj = new Date(1970);
+var descObj = new Date(0);
 
 descObj.get = function() {
   return "Date";

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-210.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-210.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var descObj = new Date();
+var descObj = new Date(1970);
 
 descObj.get = function() {
   return "Date";

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-245.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-245.js
@@ -10,7 +10,7 @@ description: >
 ---*/
 
 var data = "data";
-var descObj = new Date();
+var descObj = new Date(1970);
 var setFun = function(value) {
   data = value;
 };

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-245.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-245.js
@@ -10,7 +10,7 @@ description: >
 ---*/
 
 var data = "data";
-var descObj = new Date(1970);
+var descObj = new Date(0);
 var setFun = function(value) {
   data = value;
 };

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-25.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-25.js
@@ -10,7 +10,7 @@ description: >
 ---*/
 
 var obj = {};
-var descObj = new Date(1970);
+var descObj = new Date(0);
 var accessed = false;
 
 descObj.enumerable = true;

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-25.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-25.js
@@ -10,7 +10,7 @@ description: >
 ---*/
 
 var obj = {};
-var descObj = new Date();
+var descObj = new Date(1970);
 var accessed = false;
 
 descObj.enumerable = true;

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-50.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-50.js
@@ -13,7 +13,7 @@ var accessed = false;
 
 Object.defineProperties(obj, {
   prop: {
-    enumerable: new Date(1970)
+    enumerable: new Date(0)
   }
 });
 for (var property in obj) {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-50.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-50.js
@@ -13,7 +13,7 @@ var accessed = false;
 
 Object.defineProperties(obj, {
   prop: {
-    enumerable: new Date()
+    enumerable: new Date(1970)
   }
 });
 for (var property in obj) {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-78.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-78.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var descObj = new Date();
+var descObj = new Date(1970);
 descObj.configurable = true;
 
 Object.defineProperties(obj, {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-78.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-78.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var descObj = new Date(1970);
+var descObj = new Date(0);
 descObj.configurable = true;
 
 Object.defineProperties(obj, {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-6-a-18.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-6-a-18.js
@@ -10,7 +10,7 @@ includes: [propertyHelper.js]
 ---*/
 
 
-var obj = new Date();
+var obj = new Date(1970);
 
 Object.defineProperty(obj, "prop", {
   value: 11,

--- a/test/built-ins/Object/defineProperties/15.2.3.7-6-a-18.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-6-a-18.js
@@ -10,7 +10,7 @@ includes: [propertyHelper.js]
 ---*/
 
 
-var obj = new Date(1970);
+var obj = new Date(0);
 
 Object.defineProperty(obj, "prop", {
   value: 11,

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-117.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-117.js
@@ -11,7 +11,7 @@ description: >
 var obj = {};
 
 Object.defineProperty(obj, "property", {
-  configurable: new Date1970()
+  configurable: new Date(1970)
 });
 
 var beforeDeleted = obj.hasOwnProperty("property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-117.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-117.js
@@ -11,7 +11,7 @@ description: >
 var obj = {};
 
 Object.defineProperty(obj, "property", {
-  configurable: new Date(1970)
+  configurable: new Date(0)
 });
 
 var beforeDeleted = obj.hasOwnProperty("property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-117.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-117.js
@@ -11,7 +11,7 @@ description: >
 var obj = {};
 
 Object.defineProperty(obj, "property", {
-  configurable: new Date()
+  configurable: new Date1970()
 });
 
 var beforeDeleted = obj.hasOwnProperty("property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-145.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-145.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 
 dateObj.value = "Date";
 

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-145.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-145.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 
 dateObj.value = "Date";
 

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-171.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-171.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 
 dateObj.writable = true;
 

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-171.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-171.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 
 dateObj.writable = true;
 

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-196.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-196.js
@@ -11,7 +11,7 @@ description: >
 var obj = {};
 
 Object.defineProperty(obj, "property", {
-  writable: new Date()
+  writable: new Date(1970)
 });
 
 var beforeWrite = obj.hasOwnProperty("property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-196.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-196.js
@@ -11,7 +11,7 @@ description: >
 var obj = {};
 
 Object.defineProperty(obj, "property", {
-  writable: new Date(1970)
+  writable: new Date(0)
 });
 
 var beforeWrite = obj.hasOwnProperty("property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-224.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-224.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 
 dateObj.get = function() {
   return "dateGetProperty";

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-224.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-224.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 
 dateObj.get = function() {
   return "dateGetProperty";

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-254.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-254.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 var data = "data";
-var dateObj = new Date();
+var dateObj = new Date(1970);
 
 dateObj.set = function(value) {
   data = value;

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-254.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-254.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 var data = "data";
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 
 dateObj.set = function(value) {
   data = value;

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-39.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-39.js
@@ -12,7 +12,7 @@ description: >
 var obj = {};
 var accessed = false;
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 dateObj.enumerable = true;
 
 Object.defineProperty(obj, "property", dateObj);

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-39.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-39.js
@@ -12,7 +12,7 @@ description: >
 var obj = {};
 var accessed = false;
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 dateObj.enumerable = true;
 
 Object.defineProperty(obj, "property", dateObj);

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-64.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-64.js
@@ -12,7 +12,7 @@ var obj = {};
 var accessed = false;
 
 Object.defineProperty(obj, "property", {
-  enumerable: new Date()
+  enumerable: new Date(1970)
 });
 
 for (var prop in obj) {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-64.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-64.js
@@ -12,7 +12,7 @@ var obj = {};
 var accessed = false;
 
 Object.defineProperty(obj, "property", {
-  enumerable: new Date(1970)
+  enumerable: new Date(0)
 });
 
 for (var prop in obj) {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-92.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-92.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 
 dateObj.configurable = true;
 

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-92.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-92.js
@@ -11,7 +11,7 @@ description: >
 
 var obj = {};
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 
 dateObj.configurable = true;
 

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-39.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-39.js
@@ -9,7 +9,7 @@ description: >
     step 1)
 ---*/
 
-var desc = new Date(1970);
+var desc = new Date(0);
 
 Object.defineProperty(desc, "foo", {
   value: 12,

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-39.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-39.js
@@ -9,7 +9,7 @@ description: >
     step 1)
 ---*/
 
-var desc = new Date();
+var desc = new Date(1970);
 
 Object.defineProperty(desc, "foo", {
   value: 12,

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-392.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-392.js
@@ -9,7 +9,7 @@ description: >
 ---*/
 
 var obj = {};
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 
 Object.defineProperty(obj, "prop", {
   value: dateObj

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-392.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-392.js
@@ -9,7 +9,7 @@ description: >
 ---*/
 
 var obj = {};
-var dateObj = new Date();
+var dateObj = new Date(1970);
 
 Object.defineProperty(obj, "prop", {
   value: dateObj

--- a/test/built-ins/Object/freeze/15.2.3.9-2-d-6.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-d-6.js
@@ -6,7 +6,7 @@ es5id: 15.2.3.9-2-d-6
 description: Object.freeze - 'O' is a Date object
 ---*/
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 
 Object.freeze(dateObj);
 

--- a/test/built-ins/Object/freeze/15.2.3.9-2-d-6.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-d-6.js
@@ -6,7 +6,7 @@ es5id: 15.2.3.9-2-d-6
 description: Object.freeze - 'O' is a Date object
 ---*/
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 
 Object.freeze(dateObj);
 

--- a/test/built-ins/Object/getPrototypeOf/15.2.3.2-2-25.js
+++ b/test/built-ins/Object/getPrototypeOf/15.2.3.2-2-25.js
@@ -8,6 +8,6 @@ description: >
     (Date object)
 ---*/
 
-var obj = new Date();
+var obj = new Date(1970);
 
 assert.sameValue(Object.getPrototypeOf(obj), Date.prototype, 'Object.getPrototypeOf(obj)');

--- a/test/built-ins/Object/getPrototypeOf/15.2.3.2-2-25.js
+++ b/test/built-ins/Object/getPrototypeOf/15.2.3.2-2-25.js
@@ -8,6 +8,6 @@ description: >
     (Date object)
 ---*/
 
-var obj = new Date(1970);
+var obj = new Date(0);
 
 assert.sameValue(Object.getPrototypeOf(obj), Date.prototype, 'Object.getPrototypeOf(obj)');

--- a/test/built-ins/Object/keys/15.2.3.14-6-5.js
+++ b/test/built-ins/Object/keys/15.2.3.14-6-5.js
@@ -8,7 +8,7 @@ description: >
     with the order of properties in 'O' (any other built-in object)
 ---*/
 
-var obj = new Date();
+var obj = new Date(1970);
 obj.prop1 = 100;
 obj.prop2 = "prop2";
 

--- a/test/built-ins/Object/keys/15.2.3.14-6-5.js
+++ b/test/built-ins/Object/keys/15.2.3.14-6-5.js
@@ -8,7 +8,7 @@ description: >
     with the order of properties in 'O' (any other built-in object)
 ---*/
 
-var obj = new Date(1970);
+var obj = new Date(0);
 obj.prop1 = 100;
 obj.prop2 = "prop2";
 

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-18.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-18.js
@@ -9,7 +9,7 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-var obj = new Date(1970);
+var obj = new Date(0);
 
 assert(Object.isExtensible(obj));
 Object.preventExtensions(obj);

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-18.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-18.js
@@ -9,7 +9,7 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-var obj = new Date();
+var obj = new Date(1970);
 
 assert(Object.isExtensible(obj));
 Object.preventExtensions(obj);

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-8.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-8.js
@@ -9,7 +9,7 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-var obj = new Date(1970);
+var obj = new Date(0);
 
 assert(Object.isExtensible(obj));
 Object.preventExtensions(obj);

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-8.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-8.js
@@ -9,7 +9,7 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-var obj = new Date();
+var obj = new Date(1970);
 
 assert(Object.isExtensible(obj));
 Object.preventExtensions(obj);

--- a/test/built-ins/Object/prototype/toString/Object.prototype.toString.call-date.js
+++ b/test/built-ins/Object/prototype/toString/Object.prototype.toString.call-date.js
@@ -6,12 +6,12 @@ esid: sec-object.prototype.tostring
 description: is a String exotic object, let builtinTag be "String".
 ---*/
 assert.sameValue(
-  Object.prototype.toString.call(new Date()),
+  Object.prototype.toString.call(new Date(1970)),
   "[object Date]",
-  "Object.prototype.toString.call(new Date()) returns [object Date]"
+  "Object.prototype.toString.call(new Date(1970)) returns [object Date]"
 );
 assert.sameValue(
-  Object.prototype.toString.call(Object(new Date())),
+  Object.prototype.toString.call(Object(new Date(1970))),
   "[object Date]",
-  "Object.prototype.toString.call(Object(new Date())) returns [object Date]"
+  "Object.prototype.toString.call(Object(new Date(1970))) returns [object Date]"
 );

--- a/test/built-ins/Object/prototype/toString/Object.prototype.toString.call-date.js
+++ b/test/built-ins/Object/prototype/toString/Object.prototype.toString.call-date.js
@@ -6,12 +6,12 @@ esid: sec-object.prototype.tostring
 description: is a String exotic object, let builtinTag be "String".
 ---*/
 assert.sameValue(
-  Object.prototype.toString.call(new Date(1970)),
+  Object.prototype.toString.call(new Date(0)),
   "[object Date]",
-  "Object.prototype.toString.call(new Date(1970)) returns [object Date]"
+  "Object.prototype.toString.call(new Date(0)) returns [object Date]"
 );
 assert.sameValue(
-  Object.prototype.toString.call(Object(new Date(1970))),
+  Object.prototype.toString.call(Object(new Date(0))),
   "[object Date]",
-  "Object.prototype.toString.call(Object(new Date(1970))) returns [object Date]"
+  "Object.prototype.toString.call(Object(new Date(0))) returns [object Date]"
 );

--- a/test/built-ins/Object/prototype/toString/symbol-tag-override-instances.js
+++ b/test/built-ins/Object/prototype/toString/symbol-tag-override-instances.js
@@ -46,7 +46,7 @@ custom = new Number();
 custom[Symbol.toStringTag] = 'test262';
 assert.sameValue(Object.prototype.toString.call(custom), '[object test262]');
 
-custom = new Date();
+custom = new Date(1970);
 custom[Symbol.toStringTag] = 'test262';
 assert.sameValue(Object.prototype.toString.call(custom), '[object test262]');
 

--- a/test/built-ins/Object/prototype/toString/symbol-tag-override-instances.js
+++ b/test/built-ins/Object/prototype/toString/symbol-tag-override-instances.js
@@ -46,7 +46,7 @@ custom = new Number();
 custom[Symbol.toStringTag] = 'test262';
 assert.sameValue(Object.prototype.toString.call(custom), '[object test262]');
 
-custom = new Date(1970);
+custom = new Date(0);
 custom[Symbol.toStringTag] = 'test262';
 assert.sameValue(Object.prototype.toString.call(custom), '[object test262]');
 

--- a/test/built-ins/Object/seal/object-seal-o-is-a-date-object.js
+++ b/test/built-ins/Object/seal/object-seal-o-is-a-date-object.js
@@ -6,7 +6,7 @@ esid: sec-setintegritylevel
 description: Object.seal - 'O' is a Date object
 ---*/
 
-var dateObj = new Date(1970);
+var dateObj = new Date(0);
 var preCheck = Object.isExtensible(dateObj);
 Object.seal(dateObj);
 

--- a/test/built-ins/Object/seal/object-seal-o-is-a-date-object.js
+++ b/test/built-ins/Object/seal/object-seal-o-is-a-date-object.js
@@ -6,7 +6,7 @@ esid: sec-setintegritylevel
 description: Object.seal - 'O' is a Date object
 ---*/
 
-var dateObj = new Date();
+var dateObj = new Date(1970);
 var preCheck = Object.isExtensible(dateObj);
 Object.seal(dateObj);
 

--- a/test/built-ins/Object/seal/object-seal-p-is-own-property-of-a-date-object-that-uses-object-s-get-own-property.js
+++ b/test/built-ins/Object/seal/object-seal-p-is-own-property-of-a-date-object-that-uses-object-s-get-own-property.js
@@ -9,7 +9,7 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-var obj = new Date(1970);
+var obj = new Date(0);
 
 obj.foo = 10;
 

--- a/test/built-ins/Object/seal/object-seal-p-is-own-property-of-a-date-object-that-uses-object-s-get-own-property.js
+++ b/test/built-ins/Object/seal/object-seal-p-is-own-property-of-a-date-object-that-uses-object-s-get-own-property.js
@@ -9,7 +9,7 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-var obj = new Date();
+var obj = new Date(1970);
 
 obj.foo = 10;
 

--- a/test/built-ins/Object/seal/seal-date.js
+++ b/test/built-ins/Object/seal/seal-date.js
@@ -33,4 +33,4 @@ info: |
 
 ---*/
 
-Object.seal(new Date());
+Object.seal(new Date(1970));

--- a/test/built-ins/Object/seal/seal-date.js
+++ b/test/built-ins/Object/seal/seal-date.js
@@ -33,4 +33,4 @@ info: |
 
 ---*/
 
-Object.seal(new Date(1970));
+Object.seal(new Date(0));

--- a/test/built-ins/Promise/all/invoke-then-error-close.js
+++ b/test/built-ins/Promise/all/invoke-then-error-close.js
@@ -42,9 +42,11 @@ iter[Symbol.iterator] = function() {
   };
 };
 
-promise.then = function() {
-  throw new Test262Error();
-};
+Object.defineProperty(promise, "then", {
+  value: function() {
+    throw new Test262Error();
+  }
+});
 
 Promise.all(iter);
 

--- a/test/built-ins/Promise/all/invoke-then-error-reject.js
+++ b/test/built-ins/Promise/all/invoke-then-error-reject.js
@@ -28,9 +28,11 @@ flags: [async]
 var promise = new Promise(function() {});
 var error = new Test262Error();
 
-promise.then = function() {
-  throw error;
-};
+Object.defineProperty(promise, "then", {
+  value: function() {
+    throw error;
+  }
+});
 
 Promise.all([promise]).then(function() {
   throw new Test262Error('The promise should be rejected');

--- a/test/language/expressions/addition/S11.6.1_A2.2_T2.js
+++ b/test/language/expressions/addition/S11.6.1_A2.2_T2.js
@@ -8,25 +8,25 @@ description: If Type(value) is Date object, evaluate ToPrimitive(value, String)
 ---*/
 
 //CHECK#1
-var date = new Date(1970);
+var date = new Date(0);
 if (date + date !== date.toString() + date.toString()) {
-  throw new Test262Error('#1: var date = new Date(); date + date === date.toString() + date.toString(). Actual: ' + (date + date));  
+  throw new Test262Error('#1: var date = new Date(0); date + date === date.toString() + date.toString(). Actual: ' + (date + date));  
 }
 
 //CHECK#2
-var date = new Date(1970);
+var date = new Date(0);
 if (date + 0 !== date.toString() + "0") {
-  throw new Test262Error('#2: var date = new Date(); date + 0 === date.toString() + "0". Actual: ' + (date + 0));  
+  throw new Test262Error('#2: var date = new Date(0); date + 0 === date.toString() + "0". Actual: ' + (date + 0));  
 }
 
 //CHECK#3
-var date = new Date(1970);
+var date = new Date(0);
 if (date + true !== date.toString() + "true") {
-  throw new Test262Error('#3: var date = new Date(); date + true === date.toString() + "true". Actual: ' + (date + true));  
+  throw new Test262Error('#3: var date = new Date(0); date + true === date.toString() + "true". Actual: ' + (date + true));  
 }
 
 //CHECK#4
-var date = new Date(1970);
+var date = new Date(0);
 if (date + new Object() !== date.toString() + "[object Object]") {
-  throw new Test262Error('#4: var date = new Date(); date + new Object() === date.toString() + "[object Object]". Actual: ' + (date + new Object()));  
+  throw new Test262Error('#4: var date = new Date(0); date + new Object() === date.toString() + "[object Object]". Actual: ' + (date + new Object()));  
 }

--- a/test/language/expressions/addition/S11.6.1_A2.2_T2.js
+++ b/test/language/expressions/addition/S11.6.1_A2.2_T2.js
@@ -8,25 +8,25 @@ description: If Type(value) is Date object, evaluate ToPrimitive(value, String)
 ---*/
 
 //CHECK#1
-var date = new Date();
+var date = new Date(1970);
 if (date + date !== date.toString() + date.toString()) {
   throw new Test262Error('#1: var date = new Date(); date + date === date.toString() + date.toString(). Actual: ' + (date + date));  
 }
 
 //CHECK#2
-var date = new Date();
+var date = new Date(1970);
 if (date + 0 !== date.toString() + "0") {
   throw new Test262Error('#2: var date = new Date(); date + 0 === date.toString() + "0". Actual: ' + (date + 0));  
 }
 
 //CHECK#3
-var date = new Date();
+var date = new Date(1970);
 if (date + true !== date.toString() + "true") {
   throw new Test262Error('#3: var date = new Date(); date + true === date.toString() + "true". Actual: ' + (date + true));  
 }
 
 //CHECK#4
-var date = new Date();
+var date = new Date(1970);
 if (date + new Object() !== date.toString() + "[object Object]") {
   throw new Test262Error('#4: var date = new Date(); date + new Object() === date.toString() + "[object Object]". Actual: ' + (date + new Object()));  
 }

--- a/test/language/expressions/class/subclass-builtins/subclass-Date.js
+++ b/test/language/expressions/class/subclass-builtins/subclass-Date.js
@@ -9,6 +9,6 @@ flags: [generated]
 
 const Subclass = class extends Date {}
 
-const sub = new Subclass(1970);
+const sub = new Subclass(0);
 assert(sub instanceof Subclass);
 assert(sub instanceof Date);

--- a/test/language/expressions/class/subclass-builtins/subclass-Date.js
+++ b/test/language/expressions/class/subclass-builtins/subclass-Date.js
@@ -9,6 +9,6 @@ flags: [generated]
 
 const Subclass = class extends Date {}
 
-const sub = new Subclass();
+const sub = new Subclass(1970);
 assert(sub instanceof Subclass);
 assert(sub instanceof Date);

--- a/test/language/expressions/class/subclass-builtins/subclass-Date.js
+++ b/test/language/expressions/class/subclass-builtins/subclass-Date.js
@@ -2,7 +2,7 @@
 // - src/subclass-builtins/Date.case
 // - src/subclass-builtins/default/expression.template
 /*---
-description: new SubDate() instanceof Date (Subclass instanceof Heritage)
+description: new SubDate(0) instanceof Date (Subclass instanceof Heritage)
 flags: [generated]
 ---*/
 

--- a/test/language/expressions/tagged-template/template-object-template-map.js
+++ b/test/language/expressions/tagged-template/template-object-template-map.js
@@ -15,8 +15,9 @@ info: |
 ---*/
 var expect;
 var cache = [];
+var site = 1;
 function sameSite() {
-  tag`${Math.random()}`;
+  tag`${site++}`;
 }
 
 function tag(parameter) {

--- a/test/language/expressions/typeof/built-in-exotic-objects-no-call.js
+++ b/test/language/expressions/typeof/built-in-exotic-objects-no-call.js
@@ -56,9 +56,9 @@ assert.sameValue(
 );
 
 assert.sameValue(
-  typeof new Date(1970),
+  typeof new Date(0),
    "object",
-  'typeof new Date() === "object"'
+  'typeof new Date(0) === "object"'
 );
 
 assert.sameValue(

--- a/test/language/expressions/typeof/built-in-exotic-objects-no-call.js
+++ b/test/language/expressions/typeof/built-in-exotic-objects-no-call.js
@@ -56,7 +56,7 @@ assert.sameValue(
 );
 
 assert.sameValue(
-  typeof new Date(),
+  typeof new Date(1970),
    "object",
   'typeof new Date() === "object"'
 );

--- a/test/language/statements/class/subclass-builtins/subclass-Date.js
+++ b/test/language/statements/class/subclass-builtins/subclass-Date.js
@@ -9,6 +9,6 @@ flags: [generated]
 
 class Subclass extends Date {}
 
-const sub = new Subclass(1970);
+const sub = new Subclass(0);
 assert(sub instanceof Subclass);
 assert(sub instanceof Date);

--- a/test/language/statements/class/subclass-builtins/subclass-Date.js
+++ b/test/language/statements/class/subclass-builtins/subclass-Date.js
@@ -9,6 +9,6 @@ flags: [generated]
 
 class Subclass extends Date {}
 
-const sub = new Subclass();
+const sub = new Subclass(1970);
 assert(sub instanceof Subclass);
 assert(sub instanceof Date);

--- a/test/language/statements/class/subclass-builtins/subclass-Date.js
+++ b/test/language/statements/class/subclass-builtins/subclass-Date.js
@@ -2,7 +2,7 @@
 // - src/subclass-builtins/Date.case
 // - src/subclass-builtins/default/statement.template
 /*---
-description: new SubDate() instanceof Date (Subclass instanceof Heritage)
+description: new SubDate(0) instanceof Date (Subclass instanceof Heritage)
 flags: [generated]
 ---*/
 

--- a/test/language/statements/class/subclass/builtin-objects/Date/super-must-be-called.js
+++ b/test/language/statements/class/subclass/builtin-objects/Date/super-must-be-called.js
@@ -23,13 +23,13 @@ class D extends Date {
 }
 
 assert.throws(ReferenceError, function() {
-  new D();
+  new D(1970);
 });
 
 class D2 extends Date {
-  constructor() {
-    super();
+  constructor(d) {
+    super(d);
   }
 }
 
-new D2();
+new D2(1970);

--- a/test/language/statements/class/subclass/builtin-objects/Date/super-must-be-called.js
+++ b/test/language/statements/class/subclass/builtin-objects/Date/super-must-be-called.js
@@ -23,7 +23,7 @@ class D extends Date {
 }
 
 assert.throws(ReferenceError, function() {
-  new D(1970);
+  new D(0);
 });
 
 class D2 extends Date {
@@ -32,4 +32,4 @@ class D2 extends Date {
   }
 }
 
-new D2(1970);
+new D2(0);


### PR DESCRIPTION
This PR proposes changes to existing test262 tests to allow them to pass under Hardened JavaScript (see [Secure ECMAScript proposal](https://github.com/tc39/proposal-ses) and [Hardened JavaScript](https://docs.agoric.com/guides/js-programming/hardened-js)). Moddable uses Hardened JavaScript for JavaScript runtimes on resource constrained embedded devices, including those targeted by ECMA-419.

The changes fall into four groups:

1. Replace use of `new Date()` with `new Date(1970)`. Scripts running inside a `Compartment` cannot retrieve the current time, so `new Date()` throws but `new Date(1970)` succeeds. Very few tests need the current time, but instead simply need a `Date` instance.
2. Use `Object.defineProperty` instead of setting existing built-in properties directly, such as `toString` and `toValue`. In Hardened JavaScript, prototypes of built-in objects are frozen. Consequently, setting properties of an instance that exist on the prototype throw (Hardened JavaScript is always in strict mode).
3. Eliminate use of `Math.random()`. Scripts running inside a `Compartment` cannot generate random numbers. One test identified so far uses `Math.random()` in a way that can easily be replaced with a counter.
4. Narrow the scope of exception tests. Consider the following

```js
assert.throws(TypeError, () => {
  var s1 = new Date();
  s1.toString = Boolean.prototype.toString;
  s1.toString();
});
```

This test passes, but only because `new Date()` fails by throwing a `TypeError`. If the invocation of the `Date` constructor is resolved by (1) above, then the assignment to `toString` fails as per (2) above. The script should be modified as below to ensure that `assert.throws` only tests the intended statement, `s1.toString()`. The modified script tests the intended functionality and passes under Hardened JavaScript

```js
var s1 = new Date(1970);
Object.defineProperty(s1, "toString", {
  value: Boolean.prototype.toString
});
assert.throws(TypeError, () => {
  s1.toString();
});
```

This is an initial PR to begin the process of adapting test262 for use with Hardened JavaScript. Further changes are expected, with the vast majority likely to fall into the four groups described above.

Thank you to @gibson042, @kriskowal, and @erights for their advice on this work.