### PR TITLE
 RAB: Integrate staging tests for the .find method

### DIFF
--- a/test/built-ins/Array/prototype/find/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/find/resizable-buffer-grow-mid-iteration.js
@@ -6,138 +6,79 @@ esid: sec-array.prototype.find
 description: >
   Array.p.find behaves correctly when receiver is backed by resizable
   buffer that is grown mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
+// before calling this.
+function ResizeBufferMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return false;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.find.call(fixedLength, ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.find.call(fixedLengthWithOffset, ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.find.call(lengthTracking, ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.find.call(lengthTrackingWithOffset, ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-function ArrayFindHelper(ta, p) {
-  return Array.prototype.find.call(ta, p);
-}
-
-function FindGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return false;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindHelper(fixedLength, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindHelper(lengthTracking, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-}
-
-FindGrowMidIteration();

--- a/test/built-ins/Array/prototype/find/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/find/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,143 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.find
+description: >
+  Array.p.find behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayFindHelper(ta, p) {
+  return Array.prototype.find.call(ta, p);
+}
+
+function FindGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindHelper(fixedLength, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindHelper(lengthTracking, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+FindGrowMidIteration();

--- a/test/built-ins/Array/prototype/find/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/find/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,143 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.find
+description: >
+  Array.p.find behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayFindHelper(ta, p) {
+  return Array.prototype.find.call(ta, p);
+}
+
+function FindShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindHelper(fixedLength, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      undefined,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindHelper(lengthTracking, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+}
+
+FindShrinkMidIteration();

--- a/test/built-ins/Array/prototype/find/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/find/resizable-buffer-shrink-mid-iteration.js
@@ -6,138 +6,84 @@ esid: sec-array.prototype.find
 description: >
   Array.p.find behaves correctly when receiver is backed by resizable
   buffer that is shrunk mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
-
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
 
 function ArrayFindHelper(ta, p) {
   return Array.prototype.find.call(ta, p);
 }
 
-function FindShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  const values = [];
+  const resizeAfter = 2;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  function CollectResize(n) {
+    CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
     return false;
   }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindHelper(fixedLength, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      0,
-      2,
-      undefined,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindHelper(lengthTracking, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      4,
-      undefined
-    ]);
-  }
+  assert.sameValue(ArrayFindHelper(fixedLength, CollectResize), undefined);
+  assert.compareArray(values, [
+    0,
+    2,
+    undefined,
+    undefined
+  ]);
 }
-
-FindShrinkMidIteration();
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const values = [];
+  const resizeAfter = 1;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  function CollectResize(n) {
+    CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+    return false;
+  }
+  assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, CollectResize), undefined);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  const values = [];
+  const resizeAfter = 2;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  function CollectResize(n) {
+    CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+    return false;
+  }
+  assert.sameValue(ArrayFindHelper(lengthTracking, CollectResize), undefined);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  const values = [];
+  const resizeAfter = 1;
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  function CollectResize(n) {
+    CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+    return false;
+  }
+  assert.sameValue(ArrayFindHelper(lengthTrackingWithOffset, CollectResize), undefined);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
+}

--- a/test/built-ins/Array/prototype/find/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/find/resizable-buffer.js
@@ -6,131 +6,82 @@ esid: sec-array.prototype.find
 description: >
   Array.p.find behaves correctly when receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-function ArrayFindHelper(ta, p) {
-  return Array.prototype.find.call(ta, p);
-}
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
 
-function TestFind() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    function isTwoOrFour(n) {
-      return n == 2 || n == 4;
-    }
-    assert.sameValue(Number(ArrayFindHelper(fixedLength, isTwoOrFour)), 2);
-    assert.sameValue(Number(ArrayFindHelper(fixedLengthWithOffset, isTwoOrFour)), 4);
-    assert.sameValue(Number(ArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
-    assert.sameValue(Number(ArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayFindHelper(fixedLength, isTwoOrFour), undefined);
-    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
-
-    assert.sameValue(Number(ArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
-    assert.sameValue(Number(ArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.sameValue(ArrayFindHelper(fixedLength, isTwoOrFour), undefined);
-    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
-    assert.sameValue(ArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour), undefined);
-
-    assert.sameValue(ArrayFindHelper(lengthTracking, isTwoOrFour), undefined);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.sameValue(ArrayFindHelper(fixedLength, isTwoOrFour), undefined);
-    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
-    assert.sameValue(ArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour), undefined);
-
-    assert.sameValue(ArrayFindHelper(lengthTracking, isTwoOrFour), undefined);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 0);
-    }
-    WriteToTypedArray(taWrite, 4, 2);
-    WriteToTypedArray(taWrite, 5, 4);
-
-    // Orig. array: [0, 0, 0, 0, 2, 4]
-    //              [0, 0, 0, 0] << fixedLength
-    //                    [0, 0] << fixedLengthWithOffset
-    //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
-    //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayFindHelper(fixedLength, isTwoOrFour), undefined);
-    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
-    assert.sameValue(Number(ArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
-    assert.sameValue(Number(ArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 2);
+  function isTwoOrFour(n) {
+    return n == 2 || n == 4;
   }
-}
+  assert.sameValue(Number(Array.prototype.find.call(fixedLength, isTwoOrFour)), 2);
+  assert.sameValue(Number(Array.prototype.find.call(fixedLengthWithOffset, isTwoOrFour)), 4);
+  assert.sameValue(Number(Array.prototype.find.call(lengthTracking, isTwoOrFour)), 2);
+  assert.sameValue(Number(Array.prototype.find.call(lengthTrackingWithOffset, isTwoOrFour)), 4);
 
-TestFind();
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(Array.prototype.find.call(fixedLength, isTwoOrFour), undefined);
+  assert.sameValue(Array.prototype.find.call(fixedLengthWithOffset, isTwoOrFour), undefined);
+
+  assert.sameValue(Number(Array.prototype.find.call(lengthTracking, isTwoOrFour)), 2);
+  assert.sameValue(Number(Array.prototype.find.call(lengthTrackingWithOffset, isTwoOrFour)), 4);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.sameValue(Array.prototype.find.call(fixedLength, isTwoOrFour), undefined);
+  assert.sameValue(Array.prototype.find.call(fixedLengthWithOffset, isTwoOrFour), undefined);
+  assert.sameValue(Array.prototype.find.call(lengthTrackingWithOffset, isTwoOrFour), undefined);
+
+  assert.sameValue(Array.prototype.find.call(lengthTracking, isTwoOrFour), undefined);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.sameValue(Array.prototype.find.call(fixedLength, isTwoOrFour), undefined);
+  assert.sameValue(Array.prototype.find.call(fixedLengthWithOffset, isTwoOrFour), undefined);
+  assert.sameValue(Array.prototype.find.call(lengthTrackingWithOffset, isTwoOrFour), undefined);
+
+  assert.sameValue(Array.prototype.find.call(lengthTracking, isTwoOrFour), undefined);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 0);
+  }
+  WriteToTypedArray(taWrite, 4, 2);
+  WriteToTypedArray(taWrite, 5, 4);
+
+  // Orig. array: [0, 0, 0, 0, 2, 4]
+  //              [0, 0, 0, 0] << fixedLength
+  //                    [0, 0] << fixedLengthWithOffset
+  //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
+  //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(Array.prototype.find.call(fixedLength, isTwoOrFour), undefined);
+  assert.sameValue(Array.prototype.find.call(fixedLengthWithOffset, isTwoOrFour), undefined);
+  assert.sameValue(Number(Array.prototype.find.call(lengthTracking, isTwoOrFour)), 2);
+  assert.sameValue(Number(Array.prototype.find.call(lengthTrackingWithOffset, isTwoOrFour)), 2);
+}

--- a/test/built-ins/Array/prototype/find/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/find/resizable-buffer.js
@@ -1,0 +1,136 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.find
+description: >
+  Array.p.find behaves correctly when receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayFindHelper(ta, p) {
+  return Array.prototype.find.call(ta, p);
+}
+
+function TestFind() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function isTwoOrFour(n) {
+      return n == 2 || n == 4;
+    }
+    assert.sameValue(Number(ArrayFindHelper(fixedLength, isTwoOrFour)), 2);
+    assert.sameValue(Number(ArrayFindHelper(fixedLengthWithOffset, isTwoOrFour)), 4);
+    assert.sameValue(Number(ArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
+    assert.sameValue(Number(ArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayFindHelper(fixedLength, isTwoOrFour), undefined);
+    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+
+    assert.sameValue(Number(ArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
+    assert.sameValue(Number(ArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.sameValue(ArrayFindHelper(fixedLength, isTwoOrFour), undefined);
+    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+    assert.sameValue(ArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour), undefined);
+
+    assert.sameValue(ArrayFindHelper(lengthTracking, isTwoOrFour), undefined);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.sameValue(ArrayFindHelper(fixedLength, isTwoOrFour), undefined);
+    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+    assert.sameValue(ArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour), undefined);
+
+    assert.sameValue(ArrayFindHelper(lengthTracking, isTwoOrFour), undefined);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 0);
+    }
+    WriteToTypedArray(taWrite, 4, 2);
+    WriteToTypedArray(taWrite, 5, 4);
+
+    // Orig. array: [0, 0, 0, 0, 2, 4]
+    //              [0, 0, 0, 0] << fixedLength
+    //                    [0, 0] << fixedLengthWithOffset
+    //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
+    //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayFindHelper(fixedLength, isTwoOrFour), undefined);
+    assert.sameValue(ArrayFindHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+    assert.sameValue(Number(ArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
+    assert.sameValue(Number(ArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 2);
+  }
+}
+
+TestFind();

--- a/test/built-ins/TypedArray/prototype/find/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/find/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,143 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.find
+description: >
+  TypedArray.p.find behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindHelper(ta, p) {
+  return ta.find(p);
+}
+
+function FindGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindHelper(fixedLength, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindHelper(lengthTracking, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+FindGrowMidIteration();

--- a/test/built-ins/TypedArray/prototype/find/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/find/resizable-buffer-grow-mid-iteration.js
@@ -6,138 +6,79 @@ esid: sec-%typedarray%.prototype.find
 description: >
   TypedArray.p.find behaves correctly when receiver is backed by resizable
   buffer that is grown mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset before
+// calling this.
+function ResizeBufferMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return false;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(fixedLength.find(ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(fixedLengthWithOffset.find(ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(lengthTracking.find(ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(lengthTrackingWithOffset.find(ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-function TypedArrayFindHelper(ta, p) {
-  return ta.find(p);
-}
-
-function FindGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return false;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindHelper(fixedLength, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindHelper(lengthTracking, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-}
-
-FindGrowMidIteration();

--- a/test/built-ins/TypedArray/prototype/find/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/find/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,143 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.find
+description: >
+  TypedArray.p.find behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindHelper(ta, p) {
+  return ta.find(p);
+}
+
+function FindShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindHelper(fixedLength, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      undefined,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindHelper(lengthTracking, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+}
+
+FindShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/find/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/find/resizable-buffer-shrink-mid-iteration.js
@@ -6,138 +6,80 @@ esid: sec-%typedarray%.prototype.find
 description: >
   TypedArray.p.find behaves correctly when receiver is backed by resizable
   buffer that is shrunk mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset before
+// calling this.
+function ResizeBufferMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return false;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(fixedLength.find(ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    0,
+    2,
+    undefined,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(fixedLengthWithOffset.find(ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(lengthTracking.find(ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(lengthTrackingWithOffset.find(ResizeBufferMidIteration), undefined);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
 }
 
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayFindHelper(ta, p) {
-  return ta.find(p);
-}
-
-function FindShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return false;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindHelper(fixedLength, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      0,
-      2,
-      undefined,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindHelper(lengthTracking, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
-    assert.compareArray(values, [
-      4,
-      undefined
-    ]);
-  }
-}
-
-FindShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/find/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/find/resizable-buffer.js
@@ -6,147 +6,98 @@ esid: sec-%typedarray%.prototype.find
 description: >
   TypedArray.p.find behaves correctly when receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-function TypedArrayFindHelper(ta, p) {
-  return ta.find(p);
-}
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
 
-function TestFind() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    function isTwoOrFour(n) {
-      return n == 2 || n == 4;
-    }
-    assert.sameValue(Number(TypedArrayFindHelper(fixedLength, isTwoOrFour)), 2);
-    assert.sameValue(Number(TypedArrayFindHelper(fixedLengthWithOffset, isTwoOrFour)), 4);
-    assert.sameValue(Number(TypedArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
-    assert.sameValue(Number(TypedArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert.throws(TypeError, () => {
-      TypedArrayFindHelper(fixedLength, isTwoOrFour);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayFindHelper(fixedLengthWithOffset, isTwoOrFour);
-    });
-
-    assert.sameValue(Number(TypedArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
-    assert.sameValue(Number(TypedArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      TypedArrayFindHelper(fixedLength, isTwoOrFour);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayFindHelper(fixedLengthWithOffset, isTwoOrFour);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour);
-    });
-
-    assert.sameValue(TypedArrayFindHelper(lengthTracking, isTwoOrFour), undefined);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      TypedArrayFindHelper(fixedLength, isTwoOrFour);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayFindHelper(fixedLengthWithOffset, isTwoOrFour);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour);
-    });
-
-    assert.sameValue(TypedArrayFindHelper(lengthTracking, isTwoOrFour), undefined);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 0);
-    }
-    WriteToTypedArray(taWrite, 4, 2);
-    WriteToTypedArray(taWrite, 5, 4);
-
-    // Orig. array: [0, 0, 0, 0, 2, 4]
-    //              [0, 0, 0, 0] << fixedLength
-    //                    [0, 0] << fixedLengthWithOffset
-    //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
-    //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(TypedArrayFindHelper(fixedLength, isTwoOrFour), undefined);
-    assert.sameValue(TypedArrayFindHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
-    assert.sameValue(Number(TypedArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
-    assert.sameValue(Number(TypedArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 2);
+  function isTwoOrFour(n) {
+    return n == 2 || n == 4;
   }
-}
+  assert.sameValue(Number(fixedLength.find(isTwoOrFour)), 2);
+  assert.sameValue(Number(fixedLengthWithOffset.find(isTwoOrFour)), 4);
+  assert.sameValue(Number(lengthTracking.find(isTwoOrFour)), 2);
+  assert.sameValue(Number(lengthTrackingWithOffset.find(isTwoOrFour)), 4);
 
-TestFind();
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    fixedLength.find(isTwoOrFour);
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.find(isTwoOrFour);
+  });
+
+  assert.sameValue(Number(lengthTracking.find(isTwoOrFour)), 2);
+  assert.sameValue(Number(lengthTrackingWithOffset.find(isTwoOrFour)), 4);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.find(isTwoOrFour);
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.find(isTwoOrFour);
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.find(isTwoOrFour);
+  });
+
+  assert.sameValue(lengthTracking.find(isTwoOrFour), undefined);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    fixedLength.find(isTwoOrFour);
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.find(isTwoOrFour);
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.find(isTwoOrFour);
+  });
+
+  assert.sameValue(lengthTracking.find(isTwoOrFour), undefined);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 0);
+  }
+  WriteToTypedArray(taWrite, 4, 2);
+  WriteToTypedArray(taWrite, 5, 4);
+
+  // Orig. array: [0, 0, 0, 0, 2, 4]
+  //              [0, 0, 0, 0] << fixedLength
+  //                    [0, 0] << fixedLengthWithOffset
+  //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
+  //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(fixedLength.find(isTwoOrFour), undefined);
+  assert.sameValue(fixedLengthWithOffset.find(isTwoOrFour), undefined);
+  assert.sameValue(Number(lengthTracking.find(isTwoOrFour)), 2);
+  assert.sameValue(Number(lengthTrackingWithOffset.find(isTwoOrFour)), 2);
+}

--- a/test/built-ins/TypedArray/prototype/find/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/find/resizable-buffer.js
@@ -1,0 +1,152 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.find
+description: >
+  TypedArray.p.find behaves correctly when receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindHelper(ta, p) {
+  return ta.find(p);
+}
+
+function TestFind() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function isTwoOrFour(n) {
+      return n == 2 || n == 4;
+    }
+    assert.sameValue(Number(TypedArrayFindHelper(fixedLength, isTwoOrFour)), 2);
+    assert.sameValue(Number(TypedArrayFindHelper(fixedLengthWithOffset, isTwoOrFour)), 4);
+    assert.sameValue(Number(TypedArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
+    assert.sameValue(Number(TypedArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      TypedArrayFindHelper(fixedLength, isTwoOrFour);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFindHelper(fixedLengthWithOffset, isTwoOrFour);
+    });
+
+    assert.sameValue(Number(TypedArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
+    assert.sameValue(Number(TypedArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      TypedArrayFindHelper(fixedLength, isTwoOrFour);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFindHelper(fixedLengthWithOffset, isTwoOrFour);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour);
+    });
+
+    assert.sameValue(TypedArrayFindHelper(lengthTracking, isTwoOrFour), undefined);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      TypedArrayFindHelper(fixedLength, isTwoOrFour);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFindHelper(fixedLengthWithOffset, isTwoOrFour);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour);
+    });
+
+    assert.sameValue(TypedArrayFindHelper(lengthTracking, isTwoOrFour), undefined);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 0);
+    }
+    WriteToTypedArray(taWrite, 4, 2);
+    WriteToTypedArray(taWrite, 5, 4);
+
+    // Orig. array: [0, 0, 0, 0, 2, 4]
+    //              [0, 0, 0, 0] << fixedLength
+    //                    [0, 0] << fixedLengthWithOffset
+    //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
+    //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(TypedArrayFindHelper(fixedLength, isTwoOrFour), undefined);
+    assert.sameValue(TypedArrayFindHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+    assert.sameValue(Number(TypedArrayFindHelper(lengthTracking, isTwoOrFour)), 2);
+    assert.sameValue(Number(TypedArrayFindHelper(lengthTrackingWithOffset, isTwoOrFour)), 2);
+  }
+}
+
+TestFind();


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR https://github.com/tc39/test262/pull/3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js