### PR TITLE
RAB: Integrate staging tests for the .includes method

### DIFF
--- a/test/built-ins/Array/prototype/includes/coerced-searchelement-fromindex-resize.js
+++ b/test/built-ins/Array/prototype/includes/coerced-searchelement-fromindex-resize.js
@@ -4,17 +4,17 @@
 /*---
 esid: sec-array.prototype.includes
 description: >
-  Array.p.includes behaves correctly when the receiver is resized during
-  argument coercion
+  Array.p.includes behaves correctly on TypedArrays backed by resizable buffers
+  that are resized during argument coercion.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
 
-function ArrayIncludesNumOrBigInt(array, n, fromIndex) {
-  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
-    return Array.prototype.includes.call(array, BigInt(n), fromIndex);
+function MayNeedBigInt(ta, n) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    return BigInt(n);
   }
-  return Array.prototype.includes.call(array, n, fromIndex);
+  return n;
 }
 
 for (let ctor of ctors) {
@@ -26,9 +26,9 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert(!ArrayIncludesNumOrBigInt(fixedLength, undefined));
+  assert(!Array.prototype.includes.call(fixedLength, undefined));
   // The TA is OOB so it includes only "undefined".
-  assert(ArrayIncludesNumOrBigInt(fixedLength, undefined, evil));
+  assert(Array.prototype.includes.call(fixedLength, undefined, evil));
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -39,9 +39,10 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert(ArrayIncludesNumOrBigInt(fixedLength, 0));
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  assert(Array.prototype.includes.call(fixedLength, n0));
   // The TA is OOB so it includes only "undefined".
-  assert(!ArrayIncludesNumOrBigInt(fixedLength, 0, evil));
+  assert(!Array.prototype.includes.call(fixedLength, n0, evil));
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -52,9 +53,9 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert(!ArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  assert(!Array.prototype.includes.call(lengthTracking, undefined));
   // "includes" iterates until the original length and sees "undefined"s.
-  assert(ArrayIncludesNumOrBigInt(lengthTracking, undefined, evil));
+  assert(Array.prototype.includes.call(lengthTracking, undefined, evil));
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -68,9 +69,10 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert(!ArrayIncludesNumOrBigInt(lengthTracking, 0));
+  let n0 = MayNeedBigInt(lengthTracking, 0);
+  assert(!Array.prototype.includes.call(lengthTracking, n0));
   // The TA grew but we only look at the data until the original length.
-  assert(!ArrayIncludesNumOrBigInt(lengthTracking, 0, evil));
+  assert(!Array.prototype.includes.call(lengthTracking, n0, evil));
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -82,8 +84,9 @@ for (let ctor of ctors) {
       return -4;
     }
   };
-  assert(ArrayIncludesNumOrBigInt(lengthTracking, 1, -4));
+  let n1 = MayNeedBigInt(lengthTracking, 1);
+  assert(Array.prototype.includes.call(lengthTracking, n1, -4));
   // The TA grew but the start index conversion is done based on the original
   // length.
-  assert(ArrayIncludesNumOrBigInt(lengthTracking, 1, evil));
+  assert(Array.prototype.includes.call(lengthTracking, n1, evil));
 }

--- a/test/built-ins/Array/prototype/includes/coerced-searchelement-fromindex-resize.js
+++ b/test/built-ins/Array/prototype/includes/coerced-searchelement-fromindex-resize.js
@@ -1,0 +1,134 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.includes
+description: >
+  Array.p.includes behaves correctly when the receiver is resized during
+  argument coercion
+features: [resizable-arraybuffer, Array.prototype.includes]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayIncludesHelper(array, n, fromIndex) {
+  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
+    return Array.prototype.includes.call(array, BigInt(n), fromIndex);
+  }
+  return Array.prototype.includes.call(array, n, fromIndex);
+}
+
+function IncludesParameterConversionResizes() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(!ArrayIncludesHelper(fixedLength, undefined));
+    // The TA is OOB so it includes only "undefined".
+    assert(ArrayIncludesHelper(fixedLength, undefined, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(ArrayIncludesHelper(fixedLength, 0));
+    // The TA is OOB so it includes only "undefined".
+    assert(!ArrayIncludesHelper(fixedLength, 0, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(!ArrayIncludesHelper(lengthTracking, undefined));
+    // "includes" iterates until the original length and sees "undefined"s.
+    assert(ArrayIncludesHelper(lengthTracking, undefined, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, 1);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(!ArrayIncludesHelper(lengthTracking, 0));
+    // The TA grew but we only look at the data until the original length.
+    assert(!ArrayIncludesHelper(lengthTracking, 0, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    WriteToTypedArray(lengthTracking, 0, 1);
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -4;
+      }
+    };
+    assert(ArrayIncludesHelper(lengthTracking, 1, -4));
+    // The TA grew but the start index conversion is done based on the original
+    // length.
+    assert(ArrayIncludesHelper(lengthTracking, 1, evil));
+  }
+}
+
+IncludesParameterConversionResizes();

--- a/test/built-ins/Array/prototype/includes/coerced-searchelement-fromindex-resize.js
+++ b/test/built-ins/Array/prototype/includes/coerced-searchelement-fromindex-resize.js
@@ -6,129 +6,84 @@ esid: sec-array.prototype.includes
 description: >
   Array.p.includes behaves correctly when the receiver is resized during
   argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayIncludesHelper(array, n, fromIndex) {
+function ArrayIncludesNumOrBigInt(array, n, fromIndex) {
   if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
     return Array.prototype.includes.call(array, BigInt(n), fromIndex);
   }
   return Array.prototype.includes.call(array, n, fromIndex);
 }
 
-function IncludesParameterConversionResizes() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert(!ArrayIncludesHelper(fixedLength, undefined));
-    // The TA is OOB so it includes only "undefined".
-    assert(ArrayIncludesHelper(fixedLength, undefined, evil));
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert(ArrayIncludesHelper(fixedLength, 0));
-    // The TA is OOB so it includes only "undefined".
-    assert(!ArrayIncludesHelper(fixedLength, 0, evil));
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert(!ArrayIncludesHelper(lengthTracking, undefined));
-    // "includes" iterates until the original length and sees "undefined"s.
-    assert(ArrayIncludesHelper(lengthTracking, undefined, evil));
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(lengthTracking, i, 1);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
     }
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert(!ArrayIncludesHelper(lengthTracking, 0));
-    // The TA grew but we only look at the data until the original length.
-    assert(!ArrayIncludesHelper(lengthTracking, 0, evil));
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    WriteToTypedArray(lengthTracking, 0, 1);
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return -4;
-      }
-    };
-    assert(ArrayIncludesHelper(lengthTracking, 1, -4));
-    // The TA grew but the start index conversion is done based on the original
-    // length.
-    assert(ArrayIncludesHelper(lengthTracking, 1, evil));
-  }
+  };
+  assert(!ArrayIncludesNumOrBigInt(fixedLength, undefined));
+  // The TA is OOB so it includes only "undefined".
+  assert(ArrayIncludesNumOrBigInt(fixedLength, undefined, evil));
 }
-
-IncludesParameterConversionResizes();
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert(ArrayIncludesNumOrBigInt(fixedLength, 0));
+  // The TA is OOB so it includes only "undefined".
+  assert(!ArrayIncludesNumOrBigInt(fixedLength, 0, evil));
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert(!ArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  // "includes" iterates until the original length and sees "undefined"s.
+  assert(ArrayIncludesNumOrBigInt(lengthTracking, undefined, evil));
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, 1);
+  }
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert(!ArrayIncludesNumOrBigInt(lengthTracking, 0));
+  // The TA grew but we only look at the data until the original length.
+  assert(!ArrayIncludesNumOrBigInt(lengthTracking, 0, evil));
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  WriteToTypedArray(lengthTracking, 0, 1);
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return -4;
+    }
+  };
+  assert(ArrayIncludesNumOrBigInt(lengthTracking, 1, -4));
+  // The TA grew but the start index conversion is done based on the original
+  // length.
+  assert(ArrayIncludesNumOrBigInt(lengthTracking, 1, evil));
+}

--- a/test/built-ins/Array/prototype/includes/resizable-buffer-special-float-values.js
+++ b/test/built-ins/Array/prototype/includes/resizable-buffer-special-float-values.js
@@ -1,0 +1,22 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%array%.prototype.includes
+description: >
+  Array.p.includes behaves correctly for special float values on float
+  TypedArrays backed by resizable buffers.
+includes: [resizableArrayBufferUtils.js]
+features: [resizable-arraybuffer, Array.prototype.includes]
+---*/
+
+for (let ctor of floatCtors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  lengthTracking[0] = -Infinity;
+  lengthTracking[1] = Infinity;
+  lengthTracking[2] = NaN;
+  assert(Array.prototype.includes.call(lengthTracking, -Infinity));
+  assert(Array.prototype.includes.call(lengthTracking, Infinity));
+  assert(Array.prototype.includes.call(lengthTracking, NaN));
+}

--- a/test/built-ins/Array/prototype/includes/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/includes/resizable-buffer.js
@@ -4,17 +4,16 @@
 /*---
 esid: sec-array.prototype.includes
 description: >
-  Array.p.includes behaves correctly when receiver is backed by resizable
-  buffer
+  Array.p.includes behaves correctly on TypedArrays backed by resizable buffers.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
 
-function ArrayIncludesNumOrBigInt(array, n, fromIndex) {
-  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
-    return Array.prototype.includes.call(array, BigInt(n), fromIndex);
+function MayNeedBigInt(ta, n) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    return BigInt(n);
   }
-  return Array.prototype.includes.call(array, n, fromIndex);
+  return n;
 }
 
 for (let ctor of ctors) {
@@ -36,32 +35,36 @@ for (let ctor of ctors) {
   //              [0, 2, 4, 6, ...] << lengthTracking
   //                    [4, 6, ...] << lengthTrackingWithOffset
 
-  assert(ArrayIncludesNumOrBigInt(fixedLength, 2));
-  assert(!ArrayIncludesNumOrBigInt(fixedLength, undefined));
-  assert(ArrayIncludesNumOrBigInt(fixedLength, 2, 1));
-  assert(!ArrayIncludesNumOrBigInt(fixedLength, 2, 2));
-  assert(ArrayIncludesNumOrBigInt(fixedLength, 2, -3));
-  assert(!ArrayIncludesNumOrBigInt(fixedLength, 2, -2));
-  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
-  assert(ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4));
-  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, undefined));
-  assert(ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, 0));
-  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, 1));
-  assert(ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, -2));
-  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, -1));
-  assert(ArrayIncludesNumOrBigInt(lengthTracking, 2));
-  assert(!ArrayIncludesNumOrBigInt(lengthTracking, undefined));
-  assert(ArrayIncludesNumOrBigInt(lengthTracking, 2, 1));
-  assert(!ArrayIncludesNumOrBigInt(lengthTracking, 2, 2));
-  assert(ArrayIncludesNumOrBigInt(lengthTracking, 2, -3));
-  assert(!ArrayIncludesNumOrBigInt(lengthTracking, 2, -2));
-  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
-  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
-  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
-  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, 0));
-  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, 1));
-  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, -2));
-  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, -1));
+  // If fixedLength is a BigInt array, they all are BigInt Arrays.
+  let n2 = MayNeedBigInt(fixedLength, 2);
+  let n4 = MayNeedBigInt(fixedLength, 4);
+
+  assert(Array.prototype.includes.call(fixedLength, n2));
+  assert(!Array.prototype.includes.call(fixedLength, undefined));
+  assert(Array.prototype.includes.call(fixedLength, n2, 1));
+  assert(!Array.prototype.includes.call(fixedLength, n2, 2));
+  assert(Array.prototype.includes.call(fixedLength, n2, -3));
+  assert(!Array.prototype.includes.call(fixedLength, n2, -2));
+  assert(!Array.prototype.includes.call(fixedLengthWithOffset, n2));
+  assert(Array.prototype.includes.call(fixedLengthWithOffset, n4));
+  assert(!Array.prototype.includes.call(fixedLengthWithOffset, undefined));
+  assert(Array.prototype.includes.call(fixedLengthWithOffset, n4, 0));
+  assert(!Array.prototype.includes.call(fixedLengthWithOffset, n4, 1));
+  assert(Array.prototype.includes.call(fixedLengthWithOffset, n4, -2));
+  assert(!Array.prototype.includes.call(fixedLengthWithOffset, n4, -1));
+  assert(Array.prototype.includes.call(lengthTracking, n2));
+  assert(!Array.prototype.includes.call(lengthTracking, undefined));
+  assert(Array.prototype.includes.call(lengthTracking, n2, 1));
+  assert(!Array.prototype.includes.call(lengthTracking, n2, 2));
+  assert(Array.prototype.includes.call(lengthTracking, n2, -3));
+  assert(!Array.prototype.includes.call(lengthTracking, n2, -2));
+  assert(!Array.prototype.includes.call(lengthTrackingWithOffset, n2));
+  assert(Array.prototype.includes.call(lengthTrackingWithOffset, n4));
+  assert(!Array.prototype.includes.call(lengthTrackingWithOffset, undefined));
+  assert(Array.prototype.includes.call(lengthTrackingWithOffset, n4, 0));
+  assert(!Array.prototype.includes.call(lengthTrackingWithOffset, n4, 1));
+  assert(Array.prototype.includes.call(lengthTrackingWithOffset, n4, -2));
+  assert(!Array.prototype.includes.call(lengthTrackingWithOffset, n4, -1));
 
   // Shrink so that fixed length TAs go out of bounds.
   rab.resize(3 * ctor.BYTES_PER_ELEMENT);
@@ -70,29 +73,29 @@ for (let ctor of ctors) {
   //              [0, 2, 4, ...] << lengthTracking
   //                    [4, ...] << lengthTrackingWithOffset
 
-  assert(!ArrayIncludesNumOrBigInt(fixedLength, 2));
-  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
+  assert(!Array.prototype.includes.call(fixedLength, n2));
+  assert(!Array.prototype.includes.call(fixedLengthWithOffset, n2));
 
-  assert(ArrayIncludesNumOrBigInt(lengthTracking, 2));
-  assert(!ArrayIncludesNumOrBigInt(lengthTracking, undefined));
-  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
-  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
-  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
+  assert(Array.prototype.includes.call(lengthTracking, n2));
+  assert(!Array.prototype.includes.call(lengthTracking, undefined));
+  assert(!Array.prototype.includes.call(lengthTrackingWithOffset, n2));
+  assert(Array.prototype.includes.call(lengthTrackingWithOffset, n4));
+  assert(!Array.prototype.includes.call(lengthTrackingWithOffset, undefined));
 
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-  assert(!ArrayIncludesNumOrBigInt(fixedLength, 2));
-  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
-  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
+  assert(!Array.prototype.includes.call(fixedLength, n2));
+  assert(!Array.prototype.includes.call(fixedLengthWithOffset, n2));
+  assert(!Array.prototype.includes.call(lengthTrackingWithOffset, n2));
 
   // Shrink to zero.
   rab.resize(0);
-  assert(!ArrayIncludesNumOrBigInt(fixedLength, 2));
-  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
-  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
+  assert(!Array.prototype.includes.call(fixedLength, n2));
+  assert(!Array.prototype.includes.call(fixedLengthWithOffset, n2));
+  assert(!Array.prototype.includes.call(lengthTrackingWithOffset, n2));
 
-  assert(!ArrayIncludesNumOrBigInt(lengthTracking, 2));
-  assert(!ArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  assert(!Array.prototype.includes.call(lengthTracking, n2));
+  assert(!Array.prototype.includes.call(lengthTracking, undefined));
 
   // Grow so that all TAs are back in-bounds.
   rab.resize(6 * ctor.BYTES_PER_ELEMENT);
@@ -106,18 +109,20 @@ for (let ctor of ctors) {
   //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
   //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
 
-  assert(ArrayIncludesNumOrBigInt(fixedLength, 2));
-  assert(!ArrayIncludesNumOrBigInt(fixedLength, undefined));
-  assert(!ArrayIncludesNumOrBigInt(fixedLength, 8));
-  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
-  assert(ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4));
-  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, undefined));
-  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 8));
-  assert(ArrayIncludesNumOrBigInt(lengthTracking, 2));
-  assert(!ArrayIncludesNumOrBigInt(lengthTracking, undefined));
-  assert(ArrayIncludesNumOrBigInt(lengthTracking, 8));
-  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
-  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
-  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
-  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 8));
+  let n8 = MayNeedBigInt(fixedLength, 8);
+
+  assert(Array.prototype.includes.call(fixedLength, n2));
+  assert(!Array.prototype.includes.call(fixedLength, undefined));
+  assert(!Array.prototype.includes.call(fixedLength, n8));
+  assert(!Array.prototype.includes.call(fixedLengthWithOffset, n2));
+  assert(Array.prototype.includes.call(fixedLengthWithOffset, n4));
+  assert(!Array.prototype.includes.call(fixedLengthWithOffset, undefined));
+  assert(!Array.prototype.includes.call(fixedLengthWithOffset, n8));
+  assert(Array.prototype.includes.call(lengthTracking, n2));
+  assert(!Array.prototype.includes.call(lengthTracking, undefined));
+  assert(Array.prototype.includes.call(lengthTracking, n8));
+  assert(!Array.prototype.includes.call(lengthTrackingWithOffset, n2));
+  assert(Array.prototype.includes.call(lengthTrackingWithOffset, n4));
+  assert(!Array.prototype.includes.call(lengthTrackingWithOffset, undefined));
+  assert(Array.prototype.includes.call(lengthTrackingWithOffset, n8));
 }

--- a/test/built-ins/Array/prototype/includes/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/includes/resizable-buffer.js
@@ -6,163 +6,118 @@ esid: sec-array.prototype.includes
 description: >
   Array.p.includes behaves correctly when receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayIncludesHelper(array, n, fromIndex) {
+function ArrayIncludesNumOrBigInt(array, n, fromIndex) {
   if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
     return Array.prototype.includes.call(array, BigInt(n), fromIndex);
   }
   return Array.prototype.includes.call(array, n, fromIndex);
 }
 
-function TestIncludes() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    assert(ArrayIncludesHelper(fixedLength, 2));
-    assert(!ArrayIncludesHelper(fixedLength, undefined));
-    assert(ArrayIncludesHelper(fixedLength, 2, 1));
-    assert(!ArrayIncludesHelper(fixedLength, 2, 2));
-    assert(ArrayIncludesHelper(fixedLength, 2, -3));
-    assert(!ArrayIncludesHelper(fixedLength, 2, -2));
-    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 2));
-    assert(ArrayIncludesHelper(fixedLengthWithOffset, 4));
-    assert(!ArrayIncludesHelper(fixedLengthWithOffset, undefined));
-    assert(ArrayIncludesHelper(fixedLengthWithOffset, 4, 0));
-    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 4, 1));
-    assert(ArrayIncludesHelper(fixedLengthWithOffset, 4, -2));
-    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 4, -1));
-    assert(ArrayIncludesHelper(lengthTracking, 2));
-    assert(!ArrayIncludesHelper(lengthTracking, undefined));
-    assert(ArrayIncludesHelper(lengthTracking, 2, 1));
-    assert(!ArrayIncludesHelper(lengthTracking, 2, 2));
-    assert(ArrayIncludesHelper(lengthTracking, 2, -3));
-    assert(!ArrayIncludesHelper(lengthTracking, 2, -2));
-    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 2));
-    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 4));
-    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, undefined));
-    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 4, 0));
-    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 4, 1));
-    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 4, -2));
-    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 4, -1));
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert(!ArrayIncludesHelper(fixedLength, 2));
-    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 2));
-
-    assert(ArrayIncludesHelper(lengthTracking, 2));
-    assert(!ArrayIncludesHelper(lengthTracking, undefined));
-    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 2));
-    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 4));
-    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, undefined));
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert(!ArrayIncludesHelper(fixedLength, 2));
-    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 2));
-    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 2));
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert(!ArrayIncludesHelper(fixedLength, 2));
-    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 2));
-    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 2));
-
-    assert(!ArrayIncludesHelper(lengthTracking, 2));
-    assert(!ArrayIncludesHelper(lengthTracking, undefined));
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert(ArrayIncludesHelper(fixedLength, 2));
-    assert(!ArrayIncludesHelper(fixedLength, undefined));
-    assert(!ArrayIncludesHelper(fixedLength, 8));
-    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 2));
-    assert(ArrayIncludesHelper(fixedLengthWithOffset, 4));
-    assert(!ArrayIncludesHelper(fixedLengthWithOffset, undefined));
-    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 8));
-    assert(ArrayIncludesHelper(lengthTracking, 2));
-    assert(!ArrayIncludesHelper(lengthTracking, undefined));
-    assert(ArrayIncludesHelper(lengthTracking, 8));
-    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 2));
-    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 4));
-    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, undefined));
-    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 8));
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-TestIncludes();
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  assert(ArrayIncludesNumOrBigInt(fixedLength, 2));
+  assert(!ArrayIncludesNumOrBigInt(fixedLength, undefined));
+  assert(ArrayIncludesNumOrBigInt(fixedLength, 2, 1));
+  assert(!ArrayIncludesNumOrBigInt(fixedLength, 2, 2));
+  assert(ArrayIncludesNumOrBigInt(fixedLength, 2, -3));
+  assert(!ArrayIncludesNumOrBigInt(fixedLength, 2, -2));
+  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
+  assert(ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4));
+  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, undefined));
+  assert(ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, 0));
+  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, 1));
+  assert(ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, -2));
+  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, -1));
+  assert(ArrayIncludesNumOrBigInt(lengthTracking, 2));
+  assert(!ArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  assert(ArrayIncludesNumOrBigInt(lengthTracking, 2, 1));
+  assert(!ArrayIncludesNumOrBigInt(lengthTracking, 2, 2));
+  assert(ArrayIncludesNumOrBigInt(lengthTracking, 2, -3));
+  assert(!ArrayIncludesNumOrBigInt(lengthTracking, 2, -2));
+  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
+  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
+  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
+  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, 0));
+  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, 1));
+  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, -2));
+  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, -1));
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert(!ArrayIncludesNumOrBigInt(fixedLength, 2));
+  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
+
+  assert(ArrayIncludesNumOrBigInt(lengthTracking, 2));
+  assert(!ArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
+  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
+  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert(!ArrayIncludesNumOrBigInt(fixedLength, 2));
+  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
+  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert(!ArrayIncludesNumOrBigInt(fixedLength, 2));
+  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
+  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
+
+  assert(!ArrayIncludesNumOrBigInt(lengthTracking, 2));
+  assert(!ArrayIncludesNumOrBigInt(lengthTracking, undefined));
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert(ArrayIncludesNumOrBigInt(fixedLength, 2));
+  assert(!ArrayIncludesNumOrBigInt(fixedLength, undefined));
+  assert(!ArrayIncludesNumOrBigInt(fixedLength, 8));
+  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
+  assert(ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4));
+  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, undefined));
+  assert(!ArrayIncludesNumOrBigInt(fixedLengthWithOffset, 8));
+  assert(ArrayIncludesNumOrBigInt(lengthTracking, 2));
+  assert(!ArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  assert(ArrayIncludesNumOrBigInt(lengthTracking, 8));
+  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
+  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
+  assert(!ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
+  assert(ArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 8));
+}

--- a/test/built-ins/Array/prototype/includes/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/includes/resizable-buffer.js
@@ -1,0 +1,168 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.includes
+description: >
+  Array.p.includes behaves correctly when receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer, Array.prototype.includes]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayIncludesHelper(array, n, fromIndex) {
+  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
+    return Array.prototype.includes.call(array, BigInt(n), fromIndex);
+  }
+  return Array.prototype.includes.call(array, n, fromIndex);
+}
+
+function TestIncludes() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert(ArrayIncludesHelper(fixedLength, 2));
+    assert(!ArrayIncludesHelper(fixedLength, undefined));
+    assert(ArrayIncludesHelper(fixedLength, 2, 1));
+    assert(!ArrayIncludesHelper(fixedLength, 2, 2));
+    assert(ArrayIncludesHelper(fixedLength, 2, -3));
+    assert(!ArrayIncludesHelper(fixedLength, 2, -2));
+    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 2));
+    assert(ArrayIncludesHelper(fixedLengthWithOffset, 4));
+    assert(!ArrayIncludesHelper(fixedLengthWithOffset, undefined));
+    assert(ArrayIncludesHelper(fixedLengthWithOffset, 4, 0));
+    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 4, 1));
+    assert(ArrayIncludesHelper(fixedLengthWithOffset, 4, -2));
+    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 4, -1));
+    assert(ArrayIncludesHelper(lengthTracking, 2));
+    assert(!ArrayIncludesHelper(lengthTracking, undefined));
+    assert(ArrayIncludesHelper(lengthTracking, 2, 1));
+    assert(!ArrayIncludesHelper(lengthTracking, 2, 2));
+    assert(ArrayIncludesHelper(lengthTracking, 2, -3));
+    assert(!ArrayIncludesHelper(lengthTracking, 2, -2));
+    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 2));
+    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 4));
+    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, undefined));
+    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 4, 0));
+    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 4, 1));
+    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 4, -2));
+    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 4, -1));
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert(!ArrayIncludesHelper(fixedLength, 2));
+    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 2));
+
+    assert(ArrayIncludesHelper(lengthTracking, 2));
+    assert(!ArrayIncludesHelper(lengthTracking, undefined));
+    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 2));
+    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 4));
+    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, undefined));
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert(!ArrayIncludesHelper(fixedLength, 2));
+    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 2));
+    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 2));
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert(!ArrayIncludesHelper(fixedLength, 2));
+    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 2));
+    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 2));
+
+    assert(!ArrayIncludesHelper(lengthTracking, 2));
+    assert(!ArrayIncludesHelper(lengthTracking, undefined));
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert(ArrayIncludesHelper(fixedLength, 2));
+    assert(!ArrayIncludesHelper(fixedLength, undefined));
+    assert(!ArrayIncludesHelper(fixedLength, 8));
+    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 2));
+    assert(ArrayIncludesHelper(fixedLengthWithOffset, 4));
+    assert(!ArrayIncludesHelper(fixedLengthWithOffset, undefined));
+    assert(!ArrayIncludesHelper(fixedLengthWithOffset, 8));
+    assert(ArrayIncludesHelper(lengthTracking, 2));
+    assert(!ArrayIncludesHelper(lengthTracking, undefined));
+    assert(ArrayIncludesHelper(lengthTracking, 8));
+    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, 2));
+    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 4));
+    assert(!ArrayIncludesHelper(lengthTrackingWithOffset, undefined));
+    assert(ArrayIncludesHelper(lengthTrackingWithOffset, 8));
+  }
+}
+
+TestIncludes();

--- a/test/built-ins/TypedArray/prototype/includes/coerced-searchelement-fromindex-resize.js
+++ b/test/built-ins/TypedArray/prototype/includes/coerced-searchelement-fromindex-resize.js
@@ -1,0 +1,134 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.includes
+description: >
+  TypedArray.p.includes behaves correctly when the receiver is resized during
+  argument coercion
+features: [resizable-arraybuffer, Array.prototype.includes]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayIncludesHelper(array, n, fromIndex) {
+  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
+    return array.includes(BigInt(n), fromIndex);
+  }
+  return array.includes(n, fromIndex);
+}
+
+function IncludesParameterConversionResizes() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(!TypedArrayIncludesHelper(fixedLength, undefined));
+    // The TA is OOB so it includes only "undefined".
+    assert(TypedArrayIncludesHelper(fixedLength, undefined, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(TypedArrayIncludesHelper(fixedLength, 0));
+    // The TA is OOB so it includes only "undefined".
+    assert(!TypedArrayIncludesHelper(fixedLength, 0, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(!TypedArrayIncludesHelper(lengthTracking, undefined));
+    // "includes" iterates until the original length and sees "undefined"s.
+    assert(TypedArrayIncludesHelper(lengthTracking, undefined, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, 1);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(!TypedArrayIncludesHelper(lengthTracking, 0));
+    // The TA grew but we only look at the data until the original length.
+    assert(!TypedArrayIncludesHelper(lengthTracking, 0, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    WriteToTypedArray(lengthTracking, 0, 1);
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -4;
+      }
+    };
+    assert(TypedArrayIncludesHelper(lengthTracking, 1, -4));
+    // The TA grew but the start index conversion is done based on the original
+    // length.
+    assert(TypedArrayIncludesHelper(lengthTracking, 1, evil));
+  }
+}
+
+IncludesParameterConversionResizes();

--- a/test/built-ins/TypedArray/prototype/includes/coerced-searchelement-fromindex-resize.js
+++ b/test/built-ins/TypedArray/prototype/includes/coerced-searchelement-fromindex-resize.js
@@ -6,129 +6,84 @@ esid: sec-%typedarray%.prototype.includes
 description: >
   TypedArray.p.includes behaves correctly when the receiver is resized during
   argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayIncludesHelper(array, n, fromIndex) {
+function TypedArrayIncludesNumOrBigInt(array, n, fromIndex) {
   if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
     return array.includes(BigInt(n), fromIndex);
   }
   return array.includes(n, fromIndex);
 }
 
-function IncludesParameterConversionResizes() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert(!TypedArrayIncludesHelper(fixedLength, undefined));
-    // The TA is OOB so it includes only "undefined".
-    assert(TypedArrayIncludesHelper(fixedLength, undefined, evil));
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert(TypedArrayIncludesHelper(fixedLength, 0));
-    // The TA is OOB so it includes only "undefined".
-    assert(!TypedArrayIncludesHelper(fixedLength, 0, evil));
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert(!TypedArrayIncludesHelper(lengthTracking, undefined));
-    // "includes" iterates until the original length and sees "undefined"s.
-    assert(TypedArrayIncludesHelper(lengthTracking, undefined, evil));
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(lengthTracking, i, 1);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
     }
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert(!TypedArrayIncludesHelper(lengthTracking, 0));
-    // The TA grew but we only look at the data until the original length.
-    assert(!TypedArrayIncludesHelper(lengthTracking, 0, evil));
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    WriteToTypedArray(lengthTracking, 0, 1);
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return -4;
-      }
-    };
-    assert(TypedArrayIncludesHelper(lengthTracking, 1, -4));
-    // The TA grew but the start index conversion is done based on the original
-    // length.
-    assert(TypedArrayIncludesHelper(lengthTracking, 1, evil));
-  }
+  };
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, undefined));
+  // The TA is OOB so it includes only "undefined".
+  assert(TypedArrayIncludesNumOrBigInt(fixedLength, undefined, evil));
 }
-
-IncludesParameterConversionResizes();
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert(TypedArrayIncludesNumOrBigInt(fixedLength, 0));
+  // The TA is OOB so it includes only "undefined".
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, 0, evil));
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  // "includes" iterates until the original length and sees "undefined"s.
+  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, undefined, evil));
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, 1);
+  }
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, 0));
+  // The TA grew but we only look at the data until the original length.
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, 0, evil));
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  WriteToTypedArray(lengthTracking, 0, 1);
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return -4;
+    }
+  };
+  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 1, -4));
+  // The TA grew but the start index conversion is done based on the original
+  // length.
+  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 1, evil));
+}

--- a/test/built-ins/TypedArray/prototype/includes/coerced-searchelement-fromindex-resize.js
+++ b/test/built-ins/TypedArray/prototype/includes/coerced-searchelement-fromindex-resize.js
@@ -4,17 +4,17 @@
 /*---
 esid: sec-%typedarray%.prototype.includes
 description: >
-  TypedArray.p.includes behaves correctly when the receiver is resized during
-  argument coercion
+  TypedArray.p.includes behaves correctly on TypedArrays backed by resizable
+  buffers that are resized during argument coercion.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
 
-function TypedArrayIncludesNumOrBigInt(array, n, fromIndex) {
-  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
-    return array.includes(BigInt(n), fromIndex);
+function MayNeedBigInt(ta, n) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    return BigInt(n);
   }
-  return array.includes(n, fromIndex);
+  return n;
 }
 
 for (let ctor of ctors) {
@@ -26,9 +26,9 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, undefined));
+  assert(!fixedLength.includes(undefined));
   // The TA is OOB so it includes only "undefined".
-  assert(TypedArrayIncludesNumOrBigInt(fixedLength, undefined, evil));
+  assert(fixedLength.includes(undefined, evil));
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -39,9 +39,10 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert(TypedArrayIncludesNumOrBigInt(fixedLength, 0));
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  assert(fixedLength.includes(n0));
   // The TA is OOB so it includes only "undefined".
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, 0, evil));
+  assert(!fixedLength.includes(n0, evil));
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -52,9 +53,9 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  assert(!lengthTracking.includes(undefined));
   // "includes" iterates until the original length and sees "undefined"s.
-  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, undefined, evil));
+  assert(lengthTracking.includes(undefined, evil));
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -68,9 +69,10 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, 0));
+  let n0 = MayNeedBigInt(lengthTracking, 0);
+  assert(!lengthTracking.includes(n0));
   // The TA grew but we only look at the data until the original length.
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, 0, evil));
+  assert(!lengthTracking.includes(n0, evil));
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -82,8 +84,9 @@ for (let ctor of ctors) {
       return -4;
     }
   };
-  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 1, -4));
+  let n1 = MayNeedBigInt(lengthTracking, 1);
+  assert(lengthTracking.includes(n1, -4));
   // The TA grew but the start index conversion is done based on the original
   // length.
-  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 1, evil));
+  assert(lengthTracking.includes(n1, evil));
 }

--- a/test/built-ins/TypedArray/prototype/includes/resizable-buffer-special-float-values.js
+++ b/test/built-ins/TypedArray/prototype/includes/resizable-buffer-special-float-values.js
@@ -5,7 +5,7 @@
 esid: sec-%typedarray%.prototype.includes
 description: >
   TypedArray.p.includes behaves correctly for special float values when
-  receiver is a float TypedArray backed by a resizable buffer
+  receiver is a float TypedArray backed by a resizable buffer.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/

--- a/test/built-ins/TypedArray/prototype/includes/resizable-buffer-special-float-values.js
+++ b/test/built-ins/TypedArray/prototype/includes/resizable-buffer-special-float-values.js
@@ -6,21 +6,9 @@ esid: sec-%typedarray%.prototype.includes
 description: >
   TypedArray.p.includes behaves correctly for special float values when
   receiver is a float TypedArray backed by a resizable buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
-
-class MyFloat32Array extends Float32Array {
-}
-
-const floatCtors = [
-  Float32Array,
-  Float64Array,
-  MyFloat32Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
 
 for (let ctor of floatCtors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);

--- a/test/built-ins/TypedArray/prototype/includes/resizable-buffer-special-float-values.js
+++ b/test/built-ins/TypedArray/prototype/includes/resizable-buffer-special-float-values.js
@@ -1,0 +1,34 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.includes
+description: >
+  TypedArray.p.includes behaves correctly for special float values when
+  receiver is a float TypedArray backed by a resizable buffer
+features: [resizable-arraybuffer, Array.prototype.includes]
+---*/
+
+class MyFloat32Array extends Float32Array {
+}
+
+const floatCtors = [
+  Float32Array,
+  Float64Array,
+  MyFloat32Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+for (let ctor of floatCtors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  lengthTracking[0] = -Infinity;
+  lengthTracking[1] = Infinity;
+  lengthTracking[2] = NaN;
+  assert(lengthTracking.includes(-Infinity));
+  assert(lengthTracking.includes(Infinity));
+  assert(lengthTracking.includes(NaN));
+}

--- a/test/built-ins/TypedArray/prototype/includes/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/includes/resizable-buffer.js
@@ -1,0 +1,183 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.includes
+description: >
+  TypedArray.p.includes behaves correctly when receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer, Array.prototype.includes]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayIncludesHelper(array, n, fromIndex) {
+  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
+    return array.includes(BigInt(n), fromIndex);
+  }
+  return array.includes(n, fromIndex);
+}
+
+function TestIncludes() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert(TypedArrayIncludesHelper(fixedLength, 2));
+    assert(!TypedArrayIncludesHelper(fixedLength, undefined));
+    assert(TypedArrayIncludesHelper(fixedLength, 2, 1));
+    assert(!TypedArrayIncludesHelper(fixedLength, 2, 2));
+    assert(TypedArrayIncludesHelper(fixedLength, 2, -3));
+    assert(!TypedArrayIncludesHelper(fixedLength, 2, -2));
+    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, 2));
+    assert(TypedArrayIncludesHelper(fixedLengthWithOffset, 4));
+    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, undefined));
+    assert(TypedArrayIncludesHelper(fixedLengthWithOffset, 4, 0));
+    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, 4, 1));
+    assert(TypedArrayIncludesHelper(fixedLengthWithOffset, 4, -2));
+    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, 4, -1));
+    assert(TypedArrayIncludesHelper(lengthTracking, 2));
+    assert(!TypedArrayIncludesHelper(lengthTracking, undefined));
+    assert(TypedArrayIncludesHelper(lengthTracking, 2, 1));
+    assert(!TypedArrayIncludesHelper(lengthTracking, 2, 2));
+    assert(TypedArrayIncludesHelper(lengthTracking, 2, -3));
+    assert(!TypedArrayIncludesHelper(lengthTracking, 2, -2));
+    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, 2));
+    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 4));
+    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, undefined));
+    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 4, 0));
+    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, 4, 1));
+    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 4, -2));
+    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, 4, -1));
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      TypedArrayIncludesHelper(fixedLength, 2);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayIncludesHelper(fixedLengthWithOffset, 2);
+    });
+
+    assert(TypedArrayIncludesHelper(lengthTracking, 2));
+    assert(!TypedArrayIncludesHelper(lengthTracking, undefined));
+    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, 2));
+    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 4));
+    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, undefined));
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      TypedArrayIncludesHelper(fixedLength, 2);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayIncludesHelper(fixedLengthWithOffset, 2);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayIncludesHelper(lengthTrackingWithOffset, 2);
+    });
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      TypedArrayIncludesHelper(fixedLength, 2);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayIncludesHelper(fixedLengthWithOffset, 2);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayIncludesHelper(lengthTrackingWithOffset, 2);
+    });
+    assert(!TypedArrayIncludesHelper(lengthTracking, 2));
+    assert(!TypedArrayIncludesHelper(lengthTracking, undefined));
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert(TypedArrayIncludesHelper(fixedLength, 2));
+    assert(!TypedArrayIncludesHelper(fixedLength, undefined));
+    assert(!TypedArrayIncludesHelper(fixedLength, 8));
+    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, 2));
+    assert(TypedArrayIncludesHelper(fixedLengthWithOffset, 4));
+    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, undefined));
+    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, 8));
+    assert(TypedArrayIncludesHelper(lengthTracking, 2));
+    assert(!TypedArrayIncludesHelper(lengthTracking, undefined));
+    assert(TypedArrayIncludesHelper(lengthTracking, 8));
+    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, 2));
+    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 4));
+    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, undefined));
+    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 8));
+  }
+}
+
+TestIncludes();

--- a/test/built-ins/TypedArray/prototype/includes/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/includes/resizable-buffer.js
@@ -4,17 +4,17 @@
 /*---
 esid: sec-%typedarray%.prototype.includes
 description: >
-  TypedArray.p.includes behaves correctly when receiver is backed by resizable
-  buffer
+  TypedArray.p.includes behaves correctly on TypedArrays backed by resizable
+  buffers.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
 
-function TypedArrayIncludesNumOrBigInt(array, n, fromIndex) {
-  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
-    return array.includes(BigInt(n), fromIndex);
+function MayNeedBigInt(ta, n) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    return BigInt(n);
   }
-  return array.includes(n, fromIndex);
+  return n;
 }
 
 for (let ctor of ctors) {
@@ -36,32 +36,36 @@ for (let ctor of ctors) {
   //              [0, 2, 4, 6, ...] << lengthTracking
   //                    [4, 6, ...] << lengthTrackingWithOffset
 
-  assert(TypedArrayIncludesNumOrBigInt(fixedLength, 2));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, undefined));
-  assert(TypedArrayIncludesNumOrBigInt(fixedLength, 2, 1));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, 2, 2));
-  assert(TypedArrayIncludesNumOrBigInt(fixedLength, 2, -3));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, 2, -2));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
-  assert(TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, undefined));
-  assert(TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, 0));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, 1));
-  assert(TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, -2));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, -1));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 2));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, undefined));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 2, 1));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, 2, 2));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 2, -3));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, 2, -2));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, 0));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, 1));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, -2));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, -1));
+  // If fixedLength is a BigInt array, they all are BigInt Arrays.
+  let n2 = MayNeedBigInt(fixedLength, 2);
+  let n4 = MayNeedBigInt(fixedLength, 4);
+
+  assert(fixedLength.includes(n2));
+  assert(!fixedLength.includes(undefined));
+  assert(fixedLength.includes(n2, 1));
+  assert(!fixedLength.includes(n2, 2));
+  assert(fixedLength.includes(n2, -3));
+  assert(!fixedLength.includes(n2, -2));
+  assert(!fixedLengthWithOffset.includes(n2));
+  assert(fixedLengthWithOffset.includes(n4));
+  assert(!fixedLengthWithOffset.includes(undefined));
+  assert(fixedLengthWithOffset.includes(n4, 0));
+  assert(!fixedLengthWithOffset.includes(n4, 1));
+  assert(fixedLengthWithOffset.includes(n4, -2));
+  assert(!fixedLengthWithOffset.includes(n4, -1));
+  assert(lengthTracking.includes(n2));
+  assert(!lengthTracking.includes(undefined));
+  assert(lengthTracking.includes(n2, 1));
+  assert(!lengthTracking.includes(n2, 2));
+  assert(lengthTracking.includes(n2, -3));
+  assert(!lengthTracking.includes(n2, -2));
+  assert(!lengthTrackingWithOffset.includes(n2));
+  assert(lengthTrackingWithOffset.includes(n4));
+  assert(!lengthTrackingWithOffset.includes(undefined));
+  assert(lengthTrackingWithOffset.includes(n4, 0));
+  assert(!lengthTrackingWithOffset.includes(n4, 1));
+  assert(lengthTrackingWithOffset.includes(n4, -2));
+  assert(!lengthTrackingWithOffset.includes(n4, -1));
 
   // Shrink so that fixed length TAs go out of bounds.
   rab.resize(3 * ctor.BYTES_PER_ELEMENT);
@@ -71,43 +75,43 @@ for (let ctor of ctors) {
   //                    [4, ...] << lengthTrackingWithOffset
 
   assert.throws(TypeError, () => {
-    TypedArrayIncludesNumOrBigInt(fixedLength, 2);
+    fixedLength.includes(n2);
   });
   assert.throws(TypeError, () => {
-    TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2);
+    fixedLengthWithOffset.includes(n2);
   });
 
-  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 2));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, undefined));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
+  assert(lengthTracking.includes(n2));
+  assert(!lengthTracking.includes(undefined));
+  assert(!lengthTrackingWithOffset.includes(n2));
+  assert(lengthTrackingWithOffset.includes(n4));
+  assert(!lengthTrackingWithOffset.includes(undefined));
 
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
   assert.throws(TypeError, () => {
-    TypedArrayIncludesNumOrBigInt(fixedLength, 2);
+    fixedLength.includes(n2);
   });
   assert.throws(TypeError, () => {
-    TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2);
+    fixedLengthWithOffset.includes(n2);
   });
   assert.throws(TypeError, () => {
-    TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2);
+    lengthTrackingWithOffset.includes(n2);
   });
 
   // Shrink to zero.
   rab.resize(0);
   assert.throws(TypeError, () => {
-    TypedArrayIncludesNumOrBigInt(fixedLength, 2);
+    fixedLength.includes(n2);
   });
   assert.throws(TypeError, () => {
-    TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2);
+    fixedLengthWithOffset.includes(n2);
   });
   assert.throws(TypeError, () => {
-    TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2);
+    lengthTrackingWithOffset.includes(n2);
   });
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, 2));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  assert(!lengthTracking.includes(n2));
+  assert(!lengthTracking.includes(undefined));
 
   // Grow so that all TAs are back in-bounds.
   rab.resize(6 * ctor.BYTES_PER_ELEMENT);
@@ -121,18 +125,20 @@ for (let ctor of ctors) {
   //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
   //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
 
-  assert(TypedArrayIncludesNumOrBigInt(fixedLength, 2));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, undefined));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, 8));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
-  assert(TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, undefined));
-  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 8));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 2));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, undefined));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 8));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
-  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
-  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 8));
+  let n8 = MayNeedBigInt(fixedLength, 8);
+
+  assert(fixedLength.includes(n2));
+  assert(!fixedLength.includes(undefined));
+  assert(!fixedLength.includes(n8));
+  assert(!fixedLengthWithOffset.includes(n2));
+  assert(fixedLengthWithOffset.includes(n4));
+  assert(!fixedLengthWithOffset.includes(undefined));
+  assert(!fixedLengthWithOffset.includes(n8));
+  assert(lengthTracking.includes(n2));
+  assert(!lengthTracking.includes(undefined));
+  assert(lengthTracking.includes(n8));
+  assert(!lengthTrackingWithOffset.includes(n2));
+  assert(lengthTrackingWithOffset.includes(n4));
+  assert(!lengthTrackingWithOffset.includes(undefined));
+  assert(lengthTrackingWithOffset.includes(n8));
 }

--- a/test/built-ins/TypedArray/prototype/includes/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/includes/resizable-buffer.js
@@ -6,178 +6,133 @@ esid: sec-%typedarray%.prototype.includes
 description: >
   TypedArray.p.includes behaves correctly when receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayIncludesHelper(array, n, fromIndex) {
+function TypedArrayIncludesNumOrBigInt(array, n, fromIndex) {
   if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
     return array.includes(BigInt(n), fromIndex);
   }
   return array.includes(n, fromIndex);
 }
 
-function TestIncludes() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    assert(TypedArrayIncludesHelper(fixedLength, 2));
-    assert(!TypedArrayIncludesHelper(fixedLength, undefined));
-    assert(TypedArrayIncludesHelper(fixedLength, 2, 1));
-    assert(!TypedArrayIncludesHelper(fixedLength, 2, 2));
-    assert(TypedArrayIncludesHelper(fixedLength, 2, -3));
-    assert(!TypedArrayIncludesHelper(fixedLength, 2, -2));
-    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, 2));
-    assert(TypedArrayIncludesHelper(fixedLengthWithOffset, 4));
-    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, undefined));
-    assert(TypedArrayIncludesHelper(fixedLengthWithOffset, 4, 0));
-    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, 4, 1));
-    assert(TypedArrayIncludesHelper(fixedLengthWithOffset, 4, -2));
-    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, 4, -1));
-    assert(TypedArrayIncludesHelper(lengthTracking, 2));
-    assert(!TypedArrayIncludesHelper(lengthTracking, undefined));
-    assert(TypedArrayIncludesHelper(lengthTracking, 2, 1));
-    assert(!TypedArrayIncludesHelper(lengthTracking, 2, 2));
-    assert(TypedArrayIncludesHelper(lengthTracking, 2, -3));
-    assert(!TypedArrayIncludesHelper(lengthTracking, 2, -2));
-    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, 2));
-    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 4));
-    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, undefined));
-    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 4, 0));
-    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, 4, 1));
-    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 4, -2));
-    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, 4, -1));
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert.throws(TypeError, () => {
-      TypedArrayIncludesHelper(fixedLength, 2);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayIncludesHelper(fixedLengthWithOffset, 2);
-    });
-
-    assert(TypedArrayIncludesHelper(lengthTracking, 2));
-    assert(!TypedArrayIncludesHelper(lengthTracking, undefined));
-    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, 2));
-    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 4));
-    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, undefined));
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      TypedArrayIncludesHelper(fixedLength, 2);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayIncludesHelper(fixedLengthWithOffset, 2);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayIncludesHelper(lengthTrackingWithOffset, 2);
-    });
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      TypedArrayIncludesHelper(fixedLength, 2);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayIncludesHelper(fixedLengthWithOffset, 2);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayIncludesHelper(lengthTrackingWithOffset, 2);
-    });
-    assert(!TypedArrayIncludesHelper(lengthTracking, 2));
-    assert(!TypedArrayIncludesHelper(lengthTracking, undefined));
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert(TypedArrayIncludesHelper(fixedLength, 2));
-    assert(!TypedArrayIncludesHelper(fixedLength, undefined));
-    assert(!TypedArrayIncludesHelper(fixedLength, 8));
-    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, 2));
-    assert(TypedArrayIncludesHelper(fixedLengthWithOffset, 4));
-    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, undefined));
-    assert(!TypedArrayIncludesHelper(fixedLengthWithOffset, 8));
-    assert(TypedArrayIncludesHelper(lengthTracking, 2));
-    assert(!TypedArrayIncludesHelper(lengthTracking, undefined));
-    assert(TypedArrayIncludesHelper(lengthTracking, 8));
-    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, 2));
-    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 4));
-    assert(!TypedArrayIncludesHelper(lengthTrackingWithOffset, undefined));
-    assert(TypedArrayIncludesHelper(lengthTrackingWithOffset, 8));
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-TestIncludes();
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  assert(TypedArrayIncludesNumOrBigInt(fixedLength, 2));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, undefined));
+  assert(TypedArrayIncludesNumOrBigInt(fixedLength, 2, 1));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, 2, 2));
+  assert(TypedArrayIncludesNumOrBigInt(fixedLength, 2, -3));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, 2, -2));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
+  assert(TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, undefined));
+  assert(TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, 0));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, 1));
+  assert(TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, -2));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4, -1));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 2));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 2, 1));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, 2, 2));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 2, -3));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, 2, -2));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, 0));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, 1));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, -2));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4, -1));
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    TypedArrayIncludesNumOrBigInt(fixedLength, 2);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2);
+  });
+
+  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 2));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    TypedArrayIncludesNumOrBigInt(fixedLength, 2);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2);
+  });
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    TypedArrayIncludesNumOrBigInt(fixedLength, 2);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2);
+  });
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, 2));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, undefined));
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert(TypedArrayIncludesNumOrBigInt(fixedLength, 2));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, undefined));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLength, 8));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 2));
+  assert(TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 4));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, undefined));
+  assert(!TypedArrayIncludesNumOrBigInt(fixedLengthWithOffset, 8));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 2));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTracking, undefined));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTracking, 8));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 2));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 4));
+  assert(!TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, undefined));
+  assert(TypedArrayIncludesNumOrBigInt(lengthTrackingWithOffset, 8));
+}


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR #3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js
