### PR TITLE
RAB: Integrate staging tests for the .keys method

### DIFF
--- a/test/built-ins/Array/prototype/keys/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/keys/resizable-buffer-grow-mid-iteration.js
@@ -16,7 +16,6 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
 
-// Iterating with keys() (the 4 loops below).
 for (let ctor of ctors) {
   const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);

--- a/test/built-ins/Array/prototype/keys/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/keys/resizable-buffer-grow-mid-iteration.js
@@ -7,135 +7,55 @@ description: >
   Array.p.keys behaves correctly when receiver is backed by a resizable
   buffer and is grown mid-iteration
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+// Iterating with keys() (the 4 loops below).
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(Array.prototype.keys.call(fixedLength), [
+    0,
+    1,
+    2,
+    3
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-class MyFloat32Array extends Float32Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(Array.prototype.keys.call(fixedLengthWithOffset), [
+    0,
+    1
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(Array.prototype.keys.call(lengthTracking), [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  TestIterationAndResize(Array.prototype.keys.call(lengthTrackingWithOffset), [
+    0,
+    1,
+    2,
+    3
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayKeysHelper(ta) {
-  return Array.prototype.keys.call(ta);
-}
-
-function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
-  let values = [];
-  let resized = false;
-  for (const value of ta) {
-    if (value instanceof Array) {
-      values.push([
-        value[0],
-        Number(value[1])
-      ]);
-    } else {
-      values.push(Number(value));
-    }
-    if (!resized && values.length == resize_after) {
-      rab.resize(new_byte_length);
-      resized = true;
-    }
-  }
-  assert.compareArray(values.flat(), expected.flat());
-  assert(resized);
-}
-
-function KeysGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-
-  // Iterating with keys() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(ArrayKeysHelper(fixedLength), [
-      0,
-      1,
-      2,
-      3
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(ArrayKeysHelper(fixedLengthWithOffset), [
-      0,
-      1
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(ArrayKeysHelper(lengthTracking), [
-      0,
-      1,
-      2,
-      3,
-      4,
-      5
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    TestIterationAndResize(ArrayKeysHelper(lengthTrackingWithOffset), [
-      0,
-      1,
-      2,
-      3
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-}
-
-KeysGrowMidIteration();

--- a/test/built-ins/Array/prototype/keys/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/keys/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,141 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.keys
+description: >
+  Array.p.keys behaves correctly when receiver is backed by a resizable
+  buffer and is grown mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayKeysHelper(ta) {
+  return Array.prototype.keys.call(ta);
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values.flat(), expected.flat());
+  assert(resized);
+}
+
+function KeysGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+
+  // Iterating with keys() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(ArrayKeysHelper(fixedLength), [
+      0,
+      1,
+      2,
+      3
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(ArrayKeysHelper(fixedLengthWithOffset), [
+      0,
+      1
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(ArrayKeysHelper(lengthTracking), [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(ArrayKeysHelper(lengthTrackingWithOffset), [
+      0,
+      1,
+      2,
+      3
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+KeysGrowMidIteration();

--- a/test/built-ins/Array/prototype/keys/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/keys/resizable-buffer-shrink-mid-iteration.js
@@ -15,7 +15,7 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 //                    [4, 6] << fixedLengthWithOffset
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
-// Iterating with keys() (the 4 loops below).
+
 for (let ctor of ctors) {
   const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);

--- a/test/built-ins/Array/prototype/keys/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/keys/resizable-buffer-shrink-mid-iteration.js
@@ -7,127 +7,47 @@ description: >
   Array.p.keys behaves correctly when receiver is backed by resizable
   buffer that is shrunk mid-iteration
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+// Iterating with keys() (the 4 loops below).
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+
+  // The fixed length array goes out of bounds when the RAB is resized.
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(Array.prototype.keys.call(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  });
 }
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
 
-class MyFloat32Array extends Float32Array {
+  // The fixed length array goes out of bounds when the RAB is resized.
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(Array.prototype.keys.call(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  });
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(Array.prototype.keys.call(lengthTracking), [
+    0,
+    1,
+    2
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  TestIterationAndResize(Array.prototype.keys.call(lengthTrackingWithOffset), [
+    0,
+    1
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayKeysHelper(ta) {
-  return Array.prototype.keys.call(ta);
-}
-
-function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
-  let values = [];
-  let resized = false;
-  for (const value of ta) {
-    if (value instanceof Array) {
-      values.push([
-        value[0],
-        Number(value[1])
-      ]);
-    } else {
-      values.push(Number(value));
-    }
-    if (!resized && values.length == resize_after) {
-      rab.resize(new_byte_length);
-      resized = true;
-    }
-  }
-  assert.compareArray(values.flat(), expected.flat());
-  assert(resized);
-}
-
-function KeysShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-
-  // Iterating with keys() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-
-    // The fixed length array goes out of bounds when the RAB is resized.
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(ArrayKeysHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-
-    // The fixed length array goes out of bounds when the RAB is resized.
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(ArrayKeysHelper(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(ArrayKeysHelper(lengthTracking), [
-      0,
-      1,
-      2
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    TestIterationAndResize(ArrayKeysHelper(lengthTrackingWithOffset), [
-      0,
-      1
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
-}
-
-KeysShrinkMidIteration();

--- a/test/built-ins/Array/prototype/keys/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/keys/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,133 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.keys
+description: >
+  Array.p.keys behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayKeysHelper(ta) {
+  return Array.prototype.keys.call(ta);
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values.flat(), expected.flat());
+  assert(resized);
+}
+
+function KeysShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+
+  // Iterating with keys() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(ArrayKeysHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(ArrayKeysHelper(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(ArrayKeysHelper(lengthTracking), [
+      0,
+      1,
+      2
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(ArrayKeysHelper(lengthTrackingWithOffset), [
+      0,
+      1
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+KeysShrinkMidIteration();

--- a/test/built-ins/Array/prototype/keys/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/keys/resizable-buffer.js
@@ -6,187 +6,137 @@ esid: sec-array.prototype.keys
 description: >
   Array.p.keys behaves correctly when receiver is backed by resizable
   buffer
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-function ArrayKeysHelper(ta) {
-  return Array.prototype.keys.call(ta);
-}
+  assert.compareArray(Array.from(Array.prototype.keys.call(fixedLength)), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(Array.from(Array.prototype.keys.call(fixedLengthWithOffset)), [
+    0,
+    1
+  ]);
+  assert.compareArray(Array.from(Array.prototype.keys.call(lengthTracking)), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(Array.from(Array.prototype.keys.call(lengthTrackingWithOffset)), [
+    0,
+    1
+  ]);
 
-function TestKeys() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
 
-    assert.compareArray(Array.from(ArrayKeysHelper(fixedLength)), [
-      0,
-      1,
-      2,
-      3
-    ]);
-    assert.compareArray(Array.from(ArrayKeysHelper(fixedLengthWithOffset)), [
-      0,
-      1
-    ]);
-    assert.compareArray(Array.from(ArrayKeysHelper(lengthTracking)), [
-      0,
-      1,
-      2,
-      3
-    ]);
-    assert.compareArray(Array.from(ArrayKeysHelper(lengthTrackingWithOffset)), [
-      0,
-      1
-    ]);
+  // TypedArray.prototype.{entries, keys, values} throw right away when
+  // called. Array.prototype.{entries, keys, values} don't throw, but when
+  // we try to iterate the returned ArrayIterator, that throws.
+  Array.prototype.keys.call(fixedLength);
+  Array.prototype.keys.call(fixedLengthWithOffset);
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.keys.call(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.keys.call(fixedLengthWithOffset));
+  });
+  assert.compareArray(Array.from(Array.prototype.keys.call(lengthTracking)), [
+    0,
+    1,
+    2
+  ]);
+  assert.compareArray(Array.from(Array.prototype.keys.call(lengthTrackingWithOffset)), [0]);
 
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  Array.prototype.keys.call(fixedLength);
+  Array.prototype.keys.call(fixedLengthWithOffset);
+  Array.prototype.keys.call(lengthTrackingWithOffset);
 
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.keys.call(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.keys.call(fixedLengthWithOffset));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.keys.call(lengthTrackingWithOffset));
+  });
+  assert.compareArray(Array.from(Array.prototype.keys.call(lengthTracking)), [0]);
 
-    // TypedArray.prototype.{entries, keys, values} throw right away when
-    // called. Array.prototype.{entries, keys, values} don't throw, but when
-    // we try to iterate the returned ArrayIterator, that throws.
-    ArrayKeysHelper(fixedLength);
-    ArrayKeysHelper(fixedLengthWithOffset);
-    assert.throws(TypeError, () => {
-      Array.from(ArrayKeysHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayKeysHelper(fixedLengthWithOffset));
-    });
-    assert.compareArray(Array.from(ArrayKeysHelper(lengthTracking)), [
-      0,
-      1,
-      2
-    ]);
-    assert.compareArray(Array.from(ArrayKeysHelper(lengthTrackingWithOffset)), [0]);
+  // Shrink to zero.
+  rab.resize(0);
+  Array.prototype.keys.call(fixedLength);
+  Array.prototype.keys.call(fixedLengthWithOffset);
+  Array.prototype.keys.call(lengthTrackingWithOffset);
 
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    ArrayKeysHelper(fixedLength);
-    ArrayKeysHelper(fixedLengthWithOffset);
-    ArrayKeysHelper(lengthTrackingWithOffset);
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.keys.call(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.keys.call(fixedLengthWithOffset));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.keys.call(lengthTrackingWithOffset));
+  });
+  assert.compareArray(Array.from(Array.prototype.keys.call(lengthTracking)), []);
 
-    assert.throws(TypeError, () => {
-      Array.from(ArrayKeysHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayKeysHelper(fixedLengthWithOffset));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayKeysHelper(lengthTrackingWithOffset));
-    });
-    assert.compareArray(Array.from(ArrayKeysHelper(lengthTracking)), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    ArrayKeysHelper(fixedLength);
-    ArrayKeysHelper(fixedLengthWithOffset);
-    ArrayKeysHelper(lengthTrackingWithOffset);
-
-    assert.throws(TypeError, () => {
-      Array.from(ArrayKeysHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayKeysHelper(fixedLengthWithOffset));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayKeysHelper(lengthTrackingWithOffset));
-    });
-    assert.compareArray(Array.from(ArrayKeysHelper(lengthTracking)), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(Array.from(ArrayKeysHelper(fixedLength)), [
-      0,
-      1,
-      2,
-      3
-    ]);
-    assert.compareArray(Array.from(ArrayKeysHelper(fixedLengthWithOffset)), [
-      0,
-      1
-    ]);
-    assert.compareArray(Array.from(ArrayKeysHelper(lengthTracking)), [
-      0,
-      1,
-      2,
-      3,
-      4,
-      5
-    ]);
-    assert.compareArray(Array.from(ArrayKeysHelper(lengthTrackingWithOffset)), [
-      0,
-      1,
-      2,
-      3
-    ]);
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-TestKeys();
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(Array.from(Array.prototype.keys.call(fixedLength)), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(Array.from(Array.prototype.keys.call(fixedLengthWithOffset)), [
+    0,
+    1
+  ]);
+  assert.compareArray(Array.from(Array.prototype.keys.call(lengthTracking)), [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5
+  ]);
+  assert.compareArray(Array.from(Array.prototype.keys.call(lengthTrackingWithOffset)), [
+    0,
+    1,
+    2,
+    3
+  ]);
+}

--- a/test/built-ins/Array/prototype/keys/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/keys/resizable-buffer.js
@@ -1,0 +1,192 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.keys
+description: >
+  Array.p.keys behaves correctly when receiver is backed by resizable
+  buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayKeysHelper(ta) {
+  return Array.prototype.keys.call(ta);
+}
+
+function TestKeys() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    assert.compareArray(Array.from(ArrayKeysHelper(fixedLength)), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.compareArray(Array.from(ArrayKeysHelper(fixedLengthWithOffset)), [
+      0,
+      1
+    ]);
+    assert.compareArray(Array.from(ArrayKeysHelper(lengthTracking)), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.compareArray(Array.from(ArrayKeysHelper(lengthTrackingWithOffset)), [
+      0,
+      1
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    // TypedArray.prototype.{entries, keys, values} throw right away when
+    // called. Array.prototype.{entries, keys, values} don't throw, but when
+    // we try to iterate the returned ArrayIterator, that throws.
+    ArrayKeysHelper(fixedLength);
+    ArrayKeysHelper(fixedLengthWithOffset);
+    assert.throws(TypeError, () => {
+      Array.from(ArrayKeysHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayKeysHelper(fixedLengthWithOffset));
+    });
+    assert.compareArray(Array.from(ArrayKeysHelper(lengthTracking)), [
+      0,
+      1,
+      2
+    ]);
+    assert.compareArray(Array.from(ArrayKeysHelper(lengthTrackingWithOffset)), [0]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    ArrayKeysHelper(fixedLength);
+    ArrayKeysHelper(fixedLengthWithOffset);
+    ArrayKeysHelper(lengthTrackingWithOffset);
+
+    assert.throws(TypeError, () => {
+      Array.from(ArrayKeysHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayKeysHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayKeysHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(Array.from(ArrayKeysHelper(lengthTracking)), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    ArrayKeysHelper(fixedLength);
+    ArrayKeysHelper(fixedLengthWithOffset);
+    ArrayKeysHelper(lengthTrackingWithOffset);
+
+    assert.throws(TypeError, () => {
+      Array.from(ArrayKeysHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayKeysHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayKeysHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(Array.from(ArrayKeysHelper(lengthTracking)), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Array.from(ArrayKeysHelper(fixedLength)), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.compareArray(Array.from(ArrayKeysHelper(fixedLengthWithOffset)), [
+      0,
+      1
+    ]);
+    assert.compareArray(Array.from(ArrayKeysHelper(lengthTracking)), [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ]);
+    assert.compareArray(Array.from(ArrayKeysHelper(lengthTrackingWithOffset)), [
+      0,
+      1,
+      2,
+      3
+    ]);
+  }
+}
+
+TestKeys();

--- a/test/built-ins/TypedArray/prototype/keys/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/keys/resizable-buffer-grow-mid-iteration.js
@@ -7,133 +7,55 @@ description: >
   TypedArray.p.keys behaves correctly when receiver is backed by a resizable
   buffer and is grown mid-iteration
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+// Iterating with keys() (the 4 loops below).
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(fixedLength.keys(), [
+    0,
+    1,
+    2,
+    3
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-class MyFloat32Array extends Float32Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(fixedLengthWithOffset.keys(), [
+    0,
+    1
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(lengthTracking.keys(), [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  TestIterationAndResize(lengthTrackingWithOffset.keys(), [
+    0,
+    1,
+    2,
+    3
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-
-function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
-  let values = [];
-  let resized = false;
-  for (const value of ta) {
-    if (value instanceof Array) {
-      values.push([
-        value[0],
-        Number(value[1])
-      ]);
-    } else {
-      values.push(Number(value));
-    }
-    if (!resized && values.length == resize_after) {
-      rab.resize(new_byte_length);
-      resized = true;
-    }
-  }
-  assert.compareArray(values.flat(), expected.flat());
-  assert(resized);
-}
-
-function KeysGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-
-  // Iterating with keys() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(fixedLength.keys(), [
-      0,
-      1,
-      2,
-      3
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(fixedLengthWithOffset.keys(), [
-      0,
-      1
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(lengthTracking.keys(), [
-      0,
-      1,
-      2,
-      3,
-      4,
-      5
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    TestIterationAndResize(lengthTrackingWithOffset.keys(), [
-      0,
-      1,
-      2,
-      3
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-}
-
-KeysGrowMidIteration();
-

--- a/test/built-ins/TypedArray/prototype/keys/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/keys/resizable-buffer-grow-mid-iteration.js
@@ -16,7 +16,6 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
 
-// Iterating with keys() (the 4 loops below).
 for (let ctor of ctors) {
   const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);

--- a/test/built-ins/TypedArray/prototype/keys/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/keys/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,139 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.keys
+description: >
+  TypedArray.p.keys behaves correctly when receiver is backed by a resizable
+  buffer and is grown mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values.flat(), expected.flat());
+  assert(resized);
+}
+
+function KeysGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+
+  // Iterating with keys() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(fixedLength.keys(), [
+      0,
+      1,
+      2,
+      3
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(fixedLengthWithOffset.keys(), [
+      0,
+      1
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(lengthTracking.keys(), [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(lengthTrackingWithOffset.keys(), [
+      0,
+      1,
+      2,
+      3
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+KeysGrowMidIteration();
+

--- a/test/built-ins/TypedArray/prototype/keys/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/keys/resizable-buffer-shrink-mid-iteration.js
@@ -15,7 +15,7 @@ includes: [compareArray.js, resizableArrayBufferUtils.js]
 //                    [4, 6] << fixedLengthWithOffset
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
-// Iterating with keys() (the 4 loops below).
+
 for (let ctor of ctors) {
   const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);

--- a/test/built-ins/TypedArray/prototype/keys/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/keys/resizable-buffer-shrink-mid-iteration.js
@@ -7,127 +7,47 @@ description: >
   TypedArray.p.keys behaves correctly when receiver is backed by resizable
   buffer that is shrunk mid-iteration
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+// Iterating with keys() (the 4 loops below).
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+
+  // The fixed length array goes out of bounds when the RAB is resized.
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(fixedLength.keys(), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  });
 }
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
 
-class MyFloat32Array extends Float32Array {
+  // The fixed length array goes out of bounds when the RAB is resized.
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(fixedLengthWithOffset.keys(), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  });
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(lengthTracking.keys(), [
+    0,
+    1,
+    2
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  TestIterationAndResize(lengthTrackingWithOffset.keys(), [
+    0,
+    1
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayKeysHelper(ta) {
-  return ta.keys();
-}
-
-function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
-  let values = [];
-  let resized = false;
-  for (const value of ta) {
-    if (value instanceof Array) {
-      values.push([
-        value[0],
-        Number(value[1])
-      ]);
-    } else {
-      values.push(Number(value));
-    }
-    if (!resized && values.length == resize_after) {
-      rab.resize(new_byte_length);
-      resized = true;
-    }
-  }
-  assert.compareArray(values.flat(), expected.flat());
-  assert(resized);
-}
-
-function KeysShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-
-  // Iterating with keys() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-
-    // The fixed length array goes out of bounds when the RAB is resized.
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(TypedArrayKeysHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-
-    // The fixed length array goes out of bounds when the RAB is resized.
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(TypedArrayKeysHelper(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(TypedArrayKeysHelper(lengthTracking), [
-      0,
-      1,
-      2
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    TestIterationAndResize(TypedArrayKeysHelper(lengthTrackingWithOffset), [
-      0,
-      1
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
-}
-
-KeysShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/keys/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/keys/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,133 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.keys
+description: >
+  TypedArray.p.keys behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayKeysHelper(ta) {
+  return ta.keys();
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values.flat(), expected.flat());
+  assert(resized);
+}
+
+function KeysShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+
+  // Iterating with keys() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(TypedArrayKeysHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(TypedArrayKeysHelper(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(TypedArrayKeysHelper(lengthTracking), [
+      0,
+      1,
+      2
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(TypedArrayKeysHelper(lengthTrackingWithOffset), [
+      0,
+      1
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+KeysShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/keys/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/keys/resizable-buffer.js
@@ -6,210 +6,160 @@ esid: sec-%typedarray%.prototype.keys
 description: >
   TypedArray.p.keys behaves correctly when receiver is backed by resizable
   buffer
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-function TypedArrayKeysHelper(ta) {
-  return ta.keys();
-}
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
 
-function TestKeys() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  assert.compareArray(Array.from(fixedLength.keys()), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(Array.from(fixedLengthWithOffset.keys()), [
+    0,
+    1
+  ]);
+  assert.compareArray(Array.from(lengthTracking.keys()), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(Array.from(lengthTrackingWithOffset.keys()), [
+    0,
+    1
+  ]);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
 
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
 
-    assert.compareArray(Array.from(fixedLength.keys()), [
-      0,
-      1,
-      2,
-      3
-    ]);
-    assert.compareArray(Array.from(fixedLengthWithOffset.keys()), [
-      0,
-      1
-    ]);
-    assert.compareArray(Array.from(lengthTracking.keys()), [
-      0,
-      1,
-      2,
-      3
-    ]);
-    assert.compareArray(Array.from(lengthTrackingWithOffset.keys()), [
-      0,
-      1
-    ]);
+  // TypedArray.prototype.{entries, keys, values} throw right away when
+  // called. Array.prototype.{entries, keys, values} don't throw, but when
+  // we try to iterate the returned ArrayIterator, that throws.
+  assert.throws(TypeError, () => {
+    fixedLength.keys();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.keys();
+  });
 
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    Array.from(fixedLength.keys());
+  });
+  assert.throws(TypeError, () => {
+    Array.from(fixedLengthWithOffset.keys());
+  });
+  assert.compareArray(Array.from(lengthTracking.keys()), [
+    0,
+    1,
+    2
+  ]);
+  assert.compareArray(Array.from(lengthTrackingWithOffset.keys()), [0]);
 
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.keys();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.keys();
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.keys();
+  });
 
-    // TypedArray.prototype.{entries, keys, values} throw right away when
-    // called. Array.prototype.{entries, keys, values} don't throw, but when
-    // we try to iterate the returned ArrayIterator, that throws.
-    assert.throws(TypeError, () => {
-      fixedLength.keys();
-    });
-    assert.throws(TypeError, () => {
-      fixedLengthWithOffset.keys();
-    });
+  assert.throws(TypeError, () => {
+    Array.from(fixedLength.keys());
+  });
+  assert.throws(TypeError, () => {
+    Array.from(fixedLengthWithOffset.keys());
+  });
+  assert.throws(TypeError, () => {
+    Array.from(lengthTrackingWithOffset.keys());
+  });
+  assert.compareArray(Array.from(lengthTracking.keys()), [0]);
 
-    assert.throws(TypeError, () => {
-      Array.from(fixedLength.keys());
-    });
-    assert.throws(TypeError, () => {
-      Array.from(fixedLengthWithOffset.keys());
-    });
-    assert.compareArray(Array.from(lengthTracking.keys()), [
-      0,
-      1,
-      2
-    ]);
-    assert.compareArray(Array.from(lengthTrackingWithOffset.keys()), [0]);
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    fixedLength.keys();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.keys();
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.keys();
+  });
 
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      fixedLength.keys();
-    });
-    assert.throws(TypeError, () => {
-      fixedLengthWithOffset.keys();
-    });
-    assert.throws(TypeError, () => {
-      lengthTrackingWithOffset.keys();
-    });
+  assert.throws(TypeError, () => {
+    Array.from(fixedLength.keys());
+  });
+  assert.throws(TypeError, () => {
+    Array.from(fixedLengthWithOffset.keys());
+  });
+  assert.throws(TypeError, () => {
+    Array.from(lengthTrackingWithOffset.keys());
+  });
+  assert.compareArray(Array.from(lengthTracking.keys()), []);
 
-    assert.throws(TypeError, () => {
-      Array.from(fixedLength.keys());
-    });
-    assert.throws(TypeError, () => {
-      Array.from(fixedLengthWithOffset.keys());
-    });
-    assert.throws(TypeError, () => {
-      Array.from(lengthTrackingWithOffset.keys());
-    });
-    assert.compareArray(Array.from(lengthTracking.keys()), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      fixedLength.keys();
-    });
-    assert.throws(TypeError, () => {
-      fixedLengthWithOffset.keys();
-    });
-    assert.throws(TypeError, () => {
-      lengthTrackingWithOffset.keys();
-    });
-
-    assert.throws(TypeError, () => {
-      Array.from(fixedLength.keys());
-    });
-    assert.throws(TypeError, () => {
-      Array.from(fixedLengthWithOffset.keys());
-    });
-    assert.throws(TypeError, () => {
-      Array.from(lengthTrackingWithOffset.keys());
-    });
-    assert.compareArray(Array.from(lengthTracking.keys()), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(Array.from(fixedLength.keys()), [
-      0,
-      1,
-      2,
-      3
-    ]);
-    assert.compareArray(Array.from(fixedLengthWithOffset.keys()), [
-      0,
-      1
-    ]);
-    assert.compareArray(Array.from(lengthTracking.keys()), [
-      0,
-      1,
-      2,
-      3,
-      4,
-      5
-    ]);
-    assert.compareArray(Array.from(lengthTrackingWithOffset.keys()), [
-      0,
-      1,
-      2,
-      3
-    ]);
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-TestKeys();
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(Array.from(fixedLength.keys()), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(Array.from(fixedLengthWithOffset.keys()), [
+    0,
+    1
+  ]);
+  assert.compareArray(Array.from(lengthTracking.keys()), [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5
+  ]);
+  assert.compareArray(Array.from(lengthTrackingWithOffset.keys()), [
+    0,
+    1,
+    2,
+    3
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/keys/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/keys/resizable-buffer.js
@@ -1,0 +1,215 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.keys
+description: >
+  TypedArray.p.keys behaves correctly when receiver is backed by resizable
+  buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayKeysHelper(ta) {
+  return ta.keys();
+}
+
+function TestKeys() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Array.from(fixedLength.keys()), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.compareArray(Array.from(fixedLengthWithOffset.keys()), [
+      0,
+      1
+    ]);
+    assert.compareArray(Array.from(lengthTracking.keys()), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.compareArray(Array.from(lengthTrackingWithOffset.keys()), [
+      0,
+      1
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    // TypedArray.prototype.{entries, keys, values} throw right away when
+    // called. Array.prototype.{entries, keys, values} don't throw, but when
+    // we try to iterate the returned ArrayIterator, that throws.
+    assert.throws(TypeError, () => {
+      fixedLength.keys();
+    });
+    assert.throws(TypeError, () => {
+      fixedLengthWithOffset.keys();
+    });
+
+    assert.throws(TypeError, () => {
+      Array.from(fixedLength.keys());
+    });
+    assert.throws(TypeError, () => {
+      Array.from(fixedLengthWithOffset.keys());
+    });
+    assert.compareArray(Array.from(lengthTracking.keys()), [
+      0,
+      1,
+      2
+    ]);
+    assert.compareArray(Array.from(lengthTrackingWithOffset.keys()), [0]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      fixedLength.keys();
+    });
+    assert.throws(TypeError, () => {
+      fixedLengthWithOffset.keys();
+    });
+    assert.throws(TypeError, () => {
+      lengthTrackingWithOffset.keys();
+    });
+
+    assert.throws(TypeError, () => {
+      Array.from(fixedLength.keys());
+    });
+    assert.throws(TypeError, () => {
+      Array.from(fixedLengthWithOffset.keys());
+    });
+    assert.throws(TypeError, () => {
+      Array.from(lengthTrackingWithOffset.keys());
+    });
+    assert.compareArray(Array.from(lengthTracking.keys()), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      fixedLength.keys();
+    });
+    assert.throws(TypeError, () => {
+      fixedLengthWithOffset.keys();
+    });
+    assert.throws(TypeError, () => {
+      lengthTrackingWithOffset.keys();
+    });
+
+    assert.throws(TypeError, () => {
+      Array.from(fixedLength.keys());
+    });
+    assert.throws(TypeError, () => {
+      Array.from(fixedLengthWithOffset.keys());
+    });
+    assert.throws(TypeError, () => {
+      Array.from(lengthTrackingWithOffset.keys());
+    });
+    assert.compareArray(Array.from(lengthTracking.keys()), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Array.from(fixedLength.keys()), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.compareArray(Array.from(fixedLengthWithOffset.keys()), [
+      0,
+      1
+    ]);
+    assert.compareArray(Array.from(lengthTracking.keys()), [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ]);
+    assert.compareArray(Array.from(lengthTrackingWithOffset.keys()), [
+      0,
+      1,
+      2,
+      3
+    ]);
+  }
+}
+
+TestKeys();

--- a/test/built-ins/TypedArray/prototype/keys/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/keys/resizable-buffer.js
@@ -67,12 +67,6 @@ for (let ctor of ctors) {
     fixedLengthWithOffset.keys();
   });
 
-  assert.throws(TypeError, () => {
-    Array.from(fixedLength.keys());
-  });
-  assert.throws(TypeError, () => {
-    Array.from(fixedLengthWithOffset.keys());
-  });
   assert.compareArray(Array.from(lengthTracking.keys()), [
     0,
     1,
@@ -92,15 +86,6 @@ for (let ctor of ctors) {
     lengthTrackingWithOffset.keys();
   });
 
-  assert.throws(TypeError, () => {
-    Array.from(fixedLength.keys());
-  });
-  assert.throws(TypeError, () => {
-    Array.from(fixedLengthWithOffset.keys());
-  });
-  assert.throws(TypeError, () => {
-    Array.from(lengthTrackingWithOffset.keys());
-  });
   assert.compareArray(Array.from(lengthTracking.keys()), [0]);
 
   // Shrink to zero.
@@ -115,15 +100,6 @@ for (let ctor of ctors) {
     lengthTrackingWithOffset.keys();
   });
 
-  assert.throws(TypeError, () => {
-    Array.from(fixedLength.keys());
-  });
-  assert.throws(TypeError, () => {
-    Array.from(fixedLengthWithOffset.keys());
-  });
-  assert.throws(TypeError, () => {
-    Array.from(lengthTrackingWithOffset.keys());
-  });
   assert.compareArray(Array.from(lengthTracking.keys()), []);
 
   // Grow so that all TAs are back in-bounds.


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR #3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js