### PR TITLE
RAB: Integrate staging tests for the .indexOf method

### DIFF
--- a/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-grow.js
+++ b/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-grow.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-array.prototype.indexof
 description: >
-  Array.p.indexOf behaves correctly when the receiver is grown during
-  argument coercion
+  Array.p.indexOf behaves correctly when the backing resizable buffer is grown
+  during argument coercion.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function ArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return Array.prototype.indexOf.call(ta, BigInt(n));
-    }
-    return Array.prototype.indexOf.call(ta, BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return Array.prototype.indexOf.call(ta, n);
-  }
-  return Array.prototype.indexOf.call(ta, n, fromIndex);
+  return n;
 }
 
 // Growing + length-tracking TA.
@@ -36,9 +30,10 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  let n0 = MayNeedBigInt(lengthTracking, 0);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n0), -1);
   // The TA grew but we only look at the data until the original length.
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0, evil), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n0, evil), -1);
 }
 
 // Growing + length-tracking TA, index conversion.
@@ -52,8 +47,9 @@ for (let ctor of ctors) {
       return -4;
     }
   };
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 1, -4), 0);
+  let n1 = MayNeedBigInt(lengthTracking, 1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n1, -4), 0);
   // The TA grew but the start index conversion is done based on the original
   // length.
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 1, evil), 0);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n1, evil), 0);
 }

--- a/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-grow.js
+++ b/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-grow.js
@@ -6,52 +6,11 @@ esid: sec-array.prototype.indexof
 description: >
   Array.p.indexOf behaves correctly when the receiver is grown during
   argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayIndexOfHelper(ta, n, fromIndex) {
+function ArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return Array.prototype.indexOf.call(ta, BigInt(n));
@@ -64,41 +23,37 @@ function ArrayIndexOfHelper(ta, n, fromIndex) {
   return Array.prototype.indexOf.call(ta, n, fromIndex);
 }
 
-function IndexOfParameterConversionGrows() {
-  // Growing + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(lengthTracking, i, 1);
+// Growing + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, 1);
+  }
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return 0;
     }
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0), -1);
-    // The TA grew but we only look at the data until the original length.
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0, evil), -1);
-  }
-
-  // Growing + length-tracking TA, index conversion.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    WriteToTypedArray(lengthTracking, 0, 1);
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return -4;
-      }
-    };
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 1, -4), 0);
-    // The TA grew but the start index conversion is done based on the original
-    // length.
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 1, evil), 0);
-  }
+  };
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  // The TA grew but we only look at the data until the original length.
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0, evil), -1);
 }
 
-IndexOfParameterConversionGrows();
+// Growing + length-tracking TA, index conversion.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  WriteToTypedArray(lengthTracking, 0, 1);
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return -4;
+    }
+  };
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 1, -4), 0);
+  // The TA grew but the start index conversion is done based on the original
+  // length.
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 1, evil), 0);
+}

--- a/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-grow.js
+++ b/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-grow.js
@@ -1,0 +1,104 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.indexof
+description: >
+  Array.p.indexOf behaves correctly when the receiver is grown during
+  argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.indexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.indexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.indexOf.call(ta, n);
+  }
+  return Array.prototype.indexOf.call(ta, n, fromIndex);
+}
+
+function IndexOfParameterConversionGrows() {
+  // Growing + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, 1);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0), -1);
+    // The TA grew but we only look at the data until the original length.
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0, evil), -1);
+  }
+
+  // Growing + length-tracking TA, index conversion.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    WriteToTypedArray(lengthTracking, 0, 1);
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -4;
+      }
+    };
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 1, -4), 0);
+    // The TA grew but the start index conversion is done based on the original
+    // length.
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 1, evil), 0);
+  }
+}
+
+IndexOfParameterConversionGrows();

--- a/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
+++ b/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
@@ -1,0 +1,116 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.indexof
+description: >
+  Array.p.indexOf behaves correctly when the receiver is shrunk
+  during argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.indexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.indexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.indexOf.call(ta, n);
+  }
+  return Array.prototype.indexOf.call(ta, n, fromIndex);
+}
+
+function IndexOfParameterConversionShrinks() {
+  // Shrinking + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0), 0);
+    // The TA is OOB so indexOf returns -1.
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0, evil), -1);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0), 0);
+    // The TA is OOB so indexOf returns -1, also for undefined).
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, undefined, evil), -1);
+  }
+
+  // Shrinking + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 2), 2);
+    // 2 no longer found.
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 2, evil), -1);
+  }
+}
+
+IndexOfParameterConversionShrinks();
+

--- a/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
+++ b/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-array.prototype.indexof
 description: >
-  Array.p.indexOf behaves correctly when the receiver is shrunk
-  during argument coercion
+  Array.p.indexOf behaves correctly when the backing resizable buffer is shrunk
+  during argument coercion.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function ArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return Array.prototype.indexOf.call(ta, BigInt(n));
-    }
-    return Array.prototype.indexOf.call(ta, BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return Array.prototype.indexOf.call(ta, n);
-  }
-  return Array.prototype.indexOf.call(ta, n, fromIndex);
+  return n;
 }
 
 // Shrinking + fixed-length TA.
@@ -33,9 +27,10 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n0), 0);
   // The TA is OOB so indexOf returns -1.
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0, evil), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n0, evil), -1);
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -46,9 +41,10 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n0), 0);
   // The TA is OOB so indexOf returns -1, also for undefined).
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, undefined, evil), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, undefined, evil), -1);
 }
 
 // Shrinking + length-tracking TA.
@@ -64,7 +60,8 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 2), 2);
+  let n2 = MayNeedBigInt(lengthTracking, 2);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n2), 2);
   // 2 no longer found.
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 2, evil), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n2, evil), -1);
 }

--- a/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
+++ b/test/built-ins/Array/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
@@ -6,52 +6,11 @@ esid: sec-array.prototype.indexof
 description: >
   Array.p.indexOf behaves correctly when the receiver is shrunk
   during argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayIndexOfHelper(ta, n, fromIndex) {
+function ArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return Array.prototype.indexOf.call(ta, BigInt(n));
@@ -64,53 +23,48 @@ function ArrayIndexOfHelper(ta, n, fromIndex) {
   return Array.prototype.indexOf.call(ta, n, fromIndex);
 }
 
-function IndexOfParameterConversionShrinks() {
-  // Shrinking + fixed-length TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0), 0);
-    // The TA is OOB so indexOf returns -1.
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0, evil), -1);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0), 0);
-    // The TA is OOB so indexOf returns -1, also for undefined).
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, undefined, evil), -1);
-  }
-
-  // Shrinking + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(lengthTracking, i, i);
+// Shrinking + fixed-length TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
     }
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 2), 2);
-    // 2 no longer found.
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 2, evil), -1);
-  }
+  };
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
+  // The TA is OOB so indexOf returns -1.
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0, evil), -1);
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
+  // The TA is OOB so indexOf returns -1, also for undefined).
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, undefined, evil), -1);
 }
 
-IndexOfParameterConversionShrinks();
-
+// Shrinking + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 2), 2);
+  // 2 no longer found.
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 2, evil), -1);
+}

--- a/test/built-ins/Array/prototype/indexOf/resizable-buffer-special-float-values.js
+++ b/test/built-ins/Array/prototype/indexOf/resizable-buffer-special-float-values.js
@@ -1,0 +1,26 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%array%.prototype.indexof
+description: >
+  Array.p.indexOf behaves correctly for special float values on TypedArrays
+  backed by resizable buffers.
+includes: [resizableArrayBufferUtils.js]
+features: [resizable-arraybuffer, Array.prototype.includes]
+---*/
+
+for (let ctor of floatCtors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  lengthTracking[0] = -Infinity;
+  lengthTracking[1] = -Infinity;
+  lengthTracking[2] = Infinity;
+  lengthTracking[3] = Infinity;
+  lengthTracking[4] = NaN;
+  lengthTracking[5] = NaN;
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, -Infinity), 0);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, Infinity), 2);
+  // NaN is never found.
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, NaN), -1);
+}

--- a/test/built-ins/Array/prototype/indexOf/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/indexOf/resizable-buffer.js
@@ -6,52 +6,11 @@ esid: sec-array.prototype.indexof
 description: >
   Array.p.indexOf behaves correctly when receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayIndexOfHelper(ta, n, fromIndex) {
+function ArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return Array.prototype.indexOf.call(ta, BigInt(n));
@@ -64,109 +23,105 @@ function ArrayIndexOfHelper(ta, n, fromIndex) {
   return Array.prototype.indexOf.call(ta, n, fromIndex);
 }
 
-function TestIndexOf() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
-    }
-
-    // Orig. array: [0, 0, 1, 1]
-    //              [0, 0, 1, 1] << fixedLength
-    //                    [1, 1] << fixedLengthWithOffset
-    //              [0, 0, 1, 1, ...] << lengthTracking
-    //                    [1, 1, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0), 0);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0, 1), 1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0, 2), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0, -2), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0, -3), 1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 1, 1), 2);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 1, -3), 2);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 1, -2), 2);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, undefined), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 1), 0);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 1, -2), 0);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 1, -1), 1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, undefined), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0), 0);
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0, 2), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 1, -3), 2);
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 1, 1), 1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 1, -2), 0);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 0, 1]
-    //              [0, 0, 1, ...] << lengthTracking
-    //                    [1, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 1), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 1), -1);
-
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 1), 2);
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0), 0);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, undefined), -1);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
-    }
-
-    // Orig. array: [0, 0, 1, 1, 2, 2]
-    //              [0, 0, 1, 1] << fixedLength
-    //                    [1, 1] << fixedLengthWithOffset
-    //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
-    //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 1), 2);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, 2), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLength, undefined), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 1), 0);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 2), -1);
-    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, undefined), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 1), 2);
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 2), 4);
-    assert.sameValue(ArrayIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 2), 2);
-    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, Math.floor(i / 2));
   }
-}
 
-TestIndexOf();
+  // Orig. array: [0, 0, 1, 1]
+  //              [0, 0, 1, 1] << fixedLength
+  //                    [1, 1] << fixedLengthWithOffset
+  //              [0, 0, 1, 1, ...] << lengthTracking
+  //                    [1, 1, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0, 1), 1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0, 2), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0, -2), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0, -3), 1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 1, 1), 2);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 1, -3), 2);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 1, -2), 2);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, undefined), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 0);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -2), 0);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -1), 1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0), 0);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0, 2), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 1, -3), 2);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, 1), 1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -2), 0);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 0, 1]
+  //              [0, 0, 1, ...] << lengthTracking
+  //                    [1, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 1), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1), -1);
+
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 1), 2);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0), 0);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+  }
+
+  // Orig. array: [0, 0, 1, 1, 2, 2]
+  //              [0, 0, 1, 1] << fixedLength
+  //                    [1, 1] << fixedLengthWithOffset
+  //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
+  //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 1), 2);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 2), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, undefined), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 0);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 2), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 1), 2);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 2), 4);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 2), 2);
+  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+}

--- a/test/built-ins/Array/prototype/indexOf/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/indexOf/resizable-buffer.js
@@ -1,0 +1,172 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.indexof
+description: >
+  Array.p.indexOf behaves correctly when receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.indexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.indexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.indexOf.call(ta, n);
+  }
+  return Array.prototype.indexOf.call(ta, n, fromIndex);
+}
+
+function TestIndexOf() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+    }
+
+    // Orig. array: [0, 0, 1, 1]
+    //              [0, 0, 1, 1] << fixedLength
+    //                    [1, 1] << fixedLengthWithOffset
+    //              [0, 0, 1, 1, ...] << lengthTracking
+    //                    [1, 1, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0), 0);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0, 1), 1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0, 2), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0, -2), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0, -3), 1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 1, 1), 2);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 1, -3), 2);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 1, -2), 2);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 1), 0);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 1, -2), 0);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 1, -1), 1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0), 0);
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0, 2), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 1, -3), 2);
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 1, 1), 1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 1, -2), 0);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 0, 1]
+    //              [0, 0, 1, ...] << lengthTracking
+    //                    [1, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 1), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 1), -1);
+
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 1), 2);
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0), 0);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, undefined), -1);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+    }
+
+    // Orig. array: [0, 0, 1, 1, 2, 2]
+    //              [0, 0, 1, 1] << fixedLength
+    //                    [1, 1] << fixedLengthWithOffset
+    //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
+    //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 1), 2);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, 2), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 1), 0);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, 2), -1);
+    assert.sameValue(ArrayIndexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 1), 2);
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, 2), 4);
+    assert.sameValue(ArrayIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, 2), 2);
+    assert.sameValue(ArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+  }
+}
+
+TestIndexOf();

--- a/test/built-ins/Array/prototype/indexOf/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/indexOf/resizable-buffer.js
@@ -4,23 +4,16 @@
 /*---
 esid: sec-array.prototype.indexof
 description: >
-  Array.p.indexOf behaves correctly when receiver is backed by resizable
-  buffer
+  Array.p.indexOf behaves correctly on TypedArrays backed by resizable buffers.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function ArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return Array.prototype.indexOf.call(ta, BigInt(n));
-    }
-    return Array.prototype.indexOf.call(ta, BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return Array.prototype.indexOf.call(ta, n);
-  }
-  return Array.prototype.indexOf.call(ta, n, fromIndex);
+  return n;
 }
 
 for (let ctor of ctors) {
@@ -42,29 +35,33 @@ for (let ctor of ctors) {
   //              [0, 0, 1, 1, ...] << lengthTracking
   //                    [1, 1, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0, 1), 1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0, 2), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0, -2), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0, -3), 1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 1, 1), 2);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 1, -3), 2);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 1, -2), 2);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, undefined), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 0);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -2), 0);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -1), 1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0), 0);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0, 2), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 1, -3), 2);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, 1), 1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -2), 0);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  // If fixedLength is a BigInt array, they all are BigInt Arrays.
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  let n1 = MayNeedBigInt(fixedLength, 1);
+
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n0), 0);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n0, 1), 1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n0, 2), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n0, -2), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n0, -3), 1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n1, 1), 2);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n1, -3), 2);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n1, -2), 2);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, undefined), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, n1), 0);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, n1, -2), 0);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, n1, -1), 1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n0), 0);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n0, 2), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n1, -3), 2);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, undefined), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n1), 0);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n1, 1), 1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n1, -2), 0);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, undefined), -1);
 
   // Shrink so that fixed length TAs go out of bounds.
   rab.resize(3 * ctor.BYTES_PER_ELEMENT);
@@ -73,30 +70,30 @@ for (let ctor of ctors) {
   //              [0, 0, 1, ...] << lengthTracking
   //                    [1, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 1), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n1), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, n1), -1);
 
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 1), 2);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n1), 2);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, undefined), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n1), 0);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, undefined), -1);
 
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n0), -1);
 
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0), 0);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n0), 0);
 
   // Shrink to zero.
   rab.resize(0);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, undefined), -1);
 
   // Grow so that all TAs are back in-bounds.
   rab.resize(6 * ctor.BYTES_PER_ELEMENT);
@@ -110,18 +107,20 @@ for (let ctor of ctors) {
   //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
   //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 1), 2);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, 2), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLength, undefined), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 0);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 2), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 1), 2);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, 2), 4);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 2), 2);
-  assert.sameValue(ArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  let n2 = MayNeedBigInt(fixedLength, 2);
+
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n1), 2);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, n2), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLength, undefined), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, n1), 0);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, n2), -1);
+  assert.sameValue(Array.prototype.indexOf.call(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n1), 2);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, n2), 4);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTracking, undefined), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n1), 0);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, n2), 2);
+  assert.sameValue(Array.prototype.indexOf.call(lengthTrackingWithOffset, undefined), -1);
 }

--- a/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-grow.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-grow.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-%typedarray%.prototype.indexof
 description: >
-  TypedArray.p.indexOf behaves correctly when the receiver is grown during
-  argument coercion
+  TypedArray.p.indexOf behaves correctly when the backing resizable buffer is
+  grown during argument coercion.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function TypedArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return ta.indexOf(BigInt(n));
-    }
-    return ta.indexOf(BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return ta.indexOf(n);
-  }
-  return ta.indexOf(n, fromIndex);
+  return n;
 }
 
 // Growing + length-tracking TA.
@@ -36,9 +30,10 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  let n0 = MayNeedBigInt(lengthTracking, 0);
+  assert.sameValue(lengthTracking.indexOf(n0), -1);
   // The TA grew but we only look at the data until the original length.
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0, evil), -1);
+  assert.sameValue(lengthTracking.indexOf(n0, evil), -1);
 }
 
 // Growing + length-tracking TA, index conversion.
@@ -52,8 +47,9 @@ for (let ctor of ctors) {
       return -4;
     }
   };
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 1, -4), 0);
+  let n1 = MayNeedBigInt(lengthTracking, 1);
+  assert.sameValue(lengthTracking.indexOf(n1, -4), 0);
   // The TA grew but the start index conversion is done based on the original
   // length.
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 1, evil), 0);
+  assert.sameValue(lengthTracking.indexOf(n1, evil), 0);
 }

--- a/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-grow.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-grow.js
@@ -6,52 +6,11 @@ esid: sec-%typedarray%.prototype.indexof
 description: >
   TypedArray.p.indexOf behaves correctly when the receiver is grown during
   argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayIndexOfHelper(ta, n, fromIndex) {
+function TypedArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return ta.indexOf(BigInt(n));
@@ -64,42 +23,37 @@ function TypedArrayIndexOfHelper(ta, n, fromIndex) {
   return ta.indexOf(n, fromIndex);
 }
 
-function IndexOfParameterConversionGrows() {
-  // Growing + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(lengthTracking, i, 1);
+// Growing + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, 1);
+  }
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return 0;
     }
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0), -1);
-    // The TA grew but we only look at the data until the original length.
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0, evil), -1);
-  }
-
-  // Growing + length-tracking TA, index conversion.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    WriteToTypedArray(lengthTracking, 0, 1);
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return -4;
-      }
-    };
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 1, -4), 0);
-    // The TA grew but the start index conversion is done based on the original
-    // length.
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 1, evil), 0);
-  }
+  };
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  // The TA grew but we only look at the data until the original length.
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0, evil), -1);
 }
 
-IndexOfParameterConversionGrows();
-
+// Growing + length-tracking TA, index conversion.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  WriteToTypedArray(lengthTracking, 0, 1);
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return -4;
+    }
+  };
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 1, -4), 0);
+  // The TA grew but the start index conversion is done based on the original
+  // length.
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 1, evil), 0);
+}

--- a/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-grow.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-grow.js
@@ -1,0 +1,105 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.indexof
+description: >
+  TypedArray.p.indexOf behaves correctly when the receiver is grown during
+  argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.indexOf(BigInt(n));
+    }
+    return ta.indexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.indexOf(n);
+  }
+  return ta.indexOf(n, fromIndex);
+}
+
+function IndexOfParameterConversionGrows() {
+  // Growing + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, 1);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0), -1);
+    // The TA grew but we only look at the data until the original length.
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0, evil), -1);
+  }
+
+  // Growing + length-tracking TA, index conversion.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    WriteToTypedArray(lengthTracking, 0, 1);
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -4;
+      }
+    };
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 1, -4), 0);
+    // The TA grew but the start index conversion is done based on the original
+    // length.
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 1, evil), 0);
+  }
+}
+
+IndexOfParameterConversionGrows();
+

--- a/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
@@ -6,52 +6,11 @@ esid: sec-%typedarray%.prototype.indexof
 description: >
   TypedArray.p.indexOf behaves correctly when the receiver is shrunk
   during argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayIndexOfHelper(ta, n, fromIndex) {
+function TypedArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return ta.indexOf(BigInt(n));
@@ -64,52 +23,48 @@ function TypedArrayIndexOfHelper(ta, n, fromIndex) {
   return ta.indexOf(n, fromIndex);
 }
 
-function IndexOfParameterConversionShrinks() {
-  // Shrinking + fixed-length TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0), 0);
-    // The TA is OOB so indexOf returns -1.
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0, evil), -1);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0), 0);
-    // The TA is OOB so indexOf returns -1, also for undefined).
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, undefined, evil), -1);
-  }
-
-  // Shrinking + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(lengthTracking, i, i);
+// Shrinking + fixed-length TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
     }
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 0;
-      }
-    };
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 2), 2);
-    // 2 no longer found.
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 2, evil), -1);
-  }
+  };
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
+  // The TA is OOB so indexOf returns -1.
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0, evil), -1);
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
+  // The TA is OOB so indexOf returns -1, also for undefined).
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, undefined, evil), -1);
 }
 
-IndexOfParameterConversionShrinks();
+// Shrinking + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 2), 2);
+  // 2 no longer found.
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 2, evil), -1);
+}

--- a/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-%typedarray%.prototype.indexof
 description: >
-  TypedArray.p.indexOf behaves correctly when the receiver is shrunk
+  TypedArray.p.indexOf behaves correctly when receiver is shrunk
   during argument coercion
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function TypedArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return ta.indexOf(BigInt(n));
-    }
-    return ta.indexOf(BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return ta.indexOf(n);
-  }
-  return ta.indexOf(n, fromIndex);
+  return n;
 }
 
 // Shrinking + fixed-length TA.
@@ -33,9 +27,10 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  assert.sameValue(fixedLength.indexOf(n0), 0);
   // The TA is OOB so indexOf returns -1.
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0, evil), -1);
+  assert.sameValue(fixedLength.indexOf(n0, evil), -1);
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -46,9 +41,10 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  assert.sameValue(fixedLength.indexOf(n0), 0);
   // The TA is OOB so indexOf returns -1, also for undefined).
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, undefined, evil), -1);
+  assert.sameValue(fixedLength.indexOf(undefined, evil), -1);
 }
 
 // Shrinking + length-tracking TA.
@@ -64,7 +60,8 @@ for (let ctor of ctors) {
       return 0;
     }
   };
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 2), 2);
+  let n2 = MayNeedBigInt(lengthTracking, 2);
+  assert.sameValue(lengthTracking.indexOf(n2), 2);
   // 2 no longer found.
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 2, evil), -1);
+  assert.sameValue(lengthTracking.indexOf(n2, evil), -1);
 }

--- a/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-shrink.js
@@ -1,0 +1,115 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.indexof
+description: >
+  TypedArray.p.indexOf behaves correctly when the receiver is shrunk
+  during argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.indexOf(BigInt(n));
+    }
+    return ta.indexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.indexOf(n);
+  }
+  return ta.indexOf(n, fromIndex);
+}
+
+function IndexOfParameterConversionShrinks() {
+  // Shrinking + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0), 0);
+    // The TA is OOB so indexOf returns -1.
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0, evil), -1);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0), 0);
+    // The TA is OOB so indexOf returns -1, also for undefined).
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, undefined, evil), -1);
+  }
+
+  // Shrinking + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 2), 2);
+    // 2 no longer found.
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 2, evil), -1);
+  }
+}
+
+IndexOfParameterConversionShrinks();

--- a/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer-special-float-values.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer-special-float-values.js
@@ -6,21 +6,9 @@ esid: sec-%typedarray%.prototype.indexof
 description: >
   TypedArray.p.indexOf behaves correctly for special float values when
   receiver is a float TypedArray backed by a resizable buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
-
-class MyFloat32Array extends Float32Array {
-}
-
-const floatCtors = [
-  Float32Array,
-  Float64Array,
-  MyFloat32Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
 
 for (let ctor of floatCtors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);

--- a/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer-special-float-values.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer-special-float-values.js
@@ -4,8 +4,8 @@
 /*---
 esid: sec-%typedarray%.prototype.indexof
 description: >
-  TypedArray.p.indexOf behaves correctly for special float values when
-  receiver is a float TypedArray backed by a resizable buffer
+  TypedArray.p.indexOf behaves correctly for special float values on float
+  TypedArrays backed by resizable buffers.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/

--- a/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer-special-float-values.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer-special-float-values.js
@@ -1,0 +1,38 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.indexof
+description: >
+  TypedArray.p.indexOf behaves correctly for special float values when
+  receiver is a float TypedArray backed by a resizable buffer
+features: [resizable-arraybuffer, Array.prototype.includes]
+---*/
+
+class MyFloat32Array extends Float32Array {
+}
+
+const floatCtors = [
+  Float32Array,
+  Float64Array,
+  MyFloat32Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+for (let ctor of floatCtors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  lengthTracking[0] = -Infinity;
+  lengthTracking[1] = -Infinity;
+  lengthTracking[2] = Infinity;
+  lengthTracking[3] = Infinity;
+  lengthTracking[4] = NaN;
+  lengthTracking[5] = NaN;
+  assert.sameValue(lengthTracking.indexOf(-Infinity), 0);
+  assert.sameValue(lengthTracking.indexOf(Infinity), 2);
+  // NaN is never found.
+  assert.sameValue(lengthTracking.indexOf(NaN), -1);
+}

--- a/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer.js
@@ -6,52 +6,11 @@ esid: sec-%typedarray%.prototype.indexof
 description: >
   TypedArray.p.indexOf behaves correctly when receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayIndexOfHelper(ta, n, fromIndex) {
+function TypedArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return ta.indexOf(BigInt(n));
@@ -64,126 +23,122 @@ function TypedArrayIndexOfHelper(ta, n, fromIndex) {
   return ta.indexOf(n, fromIndex);
 }
 
-function TestIndexOf() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
-    }
-
-    // Orig. array: [0, 0, 1, 1]
-    //              [0, 0, 1, 1] << fixedLength
-    //                    [1, 1] << fixedLengthWithOffset
-    //              [0, 0, 1, 1, ...] << lengthTracking
-    //                    [1, 1, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0), 0);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0, 1), 1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0, 2), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0, -2), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0, -3), 1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 1, 1), 2);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 1, -3), 2);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 1, -2), 2);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, undefined), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 1), 0);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 1, -2), 0);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 1, -1), 1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, undefined), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0), 0);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0, 2), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 1, -3), 2);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 1, 1), 1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 1, -2), 0);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 0, 1]
-    //              [0, 0, 1, ...] << lengthTracking
-    //                    [1, ...] << lengthTrackingWithOffset
-
-    assert.throws(TypeError, () => {
-      TypedArrayIndexOfHelper(fixedLength, 1);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayIndexOfHelper(fixedLengthWithOffset, 1);
-    });
-
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 1), 2);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      TypedArrayIndexOfHelper(fixedLength, 0);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayIndexOfHelper(fixedLengthWithOffset, 0);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayIndexOfHelper(lengthTrackingWithOffset, 0);
-    });
-
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0), 0);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      TypedArrayIndexOfHelper(fixedLength, 0);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayIndexOfHelper(fixedLengthWithOffset, 0);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayIndexOfHelper(lengthTrackingWithOffset, 0);
-    });
-
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, undefined), -1);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
-    }
-
-    // Orig. array: [0, 0, 1, 1, 2, 2]
-    //              [0, 0, 1, 1] << fixedLength
-    //                    [1, 1] << fixedLengthWithOffset
-    //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
-    //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 1), 2);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 2), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, undefined), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 1), 0);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 2), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, undefined), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 1), 2);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 2), 4);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 2), 2);
-    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, Math.floor(i / 2));
   }
-}
 
-TestIndexOf();
+  // Orig. array: [0, 0, 1, 1]
+  //              [0, 0, 1, 1] << fixedLength
+  //                    [1, 1] << fixedLengthWithOffset
+  //              [0, 0, 1, 1, ...] << lengthTracking
+  //                    [1, 1, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0, 1), 1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0, 2), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0, -2), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0, -3), 1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 1, 1), 2);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 1, -3), 2);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 1, -2), 2);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, undefined), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 0);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -2), 0);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -1), 1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0), 0);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0, 2), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 1, -3), 2);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, 1), 1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -2), 0);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 0, 1]
+  //              [0, 0, 1, ...] << lengthTracking
+  //                    [1, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    TypedArrayIndexOfNumOrBigInt(fixedLength, 1);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1);
+  });
+
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 1), 2);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    TypedArrayIndexOfNumOrBigInt(fixedLength, 0);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0);
+  });
+
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0), 0);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    TypedArrayIndexOfNumOrBigInt(fixedLength, 0);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0);
+  });
+
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+  }
+
+  // Orig. array: [0, 0, 1, 1, 2, 2]
+  //              [0, 0, 1, 1] << fixedLength
+  //                    [1, 1] << fixedLengthWithOffset
+  //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
+  //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 1), 2);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 2), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, undefined), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 0);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 2), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 1), 2);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 2), 4);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 2), 2);
+  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+}

--- a/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-%typedarray%.prototype.indexof
 description: >
-  TypedArray.p.indexOf behaves correctly when receiver is backed by resizable
-  buffer
+  TypedArray.p.indexOf behaves correctly on TypedArrays backed by resizable
+  buffers.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function TypedArrayIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return ta.indexOf(BigInt(n));
-    }
-    return ta.indexOf(BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return ta.indexOf(n);
-  }
-  return ta.indexOf(n, fromIndex);
+  return n;
 }
 
 for (let ctor of ctors) {
@@ -42,29 +36,33 @@ for (let ctor of ctors) {
   //              [0, 0, 1, 1, ...] << lengthTracking
   //                    [1, 1, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0), 0);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0, 1), 1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0, 2), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0, -2), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 0, -3), 1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 1, 1), 2);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 1, -3), 2);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 1, -2), 2);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, undefined), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 0);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -2), 0);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -1), 1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0), 0);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0, 2), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 1, -3), 2);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, 1), 1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -2), 0);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  // If fixedLength is a BigInt array, they all are BigInt Arrays.
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  let n1 = MayNeedBigInt(fixedLength, 1);
+
+  assert.sameValue(fixedLength.indexOf(n0), 0);
+  assert.sameValue(fixedLength.indexOf(n0, 1), 1);
+  assert.sameValue(fixedLength.indexOf(n0, 2), -1);
+  assert.sameValue(fixedLength.indexOf(n0, -2), -1);
+  assert.sameValue(fixedLength.indexOf(n0, -3), 1);
+  assert.sameValue(fixedLength.indexOf(n1, 1), 2);
+  assert.sameValue(fixedLength.indexOf(n1, -3), 2);
+  assert.sameValue(fixedLength.indexOf(n1, -2), 2);
+  assert.sameValue(fixedLength.indexOf(undefined), -1);
+  assert.sameValue(fixedLengthWithOffset.indexOf(n0), -1);
+  assert.sameValue(fixedLengthWithOffset.indexOf(n1), 0);
+  assert.sameValue(fixedLengthWithOffset.indexOf(n1, -2), 0);
+  assert.sameValue(fixedLengthWithOffset.indexOf(n1, -1), 1);
+  assert.sameValue(fixedLengthWithOffset.indexOf(undefined), -1);
+  assert.sameValue(lengthTracking.indexOf(n0), 0);
+  assert.sameValue(lengthTracking.indexOf(n0, 2), -1);
+  assert.sameValue(lengthTracking.indexOf(n1, -3), 2);
+  assert.sameValue(lengthTracking.indexOf(undefined), -1);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(n0), -1);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(n1), 0);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(n1, 1), 1);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(n1, -2), 0);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(undefined), -1);
 
   // Shrink so that fixed length TAs go out of bounds.
   rab.resize(3 * ctor.BYTES_PER_ELEMENT);
@@ -74,46 +72,46 @@ for (let ctor of ctors) {
   //                    [1, ...] << lengthTrackingWithOffset
 
   assert.throws(TypeError, () => {
-    TypedArrayIndexOfNumOrBigInt(fixedLength, 1);
+    fixedLength.indexOf(n1);
   });
   assert.throws(TypeError, () => {
-    TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1);
+    fixedLengthWithOffset.indexOf(n1);
   });
 
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 1), 2);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  assert.sameValue(lengthTracking.indexOf(n1), 2);
+  assert.sameValue(lengthTracking.indexOf(undefined), -1);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(n0), -1);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(n1), 0);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(undefined), -1);
 
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
   assert.throws(TypeError, () => {
-    TypedArrayIndexOfNumOrBigInt(fixedLength, 0);
+    fixedLength.indexOf(n0);
   });
   assert.throws(TypeError, () => {
-    TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0);
+    fixedLengthWithOffset.indexOf(n0);
   });
   assert.throws(TypeError, () => {
-    TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0);
+    lengthTrackingWithOffset.indexOf(n0);
   });
 
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0), 0);
+  assert.sameValue(lengthTracking.indexOf(n0), 0);
 
   // Shrink to zero.
   rab.resize(0);
   assert.throws(TypeError, () => {
-    TypedArrayIndexOfNumOrBigInt(fixedLength, 0);
+    fixedLength.indexOf(n0);
   });
   assert.throws(TypeError, () => {
-    TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0);
+    fixedLengthWithOffset.indexOf(n0);
   });
   assert.throws(TypeError, () => {
-    TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0);
+    lengthTrackingWithOffset.indexOf(n0);
   });
 
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 0), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(lengthTracking.indexOf(n0), -1);
+  assert.sameValue(lengthTracking.indexOf(undefined), -1);
 
   // Grow so that all TAs are back in-bounds.
   rab.resize(6 * ctor.BYTES_PER_ELEMENT);
@@ -127,18 +125,20 @@ for (let ctor of ctors) {
   //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
   //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 1), 2);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, 2), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLength, undefined), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 0);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, 2), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 1), 2);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, 2), 4);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, 2), 2);
-  assert.sameValue(TypedArrayIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  let n2 = MayNeedBigInt(fixedLength, 2);
+
+  assert.sameValue(fixedLength.indexOf(n1), 2);
+  assert.sameValue(fixedLength.indexOf(n2), -1);
+  assert.sameValue(fixedLength.indexOf(undefined), -1);
+  assert.sameValue(fixedLengthWithOffset.indexOf(n0), -1);
+  assert.sameValue(fixedLengthWithOffset.indexOf(n1), 0);
+  assert.sameValue(fixedLengthWithOffset.indexOf(n2), -1);
+  assert.sameValue(fixedLengthWithOffset.indexOf(undefined), -1);
+  assert.sameValue(lengthTracking.indexOf(n1), 2);
+  assert.sameValue(lengthTracking.indexOf(n2), 4);
+  assert.sameValue(lengthTracking.indexOf(undefined), -1);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(n0), -1);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(n1), 0);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(n2), 2);
+  assert.sameValue(lengthTrackingWithOffset.indexOf(undefined), -1);
 }

--- a/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/resizable-buffer.js
@@ -1,0 +1,189 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.indexof
+description: >
+  TypedArray.p.indexOf behaves correctly when receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.indexOf(BigInt(n));
+    }
+    return ta.indexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.indexOf(n);
+  }
+  return ta.indexOf(n, fromIndex);
+}
+
+function TestIndexOf() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+    }
+
+    // Orig. array: [0, 0, 1, 1]
+    //              [0, 0, 1, 1] << fixedLength
+    //                    [1, 1] << fixedLengthWithOffset
+    //              [0, 0, 1, 1, ...] << lengthTracking
+    //                    [1, 1, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0), 0);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0, 1), 1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0, 2), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0, -2), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 0, -3), 1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 1, 1), 2);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 1, -3), 2);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 1, -2), 2);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 1), 0);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 1, -2), 0);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 1, -1), 1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0), 0);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0, 2), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 1, -3), 2);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 1, 1), 1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 1, -2), 0);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 0, 1]
+    //              [0, 0, 1, ...] << lengthTracking
+    //                    [1, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      TypedArrayIndexOfHelper(fixedLength, 1);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayIndexOfHelper(fixedLengthWithOffset, 1);
+    });
+
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 1), 2);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      TypedArrayIndexOfHelper(fixedLength, 0);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayIndexOfHelper(fixedLengthWithOffset, 0);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayIndexOfHelper(lengthTrackingWithOffset, 0);
+    });
+
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0), 0);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      TypedArrayIndexOfHelper(fixedLength, 0);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayIndexOfHelper(fixedLengthWithOffset, 0);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayIndexOfHelper(lengthTrackingWithOffset, 0);
+    });
+
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 0), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, undefined), -1);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+    }
+
+    // Orig. array: [0, 0, 1, 1, 2, 2]
+    //              [0, 0, 1, 1] << fixedLength
+    //                    [1, 1] << fixedLengthWithOffset
+    //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
+    //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 1), 2);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, 2), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 1), 0);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, 2), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 1), 2);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, 2), 4);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, 2), 2);
+    assert.sameValue(TypedArrayIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+  }
+}
+
+TestIndexOf();


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR #3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js
