### PR TITLE
Test coverage for canonicalization of calendars

### DIFF
--- a/test/built-ins/Temporal/PlainDate/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/calendar-case-insensitive.js
@@ -7,7 +7,14 @@ description: Calendar names are case-insensitive
 features: [Temporal]
 ---*/
 
-const arg = "iSo8601";
+let arg = "iSo8601";
 
 const result = new Temporal.PlainDate(2000, 5, 2, arg);
 assert.sameValue(result.calendarId, "iso8601", "Calendar is case-insensitive");
+
+arg = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => new Temporal.PlainDate(2000, 5, 2, arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-case-insensitive.js
@@ -7,10 +7,20 @@ description: The calendar name is case-insensitive
 features: [Temporal]
 ---*/
 
-const calendar = "IsO8601";
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const arg = { year: 1976, monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result1 = Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18));
 assert.sameValue(result1, 0, "Calendar is case-insensitive (first argument)");
 const result2 = Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg);
 assert.sameValue(result2, 0, "Calendar is case-insensitive (second argument)");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)),
+  "calendar ID is capital dotted I is not lowercased (first argument)"
+);
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg),
+  "calendar ID is capital dotted I is not lowercased (second argument)"
+);

--- a/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-case-insensitive.js
@@ -8,8 +8,13 @@ includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const calendar = "IsO8601";
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const arg = { year: 1976, monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result = Temporal.PlainDate.from(arg);
 TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.from(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-case-insensitive.js
@@ -9,8 +9,13 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDate(1976, 11, 18);
 
-const calendar = "IsO8601";
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const arg = { year: 1976, monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result = instance.equals(arg);
 assert.sameValue(result, true, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.equals(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-case-insensitive.js
@@ -10,8 +10,13 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDate(1976, 11, 18);
 
-const calendar = "IsO8601";
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const arg = { year: 1976, monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result = instance.since(arg);
 TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.since(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-case-insensitive.js
@@ -10,8 +10,13 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDate(1976, 11, 18);
 
-const calendar = "IsO8601";
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const arg = { year: 1976, monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result = instance.until(arg);
 TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.until(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-case-insensitive.js
@@ -31,6 +31,13 @@ const instance = new Temporal.PlainDate(1976, 11, 18, {
   yearOfWeek() {},
 });
 
-const arg = "iSo8601";
+let arg = "iSo8601";
 const result = instance.withCalendar(arg);
 assert.sameValue(result.calendarId, "iso8601", "Calendar is case-insensitive");
+
+arg = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.withCalendar(arg),
+  "calendar ID is ASCII-lowercased, capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDateTime/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/calendar-case-insensitive.js
@@ -7,7 +7,14 @@ description: Calendar names are case-insensitive
 features: [Temporal]
 ---*/
 
-const arg = "iSo8601";
+let arg = "iSo8601";
 
 const result = new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg);
 assert.sameValue(result.calendarId, "iso8601", "Calendar is case-insensitive");
+
+arg = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-case-insensitive.js
@@ -7,10 +7,20 @@ description: The calendar name is case-insensitive
 features: [Temporal]
 ---*/
 
-const calendar = "IsO8601";
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const arg = { year: 1976, monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result1 = Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18));
 assert.sameValue(result1, 0, "Calendar is case-insensitive (first argument)");
 const result2 = Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg);
 assert.sameValue(result2, 0, "Calendar is case-insensitive (second argument)");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)),
+  "calendar ID is capital dotted I is not lowercased (first argument)"
+);
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg),
+  "calendar ID is capital dotted I is not lowercased (second argument)"
+);

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-case-insensitive.js
@@ -8,8 +8,13 @@ includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const calendar = "IsO8601";
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const arg = { year: 1976, monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result = Temporal.PlainDateTime.from(arg);
 TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDateTime.from(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-case-insensitive.js
@@ -9,8 +9,13 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18);
 
-const calendar = "IsO8601";
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const arg = { year: 1976, monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result = instance.equals(arg);
 assert.sameValue(result, true, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.equals(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-case-insensitive.js
@@ -10,8 +10,13 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18);
 
-const calendar = "IsO8601";
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const arg = { year: 1976, monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result = instance.since(arg);
 TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.since(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-case-insensitive.js
@@ -10,8 +10,13 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18);
 
-const calendar = "IsO8601";
-
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const arg = { year: 1976, monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result = instance.until(arg);
 TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.until(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-case-insensitive.js
@@ -31,6 +31,13 @@ const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 456, 
   yearOfWeek() {},
 });
 
-const arg = "iSo8601";
+let arg = "iSo8601";
 const result = instance.withCalendar(arg);
 assert.sameValue(result.calendarId, "iso8601", "Calendar is case-insensitive");
+
+arg = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.withCalendar(arg),
+  "calendar ID is ASCII-lowercased, capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainMonthDay/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainMonthDay/calendar-case-insensitive.js
@@ -7,7 +7,14 @@ description: Calendar names are case-insensitive
 features: [Temporal]
 ---*/
 
-const arg = "iSo8601";
+let arg = "iSo8601";
 
 const result = new Temporal.PlainMonthDay(12, 15, arg, 1972);
 assert.sameValue(result.calendarId, "iso8601", "Calendar is case-insensitive");
+
+arg = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => new Temporal.PlainMonthDay(12, 15, arg, 1972),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-case-insensitive.js
@@ -8,8 +8,13 @@ includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const calendar = "IsO8601";
-
-const arg = { monthCode: "M11", day: 18, calendar };
+const arg = { monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result = Temporal.PlainMonthDay.from(arg);
 TemporalHelpers.assertPlainMonthDay(result, "M11", 18, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-case-insensitive.js
@@ -9,8 +9,13 @@ features: [Temporal]
 
 const instance = new Temporal.PlainMonthDay(11, 18);
 
-const calendar = "IsO8601";
-
-const arg = { monthCode: "M11", day: 18, calendar };
+const arg = { monthCode: "M11", day: 18, calendar: "IsO8601" };
 const result = instance.equals(arg);
 assert.sameValue(result, true, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.equals(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainYearMonth/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/calendar-case-insensitive.js
@@ -7,7 +7,14 @@ description: Calendar names are case-insensitive
 features: [Temporal]
 ---*/
 
-const arg = "iSo8601";
+let arg = "iSo8601";
 
 const result = new Temporal.PlainYearMonth(2000, 5, arg, 1);
 assert.sameValue(result.calendarId, "iso8601", "Calendar is case-insensitive");
+
+arg = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => new Temporal.PlainYearMonth(2000, 5, arg, 1),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-case-insensitive.js
@@ -7,10 +7,20 @@ description: The calendar name is case-insensitive
 features: [Temporal]
 ---*/
 
-const calendar = "IsO8601";
-
-const arg = { year: 2019, monthCode: "M06", calendar };
+const arg = { year: 2019, monthCode: "M06", calendar: "IsO8601" };
 const result1 = Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6));
 assert.sameValue(result1, 0, "Calendar is case-insensitive (first argument)");
 const result2 = Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg);
 assert.sameValue(result2, 0, "Calendar is case-insensitive (second argument)");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)),
+  "calendar ID is capital dotted I is not lowercased (first argument)"
+);
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg),
+  "calendar ID is capital dotted I is not lowercased (second argument)"
+);

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-case-insensitive.js
@@ -8,8 +8,13 @@ includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const calendar = "IsO8601";
-
-const arg = { year: 2019, monthCode: "M06", calendar };
+const arg = { year: 2019, monthCode: "M06", calendar: "IsO8601" };
 const result = Temporal.PlainYearMonth.from(arg);
 TemporalHelpers.assertPlainYearMonth(result, 2019, 6, "M06", "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.from(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-case-insensitive.js
@@ -9,8 +9,13 @@ features: [Temporal]
 
 const instance = new Temporal.PlainYearMonth(2019, 6);
 
-const calendar = "IsO8601";
-
-const arg = { year: 2019, monthCode: "M06", calendar };
+const arg = { year: 2019, monthCode: "M06", calendar: "IsO8601" };
 const result = instance.equals(arg);
 assert.sameValue(result, true, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.equals(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-case-insensitive.js
@@ -10,8 +10,13 @@ features: [Temporal]
 
 const instance = new Temporal.PlainYearMonth(2019, 6);
 
-const calendar = "IsO8601";
-
-const arg = { year: 2019, monthCode: "M06", calendar };
+const arg = { year: 2019, monthCode: "M06", calendar: "IsO8601" };
 const result = instance.since(arg);
 TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.since(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-case-insensitive.js
@@ -10,8 +10,13 @@ features: [Temporal]
 
 const instance = new Temporal.PlainYearMonth(2019, 6);
 
-const calendar = "IsO8601";
-
-const arg = { year: 2019, monthCode: "M06", calendar };
+const arg = { year: 2019, monthCode: "M06", calendar: "IsO8601" };
 const result = instance.until(arg);
 TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.until(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/calendar-case-insensitive.js
@@ -7,7 +7,14 @@ description: Calendar names are case-insensitive
 features: [Temporal]
 ---*/
 
-const arg = "iSo8601";
+let arg = "iSo8601";
 
 const result = new Temporal.ZonedDateTime(0n, "UTC", arg);
 assert.sameValue(result.calendarId, "iso8601", "Calendar is case-insensitive");
+
+arg = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => new Temporal.ZonedDateTime(0n, "UTC", arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-case-insensitive.js
@@ -7,13 +7,23 @@ description: The calendar name is case-insensitive
 features: [Temporal]
 ---*/
 
-const calendar = "IsO8601";
-
 const timeZone = new Temporal.TimeZone("UTC");
 const datetime = new Temporal.ZonedDateTime(0n, timeZone);
 
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
+const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar: "IsO8601" };
 const result1 = Temporal.ZonedDateTime.compare(arg, datetime);
 assert.sameValue(result1, 0, "Calendar is case-insensitive (first argument)");
 const result2 = Temporal.ZonedDateTime.compare(datetime, arg);
 assert.sameValue(result2, 0, "Calendar is case-insensitive (second argument)");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => Temporal.ZonedDateTime.compare(arg, datetime),
+  "calendar ID is capital dotted I is not lowercased (first argument)"
+);
+assert.throws(
+  RangeError,
+  () => Temporal.ZonedDateTime.compare(datetime, arg),
+  "calendar ID is capital dotted I is not lowercased (second argument)"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-case-insensitive.js
@@ -7,9 +7,14 @@ description: The calendar name is case-insensitive
 features: [Temporal]
 ---*/
 
-const calendar = "IsO8601";
-
 const timeZone = new Temporal.TimeZone("UTC");
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
+const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar: "IsO8601" };
 const result = Temporal.ZonedDateTime.from(arg);
 assert.sameValue(result.calendarId, "iso8601", "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => Temporal.ZonedDateTime.from(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-case-insensitive.js
@@ -10,8 +10,13 @@ features: [Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const calendar = "IsO8601";
-
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
+const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar: "IsO8601" };
 const result = instance.equals(arg);
 assert.sameValue(result, true, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.equals(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-case-insensitive.js
@@ -11,8 +11,13 @@ features: [Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const calendar = "IsO8601";
-
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
+const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar: "IsO8601" };
 const result = instance.since(arg);
 TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.since(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-case-insensitive.js
@@ -11,8 +11,13 @@ features: [Temporal]
 const timeZone = new Temporal.TimeZone("UTC");
 const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
-const calendar = "IsO8601";
-
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
+const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar: "IsO8601" };
 const result = instance.until(arg);
 TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg.calendar = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.until(arg),
+  "calendar ID is capital dotted I is not lowercased"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-case-insensitive.js
@@ -31,6 +31,13 @@ const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", {
   yearOfWeek() {},
 });
 
-const arg = "iSo8601";
+let arg = "iSo8601";
 const result = instance.withCalendar(arg);
 assert.sameValue(result.calendarId, "iso8601", "Calendar is case-insensitive");
+
+arg = "\u0130SO8601";
+assert.throws(
+  RangeError,
+  () => instance.withCalendar(arg),
+  "calendar ID is ASCII-lowercased, capital dotted I is not lowercased"
+);

--- a/test/intl402/DateTimeFormat/canonicalize-calendar.js
+++ b/test/intl402/DateTimeFormat/canonicalize-calendar.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.datetimeformat
+description: Calendar IDs are canonicalized
+locale: [en, en-u-ca-islamic-civil]
+---*/
+
+const fmt1 = new Intl.DateTimeFormat("en", { calendar: "islamicc" });
+assert.sameValue(fmt1.resolvedOptions().calendar, "islamic-civil", "calendar ID is canonicalized (option)");
+
+const fmt2 = new Intl.DateTimeFormat("en-u-ca-islamicc");
+assert.sameValue(fmt1.resolvedOptions().calendar, "islamic-civil", "calendar ID is canonicalized (locale key)");
+
+const fmt3 = new Intl.DateTimeFormat("en", { calendar: "ISO8601" });
+assert.sameValue(fmt3.resolvedOptions().calendar, "iso8601", "calendar ID is lowercased");
+
+assert.throws(
+  RangeError,
+  () => new Intl.DateTimeFormat("en", { calendar: "\u0130SO8601" }),
+  "calendar ID is capital dotted I is not lowercased (first argument)"
+);

--- a/test/intl402/Temporal/PlainDate/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDate/canonicalize-calendar.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const result = new Temporal.PlainDate(2024, 7, 2, "islamicc");
+assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/PlainDate/from/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDate/from/canonicalize-calendar.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+[
+  "2024-07-02[u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, calendar: "islamicc" },
+].forEach((arg) => {
+  const result = Temporal.PlainDate.from(arg);
+  assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/PlainDate/prototype/equals/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDate/prototype/equals/canonicalize-calendar.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2024, 7, 2, "islamic-civil");
+
+[
+  "2024-07-02[u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, calendar: "islamicc" },
+].forEach((arg) => assert(instance.equals(arg), "calendar ID is canonicalized"));

--- a/test/intl402/Temporal/PlainDate/prototype/since/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDate/prototype/since/canonicalize-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2024, 7, 2, "islamic-civil");
+
+[
+  "2024-07-02[u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, calendar: "islamicc" },
+].forEach((arg) => {
+  const result = instance.since(arg);  // would throw if calendar was not canonicalized
+  assert(result.blank, "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/PlainDate/prototype/until/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDate/prototype/until/canonicalize-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2024, 7, 2, "islamic-civil");
+
+[
+  "2024-07-02[u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, calendar: "islamicc" },
+].forEach((arg) => {
+  const result = instance.until(arg);  // would throw if calendar was not canonicalized
+  assert(result.blank, "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/PlainDate/prototype/withCalendar/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDate/prototype/withCalendar/canonicalize-calendar.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.withcalendar
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2024, 7, 2);
+const result = instance.withCalendar("islamicc");
+assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/PlainDateTime/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/canonicalize-calendar.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const result = new Temporal.PlainDateTime(2024, 7, 2, 12, 34, 56, 987, 654, 321, "islamicc");
+assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/PlainDateTime/from/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/from/canonicalize-calendar.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+[
+  "2024-07-02T12:34[u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, hour: 12, minute: 34, calendar: "islamicc" },
+].forEach((arg) => {
+  const result = Temporal.PlainDateTime.from(arg);
+  assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/PlainDateTime/prototype/equals/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/equals/canonicalize-calendar.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2024, 7, 2, 12, 34, 0, 0, 0, 0, "islamic-civil");
+
+[
+  "2024-07-02T12:34[u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, hour: 12, minute: 34, calendar: "islamicc" },
+].forEach((arg) => assert(instance.equals(arg), "calendar ID is canonicalized"));

--- a/test/intl402/Temporal/PlainDateTime/prototype/since/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/since/canonicalize-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2024, 7, 2, 12, 34, 0, 0, 0, 0, "islamic-civil");
+
+[
+  "2024-07-02T12:34[u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, hour: 12, minute: 34, calendar: "islamicc" },
+].forEach((arg) => {
+  const result = instance.since(arg);  // would throw if calendar was not canonicalized
+  assert(result.blank, "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/PlainDateTime/prototype/until/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/until/canonicalize-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2024, 7, 2, 12, 34, 0, 0, 0, 0, "islamic-civil");
+
+[
+  "2024-07-02T12:34[u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, hour: 12, minute: 34, calendar: "islamicc" },
+].forEach((arg) => {
+  const result = instance.until(arg);  // would throw if calendar was not canonicalized
+  assert(result.blank, "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/PlainDateTime/prototype/withCalendar/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/withCalendar/canonicalize-calendar.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withcalendar
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2024, 7, 2, 12, 34);
+const result = instance.withCalendar("islamicc");
+assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/PlainMonthDay/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainMonthDay/canonicalize-calendar.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const result = new Temporal.PlainMonthDay(2, 11, "islamicc", 1972);
+assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/PlainMonthDay/from/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/canonicalize-calendar.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+[
+  "1972-02-11[u-ca=islamicc]",
+  { monthCode: "M12", day: 25, calendar: "islamicc" },
+].forEach((arg) => {
+  const result = Temporal.PlainMonthDay.from(arg);
+  assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/PlainMonthDay/prototype/equals/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainMonthDay/prototype/equals/canonicalize-calendar.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainMonthDay(2, 11, "islamic-civil", 1972);
+
+[
+  "1972-02-11[u-ca=islamicc]",
+  { monthCode: "M12", day: 25, calendar: "islamicc" },
+].forEach((arg) => assert(instance.equals(arg), "calendar ID is canonicalized"));

--- a/test/intl402/Temporal/PlainYearMonth/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainYearMonth/canonicalize-calendar.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const result = new Temporal.PlainYearMonth(2024, 6, "islamicc", 8);
+assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/PlainYearMonth/from/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/canonicalize-calendar.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+[
+  "2024-06-08[u-ca=islamicc]",
+  { year: 1445, month: 12, calendar: "islamicc" },
+].forEach((arg) => {
+  const result = Temporal.PlainYearMonth.from(arg);
+  assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/PlainYearMonth/prototype/equals/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/equals/canonicalize-calendar.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2024, 6, "islamic-civil", 8);
+
+[
+  "2024-06-08[u-ca=islamicc]",
+  { year: 1445, month: 12, calendar: "islamicc" },
+].forEach((arg) => assert(instance.equals(arg), "calendar ID is canonicalized"));

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/canonicalize-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2024, 6, "islamic-civil", 8);
+
+[
+  "2024-06-08[u-ca=islamicc]",
+  { year: 1445, month: 12, calendar: "islamicc" },
+].forEach((arg) => {
+  const result = instance.since(arg);  // would throw if calendar was not canonicalized
+  assert(result.blank, "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/canonicalize-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2024, 6, "islamic-civil", 8);
+
+[
+  "2024-06-08[u-ca=islamicc]",
+  { year: 1445, month: 12, calendar: "islamicc" },
+].forEach((arg) => {
+  const result = instance.until(arg);  // would throw if calendar was not canonicalized
+  assert(result.blank, "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/ZonedDateTime/canonicalize-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/canonicalize-calendar.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const result = new Temporal.ZonedDateTime(1719923640_000_000_000n, "UTC", "islamicc");
+assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/ZonedDateTime/from/canonicalize-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/canonicalize-calendar.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+[
+  "2024-07-02T12:34+00:00[UTC][u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, hour: 12, minute: 34, calendar: "islamicc", timeZone: "UTC" },
+].forEach((arg) => {
+  const result = Temporal.ZonedDateTime.from(arg);
+  assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/ZonedDateTime/prototype/equals/canonicalize-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/equals/canonicalize-calendar.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1719923640_000_000_000n, "UTC", "islamic-civil");
+
+[
+  "2024-07-02T12:34+00:00[UTC][u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, hour: 12, minute: 34, calendar: "islamicc", timeZone: "UTC" },
+].forEach((arg) => assert(instance.equals(arg), "calendar ID is canonicalized"));

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/canonicalize-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/canonicalize-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1719923640_000_000_000n, "UTC", "islamic-civil");
+
+[
+  "2024-07-02T12:34+00:00[UTC][u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, hour: 12, minute: 34, calendar: "islamicc", timeZone: "UTC" },
+].forEach((arg) => {
+  const result = instance.since(arg);  // would throw if calendar was not canonicalized
+  assert(result.blank, "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/canonicalize-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/canonicalize-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1719923640_000_000_000n, "UTC", "islamic-civil");
+
+[
+  "2024-07-02T12:34+00:00[UTC][u-ca=islamicc]",
+  { year: 1445, month: 12, day: 25, hour: 12, minute: 34, calendar: "islamicc", timeZone: "UTC" },
+].forEach((arg) => {
+  const result = instance.until(arg);  // would throw if calendar was not canonicalized
+  assert(result.blank, "calendar ID is canonicalized");
+});

--- a/test/intl402/Temporal/ZonedDateTime/prototype/withCalendar/canonicalize-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/withCalendar/canonicalize-calendar.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zonedatetime.prototype.withcalendar
+description: Calendar ID is canonicalized
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1719923640_000_000_000n, "UTC");
+const result = instance.withCalendar("islamicc");
+assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");

--- a/test/staging/Intl402/Temporal/old/islamic-calendars.js
+++ b/test/staging/Intl402/Temporal/old/islamic-calendars.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-temporal-intl
-description: Islamic calendars (note there are 6 variants)
+description: Islamic calendars (note there are 5 variants)
 features: [Temporal]
 ---*/
 
@@ -30,15 +30,6 @@ const tests = [
   },
   {
     calendar: "islamic-civil",
-    inLeapYear: true,
-    daysInYear: 355,
-    daysInMonth12: 30,
-    isoYear: 2023,
-    isoMonth: 7,
-    isoDay: 19
-  },
-  {
-    calendar: "islamicc", // deprecated version of islamic-civil
     inLeapYear: true,
     daysInYear: 355,
     daysInMonth12: 30,


### PR DESCRIPTION
This functionality in `Intl.DateTimeFormat` was specified several years ago in ECMA-402 but lacked coverage.

Anba recently brought Temporal's calendar canonicalization in line with ECMA-402. Add test coverage for that as well and fix one erroneous test.