### PR TITLE
 RAB: Integrate staging tests for the .findIndex method

### DIFF
--- a/test/built-ins/Array/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
@@ -6,139 +6,79 @@ esid: sec-array.prototype.findindex
 description: >
   Array.p.findIndex behaves correctly when receiver is backed by resizable
   buffer that is grown mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset before
+// calling this.
+function ResizeBufferMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return false;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.findIndex.call(fixedLength, ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-function ArrayFindIndexHelper(ta, p) {
-  return Array.prototype.findIndex.call(ta, p);
-}
-
-function FindIndexGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return false;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindIndexHelper(fixedLength, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindIndexHelper(lengthTracking, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-}
-
-FindIndexGrowMidIteration();
 

--- a/test/built-ins/Array/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,144 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.findindex
+description: >
+  Array.p.findIndex behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayFindIndexHelper(ta, p) {
+  return Array.prototype.findIndex.call(ta, p);
+}
+
+function FindIndexGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindIndexHelper(fixedLength, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindIndexHelper(lengthTracking, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+FindIndexGrowMidIteration();
+

--- a/test/built-ins/Array/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
@@ -6,138 +6,78 @@ esid: sec-array.prototype.findindex
 description: >
   Array.p.findIndex behaves correctly when receiver is backed by resizable
   buffer that is shrunk mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset before
+// calling this.
+function ResizeBufferMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return false;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.findIndex.call(fixedLength, ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    0,
+    2,
+    undefined,
+    undefined
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    undefined
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
 }
-
-function ArrayFindIndexHelper(ta, p) {
-  return Array.prototype.findIndex.call(ta, p);
-}
-
-function FindIndexShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return false;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindIndexHelper(fixedLength, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      0,
-      2,
-      undefined,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindIndexHelper(lengthTracking, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      4,
-      undefined
-    ]);
-  }
-}
-
-FindIndexShrinkMidIteration();

--- a/test/built-ins/Array/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,143 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.findindex
+description: >
+  Array.p.findIndex behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayFindIndexHelper(ta, p) {
+  return Array.prototype.findIndex.call(ta, p);
+}
+
+function FindIndexShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindIndexHelper(fixedLength, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      undefined,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindIndexHelper(lengthTracking, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+}
+
+FindIndexShrinkMidIteration();

--- a/test/built-ins/Array/prototype/findIndex/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/findIndex/resizable-buffer.js
@@ -1,0 +1,136 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.findindex
+description: >
+  Array.p.findIndex behaves correctly when receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayFindIndexHelper(ta, p) {
+  return Array.prototype.findIndex.call(ta, p);
+}
+
+function TestFindIndex() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function isTwoOrFour(n) {
+      return n == 2 || n == 4;
+    }
+    assert.sameValue(ArrayFindIndexHelper(fixedLength, isTwoOrFour), 1);
+    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), 0);
+    assert.sameValue(ArrayFindIndexHelper(lengthTracking, isTwoOrFour), 1);
+    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayFindIndexHelper(fixedLength, isTwoOrFour), -1);
+    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+
+    assert.sameValue(ArrayFindIndexHelper(lengthTracking, isTwoOrFour), 1);
+    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.sameValue(ArrayFindIndexHelper(fixedLength, isTwoOrFour), -1);
+    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), -1);
+
+    assert.sameValue(ArrayFindIndexHelper(lengthTracking, isTwoOrFour), -1);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.sameValue(ArrayFindIndexHelper(fixedLength, isTwoOrFour), -1);
+    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), -1);
+
+    assert.sameValue(ArrayFindIndexHelper(lengthTracking, isTwoOrFour), -1);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 0);
+    }
+    WriteToTypedArray(taWrite, 4, 2);
+    WriteToTypedArray(taWrite, 5, 4);
+
+    // Orig. array: [0, 0, 0, 0, 2, 4]
+    //              [0, 0, 0, 0] << fixedLength
+    //                    [0, 0] << fixedLengthWithOffset
+    //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
+    //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayFindIndexHelper(fixedLength, isTwoOrFour), -1);
+    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+    assert.sameValue(ArrayFindIndexHelper(lengthTracking, isTwoOrFour), 4);
+    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 2);
+  }
+}
+
+TestFindIndex();

--- a/test/built-ins/Array/prototype/findIndex/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/findIndex/resizable-buffer.js
@@ -6,131 +6,82 @@ esid: sec-array.prototype.findindex
 description: >
   Array.p.findIndex behaves correctly when receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-function ArrayFindIndexHelper(ta, p) {
-  return Array.prototype.findIndex.call(ta, p);
-}
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
 
-function TestFindIndex() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    function isTwoOrFour(n) {
-      return n == 2 || n == 4;
-    }
-    assert.sameValue(ArrayFindIndexHelper(fixedLength, isTwoOrFour), 1);
-    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), 0);
-    assert.sameValue(ArrayFindIndexHelper(lengthTracking, isTwoOrFour), 1);
-    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayFindIndexHelper(fixedLength, isTwoOrFour), -1);
-    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
-
-    assert.sameValue(ArrayFindIndexHelper(lengthTracking, isTwoOrFour), 1);
-    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.sameValue(ArrayFindIndexHelper(fixedLength, isTwoOrFour), -1);
-    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
-    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), -1);
-
-    assert.sameValue(ArrayFindIndexHelper(lengthTracking, isTwoOrFour), -1);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.sameValue(ArrayFindIndexHelper(fixedLength, isTwoOrFour), -1);
-    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
-    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), -1);
-
-    assert.sameValue(ArrayFindIndexHelper(lengthTracking, isTwoOrFour), -1);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 0);
-    }
-    WriteToTypedArray(taWrite, 4, 2);
-    WriteToTypedArray(taWrite, 5, 4);
-
-    // Orig. array: [0, 0, 0, 0, 2, 4]
-    //              [0, 0, 0, 0] << fixedLength
-    //                    [0, 0] << fixedLengthWithOffset
-    //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
-    //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayFindIndexHelper(fixedLength, isTwoOrFour), -1);
-    assert.sameValue(ArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
-    assert.sameValue(ArrayFindIndexHelper(lengthTracking, isTwoOrFour), 4);
-    assert.sameValue(ArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 2);
+  function isTwoOrFour(n) {
+    return n == 2 || n == 4;
   }
-}
+  assert.sameValue(Array.prototype.findIndex.call(fixedLength, isTwoOrFour), 1);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, isTwoOrFour), 0);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, isTwoOrFour), 1);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, isTwoOrFour), 0);
 
-TestFindIndex();
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(Array.prototype.findIndex.call(fixedLength, isTwoOrFour), -1);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, isTwoOrFour), -1);
+
+  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, isTwoOrFour), 1);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, isTwoOrFour), 0);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLength, isTwoOrFour), -1);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, isTwoOrFour), -1);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, isTwoOrFour), -1);
+
+  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, isTwoOrFour), -1);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLength, isTwoOrFour), -1);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, isTwoOrFour), -1);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, isTwoOrFour), -1);
+
+  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, isTwoOrFour), -1);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 0);
+  }
+  WriteToTypedArray(taWrite, 4, 2);
+  WriteToTypedArray(taWrite, 5, 4);
+
+  // Orig. array: [0, 0, 0, 0, 2, 4]
+  //              [0, 0, 0, 0] << fixedLength
+  //                    [0, 0] << fixedLengthWithOffset
+  //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
+  //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(Array.prototype.findIndex.call(fixedLength, isTwoOrFour), -1);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, isTwoOrFour), -1);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, isTwoOrFour), 4);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, isTwoOrFour), 2);
+}

--- a/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
@@ -6,138 +6,79 @@ esid: sec-%typedarray%.prototype.findindex
 description: >
   TypedArray.p.findIndex behaves correctly when receiver is backed by resizable
   buffer that is grown mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset before
+// calling this.
+function ResizeBufferMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return false;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(fixedLength.findIndex(ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(fixedLengthWithOffset.findIndex(ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(lengthTracking.findIndex(ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(lengthTrackingWithOffset.findIndex(ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-function TypedArrayFindIndexHelper(ta, p) {
-  return ta.findIndex(p);
-}
-
-function FindIndexGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return false;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindIndexHelper(fixedLength, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      4,
-      6
-    ]);
-  }
-}
-
-FindIndexGrowMidIteration();

--- a/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,143 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.findindex
+description: >
+  TypedArray.p.findIndex behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindIndexHelper(ta, p) {
+  return ta.findIndex(p);
+}
+
+function FindIndexGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindIndexHelper(fixedLength, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+FindIndexGrowMidIteration();

--- a/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,143 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.findindex
+description: >
+  TypedArray.p.findIndex behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindIndexHelper(ta, p) {
+  return ta.findIndex(p);
+}
+
+function FindIndexShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindIndexHelper(fixedLength, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      undefined,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+}
+
+FindIndexShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
@@ -6,138 +6,79 @@ esid: sec-%typedarray%.prototype.findindex
 description: >
   TypedArray.p.findIndex behaves correctly when receiver is backed by resizable
   buffer that is shrunk mid-iteration
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset before
+// calling this.
+function ResizeBufferMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return false;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(fixedLength.findIndex(ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    0,
+    2,
+    undefined,
+    undefined
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(fixedLengthWithOffset.findIndex(ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(lengthTracking.findIndex(ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    undefined
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.sameValue(lengthTrackingWithOffset.findIndex(ResizeBufferMidIteration), -1);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
 }
-
-function TypedArrayFindIndexHelper(ta, p) {
-  return ta.findIndex(p);
-}
-
-function FindIndexShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return false;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindIndexHelper(fixedLength, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      0,
-      2,
-      undefined,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    values = [];
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      0,
-      2,
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    values = [];
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
-    assert.compareArray(values, [
-      4,
-      undefined
-    ]);
-  }
-}
-
-FindIndexShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer.js
@@ -6,146 +6,97 @@ esid: sec-%typedarray%.prototype.findindex
 description: >
   TypedArray.p.findIndex behaves correctly when receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-function TypedArrayFindIndexHelper(ta, p) {
-  return ta.findIndex(p);
-}
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
 
-function TestFindIndex() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    function isTwoOrFour(n) {
-      return n == 2 || n == 4;
-    }
-    assert.sameValue(TypedArrayFindIndexHelper(fixedLength, isTwoOrFour), 1);
-    assert.sameValue(TypedArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), 0);
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, isTwoOrFour), 1);
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert.throws(TypeError, () => {
-      TypedArrayFindIndexHelper(fixedLength, isTwoOrFour);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour);
-    });
-
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, isTwoOrFour), 1);
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      TypedArrayFindIndexHelper(fixedLength, isTwoOrFour);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour);
-    });
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, isTwoOrFour), -1);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      TypedArrayFindIndexHelper(fixedLength, isTwoOrFour);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour);
-    });
-
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, isTwoOrFour), -1);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 0);
-    }
-    WriteToTypedArray(taWrite, 4, 2);
-    WriteToTypedArray(taWrite, 5, 4);
-
-    // Orig. array: [0, 0, 0, 0, 2, 4]
-    //              [0, 0, 0, 0] << fixedLength
-    //                    [0, 0] << fixedLengthWithOffset
-    //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
-    //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(TypedArrayFindIndexHelper(fixedLength, isTwoOrFour), -1);
-    assert.sameValue(TypedArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, isTwoOrFour), 4);
-    assert.sameValue(TypedArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 2);
+  function isTwoOrFour(n) {
+    return n == 2 || n == 4;
   }
-}
+  assert.sameValue(fixedLength.findIndex(isTwoOrFour), 1);
+  assert.sameValue(fixedLengthWithOffset.findIndex(isTwoOrFour), 0);
+  assert.sameValue(lengthTracking.findIndex(isTwoOrFour), 1);
+  assert.sameValue(lengthTrackingWithOffset.findIndex(isTwoOrFour), 0);
 
-TestFindIndex();
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    fixedLength.findIndex(isTwoOrFour);
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.findIndex(isTwoOrFour);
+  });
+
+  assert.sameValue(lengthTracking.findIndex(isTwoOrFour), 1);
+  assert.sameValue(lengthTrackingWithOffset.findIndex(isTwoOrFour), 0);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.findIndex(isTwoOrFour);
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.findIndex(isTwoOrFour);
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.findIndex(isTwoOrFour);
+  });
+  assert.sameValue(lengthTracking.findIndex(isTwoOrFour), -1);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    fixedLength.findIndex(isTwoOrFour);
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.findIndex(isTwoOrFour);
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.findIndex(isTwoOrFour);
+  });
+
+  assert.sameValue(lengthTracking.findIndex(isTwoOrFour), -1);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 0);
+  }
+  WriteToTypedArray(taWrite, 4, 2);
+  WriteToTypedArray(taWrite, 5, 4);
+
+  // Orig. array: [0, 0, 0, 0, 2, 4]
+  //              [0, 0, 0, 0] << fixedLength
+  //                    [0, 0] << fixedLengthWithOffset
+  //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
+  //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(fixedLength.findIndex(isTwoOrFour), -1);
+  assert.sameValue(fixedLengthWithOffset.findIndex(isTwoOrFour), -1);
+  assert.sameValue(lengthTracking.findIndex(isTwoOrFour), 4);
+  assert.sameValue(lengthTrackingWithOffset.findIndex(isTwoOrFour), 2);
+}

--- a/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer.js
@@ -1,0 +1,151 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.findindex
+description: >
+  TypedArray.p.findIndex behaves correctly when receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindIndexHelper(ta, p) {
+  return ta.findIndex(p);
+}
+
+function TestFindIndex() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function isTwoOrFour(n) {
+      return n == 2 || n == 4;
+    }
+    assert.sameValue(TypedArrayFindIndexHelper(fixedLength, isTwoOrFour), 1);
+    assert.sameValue(TypedArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), 0);
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, isTwoOrFour), 1);
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      TypedArrayFindIndexHelper(fixedLength, isTwoOrFour);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour);
+    });
+
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, isTwoOrFour), 1);
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      TypedArrayFindIndexHelper(fixedLength, isTwoOrFour);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour);
+    });
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, isTwoOrFour), -1);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      TypedArrayFindIndexHelper(fixedLength, isTwoOrFour);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour);
+    });
+
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, isTwoOrFour), -1);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 0);
+    }
+    WriteToTypedArray(taWrite, 4, 2);
+    WriteToTypedArray(taWrite, 5, 4);
+
+    // Orig. array: [0, 0, 0, 0, 2, 4]
+    //              [0, 0, 0, 0] << fixedLength
+    //                    [0, 0] << fixedLengthWithOffset
+    //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
+    //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(TypedArrayFindIndexHelper(fixedLength, isTwoOrFour), -1);
+    assert.sameValue(TypedArrayFindIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTracking, isTwoOrFour), 4);
+    assert.sameValue(TypedArrayFindIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 2);
+  }
+}
+
+TestFindIndex();


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR https://github.com/tc39/test262/pull/3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js