### PR TITLE
 RAB: Integrate staging tests for the .lastIndexOf method

### DIFF
--- a/test/built-ins/Array/prototype/lastIndexOf/coerced-position-grow.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/coerced-position-grow.js
@@ -6,52 +6,11 @@ esid: sec-array.prototype.lastindexof
 description: >
   Array.p.lastIndexOf behaves correctly when receiver is grown
   by argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayLastIndexOfHelper(ta, n, fromIndex) {
+function ArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return Array.prototype.lastIndexOf.call(ta, BigInt(n));
@@ -64,43 +23,39 @@ function ArrayLastIndexOfHelper(ta, n, fromIndex) {
   return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
 }
 
-function LastIndexOfParameterConversionGrows() {
-  // Growing + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(lengthTracking, i, 1);
+// Growing + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, 1);
+  }
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return -1;
     }
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return -1;
-      }
-    };
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0), -1);
-    // Because lastIndexOf iterates from the given index downwards, it's not
-    // possible to test that "we only look at the data until the original
-    // length" without also testing that the index conversion happening with the
-    // original length.
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0, evil), -1);
-  }
-
-  // Growing + length-tracking TA, index conversion.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return -4;
-      }
-    };
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0, -4), 0);
-    // The TA grew but the start index conversion is done based on the original
-    // length.
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0, evil), 0);
-  }
+  };
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  // Because lastIndexOf iterates from the given index downwards, it's not
+  // possible to test that "we only look at the data until the original
+  // length" without also testing that the index conversion happening with the
+  // original length.
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0, evil), -1);
 }
 
-LastIndexOfParameterConversionGrows();
+// Growing + length-tracking TA, index conversion.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return -4;
+    }
+  };
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0, -4), 0);
+  // The TA grew but the start index conversion is done based on the original
+  // length.
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0, evil), 0);
+}

--- a/test/built-ins/Array/prototype/lastIndexOf/coerced-position-grow.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/coerced-position-grow.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-array.prototype.lastindexof
 description: >
-  Array.p.lastIndexOf behaves correctly when receiver is grown
-  by argument coercion
+  Array.p.lastIndexOf behaves correctly when the resizable buffer is grown by
+  argument coercion.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function ArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return Array.prototype.lastIndexOf.call(ta, BigInt(n));
-    }
-    return Array.prototype.lastIndexOf.call(ta, BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return Array.prototype.lastIndexOf.call(ta, n);
-  }
-  return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
+  return n;
 }
 
 // Growing + length-tracking TA.
@@ -36,12 +30,13 @@ for (let ctor of ctors) {
       return -1;
     }
   };
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  let n0 = MayNeedBigInt(lengthTracking, 0);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n0), -1);
   // Because lastIndexOf iterates from the given index downwards, it's not
   // possible to test that "we only look at the data until the original
   // length" without also testing that the index conversion happening with the
   // original length.
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0, evil), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n0, evil), -1);
 }
 
 // Growing + length-tracking TA, index conversion.
@@ -54,8 +49,9 @@ for (let ctor of ctors) {
       return -4;
     }
   };
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0, -4), 0);
+  let n0 = MayNeedBigInt(lengthTracking, 0);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n0, -4), 0);
   // The TA grew but the start index conversion is done based on the original
   // length.
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0, evil), 0);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n0, evil), 0);
 }

--- a/test/built-ins/Array/prototype/lastIndexOf/coerced-position-grow.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/coerced-position-grow.js
@@ -1,0 +1,106 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.lastindexof
+description: >
+  Array.p.lastIndexOf behaves correctly when receiver is grown
+  by argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.lastIndexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.lastIndexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.lastIndexOf.call(ta, n);
+  }
+  return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
+}
+
+function LastIndexOfParameterConversionGrows() {
+  // Growing + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, 1);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -1;
+      }
+    };
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0), -1);
+    // Because lastIndexOf iterates from the given index downwards, it's not
+    // possible to test that "we only look at the data until the original
+    // length" without also testing that the index conversion happening with the
+    // original length.
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0, evil), -1);
+  }
+
+  // Growing + length-tracking TA, index conversion.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -4;
+      }
+    };
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0, -4), 0);
+    // The TA grew but the start index conversion is done based on the original
+    // length.
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0, evil), 0);
+  }
+}
+
+LastIndexOfParameterConversionGrows();

--- a/test/built-ins/Array/prototype/lastIndexOf/coerced-position-shrink.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/coerced-position-shrink.js
@@ -6,52 +6,11 @@ esid: sec-array.prototype.lastindexof
 description: >
   Array.p.lastIndexOf behaves correctly when receiver is shrunk
   by argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayLastIndexOfHelper(ta, n, fromIndex) {
+function ArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return Array.prototype.lastIndexOf.call(ta, BigInt(n));
@@ -64,53 +23,48 @@ function ArrayLastIndexOfHelper(ta, n, fromIndex) {
   return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
 }
 
-function LastIndexOfParameterConversionShrinks() {
-  // Shrinking + fixed-length TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 2;
-      }
-    };
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0), 3);
-    // The TA is OOB so lastIndexOf returns -1.
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0, evil), -1);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 2;
-      }
-    };
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0), 3);
-    // The TA is OOB so lastIndexOf returns -1, also for undefined).
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, undefined, evil), -1);
-  }
-
-  // Shrinking + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(lengthTracking, i, i);
+// Shrinking + fixed-length TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
     }
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 2;
-      }
-    };
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 2), 2);
-    // 2 no longer found.
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 2, evil), -1);
-  }
+  };
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0), 3);
+  // The TA is OOB so lastIndexOf returns -1.
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0, evil), -1);
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0), 3);
+  // The TA is OOB so lastIndexOf returns -1, also for undefined).
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, undefined, evil), -1);
 }
 
-LastIndexOfParameterConversionShrinks();
-
+// Shrinking + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 2), 2);
+  // 2 no longer found.
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 2, evil), -1);
+}

--- a/test/built-ins/Array/prototype/lastIndexOf/coerced-position-shrink.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/coerced-position-shrink.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-array.prototype.lastindexof
 description: >
-  Array.p.lastIndexOf behaves correctly when receiver is shrunk
-  by argument coercion
+  Array.p.lastIndexOf behaves correctly when the resizable buffer is shrunk by
+  argument coercion.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function ArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return Array.prototype.lastIndexOf.call(ta, BigInt(n));
-    }
-    return Array.prototype.lastIndexOf.call(ta, BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return Array.prototype.lastIndexOf.call(ta, n);
-  }
-  return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
+  return n;
 }
 
 // Shrinking + fixed-length TA.
@@ -33,9 +27,10 @@ for (let ctor of ctors) {
       return 2;
     }
   };
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0), 3);
+  let n = MayNeedBigInt(fixedLength, 0);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n), 3);
   // The TA is OOB so lastIndexOf returns -1.
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0, evil), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n, evil), -1);
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -46,9 +41,9 @@ for (let ctor of ctors) {
       return 2;
     }
   };
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0), 3);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, MayNeedBigInt(fixedLength, 0)), 3);
   // The TA is OOB so lastIndexOf returns -1, also for undefined).
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, undefined, evil), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, undefined, evil), -1);
 }
 
 // Shrinking + length-tracking TA.
@@ -64,7 +59,8 @@ for (let ctor of ctors) {
       return 2;
     }
   };
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 2), 2);
+  let n = MayNeedBigInt(lengthTracking, 2);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n), 2);
   // 2 no longer found.
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 2, evil), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n, evil), -1);
 }

--- a/test/built-ins/Array/prototype/lastIndexOf/coerced-position-shrink.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/coerced-position-shrink.js
@@ -1,0 +1,116 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.lastindexof
+description: >
+  Array.p.lastIndexOf behaves correctly when receiver is shrunk
+  by argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.lastIndexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.lastIndexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.lastIndexOf.call(ta, n);
+  }
+  return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
+}
+
+function LastIndexOfParameterConversionShrinks() {
+  // Shrinking + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 2;
+      }
+    };
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0), 3);
+    // The TA is OOB so lastIndexOf returns -1.
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0, evil), -1);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 2;
+      }
+    };
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0), 3);
+    // The TA is OOB so lastIndexOf returns -1, also for undefined).
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, undefined, evil), -1);
+  }
+
+  // Shrinking + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 2;
+      }
+    };
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 2), 2);
+    // 2 no longer found.
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 2, evil), -1);
+  }
+}
+
+LastIndexOfParameterConversionShrinks();
+

--- a/test/built-ins/Array/prototype/lastIndexOf/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/resizable-buffer.js
@@ -6,51 +6,11 @@ esid: sec-array.prototype.lastindexof
 description: >
   Array.p.lastIndexOf behaves correctly when receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-function ArrayLastIndexOfHelper(ta, n, fromIndex) {
+function ArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return Array.prototype.lastIndexOf.call(ta, BigInt(n));
@@ -63,115 +23,110 @@ function ArrayLastIndexOfHelper(ta, n, fromIndex) {
   return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
 }
 
-function TestLastIndexOf() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
-    }
-
-    // Orig. array: [0, 0, 1, 1]
-    //              [0, 0, 1, 1] << fixedLength
-    //                    [1, 1] << fixedLengthWithOffset
-    //              [0, 0, 1, 1, ...] << lengthTracking
-    //                    [1, 1, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0, 1), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0, 2), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0, -2), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0, -3), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 1, 1), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 1, -2), 2);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 1, -3), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, undefined), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 1), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 1, -2), 0);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 1, -1), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, undefined), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0, 2), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0, -3), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 1, 1), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 1, 2), 2);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 1, -3), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, 1), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, -2), 0);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, -1), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 0, 1]
-    //              [0, 0, 1, ...] << lengthTracking
-    //                    [1, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 1), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 1), -1);
-
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 0);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0), 0);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, undefined), -1);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
-    }
-
-    // Orig. array: [0, 0, 1, 1, 2, 2]
-    //              [0, 0, 1, 1] << fixedLength
-    //                    [1, 1] << fixedLengthWithOffset
-    //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
-    //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 1), 3);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 2), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, undefined), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 1), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 2), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, undefined), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 1), 3);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 2), 5);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 1);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 2), 3);
-    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, Math.floor(i / 2));
   }
+
+  // Orig. array: [0, 0, 1, 1]
+  //              [0, 0, 1, 1] << fixedLength
+  //                    [1, 1] << fixedLengthWithOffset
+  //              [0, 0, 1, 1, ...] << lengthTracking
+  //                    [1, 1, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0, 1), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0, 2), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0, -2), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0, -3), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 1, 1), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 1, -2), 2);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 1, -3), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, undefined), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -2), 0);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -1), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0, 2), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0, -3), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 1, 1), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 1, 2), 2);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 1, -3), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, 1), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -2), 0);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -1), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 0, 1]
+  //              [0, 0, 1, ...] << lengthTracking
+  //                    [1, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 1), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1), -1);
+
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 0);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+  }
+
+  // Orig. array: [0, 0, 1, 1, 2, 2]
+  //              [0, 0, 1, 1] << fixedLength
+  //                    [1, 1] << fixedLengthWithOffset
+  //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
+  //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 1), 3);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 2), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, undefined), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 2), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 1), 3);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 2), 5);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 1);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 2), 3);
+  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
 }
-
-TestLastIndexOf();
-

--- a/test/built-ins/Array/prototype/lastIndexOf/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/resizable-buffer.js
@@ -1,0 +1,177 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.lastindexof
+description: >
+  Array.p.lastIndexOf behaves correctly when receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+function ArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.lastIndexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.lastIndexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.lastIndexOf.call(ta, n);
+  }
+  return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
+}
+
+function TestLastIndexOf() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+    }
+
+    // Orig. array: [0, 0, 1, 1]
+    //              [0, 0, 1, 1] << fixedLength
+    //                    [1, 1] << fixedLengthWithOffset
+    //              [0, 0, 1, 1, ...] << lengthTracking
+    //                    [1, 1, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0, 1), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0, 2), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0, -2), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0, -3), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 1, 1), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 1, -2), 2);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 1, -3), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 1), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 1, -2), 0);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 1, -1), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0, 2), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0, -3), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 1, 1), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 1, 2), 2);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 1, -3), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, 1), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, -2), 0);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, -1), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 0, 1]
+    //              [0, 0, 1, ...] << lengthTracking
+    //                    [1, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 1), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 1), -1);
+
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0), 0);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 0), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 0), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, undefined), -1);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+    }
+
+    // Orig. array: [0, 0, 1, 1, 2, 2]
+    //              [0, 0, 1, 1] << fixedLength
+    //                    [1, 1] << fixedLengthWithOffset
+    //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
+    //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 1), 3);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, 2), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 1), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, 2), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 1), 3);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, 2), 5);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 1);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, 2), 3);
+    assert.sameValue(ArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+  }
+}
+
+TestLastIndexOf();
+

--- a/test/built-ins/Array/prototype/lastIndexOf/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/resizable-buffer.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-array.prototype.lastindexof
 description: >
-  Array.p.lastIndexOf behaves correctly when receiver is backed by resizable
-  buffer
+  Array.p.lastIndexOf behaves correctly on TypedArrays backed by resizable
+  buffers.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function ArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return Array.prototype.lastIndexOf.call(ta, BigInt(n));
-    }
-    return Array.prototype.lastIndexOf.call(ta, BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return Array.prototype.lastIndexOf.call(ta, n);
-  }
-  return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
+  return n;
 }
 
 for (let ctor of ctors) {
@@ -42,33 +36,37 @@ for (let ctor of ctors) {
   //              [0, 0, 1, 1, ...] << lengthTracking
   //                    [1, 1, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0, 1), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0, 2), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0, -2), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0, -3), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 1, 1), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 1, -2), 2);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 1, -3), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, undefined), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -2), 0);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -1), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0, 2), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0, -3), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 1, 1), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 1, 2), 2);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 1, -3), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, 1), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -2), 0);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -1), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  // If fixedLength is a BigInt array, they all are BigInt Arrays.
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  let n1 = MayNeedBigInt(fixedLength, 1);
+
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n0), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n0, 1), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n0, 2), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n0, -2), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n0, -3), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n1, 1), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n1, -2), 2);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n1, -3), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, undefined), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, n1), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, n1, -2), 0);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, n1, -1), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n0), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n0, 2), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n0, -3), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n1, 1), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n1, 2), 2);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n1, -3), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, undefined), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n1), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n1, 1), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n1, -2), 0);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n1, -1), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, undefined), -1);
 
   // Shrink so that fixed length TAs go out of bounds.
   rab.resize(3 * ctor.BYTES_PER_ELEMENT);
@@ -77,31 +75,31 @@ for (let ctor of ctors) {
   //              [0, 0, 1, ...] << lengthTracking
   //                    [1, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 1), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n1), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, n1), -1);
 
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n0), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, undefined), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n1), 0);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, undefined), -1);
 
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n0), -1);
 
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 0);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n0), 0);
 
   // Shrink to zero.
   rab.resize(0);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 0), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n0), -1);
 
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 0), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, undefined), -1);
 
   // Grow so that all TAs are back in-bounds.
   rab.resize(6 * ctor.BYTES_PER_ELEMENT);
@@ -115,18 +113,20 @@ for (let ctor of ctors) {
   //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
   //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 1), 3);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, 2), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLength, undefined), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 2), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 1), 3);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, 2), 5);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 1);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 2), 3);
-  assert.sameValue(ArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  let n2 = MayNeedBigInt(fixedLength, 2);
+
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n1), 3);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, n2), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLength, undefined), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, n1), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, n2), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n1), 3);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, n2), 5);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTracking, undefined), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n0), -1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n1), 1);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, n2), 3);
+  assert.sameValue(Array.prototype.lastIndexOf.call(lengthTrackingWithOffset, undefined), -1);
 }

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-grow.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-grow.js
@@ -6,52 +6,11 @@ esid: sec-%typedarray%.prototype.lastindexof
 description: >
   TypedArray.p.lastIndexOf behaves correctly when receiver is grown
   by argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
+function TypedArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return ta.lastIndexOf(BigInt(n));
@@ -64,43 +23,39 @@ function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
   return ta.lastIndexOf(n, fromIndex);
 }
 
-function LastIndexOfParameterConversionGrows() {
-  // Growing + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(lengthTracking, i, 1);
+// Growing + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, 1);
+  }
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return -1;
     }
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return -1;
-      }
-    };
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0), -1);
-    // Because lastIndexOf iterates from the given index downwards, it's not
-    // possible to test that "we only look at the data until the original
-    // length" without also testing that the index conversion happening with the
-    // original length.
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0, evil), -1);
-  }
-
-  // Growing + length-tracking TA, index conversion.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    let evil = {
-      valueOf: () => {
-        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-        return -4;
-      }
-    };
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0, -4), 0);
-    // The TA grew but the start index conversion is done based on the original
-    // length.
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0, evil), 0);
-  }
+  };
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  // Because lastIndexOf iterates from the given index downwards, it's not
+  // possible to test that "we only look at the data until the original
+  // length" without also testing that the index conversion happening with the
+  // original length.
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0, evil), -1);
 }
 
-LastIndexOfParameterConversionGrows();
+// Growing + length-tracking TA, index conversion.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return -4;
+    }
+  };
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0, -4), 0);
+  // The TA grew but the start index conversion is done based on the original
+  // length.
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0, evil), 0);
+}

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-grow.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-grow.js
@@ -1,0 +1,106 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.lastindexof
+description: >
+  TypedArray.p.lastIndexOf behaves correctly when receiver is grown
+  by argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.lastIndexOf(BigInt(n));
+    }
+    return ta.lastIndexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.lastIndexOf(n);
+  }
+  return ta.lastIndexOf(n, fromIndex);
+}
+
+function LastIndexOfParameterConversionGrows() {
+  // Growing + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, 1);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -1;
+      }
+    };
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0), -1);
+    // Because lastIndexOf iterates from the given index downwards, it's not
+    // possible to test that "we only look at the data until the original
+    // length" without also testing that the index conversion happening with the
+    // original length.
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0, evil), -1);
+  }
+
+  // Growing + length-tracking TA, index conversion.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -4;
+      }
+    };
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0, -4), 0);
+    // The TA grew but the start index conversion is done based on the original
+    // length.
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0, evil), 0);
+  }
+}
+
+LastIndexOfParameterConversionGrows();

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-grow.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-grow.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-%typedarray%.prototype.lastindexof
 description: >
-  TypedArray.p.lastIndexOf behaves correctly when receiver is grown
-  by argument coercion
+  TypedArray.p.lastIndexOf behaves correctly on TypedArrays backed by resizable
+  buffers that are grown by argument coercion.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function TypedArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return ta.lastIndexOf(BigInt(n));
-    }
-    return ta.lastIndexOf(BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return ta.lastIndexOf(n);
-  }
-  return ta.lastIndexOf(n, fromIndex);
+  return n;
 }
 
 // Growing + length-tracking TA.
@@ -36,12 +30,13 @@ for (let ctor of ctors) {
       return -1;
     }
   };
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  let n0 = MayNeedBigInt(lengthTracking, 0);
+  assert.sameValue(lengthTracking.lastIndexOf(n0), -1);
   // Because lastIndexOf iterates from the given index downwards, it's not
   // possible to test that "we only look at the data until the original
   // length" without also testing that the index conversion happening with the
   // original length.
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0, evil), -1);
+  assert.sameValue(lengthTracking.lastIndexOf(n0, evil), -1);
 }
 
 // Growing + length-tracking TA, index conversion.
@@ -54,8 +49,9 @@ for (let ctor of ctors) {
       return -4;
     }
   };
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0, -4), 0);
+  let n0 = MayNeedBigInt(lengthTracking, 0);
+  assert.sameValue(lengthTracking.lastIndexOf(n0, -4), 0);
   // The TA grew but the start index conversion is done based on the original
   // length.
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0, evil), 0);
+  assert.sameValue(lengthTracking.lastIndexOf(n0, evil), 0);
 }

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-shrink.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-shrink.js
@@ -6,52 +6,11 @@ esid: sec-%typedarray%.prototype.lastindexof
 description: >
   TypedArray.p.lastIndexOf behaves correctly when receiver is shrunk
   by argument coercion
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
+function TypedArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return ta.lastIndexOf(BigInt(n));
@@ -64,52 +23,48 @@ function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
   return ta.lastIndexOf(n, fromIndex);
 }
 
-function LastIndexOfParameterConversionShrinks() {
-  // Shrinking + fixed-length TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 2;
-      }
-    };
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0), 3);
-    // The TA is OOB so lastIndexOf returns -1.
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0, evil), -1);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 2;
-      }
-    };
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0), 3);
-    // The TA is OOB so lastIndexOf returns -1, also for undefined).
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, undefined, evil), -1);
-  }
-
-  // Shrinking + length-tracking TA.
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const lengthTracking = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(lengthTracking, i, i);
+// Shrinking + fixed-length TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
     }
-    let evil = {
-      valueOf: () => {
-        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-        return 2;
-      }
-    };
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 2), 2);
-    // 2 no longer found.
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 2, evil), -1);
-  }
+  };
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0), 3);
+  // The TA is OOB so lastIndexOf returns -1.
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0, evil), -1);
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0), 3);
+  // The TA is OOB so lastIndexOf returns -1, also for undefined).
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, undefined, evil), -1);
 }
 
-LastIndexOfParameterConversionShrinks();
+// Shrinking + length-tracking TA.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 2), 2);
+  // 2 no longer found.
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 2, evil), -1);
+}

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-shrink.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-shrink.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-%typedarray%.prototype.lastindexof
 description: >
-  TypedArray.p.lastIndexOf behaves correctly when receiver is shrunk
-  by argument coercion
+  TypedArray.p.lastIndexOf behaves correctly on TypedArrays backed by resizable
+  buffers that are shrunk by argument coercion.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function TypedArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return ta.lastIndexOf(BigInt(n));
-    }
-    return ta.lastIndexOf(BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return ta.lastIndexOf(n);
-  }
-  return ta.lastIndexOf(n, fromIndex);
+  return n;
 }
 
 // Shrinking + fixed-length TA.
@@ -33,9 +27,10 @@ for (let ctor of ctors) {
       return 2;
     }
   };
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0), 3);
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  assert.sameValue(fixedLength.lastIndexOf(n0), 3);
   // The TA is OOB so lastIndexOf returns -1.
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0, evil), -1);
+  assert.sameValue(fixedLength.lastIndexOf(n0, evil), -1);
 }
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
@@ -46,9 +41,10 @@ for (let ctor of ctors) {
       return 2;
     }
   };
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0), 3);
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  assert.sameValue(fixedLength.lastIndexOf(n0), 3);
   // The TA is OOB so lastIndexOf returns -1, also for undefined).
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, undefined, evil), -1);
+  assert.sameValue(fixedLength.lastIndexOf(undefined, evil), -1);
 }
 
 // Shrinking + length-tracking TA.
@@ -64,7 +60,8 @@ for (let ctor of ctors) {
       return 2;
     }
   };
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 2), 2);
+  let n2 = MayNeedBigInt(lengthTracking, 2);
+  assert.sameValue(lengthTracking.lastIndexOf(n2), 2);
   // 2 no longer found.
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 2, evil), -1);
+  assert.sameValue(lengthTracking.lastIndexOf(n2, evil), -1);
 }

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-shrink.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/coerced-position-shrink.js
@@ -1,0 +1,115 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.lastindexof
+description: >
+  TypedArray.p.lastIndexOf behaves correctly when receiver is shrunk
+  by argument coercion
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.lastIndexOf(BigInt(n));
+    }
+    return ta.lastIndexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.lastIndexOf(n);
+  }
+  return ta.lastIndexOf(n, fromIndex);
+}
+
+function LastIndexOfParameterConversionShrinks() {
+  // Shrinking + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 2;
+      }
+    };
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0), 3);
+    // The TA is OOB so lastIndexOf returns -1.
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0, evil), -1);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 2;
+      }
+    };
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0), 3);
+    // The TA is OOB so lastIndexOf returns -1, also for undefined).
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, undefined, evil), -1);
+  }
+
+  // Shrinking + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 2;
+      }
+    };
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 2), 2);
+    // 2 no longer found.
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 2, evil), -1);
+  }
+}
+
+LastIndexOfParameterConversionShrinks();

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer-special-float-values.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer-special-float-values.js
@@ -1,0 +1,38 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.lastindexof
+description: >
+  TypedArray.p.lastIndexOf behaves correctly for special float values when
+  receiver is a float TypedArray backed by a resizable buffer
+features: [resizable-arraybuffer, Array.prototype.includes]
+---*/
+
+class MyFloat32Array extends Float32Array {
+}
+
+const floatCtors = [
+  Float32Array,
+  Float64Array,
+  MyFloat32Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+for (let ctor of floatCtors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  lengthTracking[0] = -Infinity;
+  lengthTracking[1] = -Infinity;
+  lengthTracking[2] = Infinity;
+  lengthTracking[3] = Infinity;
+  lengthTracking[4] = NaN;
+  lengthTracking[5] = NaN;
+  assert.sameValue(lengthTracking.lastIndexOf(-Infinity), 1);
+  assert.sameValue(lengthTracking.lastIndexOf(Infinity), 3);
+  // NaN is never found.
+  assert.sameValue(lengthTracking.lastIndexOf(NaN), -1);
+}

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer-special-float-values.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer-special-float-values.js
@@ -4,8 +4,8 @@
 /*---
 esid: sec-%typedarray%.prototype.lastindexof
 description: >
-  TypedArray.p.lastIndexOf behaves correctly for special float values when
-  receiver is a float TypedArray backed by a resizable buffer
+  TypedArray.p.lastIndexOf behaves correctly for special float values on float
+  TypedArrays backed by resizable buffers.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer-special-float-values.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer-special-float-values.js
@@ -6,21 +6,9 @@ esid: sec-%typedarray%.prototype.lastindexof
 description: >
   TypedArray.p.lastIndexOf behaves correctly for special float values when
   receiver is a float TypedArray backed by a resizable buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer, Array.prototype.includes]
 ---*/
-
-class MyFloat32Array extends Float32Array {
-}
-
-const floatCtors = [
-  Float32Array,
-  Float64Array,
-  MyFloat32Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
 
 for (let ctor of floatCtors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer.js
@@ -1,0 +1,193 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.lastindexof
+description: >
+  TypedArray.p.lastIndexOf behaves correctly when receiver is backed by resizable
+  buffer
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.lastIndexOf(BigInt(n));
+    }
+    return ta.lastIndexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.lastIndexOf(n);
+  }
+  return ta.lastIndexOf(n, fromIndex);
+}
+
+function TestLastIndexOf() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+    }
+
+    // Orig. array: [0, 0, 1, 1]
+    //              [0, 0, 1, 1] << fixedLength
+    //                    [1, 1] << fixedLengthWithOffset
+    //              [0, 0, 1, 1, ...] << lengthTracking
+    //                    [1, 1, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0, 1), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0, 2), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0, -2), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0, -3), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 1, 1), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 1, -2), 2);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 1, -3), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 1), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 1, -2), 0);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 1, -1), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0, 2), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0, -3), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 1, 1), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 1, 2), 2);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 1, -3), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, 1), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, -2), 0);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, -1), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 0, 1]
+    //              [0, 0, 1, ...] << lengthTracking
+    //                    [1, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      TypedArrayLastIndexOfHelper(fixedLength, 1);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 1);
+    });
+
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      TypedArrayLastIndexOfHelper(fixedLength, 0);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 0);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 0);
+    });
+
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0), 0);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      TypedArrayLastIndexOfHelper(fixedLength, 0);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 0);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 0);
+    });
+
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, undefined), -1);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+    }
+
+    // Orig. array: [0, 0, 1, 1, 2, 2]
+    //              [0, 0, 1, 1] << fixedLength
+    //                    [1, 1] << fixedLengthWithOffset
+    //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
+    //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 1), 3);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 2), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 1), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 2), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 1), 3);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 2), 5);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 1);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 2), 3);
+    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+  }
+}
+
+TestLastIndexOf();

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer.js
@@ -6,52 +6,11 @@ esid: sec-%typedarray%.prototype.lastindexof
 description: >
   TypedArray.p.lastIndexOf behaves correctly when receiver is backed by resizable
   buffer
+includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
+function TypedArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
     if (fromIndex == undefined) {
       return ta.lastIndexOf(BigInt(n));
@@ -64,130 +23,126 @@ function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
   return ta.lastIndexOf(n, fromIndex);
 }
 
-function TestLastIndexOf() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
-    }
-
-    // Orig. array: [0, 0, 1, 1]
-    //              [0, 0, 1, 1] << fixedLength
-    //                    [1, 1] << fixedLengthWithOffset
-    //              [0, 0, 1, 1, ...] << lengthTracking
-    //                    [1, 1, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0, 1), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0, 2), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0, -2), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 0, -3), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 1, 1), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 1, -2), 2);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 1, -3), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, undefined), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 1), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 1, -2), 0);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 1, -1), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, undefined), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0, 2), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0, -3), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 1, 1), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 1, 2), 2);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 1, -3), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, 1), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, -2), 0);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1, -1), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 0, 1]
-    //              [0, 0, 1, ...] << lengthTracking
-    //                    [1, ...] << lengthTrackingWithOffset
-
-    assert.throws(TypeError, () => {
-      TypedArrayLastIndexOfHelper(fixedLength, 1);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 1);
-    });
-
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 0);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      TypedArrayLastIndexOfHelper(fixedLength, 0);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 0);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 0);
-    });
-
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0), 0);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      TypedArrayLastIndexOfHelper(fixedLength, 0);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 0);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 0);
-    });
-
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 0), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, undefined), -1);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
-    }
-
-    // Orig. array: [0, 0, 1, 1, 2, 2]
-    //              [0, 0, 1, 1] << fixedLength
-    //                    [1, 1] << fixedLengthWithOffset
-    //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
-    //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
-
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 1), 3);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, 2), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLength, undefined), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 0), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 1), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, 2), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(fixedLengthWithOffset, undefined), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 1), 3);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, 2), 5);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTracking, undefined), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 1), 1);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, 2), 3);
-    assert.sameValue(TypedArrayLastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, Math.floor(i / 2));
   }
-}
 
-TestLastIndexOf();
+  // Orig. array: [0, 0, 1, 1]
+  //              [0, 0, 1, 1] << fixedLength
+  //                    [1, 1] << fixedLengthWithOffset
+  //              [0, 0, 1, 1, ...] << lengthTracking
+  //                    [1, 1, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0, 1), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0, 2), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0, -2), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0, -3), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 1, 1), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 1, -2), 2);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 1, -3), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, undefined), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -2), 0);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -1), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0, 2), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0, -3), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 1, 1), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 1, 2), 2);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 1, -3), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, 1), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -2), 0);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -1), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 0, 1]
+  //              [0, 0, 1, ...] << lengthTracking
+  //                    [1, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    TypedArrayLastIndexOfNumOrBigInt(fixedLength, 1);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1);
+  });
+
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0);
+  });
+
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 0);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0);
+  });
+  assert.throws(TypeError, () => {
+    TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0);
+  });
+
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+  }
+
+  // Orig. array: [0, 0, 1, 1, 2, 2]
+  //              [0, 0, 1, 1] << fixedLength
+  //                    [1, 1] << fixedLengthWithOffset
+  //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
+  //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
+
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 1), 3);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 2), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, undefined), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 2), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 1), 3);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 2), 5);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 1);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 2), 3);
+  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+}

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/resizable-buffer.js
@@ -4,23 +4,17 @@
 /*---
 esid: sec-%typedarray%.prototype.lastindexof
 description: >
-  TypedArray.p.lastIndexOf behaves correctly when receiver is backed by resizable
-  buffer
+  TypedArray.p.lastIndexOf behaves correctly on TypedArrays backed by resizable
+  buffers.
 includes: [resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-function TypedArrayLastIndexOfNumOrBigInt(ta, n, fromIndex) {
+function MayNeedBigInt(ta, n) {
   if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
-    if (fromIndex == undefined) {
-      return ta.lastIndexOf(BigInt(n));
-    }
-    return ta.lastIndexOf(BigInt(n), fromIndex);
+    return BigInt(n);
   }
-  if (fromIndex == undefined) {
-    return ta.lastIndexOf(n);
-  }
-  return ta.lastIndexOf(n, fromIndex);
+  return n;
 }
 
 for (let ctor of ctors) {
@@ -42,33 +36,37 @@ for (let ctor of ctors) {
   //              [0, 0, 1, 1, ...] << lengthTracking
   //                    [1, 1, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0, 1), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0, 2), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0, -2), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0, -3), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 1, 1), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 1, -2), 2);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 1, -3), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, undefined), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -2), 0);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1, -1), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0, 2), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0, -3), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 1, 1), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 1, 2), 2);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 1, -3), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, 1), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -2), 0);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1, -1), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  // If fixedLength is a BigInt array, they all are BigInt Arrays.
+  let n0 = MayNeedBigInt(fixedLength, 0);
+  let n1 = MayNeedBigInt(fixedLength, 1);
+
+  assert.sameValue(fixedLength.lastIndexOf(n0), 1);
+  assert.sameValue(fixedLength.lastIndexOf(n0, 1), 1);
+  assert.sameValue(fixedLength.lastIndexOf(n0, 2), 1);
+  assert.sameValue(fixedLength.lastIndexOf(n0, -2), 1);
+  assert.sameValue(fixedLength.lastIndexOf(n0, -3), 1);
+  assert.sameValue(fixedLength.lastIndexOf(n1, 1), -1);
+  assert.sameValue(fixedLength.lastIndexOf(n1, -2), 2);
+  assert.sameValue(fixedLength.lastIndexOf(n1, -3), -1);
+  assert.sameValue(fixedLength.lastIndexOf(undefined), -1);
+  assert.sameValue(fixedLengthWithOffset.lastIndexOf(n0), -1);
+  assert.sameValue(fixedLengthWithOffset.lastIndexOf(n1), 1);
+  assert.sameValue(fixedLengthWithOffset.lastIndexOf(n1, -2), 0);
+  assert.sameValue(fixedLengthWithOffset.lastIndexOf(n1, -1), 1);
+  assert.sameValue(fixedLengthWithOffset.lastIndexOf(undefined), -1);
+  assert.sameValue(lengthTracking.lastIndexOf(n0), 1);
+  assert.sameValue(lengthTracking.lastIndexOf(n0, 2), 1);
+  assert.sameValue(lengthTracking.lastIndexOf(n0, -3), 1);
+  assert.sameValue(lengthTracking.lastIndexOf(n1, 1), -1);
+  assert.sameValue(lengthTracking.lastIndexOf(n1, 2), 2);
+  assert.sameValue(lengthTracking.lastIndexOf(n1, -3), -1);
+  assert.sameValue(lengthTracking.lastIndexOf(undefined), -1);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(n0), -1);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(n1), 1);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(n1, 1), 1);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(n1, -2), 0);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(n1, -1), 1);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(undefined), -1);
 
   // Shrink so that fixed length TAs go out of bounds.
   rab.resize(3 * ctor.BYTES_PER_ELEMENT);
@@ -78,46 +76,46 @@ for (let ctor of ctors) {
   //                    [1, ...] << lengthTrackingWithOffset
 
   assert.throws(TypeError, () => {
-    TypedArrayLastIndexOfNumOrBigInt(fixedLength, 1);
+    fixedLength.lastIndexOf(n1);
   });
   assert.throws(TypeError, () => {
-    TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1);
+    fixedLengthWithOffset.lastIndexOf(n1);
   });
 
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 0);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  assert.sameValue(lengthTracking.lastIndexOf(n0), 1);
+  assert.sameValue(lengthTracking.lastIndexOf(undefined), -1);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(n0), -1);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(n1), 0);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(undefined), -1);
 
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
   assert.throws(TypeError, () => {
-    TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0);
+    fixedLength.lastIndexOf(n0);
   });
   assert.throws(TypeError, () => {
-    TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0);
+    fixedLengthWithOffset.lastIndexOf(n0);
   });
   assert.throws(TypeError, () => {
-    TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0);
+    lengthTrackingWithOffset.lastIndexOf(n0);
   });
 
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0), 0);
+  assert.sameValue(lengthTracking.lastIndexOf(n0), 0);
 
   // Shrink to zero.
   rab.resize(0);
   assert.throws(TypeError, () => {
-    TypedArrayLastIndexOfNumOrBigInt(fixedLength, 0);
+    fixedLength.lastIndexOf(n0);
   });
   assert.throws(TypeError, () => {
-    TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0);
+    fixedLengthWithOffset.lastIndexOf(n0);
   });
   assert.throws(TypeError, () => {
-    TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0);
+    lengthTrackingWithOffset.lastIndexOf(n0);
   });
 
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 0), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
+  assert.sameValue(lengthTracking.lastIndexOf(n0), -1);
+  assert.sameValue(lengthTracking.lastIndexOf(undefined), -1);
 
   // Grow so that all TAs are back in-bounds.
   rab.resize(6 * ctor.BYTES_PER_ELEMENT);
@@ -131,18 +129,20 @@ for (let ctor of ctors) {
   //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
   //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
 
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 1), 3);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, 2), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLength, undefined), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 0), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 1), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, 2), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(fixedLengthWithOffset, undefined), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 1), 3);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, 2), 5);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTracking, undefined), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 0), -1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 1), 1);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, 2), 3);
-  assert.sameValue(TypedArrayLastIndexOfNumOrBigInt(lengthTrackingWithOffset, undefined), -1);
+  let n2 = MayNeedBigInt(fixedLength, 2);
+
+  assert.sameValue(fixedLength.lastIndexOf(n1), 3);
+  assert.sameValue(fixedLength.lastIndexOf(n2), -1);
+  assert.sameValue(fixedLength.lastIndexOf(undefined), -1);
+  assert.sameValue(fixedLengthWithOffset.lastIndexOf(n0), -1);
+  assert.sameValue(fixedLengthWithOffset.lastIndexOf(n1), 1);
+  assert.sameValue(fixedLengthWithOffset.lastIndexOf(n2), -1);
+  assert.sameValue(fixedLengthWithOffset.lastIndexOf(undefined), -1);
+  assert.sameValue(lengthTracking.lastIndexOf(n1), 3);
+  assert.sameValue(lengthTracking.lastIndexOf(n2), 5);
+  assert.sameValue(lengthTracking.lastIndexOf(undefined), -1);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(n0), -1);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(n1), 1);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(n2), 3);
+  assert.sameValue(lengthTrackingWithOffset.lastIndexOf(undefined), -1);
 }


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR https://github.com/tc39/test262/pull/3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js