### PR TITLE
Add test to check `nfOptions.roundingMode` for seconds / microseconds / nanoseconds is `"trunc"`

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/rounding-mode-trunc-for-seconds.js
+++ b/test/intl402/DurationFormat/prototype/format/rounding-mode-trunc-for-seconds.js
@@ -29,7 +29,6 @@ info: |
       15. Perform ! CreateDataPropertyOrThrow(nfOpts, "roundingMode", "trunc").
       (...)
 locale: [en]
-includes: [testIntl.js]
 features: [Intl.DurationFormat]
 ---*/
 
@@ -37,6 +36,7 @@ const durations = [
   // 1
   {
     fractionalDigits: 0,
+    numericValue: 1.5,
     duration: {
       seconds: 1,
       milliseconds: 500,
@@ -45,6 +45,7 @@ const durations = [
   // 0.001
   {
     fractionalDigits: 3,
+    numericValue: 0.0015,
     duration: {
       milliseconds: 1,
       microseconds: 500,
@@ -53,6 +54,7 @@ const durations = [
   // 0.000001
   {
     fractionalDigits: 6,
+    numericValue: 0.0000015,
     duration: {
       microseconds: 1,
       nanoseconds: 500
@@ -60,8 +62,9 @@ const durations = [
   }
 ];
 
-for (const { fractionalDigits, duration } of durations) {
+for (const { numericValue, fractionalDigits, duration } of durations) {
   const df = new Intl.DurationFormat("en", { seconds: "numeric", fractionalDigits });
-  const expected = formatDurationFormatPattern(df, duration);
-  assert.sameValue(df.format(duration), expected);
+  const nf = new Intl.NumberFormat("en", { maximumFractionDigits: fractionalDigits, roundingMode: "trunc" });
+  const expected = nf.format(numericValue);
+  sameValue(df.format(duration), expected);
 }

--- a/test/intl402/DurationFormat/prototype/format/rounding-mode-trunc-for-seconds.js
+++ b/test/intl402/DurationFormat/prototype/format/rounding-mode-trunc-for-seconds.js
@@ -66,5 +66,5 @@ for (const { numericValue, fractionalDigits, duration } of durations) {
   const df = new Intl.DurationFormat("en", { seconds: "numeric", fractionalDigits });
   const nf = new Intl.NumberFormat("en", { maximumFractionDigits: fractionalDigits, roundingMode: "trunc" });
   const expected = nf.format(numericValue);
-  sameValue(df.format(duration), expected);
+  assert.sameValue(df.format(duration), expected, 'Intl.DurationFormat should format seconds, milliseconds and microseconds with `roundingMode: "trunc"`');
 }

--- a/test/intl402/DurationFormat/prototype/format/rounding-mode-trunc-for-seconds.js
+++ b/test/intl402/DurationFormat/prototype/format/rounding-mode-trunc-for-seconds.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 Sosuke Suzuki. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
 /*---
 esid: sec-Intl.DurationFormat.prototype.format
 description: |

--- a/test/intl402/DurationFormat/prototype/format/rounding-mode-trunc-for-seconds.js
+++ b/test/intl402/DurationFormat/prototype/format/rounding-mode-trunc-for-seconds.js
@@ -1,0 +1,64 @@
+/*---
+esid: sec-Intl.DurationFormat.prototype.format
+description: |
+  nfOptions.roundingMode for seconds / microseconds / nanoseconds should be "trunc"
+info: |
+  1.1.14 PartitionDurationFormatPattern
+    (...)
+    4. While numericUnitFound is false, repeat for each row in Table 2 in table order, except the header row:
+      e. If style is "numeric" or "2-digit", then
+        i. Append FormatNumericUnits(durationFormat, duration, unit, signDisplayed) to result.
+        (...)
+      f.Else,
+        (...)
+        ii. If unit is "seconds", "milliseconds", or "microseconds", then
+          (...)
+          f. Perform ! CreateDataPropertyOrThrow(nfOpts, "roundingMode", "trunc").
+
+    1.1.12 FormatNumericUnits
+      (...)
+      18. If secondsFormatted is true, then
+        a. Append FormatNumericSeconds(durationFormat, secondsValue, minutesFormatted, signDisplayed) to numericPartsList.
+        (...)
+
+    1.1.11 FormatNumericSeconds
+      (...)
+      15. Perform ! CreateDataPropertyOrThrow(nfOpts, "roundingMode", "trunc").
+      (...)
+locale: [en]
+includes: [testIntl.js]
+features: [Intl.DurationFormat]
+---*/
+
+const durations = [
+  // 1
+  {
+    fractionalDigits: 0,
+    duration: {
+      seconds: 1,
+      milliseconds: 500,
+    },
+  },
+  // 0.001
+  {
+    fractionalDigits: 3,
+    duration: {
+      milliseconds: 1,
+      microseconds: 500,
+    }
+  },
+  // 0.000001
+  {
+    fractionalDigits: 6,
+    duration: {
+      microseconds: 1,
+      nanoseconds: 500
+    }
+  }
+];
+
+for (const { fractionalDigits, duration } of durations) {
+  const df = new Intl.DurationFormat("en", { seconds: "numeric", fractionalDigits });
+  const expected = formatDurationFormatPattern(df, duration);
+  assert.sameValue(df.format(duration), expected);
+}


### PR DESCRIPTION
According to the spec[^1], `nfOptions.roundingMode` shoule be `"trunc"` when formatting seconds, microseconds, and nanoseconds.

```
  1.1.14 PartitionDurationFormatPattern
    (...)
    4. While numericUnitFound is false, repeat for each row in Table 2 in table order, except the header row:
      e. If style is "numeric" or "2-digit", then
        i. Append FormatNumericUnits(durationFormat, duration, unit, signDisplayed) to result.
        (...)
      f. Else,
        (...)
        ii. If unit is "seconds", "milliseconds", or "microseconds", then
          (...)
          f. Perform ! CreateDataPropertyOrThrow(nfOpts, "roundingMode", "trunc").

    1.1.12 FormatNumericUnits
      (...)
      18. If secondsFormatted is true, then
        a. Append FormatNumericSeconds(durationFormat, secondsValue, minutesFormatted, signDisplayed) to numericPartsList.
        (...)

    1.1.11 FormatNumericSeconds
      (...)
      15. Perform ! CreateDataPropertyOrThrow(nfOpts, "roundingMode", "trunc").
      (...)
```

The test262 harness correctly implements this behavior, but at least WebKit does not[^2].

This PR adds a test to check this behavior.

[^1]: https://tc39.es/proposal-intl-duration-format
[^2]: https://bugs.webkit.org/show_bug.cgi?id=275745
