### PR TITLE
Avoid duplicate binding import-source-binding-name.js

### DIFF
--- a/test/language/module-code/source-phase-import/import-source-binding-name-2.js
+++ b/test/language/module-code/source-phase-import/import-source-binding-name-2.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2024 Chengzhong Wu. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  ImportBinding in ImportDeclaration may be 'source' and 'from'
+esid: sec-modules
+info: |
+  ImportDeclaration:
+    import source ImportedBinding FromClause ;
+
+negative:
+  phase: resolution
+  type: SyntaxError
+features: [source-phase-imports]
+flags: [module]
+---*/
+
+$DONOTEVALUATE();
+
+import "../resources/ensure-linking-error_FIXTURE.js";
+
+import source source from '<do not resolve>';
+import source from from '<do not resolve>';

--- a/test/language/module-code/source-phase-import/import-source-binding-name.js
+++ b/test/language/module-code/source-phase-import/import-source-binding-name.js
@@ -19,5 +19,5 @@ $DONOTEVALUATE();
 
 import "../resources/ensure-linking-error_FIXTURE.js";
 
-import source from from '<do not resolve>';
+import source from '<do not resolve>';
 import from from '<do not resolve>';

--- a/test/language/module-code/source-phase-import/import-source-binding-name.js
+++ b/test/language/module-code/source-phase-import/import-source-binding-name.js
@@ -19,7 +19,6 @@ $DONOTEVALUATE();
 
 import "../resources/ensure-linking-error_FIXTURE.js";
 
-import source source from '<do not resolve>';
 import source from from '<do not resolve>';
 import source from '<do not resolve>';
 import from from '<do not resolve>';

--- a/test/language/module-code/source-phase-import/import-source-binding-name.js
+++ b/test/language/module-code/source-phase-import/import-source-binding-name.js
@@ -20,5 +20,4 @@ $DONOTEVALUATE();
 import "../resources/ensure-linking-error_FIXTURE.js";
 
 import source from from '<do not resolve>';
-import source from '<do not resolve>';
 import from from '<do not resolve>';


### PR DESCRIPTION
The current test contained a parser error due to the duplicate binding. This splits the test in two files, so that we actually successfully parse the file.

cc @legendecas

Ref https://github.com/babel/babel/pull/16596