### PR TITLE
Fix description of `fractionalDigits` tests

### DIFF
--- a/test/intl402/DurationFormat/constructor-options-fractionalDigits-invalid.js
+++ b/test/intl402/DurationFormat/constructor-options-fractionalDigits-invalid.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-Intl.DurationFormat
-description: Tests that the option localeMatcher is processed correctly.
+description: Tests that the option fractionalDigits is processed correctly.
 info: |
     Intl.DurationFormat ( [ locales [ , options ] ] )
     (...)

--- a/test/intl402/DurationFormat/constructor-options-fractionalDigits-valid.js
+++ b/test/intl402/DurationFormat/constructor-options-fractionalDigits-valid.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-Intl.DurationFormat
-description: Tests that the option localeMatcher is processed correctly.
+description: Tests that the option fractionalDigits is processed correctly.
 info: |
     Intl.DurationFormat ( [ locales [ , options ] ] )
     (...)


### PR DESCRIPTION
Just fix descriptions for `Intl.DurationFromat`
