### PR TITLE
Add missing test for `Math.pow(1, NaN)`

### DIFF
--- a/test/built-ins/Math/pow/applying-the-exp-operator_A1.js
+++ b/test/built-ins/Math/pow/applying-the-exp-operator_A1.js
@@ -18,7 +18,7 @@ base[5] = 0.000000000000001;
 base[6] = 1.7976931348623157E308; //largest finite number
 base[7] = +Infinity;
 base[8] = NaN;
-base[9] = 1; // In some implementations, the `pow` function might incorrectly return 1, deviating from the ECMA specification.
+base[9] = 1;
 var basenum = 10;
 
 for (var i = 0; i < basenum; i++) {

--- a/test/built-ins/Math/pow/applying-the-exp-operator_A1.js
+++ b/test/built-ins/Math/pow/applying-the-exp-operator_A1.js
@@ -18,6 +18,7 @@ base[5] = 0.000000000000001;
 base[6] = 1.7976931348623157E308; //largest finite number
 base[7] = +Infinity;
 base[8] = NaN;
+base[9] = 1; // In some implementations, the `pow` function might incorrectly return 1, deviating from the ECMA specification.
 var basenum = 9;
 
 for (var i = 0; i < basenum; i++) {

--- a/test/built-ins/Math/pow/applying-the-exp-operator_A1.js
+++ b/test/built-ins/Math/pow/applying-the-exp-operator_A1.js
@@ -19,7 +19,7 @@ base[6] = 1.7976931348623157E308; //largest finite number
 base[7] = +Infinity;
 base[8] = NaN;
 base[9] = 1; // In some implementations, the `pow` function might incorrectly return 1, deviating from the ECMA specification.
-var basenum = 9;
+var basenum = 10;
 
 for (var i = 0; i < basenum; i++) {
   assert.sameValue(


### PR DESCRIPTION
In some implementations, the `pow` function may return 1, which contradicts the specification. This addition ensures that the test case covers this scenario.