### PR TITLE
Adjust Temporal staging test of the Japanese calendar for alternative implementations

### DIFF
--- a/test/staging/Intl402/Temporal/old/japanese-before-era.js
+++ b/test/staging/Intl402/Temporal/old/japanese-before-era.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2018 Bloomberg LP. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal-intl
+description: Japanese eras
+features: [Temporal]
+---*/
+
+// Dates in same year before Japanese era starts will resolve to previous era
+var date = Temporal.PlainDate.from({
+  era: "reiwa",
+  eraYear: 1,
+  month: 1,
+  day: 1,
+  calendar: "japanese"
+});
+assert.sameValue(`${ date }`, "2019-01-01[u-ca=japanese]");
+assert.sameValue(date.era, "heisei");
+assert.sameValue(date.eraYear, 31);
+
+date = Temporal.PlainDate.from({
+  era: "heisei",
+  eraYear: 1,
+  month: 1,
+  day: 1,
+  calendar: "japanese"
+});
+assert.sameValue(`${ date }`, "1989-01-01[u-ca=japanese]");
+assert.sameValue(date.era, "showa");
+assert.sameValue(date.eraYear, 64);
+date = Temporal.PlainDate.from({
+  era: "showa",
+  eraYear: 1,
+  month: 1,
+  day: 1,
+  calendar: "japanese"
+});
+assert.sameValue(`${ date }`, "1926-01-01[u-ca=japanese]");
+assert.sameValue(date.era, "taisho");
+assert.sameValue(date.eraYear, 15);
+
+date = Temporal.PlainDate.from({
+  era: "taisho",
+  eraYear: 1,
+  month: 1,
+  day: 1,
+  calendar: "japanese"
+});
+assert.sameValue(`${ date }`, "1912-01-01[u-ca=japanese]");
+assert.sameValue(date.era, "meiji");
+assert.sameValue(date.eraYear, 45);
+
+date = Temporal.PlainDate.from({
+  era: "meiji",
+  eraYear: 1,
+  month: 1,
+  day: 1,
+  calendar: "japanese"
+});
+assert.sameValue(`${ date }`, "1868-01-01[u-ca=japanese]");
+assert.sameValue(date.era, "ce");
+assert.sameValue(date.eraYear, 1868);

--- a/test/staging/Intl402/Temporal/old/japanese-era.js
+++ b/test/staging/Intl402/Temporal/old/japanese-era.js
@@ -58,61 +58,6 @@ var date = Temporal.PlainDate.from({
 });
 assert.sameValue(`${ date }`, "1869-01-01[u-ca=japanese]");
 
-// Dates in same year before Japanese era starts will resolve to previous era
-var date = Temporal.PlainDate.from({
-  era: "reiwa",
-  eraYear: 1,
-  month: 1,
-  day: 1,
-  calendar: "japanese"
-});
-assert.sameValue(`${ date }`, "2019-01-01[u-ca=japanese]");
-assert.sameValue(date.era, "heisei");
-assert.sameValue(date.eraYear, 31);
-
-date = Temporal.PlainDate.from({
-  era: "heisei",
-  eraYear: 1,
-  month: 1,
-  day: 1,
-  calendar: "japanese"
-});
-assert.sameValue(`${ date }`, "1989-01-01[u-ca=japanese]");
-assert.sameValue(date.era, "showa");
-assert.sameValue(date.eraYear, 64);
-date = Temporal.PlainDate.from({
-  era: "showa",
-  eraYear: 1,
-  month: 1,
-  day: 1,
-  calendar: "japanese"
-});
-assert.sameValue(`${ date }`, "1926-01-01[u-ca=japanese]");
-assert.sameValue(date.era, "taisho");
-assert.sameValue(date.eraYear, 15);
-
-date = Temporal.PlainDate.from({
-  era: "taisho",
-  eraYear: 1,
-  month: 1,
-  day: 1,
-  calendar: "japanese"
-});
-assert.sameValue(`${ date }`, "1912-01-01[u-ca=japanese]");
-assert.sameValue(date.era, "meiji");
-assert.sameValue(date.eraYear, 45);
-
-date = Temporal.PlainDate.from({
-  era: "meiji",
-  eraYear: 1,
-  month: 1,
-  day: 1,
-  calendar: "japanese"
-});
-assert.sameValue(`${ date }`, "1868-01-01[u-ca=japanese]");
-assert.sameValue(date.era, "ce");
-assert.sameValue(date.eraYear, 1868);
-
 // Verify that CE and BCE eras (before Meiji) are recognized
 date = Temporal.PlainDate.from({
   era: "ce",

--- a/test/staging/Intl402/Temporal/old/japanese-era.js
+++ b/test/staging/Intl402/Temporal/old/japanese-era.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-temporal-intl
 description: Japanese eras
+includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
@@ -67,7 +68,10 @@ date = Temporal.PlainDate.from({
   calendar: "japanese"
 });
 assert.sameValue(`${date}`, "1000-01-01[u-ca=japanese]");
-assert.sameValue(date.era, "ce");
+assert.sameValue(
+  TemporalHelpers.canonicalizeEraInCalendar(date, date.era),
+  TemporalHelpers.canonicalizeEraInCalendar(date, "ce"),
+);
 assert.sameValue(date.eraYear, 1000);
 
 date = Temporal.PlainDate.from({
@@ -78,5 +82,8 @@ date = Temporal.PlainDate.from({
   calendar: "japanese"
 });
 assert.sameValue(`${date}`, "0000-01-01[u-ca=japanese]");
-assert.sameValue(date.era, "bce");
+assert.sameValue(
+  TemporalHelpers.canonicalizeEraInCalendar(date, date.era),
+  TemporalHelpers.canonicalizeEraInCalendar(date, "bce"),
+);
 assert.sameValue(date.eraYear, 1);


### PR DESCRIPTION
- Move tests for before-start-of-era into a different file until there's a better specification how to handle this case &rarr; <https://github.com/tc39/proposal-temporal/issues/2865>.
- Use helper function from #4098 to allow different era names.