### PR TITLE
RAB: Integrate staging tests for the .join method

### DIFF
--- a/test/built-ins/Array/prototype/join/coerced-separator-grow.js
+++ b/test/built-ins/Array/prototype/join/coerced-separator-grow.js
@@ -10,10 +10,6 @@ includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-const ArrayJoinHelper = (ta, ...rest) => {
-  return Array.prototype.join.call(ta, ...rest);
-};
-
 // Growing + fixed-length TA.
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -24,7 +20,7 @@ for (let ctor of ctors) {
       return '.';
     }
   };
-  assert.sameValue(ArrayJoinHelper(fixedLength, evil), '0.0.0.0');
+  assert.sameValue(Array.prototype.join.call(fixedLength, evil), '0.0.0.0');
 }
 
 // Growing + length-tracking TA.
@@ -38,5 +34,5 @@ for (let ctor of ctors) {
     }
   };
   // We iterate 4 elements, since it was the starting length.
-  assert.sameValue(ArrayJoinHelper(lengthTracking, evil), '0.0.0.0');
+  assert.sameValue(Array.prototype.join.call(lengthTracking, evil), '0.0.0.0');
 }

--- a/test/built-ins/Array/prototype/join/coerced-separator-grow.js
+++ b/test/built-ins/Array/prototype/join/coerced-separator-grow.js
@@ -1,0 +1,79 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.join
+description: >
+  Array.p.join behaves correctly when the receiver is grown during
+  argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const ArrayJoinHelper = (ta, ...rest) => {
+  return Array.prototype.join.call(ta, ...rest);
+};
+
+function JoinParameterConversionGrows() {
+  // Growing + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      toString: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    assert.sameValue(ArrayJoinHelper(fixedLength, evil), '0.0.0.0');
+  }
+
+  // Growing + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      toString: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    // We iterate 4 elements, since it was the starting length.
+    assert.sameValue(ArrayJoinHelper(lengthTracking, evil), '0.0.0.0');
+  }
+}
+
+JoinParameterConversionGrows();

--- a/test/built-ins/Array/prototype/join/coerced-separator-grow.js
+++ b/test/built-ins/Array/prototype/join/coerced-separator-grow.js
@@ -6,74 +6,37 @@ esid: sec-array.prototype.join
 description: >
   Array.p.join behaves correctly when the receiver is grown during
   argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
-
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
 
 const ArrayJoinHelper = (ta, ...rest) => {
   return Array.prototype.join.call(ta, ...rest);
 };
 
-function JoinParameterConversionGrows() {
-  // Growing + fixed-length TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      toString: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return '.';
-      }
-    };
-    assert.sameValue(ArrayJoinHelper(fixedLength, evil), '0.0.0.0');
-  }
-
-  // Growing + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    let evil = {
-      toString: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return '.';
-      }
-    };
-    // We iterate 4 elements, since it was the starting length.
-    assert.sameValue(ArrayJoinHelper(lengthTracking, evil), '0.0.0.0');
-  }
+// Growing + fixed-length TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    toString: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return '.';
+    }
+  };
+  assert.sameValue(ArrayJoinHelper(fixedLength, evil), '0.0.0.0');
 }
 
-JoinParameterConversionGrows();
+// Growing + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    toString: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return '.';
+    }
+  };
+  // We iterate 4 elements, since it was the starting length.
+  assert.sameValue(ArrayJoinHelper(lengthTracking, evil), '0.0.0.0');
+}

--- a/test/built-ins/Array/prototype/join/coerced-separator-shrink.js
+++ b/test/built-ins/Array/prototype/join/coerced-separator-shrink.js
@@ -10,10 +10,6 @@ includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-const ArrayJoinHelper = (ta, ...rest) => {
-  return Array.prototype.join.call(ta, ...rest);
-};
-
 // Shrinking + fixed-length TA.
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -27,7 +23,7 @@ for (let ctor of ctors) {
   // We iterate 4 elements, since it was the starting length, but the TA is
   // OOB right after parameter conversion, so all elements are converted to
   // the empty string.
-  assert.sameValue(ArrayJoinHelper(fixedLength, evil), '...');
+  assert.sameValue(Array.prototype.join.call(fixedLength, evil), '...');
 }
 
 // Shrinking + length-tracking TA.
@@ -42,5 +38,5 @@ for (let ctor of ctors) {
   };
   // We iterate 4 elements, since it was the starting length. Elements beyond
   // the new length are converted to the empty string.
-  assert.sameValue(ArrayJoinHelper(lengthTracking, evil), '0.0..');
+  assert.sameValue(Array.prototype.join.call(lengthTracking, evil), '0.0..');
 }

--- a/test/built-ins/Array/prototype/join/coerced-separator-shrink.js
+++ b/test/built-ins/Array/prototype/join/coerced-separator-shrink.js
@@ -1,0 +1,83 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.join
+description: >
+  Array.p.join behaves correctly when the receiver is shrunk during
+  argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const ArrayJoinHelper = (ta, ...rest) => {
+  return Array.prototype.join.call(ta, ...rest);
+};
+
+function JoinParameterConversionShrinks() {
+  // Shrinking + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      toString: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    // We iterate 4 elements, since it was the starting length, but the TA is
+    // OOB right after parameter conversion, so all elements are converted to
+    // the empty string.
+    assert.sameValue(ArrayJoinHelper(fixedLength, evil), '...');
+  }
+
+  // Shrinking + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      toString: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    // We iterate 4 elements, since it was the starting length. Elements beyond
+    // the new length are converted to the empty string.
+    assert.sameValue(ArrayJoinHelper(lengthTracking, evil), '0.0..');
+  }
+}
+
+JoinParameterConversionShrinks();

--- a/test/built-ins/Array/prototype/join/coerced-separator-shrink.js
+++ b/test/built-ins/Array/prototype/join/coerced-separator-shrink.js
@@ -6,78 +6,41 @@ esid: sec-array.prototype.join
 description: >
   Array.p.join behaves correctly when the receiver is shrunk during
   argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
-
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
 
 const ArrayJoinHelper = (ta, ...rest) => {
   return Array.prototype.join.call(ta, ...rest);
 };
 
-function JoinParameterConversionShrinks() {
-  // Shrinking + fixed-length TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      toString: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return '.';
-      }
-    };
-    // We iterate 4 elements, since it was the starting length, but the TA is
-    // OOB right after parameter conversion, so all elements are converted to
-    // the empty string.
-    assert.sameValue(ArrayJoinHelper(fixedLength, evil), '...');
-  }
-
-  // Shrinking + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    let evil = {
-      toString: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return '.';
-      }
-    };
-    // We iterate 4 elements, since it was the starting length. Elements beyond
-    // the new length are converted to the empty string.
-    assert.sameValue(ArrayJoinHelper(lengthTracking, evil), '0.0..');
-  }
+// Shrinking + fixed-length TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    toString: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return '.';
+    }
+  };
+  // We iterate 4 elements, since it was the starting length, but the TA is
+  // OOB right after parameter conversion, so all elements are converted to
+  // the empty string.
+  assert.sameValue(ArrayJoinHelper(fixedLength, evil), '...');
 }
 
-JoinParameterConversionShrinks();
+// Shrinking + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    toString: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return '.';
+    }
+  };
+  // We iterate 4 elements, since it was the starting length. Elements beyond
+  // the new length are converted to the empty string.
+  assert.sameValue(ArrayJoinHelper(lengthTracking, evil), '0.0..');
+}

--- a/test/built-ins/Array/prototype/join/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/join/resizable-buffer.js
@@ -10,10 +10,6 @@ includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-const ArrayJoinHelper = (ta, ...rest) => {
-  return Array.prototype.join.call(ta, ...rest);
-};
-
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
   const fixedLength = new ctor(rab, 0, 4);
@@ -33,10 +29,10 @@ for (let ctor of ctors) {
   //              [0, 2, 4, 6, ...] << lengthTracking
   //                    [4, 6, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(ArrayJoinHelper(fixedLength), '0,2,4,6');
-  assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '4,6');
-  assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4,6');
-  assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4,6');
+  assert.sameValue(Array.prototype.join.call(fixedLength), '0,2,4,6');
+  assert.sameValue(Array.prototype.join.call(fixedLengthWithOffset), '4,6');
+  assert.sameValue(Array.prototype.join.call(lengthTracking), '0,2,4,6');
+  assert.sameValue(Array.prototype.join.call(lengthTrackingWithOffset), '4,6');
 
   // Shrink so that fixed length TAs go out of bounds.
   rab.resize(3 * ctor.BYTES_PER_ELEMENT);
@@ -45,27 +41,27 @@ for (let ctor of ctors) {
   //              [0, 2, 4, ...] << lengthTracking
   //                    [4, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(ArrayJoinHelper(fixedLength), '');
-  assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
+  assert.sameValue(Array.prototype.join.call(fixedLength), '');
+  assert.sameValue(Array.prototype.join.call(fixedLengthWithOffset), '');
 
-  assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4');
-  assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4');
+  assert.sameValue(Array.prototype.join.call(lengthTracking), '0,2,4');
+  assert.sameValue(Array.prototype.join.call(lengthTrackingWithOffset), '4');
 
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-  assert.sameValue(ArrayJoinHelper(fixedLength), '');
-  assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
-  assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '');
+  assert.sameValue(Array.prototype.join.call(fixedLength), '');
+  assert.sameValue(Array.prototype.join.call(fixedLengthWithOffset), '');
+  assert.sameValue(Array.prototype.join.call(lengthTrackingWithOffset), '');
 
-  assert.sameValue(ArrayJoinHelper(lengthTracking), '0');
+  assert.sameValue(Array.prototype.join.call(lengthTracking), '0');
 
   // Shrink to zero.
   rab.resize(0);
-  assert.sameValue(ArrayJoinHelper(fixedLength), '');
-  assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
-  assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '');
+  assert.sameValue(Array.prototype.join.call(fixedLength), '');
+  assert.sameValue(Array.prototype.join.call(fixedLengthWithOffset), '');
+  assert.sameValue(Array.prototype.join.call(lengthTrackingWithOffset), '');
 
-  assert.sameValue(ArrayJoinHelper(lengthTracking), '');
+  assert.sameValue(Array.prototype.join.call(lengthTracking), '');
 
   // Grow so that all TAs are back in-bounds.
   rab.resize(6 * ctor.BYTES_PER_ELEMENT);
@@ -79,8 +75,8 @@ for (let ctor of ctors) {
   //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
   //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(ArrayJoinHelper(fixedLength), '0,2,4,6');
-  assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '4,6');
-  assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4,6,8,10');
-  assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4,6,8,10');
+  assert.sameValue(Array.prototype.join.call(fixedLength), '0,2,4,6');
+  assert.sameValue(Array.prototype.join.call(fixedLengthWithOffset), '4,6');
+  assert.sameValue(Array.prototype.join.call(lengthTracking), '0,2,4,6,8,10');
+  assert.sameValue(Array.prototype.join.call(lengthTrackingWithOffset), '4,6,8,10');
 }

--- a/test/built-ins/Array/prototype/join/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/join/resizable-buffer.js
@@ -6,126 +6,81 @@ esid: sec-array.prototype.join
 description: >
   Array.p.join behaves correctly when the receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
-
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
 
 const ArrayJoinHelper = (ta, ...rest) => {
   return Array.prototype.join.call(ta, ...rest);
 };
 
-function TestJoin() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    const taWrite = new ctor(rab);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
 
-    // Write some data into the array.
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayJoinHelper(fixedLength), '0,2,4,6');
-    assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '4,6');
-    assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4,6');
-    assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4,6');
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayJoinHelper(fixedLength), '');
-    assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
-
-    assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4');
-    assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4');
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.sameValue(ArrayJoinHelper(fixedLength), '');
-    assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
-    assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '');
-
-    assert.sameValue(ArrayJoinHelper(lengthTracking), '0');
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.sameValue(ArrayJoinHelper(fixedLength), '');
-    assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
-    assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '');
-
-    assert.sameValue(ArrayJoinHelper(lengthTracking), '');
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayJoinHelper(fixedLength), '0,2,4,6');
-    assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '4,6');
-    assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4,6,8,10');
-    assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4,6,8,10');
+  // Write some data into the array.
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-TestJoin();
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(ArrayJoinHelper(fixedLength), '0,2,4,6');
+  assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '4,6');
+  assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4,6');
+  assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4,6');
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(ArrayJoinHelper(fixedLength), '');
+  assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
+
+  assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4');
+  assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4');
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.sameValue(ArrayJoinHelper(fixedLength), '');
+  assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
+  assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '');
+
+  assert.sameValue(ArrayJoinHelper(lengthTracking), '0');
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.sameValue(ArrayJoinHelper(fixedLength), '');
+  assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
+  assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '');
+
+  assert.sameValue(ArrayJoinHelper(lengthTracking), '');
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(ArrayJoinHelper(fixedLength), '0,2,4,6');
+  assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '4,6');
+  assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4,6,8,10');
+  assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4,6,8,10');
+}

--- a/test/built-ins/Array/prototype/join/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/join/resizable-buffer.js
@@ -1,0 +1,131 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.join
+description: >
+  Array.p.join behaves correctly when the receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const ArrayJoinHelper = (ta, ...rest) => {
+  return Array.prototype.join.call(ta, ...rest);
+};
+
+function TestJoin() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    const taWrite = new ctor(rab);
+
+    // Write some data into the array.
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayJoinHelper(fixedLength), '0,2,4,6');
+    assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '4,6');
+    assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4,6');
+    assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4,6');
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayJoinHelper(fixedLength), '');
+    assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
+
+    assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4');
+    assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4');
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.sameValue(ArrayJoinHelper(fixedLength), '');
+    assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
+    assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '');
+
+    assert.sameValue(ArrayJoinHelper(lengthTracking), '0');
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.sameValue(ArrayJoinHelper(fixedLength), '');
+    assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '');
+    assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '');
+
+    assert.sameValue(ArrayJoinHelper(lengthTracking), '');
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayJoinHelper(fixedLength), '0,2,4,6');
+    assert.sameValue(ArrayJoinHelper(fixedLengthWithOffset), '4,6');
+    assert.sameValue(ArrayJoinHelper(lengthTracking), '0,2,4,6,8,10');
+    assert.sameValue(ArrayJoinHelper(lengthTrackingWithOffset), '4,6,8,10');
+  }
+}
+
+TestJoin();

--- a/test/built-ins/TypedArray/prototype/join/coerced-separator-grow.js
+++ b/test/built-ins/TypedArray/prototype/join/coerced-separator-grow.js
@@ -6,75 +6,33 @@ esid: sec-%typedarray%.prototype.join
 description: >
   TypedArray.p.join behaves correctly when the receiver is grown during
   argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+// Growing + fixed-length TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    toString: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return '.';
+    }
+  };
+  assert.sameValue(fixedLength.join(evil), '0.0.0.0');
 }
 
-class MyFloat32Array extends Float32Array {
+// Growing + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    toString: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return '.';
+    }
+  };
+  // We iterate 4 elements, since it was the starting length.
+  assert.sameValue(lengthTracking.join(evil), '0.0.0.0');
 }
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-const TypedArrayJoinHelper = (ta, ...rest) => {
-  return ta.join(...rest);
-};
-
-function JoinParameterConversionGrows() {
-  // Growing + fixed-length TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      toString: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return '.';
-      }
-    };
-    assert.sameValue(TypedArrayJoinHelper(fixedLength, evil), '0.0.0.0');
-  }
-
-  // Growing + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    let evil = {
-      toString: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return '.';
-      }
-    };
-    // We iterate 4 elements, since it was the starting length.
-    assert.sameValue(TypedArrayJoinHelper(lengthTracking, evil), '0.0.0.0');
-  }
-}
-
-JoinParameterConversionGrows();
-

--- a/test/built-ins/TypedArray/prototype/join/coerced-separator-grow.js
+++ b/test/built-ins/TypedArray/prototype/join/coerced-separator-grow.js
@@ -1,0 +1,80 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.join
+description: >
+  TypedArray.p.join behaves correctly when the receiver is grown during
+  argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const TypedArrayJoinHelper = (ta, ...rest) => {
+  return ta.join(...rest);
+};
+
+function JoinParameterConversionGrows() {
+  // Growing + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      toString: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    assert.sameValue(TypedArrayJoinHelper(fixedLength, evil), '0.0.0.0');
+  }
+
+  // Growing + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      toString: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    // We iterate 4 elements, since it was the starting length.
+    assert.sameValue(TypedArrayJoinHelper(lengthTracking, evil), '0.0.0.0');
+  }
+}
+
+JoinParameterConversionGrows();
+

--- a/test/built-ins/TypedArray/prototype/join/coerced-separator-shrink.js
+++ b/test/built-ins/TypedArray/prototype/join/coerced-separator-shrink.js
@@ -6,78 +6,37 @@ esid: sec-%typedarray%.prototype.join
 description: >
   TypedArray.p.join behaves correctly when the receiver is shrunk during
   argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+// Shrinking + fixed-length TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    toString: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return '.';
+    }
+  };
+  // We iterate 4 elements, since it was the starting length, but the TA is
+  // OOB right after parameter conversion, so all elements are converted to
+  // the empty string.
+  assert.sameValue(fixedLength.join(evil), '...');
 }
 
-class MyFloat32Array extends Float32Array {
+// Shrinking + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    toString: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return '.';
+    }
+  };
+  // We iterate 4 elements, since it was the starting length. Elements beyond
+  // the new length are converted to the empty string.
+  assert.sameValue(lengthTracking.join(evil), '0.0..');
 }
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-const TypedArrayJoinHelper = (ta, ...rest) => {
-  return ta.join(...rest);
-};
-
-function JoinParameterConversionShrinks() {
-  // Shrinking + fixed-length TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      toString: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return '.';
-      }
-    };
-    // We iterate 4 elements, since it was the starting length, but the TA is
-    // OOB right after parameter conversion, so all elements are converted to
-    // the empty string.
-    assert.sameValue(TypedArrayJoinHelper(fixedLength, evil), '...');
-  }
-
-  // Shrinking + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    let evil = {
-      toString: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return '.';
-      }
-    };
-    // We iterate 4 elements, since it was the starting length. Elements beyond
-    // the new length are converted to the empty string.
-    assert.sameValue(TypedArrayJoinHelper(lengthTracking, evil), '0.0..');
-  }
-}
-
-JoinParameterConversionShrinks();

--- a/test/built-ins/TypedArray/prototype/join/coerced-separator-shrink.js
+++ b/test/built-ins/TypedArray/prototype/join/coerced-separator-shrink.js
@@ -1,0 +1,83 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.join
+description: >
+  TypedArray.p.join behaves correctly when the receiver is shrunk during
+  argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const TypedArrayJoinHelper = (ta, ...rest) => {
+  return ta.join(...rest);
+};
+
+function JoinParameterConversionShrinks() {
+  // Shrinking + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      toString: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    // We iterate 4 elements, since it was the starting length, but the TA is
+    // OOB right after parameter conversion, so all elements are converted to
+    // the empty string.
+    assert.sameValue(TypedArrayJoinHelper(fixedLength, evil), '...');
+  }
+
+  // Shrinking + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      toString: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    // We iterate 4 elements, since it was the starting length. Elements beyond
+    // the new length are converted to the empty string.
+    assert.sameValue(TypedArrayJoinHelper(lengthTracking, evil), '0.0..');
+  }
+}
+
+JoinParameterConversionShrinks();

--- a/test/built-ins/TypedArray/prototype/join/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/join/resizable-buffer.js
@@ -6,142 +6,93 @@ esid: sec-%typedarray%.prototype.join
 description: >
   TypedArray.p.join behaves correctly when the receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-const TypedArrayJoinHelper = (ta, ...rest) => {
-  return ta.join(...rest);
-};
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
 
-function TestJoin() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    const taWrite = new ctor(rab);
+  assert.sameValue(fixedLength.join(), '0,2,4,6');
+  assert.sameValue(fixedLengthWithOffset.join(), '4,6');
+  assert.sameValue(lengthTracking.join(), '0,2,4,6');
+  assert.sameValue(lengthTrackingWithOffset.join(), '4,6');
 
-    // Write some data into the array.
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
 
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
 
-    assert.sameValue(TypedArrayJoinHelper(fixedLength), '0,2,4,6');
-    assert.sameValue(TypedArrayJoinHelper(fixedLengthWithOffset), '4,6');
-    assert.sameValue(TypedArrayJoinHelper(lengthTracking), '0,2,4,6');
-    assert.sameValue(TypedArrayJoinHelper(lengthTrackingWithOffset), '4,6');
+  assert.throws(TypeError, () => {
+    fixedLength.join();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.join();
+  });
 
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+  assert.sameValue(lengthTracking.join(), '0,2,4');
+  assert.sameValue(lengthTrackingWithOffset.join(), '4');
 
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.join();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.join();
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.join();
+  });
 
-    assert.throws(TypeError, () => {
-      TypedArrayJoinHelper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayJoinHelper(fixedLengthWithOffset);
-    });
+  assert.sameValue(lengthTracking.join(), '0');
 
-    assert.sameValue(TypedArrayJoinHelper(lengthTracking), '0,2,4');
-    assert.sameValue(TypedArrayJoinHelper(lengthTrackingWithOffset), '4');
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    fixedLength.join();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.join();
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.join();
+  });
 
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      TypedArrayJoinHelper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayJoinHelper(fixedLengthWithOffset);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayJoinHelper(lengthTrackingWithOffset);
-    });
+  assert.sameValue(lengthTracking.join(), '');
 
-    assert.sameValue(TypedArrayJoinHelper(lengthTracking), '0');
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      TypedArrayJoinHelper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayJoinHelper(fixedLengthWithOffset);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayJoinHelper(lengthTrackingWithOffset);
-    });
-
-    assert.sameValue(TypedArrayJoinHelper(lengthTracking), '');
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(TypedArrayJoinHelper(fixedLength), '0,2,4,6');
-    assert.sameValue(TypedArrayJoinHelper(fixedLengthWithOffset), '4,6');
-    assert.sameValue(TypedArrayJoinHelper(lengthTracking), '0,2,4,6,8,10');
-    assert.sameValue(TypedArrayJoinHelper(lengthTrackingWithOffset), '4,6,8,10');
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-TestJoin();
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(fixedLength.join(), '0,2,4,6');
+  assert.sameValue(fixedLengthWithOffset.join(), '4,6');
+  assert.sameValue(lengthTracking.join(), '0,2,4,6,8,10');
+  assert.sameValue(lengthTrackingWithOffset.join(), '4,6,8,10');
+}

--- a/test/built-ins/TypedArray/prototype/join/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/join/resizable-buffer.js
@@ -1,0 +1,147 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.join
+description: >
+  TypedArray.p.join behaves correctly when the receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayJoinHelper = (ta, ...rest) => {
+  return ta.join(...rest);
+};
+
+function TestJoin() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    const taWrite = new ctor(rab);
+
+    // Write some data into the array.
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(TypedArrayJoinHelper(fixedLength), '0,2,4,6');
+    assert.sameValue(TypedArrayJoinHelper(fixedLengthWithOffset), '4,6');
+    assert.sameValue(TypedArrayJoinHelper(lengthTracking), '0,2,4,6');
+    assert.sameValue(TypedArrayJoinHelper(lengthTrackingWithOffset), '4,6');
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      TypedArrayJoinHelper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayJoinHelper(fixedLengthWithOffset);
+    });
+
+    assert.sameValue(TypedArrayJoinHelper(lengthTracking), '0,2,4');
+    assert.sameValue(TypedArrayJoinHelper(lengthTrackingWithOffset), '4');
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      TypedArrayJoinHelper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayJoinHelper(fixedLengthWithOffset);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayJoinHelper(lengthTrackingWithOffset);
+    });
+
+    assert.sameValue(TypedArrayJoinHelper(lengthTracking), '0');
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      TypedArrayJoinHelper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayJoinHelper(fixedLengthWithOffset);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayJoinHelper(lengthTrackingWithOffset);
+    });
+
+    assert.sameValue(TypedArrayJoinHelper(lengthTracking), '');
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(TypedArrayJoinHelper(fixedLength), '0,2,4,6');
+    assert.sameValue(TypedArrayJoinHelper(fixedLengthWithOffset), '4,6');
+    assert.sameValue(TypedArrayJoinHelper(lengthTracking), '0,2,4,6,8,10');
+    assert.sameValue(TypedArrayJoinHelper(lengthTrackingWithOffset), '4,6,8,10');
+  }
+}
+
+TestJoin();


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR #3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js