### PR TITLE
Tests for later base64 changes

### DIFF
--- a/test/built-ins/Uint8Array/prototype/setFromBase64/writes-up-to-error.js
+++ b/test/built-ins/Uint8Array/prototype/setFromBase64/writes-up-to-error.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-uint8array.prototype.setfrombase64
+description: Uint8Array.prototype.setFromBase64 decodes and writes chunks which occur prior to bad data
+features: [uint8array-base64, TypedArray]
+---*/
+
+var target = new Uint8Array([255, 255, 255, 255, 255]);
+assert.throws(SyntaxError, function() {
+  target.setFromBase64("MjYyZm.9v");
+}, "illegal character in second chunk");
+assert.compareArray(target, [50, 54, 50, 255, 255], "decoding from MjYyZm.9v should only write the valid chunks");
+
+target = new Uint8Array([255, 255, 255, 255, 255]);
+assert.throws(SyntaxError, function() {
+  target.setFromBase64("MjYyZg", { lastChunkHandling: "strict" });
+}, "padding omitted with lastChunkHandling: strict");
+assert.compareArray(target, [50, 54, 50, 255, 255], "decoding from MjYyZg should only write the valid chunks");
+
+target = new Uint8Array([255, 255, 255, 255, 255]);
+assert.throws(SyntaxError, function() {
+  target.setFromBase64("MjYyZg===");
+}, "extra characters after padding");
+assert.compareArray(target, [50, 54, 50, 255, 255], "decoding from MjYyZg=== should not write the last chunk because it has extra padding ");

--- a/test/built-ins/Uint8Array/prototype/setFromBase64/writes-up-to-error.js
+++ b/test/built-ins/Uint8Array/prototype/setFromBase64/writes-up-to-error.js
@@ -22,4 +22,4 @@ target = new Uint8Array([255, 255, 255, 255, 255]);
 assert.throws(SyntaxError, function() {
   target.setFromBase64("MjYyZg===");
 }, "extra characters after padding");
-assert.compareArray(target, [50, 54, 50, 255, 255], "decoding from MjYyZg=== should not write the last chunk because it has extra padding ");
+assert.compareArray(target, [50, 54, 50, 255, 255], "decoding from MjYyZg=== should not write the last chunk because it has extra padding");

--- a/test/built-ins/Uint8Array/prototype/setFromHex/writes-up-to-error.js
+++ b/test/built-ins/Uint8Array/prototype/setFromHex/writes-up-to-error.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-uint8array.prototype.setfromhex
+description: Uint8Array.prototype.setFromHex decodes and writes pairs which occur prior to bad data
+features: [uint8array-base64, TypedArray]
+---*/
+
+var illegal = [
+  'aaa ',
+  'aaag',
+];
+illegal.forEach(function(value) {
+  var target = new Uint8Array([255, 255, 255, 255, 255]);
+  assert.throws(SyntaxError, function() {
+    target.setFromHex(value);
+  });
+  assert.compareArray(target, [170, 255, 255, 255, 255], "decoding from " + value);
+});
+
+var target = new Uint8Array([255, 255, 255, 255, 255]);
+assert.throws(SyntaxError, function() {
+  target.setFromHex('aaa');
+});
+assert.compareArray(target, [255, 255, 255, 255, 255], "when length is odd no data is written");

--- a/test/built-ins/Uint8Array/prototype/toBase64/omit-padding.js
+++ b/test/built-ins/Uint8Array/prototype/toBase64/omit-padding.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-uint8array.prototype.tobase64
+description: Conversion of Uint8Arrays to base64 strings exercising the omitPadding option
+features: [uint8array-base64, TypedArray]
+---*/
+
+// works with default alphabet
+assert.sameValue((new Uint8Array([199, 239])).toBase64(), "x+8=");
+assert.sameValue((new Uint8Array([199, 239])).toBase64({ omitPadding: false }), "x+8=");
+assert.sameValue((new Uint8Array([199, 239])).toBase64({ omitPadding: true }), "x+8");
+assert.sameValue((new Uint8Array([255])).toBase64({ omitPadding: true }), "/w");
+
+// works with base64url alphabet
+assert.sameValue((new Uint8Array([199, 239])).toBase64({ alphabet: "base64url" }), "x-8=");
+assert.sameValue((new Uint8Array([199, 239])).toBase64({ alphabet: "base64url", omitPadding: false }), "x-8=");
+assert.sameValue((new Uint8Array([199, 239])).toBase64({ alphabet: "base64url", omitPadding: true }), "x-8");
+assert.sameValue((new Uint8Array([255])).toBase64({ alphabet: "base64url", omitPadding: true }), "_w");
+
+// performs ToBoolean on the argument
+assert.sameValue((new Uint8Array([255])).toBase64({ omitPadding: 0 }), "/w==");
+assert.sameValue((new Uint8Array([255])).toBase64({ omitPadding: 1 }), "/w");


### PR DESCRIPTION
Tests for https://github.com/tc39/proposal-arraybuffer-base64/pull/60 and https://github.com/tc39/proposal-arraybuffer-base64/pull/58, which got consensus after the proposal had achieved stage 3 based on user and implementer feedback.

Based on https://github.com/tc39/test262/pull/3994 (which incidentally is ready).