### PR TITLE
RAB: Integrate staging tests for the .filter method

### DIFF
--- a/test/built-ins/Array/prototype/filter/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/filter/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,158 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.filter
+description: >
+  Array.p.filter behaves correctly on receivers backed by resizable
+  buffers that grow mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const ArrayFilterHelper = (ta, ...rest) => {
+  return Array.prototype.filter.call(ta, ...rest);
+};
+
+function FilterGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLength, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLengthWithOffset, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTrackingWithOffset, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+FilterGrowMidIteration()

--- a/test/built-ins/Array/prototype/filter/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/filter/resizable-buffer-grow-mid-iteration.js
@@ -6,153 +6,80 @@ esid: sec-array.prototype.filter
 description: >
   Array.p.filter behaves correctly on receivers backed by resizable
   buffers that grow mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
+// before calling this.
+function ResizeBufferMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return false;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLength, ResizeBufferMidIteration)), []);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLengthWithOffset, ResizeBufferMidIteration)), []);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTracking, ResizeBufferMidIteration)), []);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTrackingWithOffset, ResizeBufferMidIteration)), []);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
 
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
-  }
-  return item;
-}
-
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
-  }
-  return result;
-}
-
-const ArrayFilterHelper = (ta, ...rest) => {
-  return Array.prototype.filter.call(ta, ...rest);
-};
-
-function FilterGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return false;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLength, CollectValuesAndResize)), []);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLengthWithOffset, CollectValuesAndResize)), []);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, CollectValuesAndResize)), []);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTrackingWithOffset, CollectValuesAndResize)), []);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-}
-
-FilterGrowMidIteration()

--- a/test/built-ins/Array/prototype/filter/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/filter/resizable-buffer.js
@@ -1,0 +1,170 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.filter
+description: >
+  Array.p.filter behaves correctly on receivers backed by resizable
+  buffers
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const ArrayFilterHelper = (ta, ...rest) => {
+  return Array.prototype.filter.call(ta, ...rest);
+};
+
+function TestFilter() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, ...] << lengthTracking
+    //                    [2, 3, ...] << lengthTrackingWithOffset
+
+    function isEven(n) {
+      return n != undefined && Number(n) % 2 == 0;
+    }
+    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLength, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLengthWithOffset, isEven)), [2]);
+    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTrackingWithOffset, isEven)), [2]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 1, 2]
+    //              [0, 1, 2, ...] << lengthTracking
+    //                    [2, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ArrayFilterHelper(fixedLength, isEven), []);
+    assert.compareArray(ArrayFilterHelper(fixedLengthWithOffset, isEven), []);
+
+    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTrackingWithOffset, isEven)), [2]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.compareArray(ArrayFilterHelper(fixedLength, isEven), []);
+    assert.compareArray(ArrayFilterHelper(fixedLengthWithOffset, isEven), []);
+    assert.compareArray(ArrayFilterHelper(lengthTrackingWithOffset, isEven), []);
+
+    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, isEven)), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.compareArray(ArrayFilterHelper(fixedLength, isEven), []);
+    assert.compareArray(ArrayFilterHelper(fixedLengthWithOffset, isEven), []);
+    assert.compareArray(ArrayFilterHelper(lengthTrackingWithOffset, isEven), []);
+
+    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, isEven)), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3, 4, 5]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLength, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLengthWithOffset, isEven)), [2]);
+    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, isEven)), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTrackingWithOffset, isEven)), [
+      2,
+      4
+    ]);
+  }
+}
+
+TestFilter();

--- a/test/built-ins/Array/prototype/filter/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/filter/resizable-buffer.js
@@ -6,165 +6,100 @@ esid: sec-array.prototype.filter
 description: >
   Array.p.filter behaves correctly on receivers backed by resizable
   buffers
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 flags: [onlyStrict]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
   }
-}
 
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
+  // Orig. array: [0, 1, 2, 3]
+  //              [0, 1, 2, 3] << fixedLength
+  //                    [2, 3] << fixedLengthWithOffset
+  //              [0, 1, 2, 3, ...] << lengthTracking
+  //                    [2, 3, ...] << lengthTrackingWithOffset
+
+  function isEven(n) {
+    return n != undefined && Number(n) % 2 == 0;
   }
-  return item;
-}
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLength, isEven)), [
+    0,
+    2
+  ]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLengthWithOffset, isEven)), [2]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTracking, isEven)), [
+    0,
+    2
+  ]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTrackingWithOffset, isEven)), [2]);
 
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 1, 2]
+  //              [0, 1, 2, ...] << lengthTracking
+  //                    [2, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(Array.prototype.filter.call(fixedLength, isEven), []);
+  assert.compareArray(Array.prototype.filter.call(fixedLengthWithOffset, isEven), []);
+
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTracking, isEven)), [
+    0,
+    2
+  ]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTrackingWithOffset, isEven)), [2]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.compareArray(Array.prototype.filter.call(fixedLength, isEven), []);
+  assert.compareArray(Array.prototype.filter.call(fixedLengthWithOffset, isEven), []);
+  assert.compareArray(Array.prototype.filter.call(lengthTrackingWithOffset, isEven), []);
+
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTracking, isEven)), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.compareArray(Array.prototype.filter.call(fixedLength, isEven), []);
+  assert.compareArray(Array.prototype.filter.call(fixedLengthWithOffset, isEven), []);
+  assert.compareArray(Array.prototype.filter.call(lengthTrackingWithOffset, isEven), []);
+
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTracking, isEven)), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, i);
   }
-  return result;
+
+  // Orig. array: [0, 1, 2, 3, 4, 5]
+  //              [0, 1, 2, 3] << fixedLength
+  //                    [2, 3] << fixedLengthWithOffset
+  //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+  //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLength, isEven)), [
+    0,
+    2
+  ]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLengthWithOffset, isEven)), [2]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTracking, isEven)), [
+    0,
+    2,
+    4
+  ]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTrackingWithOffset, isEven)), [
+    2,
+    4
+  ]);
 }
-
-const ArrayFilterHelper = (ta, ...rest) => {
-  return Array.prototype.filter.call(ta, ...rest);
-};
-
-function TestFilter() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    // Orig. array: [0, 1, 2, 3]
-    //              [0, 1, 2, 3] << fixedLength
-    //                    [2, 3] << fixedLengthWithOffset
-    //              [0, 1, 2, 3, ...] << lengthTracking
-    //                    [2, 3, ...] << lengthTrackingWithOffset
-
-    function isEven(n) {
-      return n != undefined && Number(n) % 2 == 0;
-    }
-    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLength, isEven)), [
-      0,
-      2
-    ]);
-    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLengthWithOffset, isEven)), [2]);
-    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, isEven)), [
-      0,
-      2
-    ]);
-    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTrackingWithOffset, isEven)), [2]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 1, 2]
-    //              [0, 1, 2, ...] << lengthTracking
-    //                    [2, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(ArrayFilterHelper(fixedLength, isEven), []);
-    assert.compareArray(ArrayFilterHelper(fixedLengthWithOffset, isEven), []);
-
-    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, isEven)), [
-      0,
-      2
-    ]);
-    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTrackingWithOffset, isEven)), [2]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.compareArray(ArrayFilterHelper(fixedLength, isEven), []);
-    assert.compareArray(ArrayFilterHelper(fixedLengthWithOffset, isEven), []);
-    assert.compareArray(ArrayFilterHelper(lengthTrackingWithOffset, isEven), []);
-
-    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, isEven)), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.compareArray(ArrayFilterHelper(fixedLength, isEven), []);
-    assert.compareArray(ArrayFilterHelper(fixedLengthWithOffset, isEven), []);
-    assert.compareArray(ArrayFilterHelper(lengthTrackingWithOffset, isEven), []);
-
-    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, isEven)), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, i);
-    }
-
-    // Orig. array: [0, 1, 2, 3, 4, 5]
-    //              [0, 1, 2, 3] << fixedLength
-    //                    [2, 3] << fixedLengthWithOffset
-    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
-    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLength, isEven)), [
-      0,
-      2
-    ]);
-    assert.compareArray(ToNumbers(ArrayFilterHelper(fixedLengthWithOffset, isEven)), [2]);
-    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTracking, isEven)), [
-      0,
-      2,
-      4
-    ]);
-    assert.compareArray(ToNumbers(ArrayFilterHelper(lengthTrackingWithOffset, isEven)), [
-      2,
-      4
-    ]);
-  }
-}
-
-TestFilter();

--- a/test/built-ins/Array/prototype/filter/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/filter/resizable-buffer.js
@@ -8,7 +8,6 @@ description: >
   buffers
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
-flags: [onlyStrict]
 ---*/
 
 for (let ctor of ctors) {

--- a/test/built-ins/TypedArray/prototype/filter/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/filter/resizable-buffer-grow-mid-iteration.js
@@ -6,153 +6,79 @@ esid: sec-%typedarray%.prototype.filter
 description: >
   TypedArray.p.filter behaves correctly on receivers backed by resizable
   buffers that grow mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
+// before calling this.
+function ResizeBufferMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return false;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(fixedLength.filter(ResizeBufferMidIteration)), []);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(fixedLengthWithOffset.filter(ResizeBufferMidIteration)), []);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(lengthTracking.filter(ResizeBufferMidIteration)), []);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset.filter(ResizeBufferMidIteration)), []);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
-  }
-  return item;
-}
-
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
-  }
-  return result;
-}
-
-const TypedArrayFilterHelper = (ta, ...rest) => {
-  return ta.filter(...rest);
-};
-
-function FilterGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return false;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ToNumbers(TypedArrayFilterHelper(fixedLength, CollectValuesAndResize)), []);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ToNumbers(TypedArrayFilterHelper(fixedLengthWithOffset, CollectValuesAndResize)), []);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTracking, CollectValuesAndResize)), []);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTrackingWithOffset, CollectValuesAndResize)), []);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-}
-
-FilterGrowMidIteration()

--- a/test/built-ins/TypedArray/prototype/filter/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/filter/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,158 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.filter
+description: >
+  TypedArray.p.filter behaves correctly on receivers backed by resizable
+  buffers that grow mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArrayFilterHelper = (ta, ...rest) => {
+  return ta.filter(...rest);
+};
+
+function FilterGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(fixedLength, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(fixedLengthWithOffset, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTracking, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTrackingWithOffset, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+FilterGrowMidIteration()

--- a/test/built-ins/TypedArray/prototype/filter/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/filter/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,150 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.filter
+description: >
+  TypedArray.p.filter behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+function CollectValuesAndResize(n) {
+  if (typeof n == 'bigint') {
+    values.push(Number(n));
+  } else {
+    values.push(n);
+  }
+  if (values.length == resizeAfter) {
+    rab.resize(resizeTo);
+  }
+  return false;
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(fixedLength.filter(CollectValuesAndResize)), []);
+  assert.compareArray(values, [
+    0,
+    2,
+    undefined,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(fixedLengthWithOffset.filter(CollectValuesAndResize)), []);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(lengthTracking.filter(CollectValuesAndResize)), []);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset.filter(CollectValuesAndResize)), []);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/filter/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/filter/resizable-buffer.js
@@ -1,0 +1,186 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.filter
+description: >
+  TypedArray.p.filter behaves correctly on receivers backed by resizable
+  buffers
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArrayFilterHelper = (ta, ...rest) => {
+  return ta.filter(...rest);
+};
+
+function TestFilter() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, ...] << lengthTracking
+    //                    [2, 3, ...] << lengthTrackingWithOffset
+
+    function isEven(n) {
+      return n != undefined && Number(n) % 2 == 0;
+    }
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(fixedLength, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(fixedLengthWithOffset, isEven)), [2]);
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTracking, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTrackingWithOffset, isEven)), [2]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 1, 2]
+    //              [0, 1, 2, ...] << lengthTracking
+    //                    [2, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      TypedArrayFilterHelper(fixedLength, isEven);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFilterHelper(fixedLengthWithOffset, isEven);
+    });
+
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTracking, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTrackingWithOffset, isEven)), [2]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      TypedArrayFilterHelper(fixedLength, isEven);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFilterHelper(fixedLengthWithOffset, isEven);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFilterHelper(lengthTrackingWithOffset, isEven);
+    });
+
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTracking, isEven)), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      TypedArrayFilterHelper(fixedLength, isEven);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFilterHelper(fixedLengthWithOffset, isEven);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFilterHelper(lengthTrackingWithOffset, isEven);
+    });
+
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTracking, isEven)), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3, 4, 5]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(fixedLength, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(fixedLengthWithOffset, isEven)), [2]);
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTracking, isEven)), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(ToNumbers(TypedArrayFilterHelper(lengthTrackingWithOffset, isEven)), [
+      2,
+      4
+    ]);
+  }
+}
+
+TestFilter();


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR https://github.com/tc39/test262/pull/3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js