### PR TITLE
chore(ci): Update branch version for ES-META repo

### DIFF
--- a/.github/workflows/esmeta-test262.yml
+++ b/.github/workflows/esmeta-test262.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
@@ -21,7 +21,7 @@ jobs:
       - name: download esmeta
         run: |
           mkdir -p "${ESMETA_HOME}"
-          git clone --branch v0.1.0-rc8 --depth 1 https://github.com/es-meta/esmeta.git "${ESMETA_HOME}"
+          git clone --branch v0.4.1 --depth 1 https://github.com/es-meta/esmeta.git "${ESMETA_HOME}"
           cd "${ESMETA_HOME}" && git submodule update --init --depth 1
       - name: build esmeta
         working-directory: ${{ env.ESMETA_HOME }}


### PR DESCRIPTION
Updates the branch version to clone in CI to v0.4.1.

[Changes](https://github.com/es-meta/esmeta/compare/v0.1.0-rc8...v0.4.1)