### PR TITLE
Update the expctation of constructor-options-firstDayOfWeek-valid.js

### DIFF
--- a/test/intl402/Locale/constructor-options-firstDayOfWeek-valid.js
+++ b/test/intl402/Locale/constructor-options-firstDayOfWeek-valid.js
@@ -47,7 +47,7 @@ const validFirstDayOfWeekOptions = [
   [6, "en-u-fw-sat"],
   [7, "en-u-fw-sun"],
   [0, "en-u-fw-sun"],
-  [true, "en-u-fw-true"],
+  [true, "en-u-fw"],
   [false, "en-u-fw-false"],
   [null, "en-u-fw-null"],
   ["primidi", "en-u-fw-primidi"],


### PR DESCRIPTION
true will be dropped inside UTS35
See https://github.com/tc39/test262/pull/4141#pullrequestreview-2171902863 for more info