### PR TITLE
Add missing compareArray includes

### DIFF
--- a/test/built-ins/Uint8Array/prototype/setFromBase64/writes-up-to-error.js
+++ b/test/built-ins/Uint8Array/prototype/setFromBase64/writes-up-to-error.js
@@ -3,6 +3,7 @@
 /*---
 esid: sec-uint8array.prototype.setfrombase64
 description: Uint8Array.prototype.setFromBase64 decodes and writes chunks which occur prior to bad data
+includes: [compareArray.js]
 features: [uint8array-base64, TypedArray]
 ---*/
 

--- a/test/built-ins/Uint8Array/prototype/setFromHex/writes-up-to-error.js
+++ b/test/built-ins/Uint8Array/prototype/setFromHex/writes-up-to-error.js
@@ -3,6 +3,7 @@
 /*---
 esid: sec-uint8array.prototype.setfromhex
 description: Uint8Array.prototype.setFromHex decodes and writes pairs which occur prior to bad data
+includes: [compareArray.js]
 features: [uint8array-base64, TypedArray]
 ---*/
 


### PR DESCRIPTION
#4133 brought couple test files which are using `assert.compareArray`, but the include is missing and causes errors when harness is being run.