### PR TITLE
RAB: Adds missing Array.prototype.filter 'shrink' tests plus typesetting

### DIFF
--- a/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   // Returns true by default.
   return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(Array.prototype.every.call(fixedLength, ResizeBufferMidIteration));
+  assert(Array.prototype.every.call(fixedLength, ResizeMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(Array.prototype.every.call(fixedLengthWithOffset, ResizeBufferMidIteration));
+  assert(Array.prototype.every.call(fixedLengthWithOffset, ResizeMidIteration));
   assert.compareArray(values, [
     4,
     6
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(Array.prototype.every.call(lengthTracking, ResizeBufferMidIteration));
+  assert(Array.prototype.every.call(lengthTracking, ResizeMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(Array.prototype.every.call(lengthTrackingWithOffset, ResizeBufferMidIteration));
+  assert(Array.prototype.every.call(lengthTrackingWithOffset, ResizeMidIteration));
   assert.compareArray(values, [
     4,
     6

--- a/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   // Returns true by default.
   return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(Array.prototype.every.call(fixedLength, ResizeBufferMidIteration));
+  assert(Array.prototype.every.call(fixedLength, ResizeMidIteration));
   assert.compareArray(values, [
     0,
     2
@@ -47,7 +47,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(Array.prototype.every.call(fixedLengthWithOffset, ResizeBufferMidIteration));
+  assert(Array.prototype.every.call(fixedLengthWithOffset, ResizeMidIteration));
   assert.compareArray(values, [4]);
 }
 for (let ctor of ctors) {
@@ -56,7 +56,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(Array.prototype.every.call(lengthTracking, ResizeBufferMidIteration));
+  assert(Array.prototype.every.call(lengthTracking, ResizeMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -69,6 +69,6 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(Array.prototype.every.call(lengthTrackingWithOffset, ResizeBufferMidIteration));
+  assert(Array.prototype.every.call(lengthTrackingWithOffset, ResizeMidIteration));
   assert.compareArray(values, [4]);
 }

--- a/test/built-ins/Array/prototype/filter/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/filter/resizable-buffer-grow-mid-iteration.js
@@ -4,8 +4,8 @@
 /*---
 esid: sec-array.prototype.filter
 description: >
-  Array.p.filter behaves correctly on receivers backed by resizable
-  buffers that grow mid-iteration
+  Array.p.filter behaves correctly on TypedArrays backed by resizable buffers
+  that grow mid-iteration.
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -36,7 +36,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLength, ResizeBufferMidIteration)), []);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLength, ResizeMidIteration)), []);
   assert.compareArray(values, [
     0,
     2,
@@ -50,7 +50,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLengthWithOffset, ResizeBufferMidIteration)), []);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLengthWithOffset, ResizeMidIteration)), []);
   assert.compareArray(values, [
     4,
     6
@@ -62,7 +62,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTracking, ResizeBufferMidIteration)), []);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTracking, ResizeMidIteration)), []);
   assert.compareArray(values, [
     0,
     2,
@@ -76,10 +76,9 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTrackingWithOffset, ResizeBufferMidIteration)), []);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTrackingWithOffset, ResizeMidIteration)), []);
   assert.compareArray(values, [
     4,
     6
   ]);
 }
-

--- a/test/built-ins/Array/prototype/filter/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/filter/resizable-buffer-shrink-mid-iteration.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-%typedarray%.prototype.filter
+esid: sec-%array%.prototype.filter
 description: >
-  TypedArray.p.filter behaves correctly on TypedArrays backed by resizable
-  buffers that are shrunk mid-iteration.
+  Array.p.filter behaves correctly on TypedArrays backed by resizable buffers
+  that shrink mid-iteration.
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
@@ -36,12 +36,10 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(fixedLength.filter(ResizeMidIteration)),[]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLength, ResizeMidIteration)),[]);
   assert.compareArray(values, [
     0,
-    2,
-    undefined,
-    undefined
+    2
   ]);
 }
 for (let ctor of ctors) {
@@ -50,10 +48,9 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(fixedLengthWithOffset.filter(ResizeMidIteration)),[]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(fixedLengthWithOffset, ResizeMidIteration)),[]);
   assert.compareArray(values, [
-    4,
-    undefined
+    4
   ]);
 }
 for (let ctor of ctors) {
@@ -62,12 +59,11 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(lengthTracking.filter(ResizeMidIteration)),[]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTracking, ResizeMidIteration)),[]);
   assert.compareArray(values, [
     0,
     2,
-    4,
-    undefined
+    4
   ]);
 }
 for (let ctor of ctors) {
@@ -76,9 +72,8 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(lengthTrackingWithOffset.filter(ResizeMidIteration)),[]);
+  assert.compareArray(ToNumbers(Array.prototype.filter.call(lengthTrackingWithOffset, ResizeMidIteration)),[]);
   assert.compareArray(values, [
-    4,
-    undefined
+    4
   ]);
 }

--- a/test/built-ins/Array/prototype/filter/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/filter/resizable-buffer.js
@@ -4,8 +4,7 @@
 /*---
 esid: sec-array.prototype.filter
 description: >
-  Array.p.filter behaves correctly on receivers backed by resizable
-  buffers
+  Array.p.filter behaves correctly on TypedArrays backed by resizable buffers.
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/

--- a/test/built-ins/Array/prototype/find/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/find/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -36,7 +36,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.find.call(fixedLength, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.find.call(fixedLength, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     0,
     2,
@@ -50,7 +50,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.find.call(fixedLengthWithOffset, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.find.call(fixedLengthWithOffset, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     4,
     6
@@ -62,7 +62,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.find.call(lengthTracking, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.find.call(lengthTracking, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     0,
     2,
@@ -76,7 +76,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.find.call(lengthTrackingWithOffset, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.find.call(lengthTrackingWithOffset, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     4,
     6

--- a/test/built-ins/Array/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findIndex.call(fixedLength, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLength, ResizeMidIteration), -1);
   assert.compareArray(values, [
     0,
     2,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, ResizeMidIteration), -1);
   assert.compareArray(values, [
     4,
     6
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, ResizeMidIteration), -1);
   assert.compareArray(values, [
     0,
     2,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, ResizeMidIteration), -1);
   assert.compareArray(values, [
     4,
     6

--- a/test/built-ins/Array/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findIndex.call(fixedLength, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLength, ResizeMidIteration), -1);
   assert.compareArray(values, [
     0,
     2,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findIndex.call(fixedLengthWithOffset, ResizeMidIteration), -1);
   assert.compareArray(values, [
     4,
     undefined
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTracking, ResizeMidIteration), -1);
   assert.compareArray(values, [
     0,
     2,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findIndex.call(lengthTrackingWithOffset, ResizeMidIteration), -1);
   assert.compareArray(values, [
     4,
     undefined

--- a/test/built-ins/Array/prototype/findLast/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/findLast/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLast.call(fixedLength, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.findLast.call(fixedLength, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLast.call(fixedLengthWithOffset, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.findLast.call(fixedLengthWithOffset, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLast.call(lengthTracking, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.findLast.call(lengthTracking, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLast.call(lengthTrackingWithOffset, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.findLast.call(lengthTrackingWithOffset, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4

--- a/test/built-ins/Array/prototype/findLast/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/findLast/resizable-buffer-shrink-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -36,7 +36,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLast.call(fixedLength, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.findLast.call(fixedLength, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4,
@@ -50,7 +50,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLast.call(fixedLengthWithOffset, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.findLast.call(fixedLengthWithOffset, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     undefined
@@ -62,7 +62,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLast.call(lengthTracking, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.findLast.call(lengthTracking, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4,
@@ -76,7 +76,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLast.call(lengthTrackingWithOffset, ResizeBufferMidIteration), undefined);
+  assert.sameValue(Array.prototype.findLast.call(lengthTrackingWithOffset, ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4

--- a/test/built-ins/Array/prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLastIndex.call(fixedLength, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findLastIndex.call(fixedLength, ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLastIndex.call(fixedLengthWithOffset, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findLastIndex.call(fixedLengthWithOffset, ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLastIndex.call(lengthTracking, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findLastIndex.call(lengthTracking, ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLastIndex.call(lengthTrackingWithOffset, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findLastIndex.call(lengthTrackingWithOffset, ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4

--- a/test/built-ins/Array/prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLastIndex.call(fixedLength, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findLastIndex.call(fixedLength, ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLastIndex.call(fixedLengthWithOffset, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findLastIndex.call(fixedLengthWithOffset, ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     undefined
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLastIndex.call(lengthTracking, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findLastIndex.call(lengthTracking, ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 2 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLastIndex.call(lengthTracking, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findLastIndex.call(lengthTracking, ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     undefined,
@@ -89,7 +89,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(Array.prototype.findLastIndex.call(lengthTrackingWithOffset, ResizeBufferMidIteration), -1);
+  assert.sameValue(Array.prototype.findLastIndex.call(lengthTrackingWithOffset, ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   // Returns true by default.
   return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(fixedLength.every(ResizeBufferMidIteration));
+  assert(fixedLength.every(ResizeMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(fixedLengthWithOffset.every(ResizeBufferMidIteration));
+  assert(fixedLengthWithOffset.every(ResizeMidIteration));
   assert.compareArray(values, [
     4,
     6
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(lengthTracking.every(ResizeBufferMidIteration));
+  assert(lengthTracking.every(ResizeMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert(lengthTrackingWithOffset.every(ResizeBufferMidIteration));
+  assert(lengthTrackingWithOffset.every(ResizeMidIteration));
   assert.compareArray(values, [
     4,
     6

--- a/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/every/resizable-buffer-shrink-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   // Returns true by default.
   return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(fixedLength.every(ResizeBufferMidIteration));
+  assert(fixedLength.every(ResizeMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(fixedLengthWithOffset.every(ResizeBufferMidIteration));
+  assert(fixedLengthWithOffset.every(ResizeMidIteration));
   assert.compareArray(values, [
     4,
     undefined
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(lengthTracking.every(ResizeBufferMidIteration));
+  assert(lengthTracking.every(ResizeMidIteration));
   assert.compareArray(values, [
     0,
     2,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert(lengthTrackingWithOffset.every(ResizeBufferMidIteration));
+  assert(lengthTrackingWithOffset.every(ResizeMidIteration));
   assert.compareArray(values, [
     4,
     undefined

--- a/test/built-ins/TypedArray/prototype/filter/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/filter/resizable-buffer-grow-mid-iteration.js
@@ -4,8 +4,8 @@
 /*---
 esid: sec-%typedarray%.prototype.filter
 description: >
-  TypedArray.p.filter behaves correctly on receivers backed by resizable
-  buffers that grow mid-iteration
+  TypedArray.p.filter behaves correctly on TypedArrays backed by resizable
+  buffers that grow mid-iteration.
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -36,7 +36,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(fixedLength.filter(ResizeBufferMidIteration)), []);
+  assert.compareArray(ToNumbers(fixedLength.filter(ResizeMidIteration)), []);
   assert.compareArray(values, [
     0,
     2,
@@ -50,7 +50,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(fixedLengthWithOffset.filter(ResizeBufferMidIteration)), []);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset.filter(ResizeMidIteration)), []);
   assert.compareArray(values, [
     4,
     6
@@ -62,7 +62,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(lengthTracking.filter(ResizeBufferMidIteration)), []);
+  assert.compareArray(ToNumbers(lengthTracking.filter(ResizeMidIteration)), []);
   assert.compareArray(values, [
     0,
     2,
@@ -76,7 +76,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.compareArray(ToNumbers(lengthTrackingWithOffset.filter(ResizeBufferMidIteration)), []);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset.filter(ResizeMidIteration)), []);
   assert.compareArray(values, [
     4,
     6

--- a/test/built-ins/TypedArray/prototype/filter/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/filter/resizable-buffer.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-%typedarray%.prototype.filter
 description: >
-  TypedArray.p.filter behaves correctly on receivers backed by resizable
+  TypedArray.p.filter behaves correctly on TypedArrays backed by resizable
   buffers
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]

--- a/test/built-ins/TypedArray/prototype/find/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/find/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -36,7 +36,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLength.find(ResizeBufferMidIteration), undefined);
+  assert.sameValue(fixedLength.find(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     0,
     2,
@@ -50,7 +50,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLengthWithOffset.find(ResizeBufferMidIteration), undefined);
+  assert.sameValue(fixedLengthWithOffset.find(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     4,
     6
@@ -62,7 +62,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTracking.find(ResizeBufferMidIteration), undefined);
+  assert.sameValue(lengthTracking.find(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     0,
     2,
@@ -76,7 +76,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTrackingWithOffset.find(ResizeBufferMidIteration), undefined);
+  assert.sameValue(lengthTrackingWithOffset.find(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     4,
     6

--- a/test/built-ins/TypedArray/prototype/find/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/find/resizable-buffer-shrink-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -36,7 +36,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLength.find(ResizeBufferMidIteration), undefined);
+  assert.sameValue(fixedLength.find(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     0,
     2,
@@ -50,7 +50,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLengthWithOffset.find(ResizeBufferMidIteration), undefined);
+  assert.sameValue(fixedLengthWithOffset.find(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     4,
     undefined
@@ -62,7 +62,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTracking.find(ResizeBufferMidIteration), undefined);
+  assert.sameValue(lengthTracking.find(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     0,
     2,
@@ -76,7 +76,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTrackingWithOffset.find(ResizeBufferMidIteration), undefined);
+  assert.sameValue(lengthTrackingWithOffset.find(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     4,
     undefined

--- a/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -36,7 +36,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLength.findIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(fixedLength.findIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     0,
     2,
@@ -50,7 +50,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLengthWithOffset.findIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(fixedLengthWithOffset.findIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     4,
     6
@@ -62,7 +62,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTracking.findIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(lengthTracking.findIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     0,
     2,
@@ -76,7 +76,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTrackingWithOffset.findIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(lengthTrackingWithOffset.findIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     4,
     6

--- a/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -36,7 +36,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLength.findIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(fixedLength.findIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     0,
     2,
@@ -50,7 +50,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLengthWithOffset.findIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(fixedLengthWithOffset.findIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     4,
     undefined
@@ -62,7 +62,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTracking.findIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(lengthTracking.findIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     0,
     2,
@@ -76,7 +76,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTrackingWithOffset.findIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(lengthTrackingWithOffset.findIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     4,
     undefined

--- a/test/built-ins/TypedArray/prototype/findLast/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/findLast/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLength.findLast(ResizeBufferMidIteration), undefined);
+  assert.sameValue(fixedLength.findLast(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLengthWithOffset.findLast(ResizeBufferMidIteration), undefined);
+  assert.sameValue(fixedLengthWithOffset.findLast(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTracking.findLast(ResizeBufferMidIteration), undefined);
+  assert.sameValue(lengthTracking.findLast(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTrackingWithOffset.findLast(ResizeBufferMidIteration), undefined);
+  assert.sameValue(lengthTrackingWithOffset.findLast(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4

--- a/test/built-ins/TypedArray/prototype/findLast/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/findLast/resizable-buffer-shrink-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -36,7 +36,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLength.findLast(ResizeBufferMidIteration), undefined);
+  assert.sameValue(fixedLength.findLast(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4,
@@ -50,7 +50,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLengthWithOffset.findLast(ResizeBufferMidIteration), undefined);
+  assert.sameValue(fixedLengthWithOffset.findLast(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     undefined
@@ -62,7 +62,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTracking.findLast(ResizeBufferMidIteration), undefined);
+  assert.sameValue(lengthTracking.findLast(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4,
@@ -76,7 +76,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTrackingWithOffset.findLast(ResizeBufferMidIteration), undefined);
+  assert.sameValue(lengthTrackingWithOffset.findLast(ResizeMidIteration), undefined);
   assert.compareArray(values, [
     6,
     4

--- a/test/built-ins/TypedArray/prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLength.findLastIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(fixedLength.findLastIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLengthWithOffset.findLastIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(fixedLengthWithOffset.findLastIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTracking.findLastIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(lengthTracking.findLastIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTrackingWithOffset.findLastIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(lengthTrackingWithOffset.findLastIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4

--- a/test/built-ins/TypedArray/prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset before
 // calling this.
-function ResizeBufferMidIteration(n) {
+function ResizeMidIteration(n) {
   CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
   return false;
 }
@@ -35,7 +35,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLength.findLastIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(fixedLength.findLastIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4,
@@ -49,7 +49,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(fixedLengthWithOffset.findLastIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(fixedLengthWithOffset.findLastIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     undefined
@@ -61,7 +61,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 2;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTracking.findLastIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(lengthTracking.findLastIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4,
@@ -75,7 +75,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 2 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTracking.findLastIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(lengthTracking.findLastIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     undefined,
@@ -89,7 +89,7 @@ for (let ctor of ctors) {
   values = [];
   resizeAfter = 1;
   resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  assert.sameValue(lengthTrackingWithOffset.findLastIndex(ResizeBufferMidIteration), -1);
+  assert.sameValue(lengthTrackingWithOffset.findLastIndex(ResizeMidIteration), -1);
   assert.compareArray(values, [
     6,
     4


### PR DESCRIPTION
Also renames `ResizeBufferMidIteration` to `ResizeMidIteration`.