### PR TITLE
Add missing `return` statement to `throwsAsync` callback

### DIFF
--- a/test/built-ins/Promise/try/throws.js
+++ b/test/built-ins/Promise/try/throws.js
@@ -13,7 +13,7 @@ asyncTest(function () {
   return assert.throwsAsync(
     Test262Error,
     function () {
-      Promise.try(function () { throw new Test262Error(); })
+      return Promise.try(function () { throw new Test262Error(); })
     },
     "error thrown from callback must become a rejection"
   );


### PR DESCRIPTION
This callback is expected to return a thenable.