### PR TITLE
 RAB: Integrate staging tests for the .length method

### DIFF
--- a/test/built-ins/TypedArray/prototype/byteLength/resized-out-of-bounds-1.js
+++ b/test/built-ins/TypedArray/prototype/byteLength/resized-out-of-bounds-1.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-get-%typedarray%.prototype.length
+esid: sec-get-%typedarray%.prototype.byteLength
 description: >
-  TypedArray.p.length behaves correctly when the underlying resizable buffer is
-  resized such that the TypedArray becomes out of bounds.
+  TypedArray.p.byteLength behaves correctly when the underlying resizable buffer
+  is resized such that the TypedArray becomes out of bounds.
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
@@ -22,18 +22,18 @@ for (let ctor of ctors) {
   ]);
 }
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
 }
 rab.resize(2);
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteLength, 0);
 }
 // Resize the rab so that it just barely covers the needed 8 bytes.
 rab.resize(8);
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
 }
 rab.resize(40);
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
 }

--- a/test/built-ins/TypedArray/prototype/byteLength/resized-out-of-bounds-2.js
+++ b/test/built-ins/TypedArray/prototype/byteLength/resized-out-of-bounds-2.js
@@ -2,38 +2,38 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-get-%typedarray%.prototype.length
+esid: sec-get-%typedarray%.prototype.byteLength
 description: >
-  TypedArray.p.length behaves correctly when the underlying resizable buffer is
-  resized such that the TypedArray becomes out of bounds.
+  TypedArray.p.byteLength behaves as expected when the underlying resizable
+  buffer is resized such that the TypedArray becomes out of bounds.
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-const rab = CreateResizableArrayBuffer(16, 40);
+const rab = CreateResizableArrayBuffer(20, 40);
 
-// Create TAs which cover the bytes 0-7.
+// Create TAs with offset, which cover the bytes 8-15.
 let tas_and_lengths = [];
 for (let ctor of ctors) {
   const length = 8 / ctor.BYTES_PER_ELEMENT;
   tas_and_lengths.push([
-    new ctor(rab, 0, length),
+    new ctor(rab, 8, length),
     length
   ]);
 }
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
 }
-rab.resize(2);
+rab.resize(10);
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteLength, 0);
 }
 // Resize the rab so that it just barely covers the needed 8 bytes.
-rab.resize(8);
+rab.resize(16);
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
 }
 rab.resize(40);
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
 }

--- a/test/built-ins/TypedArray/prototype/byteOffset/resized-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/resized-out-of-bounds.js
@@ -2,38 +2,38 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-get-%typedarray%.prototype.length
+esid: sec-get-%typedarray%.prototype.byteOffset
 description: >
-  TypedArray.p.length behaves correctly when the underlying resizable buffer is
-  resized such that the TypedArray becomes out of bounds.
+  TypedArray.p.byteOffset behaves as expected when the underlying resizable
+  buffer is resized such that the TypedArray becomes out of bounds.
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-const rab = CreateResizableArrayBuffer(16, 40);
+const rab = CreateResizableArrayBuffer(20, 40);
 
-// Create TAs which cover the bytes 0-7.
+// Create TAs which cover the bytes 8-15.
 let tas_and_lengths = [];
 for (let ctor of ctors) {
   const length = 8 / ctor.BYTES_PER_ELEMENT;
   tas_and_lengths.push([
-    new ctor(rab, 0, length),
+    new ctor(rab, 8, length),
     length
   ]);
 }
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteOffset, 8);
 }
-rab.resize(2);
+rab.resize(10);
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteOffset, 0);
 }
 // Resize the rab so that it just barely covers the needed 8 bytes.
-rab.resize(8);
+rab.resize(16);
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteOffset, 8);
 }
 rab.resize(40);
 for (let [ta, length] of tas_and_lengths) {
-  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteOffset, 8);
 }

--- a/test/built-ins/TypedArray/prototype/length/resizable-buffer-assorted.js
+++ b/test/built-ins/TypedArray/prototype/length/resizable-buffer-assorted.js
@@ -1,0 +1,71 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-%typedarray%.prototype.length
+description: >
+  TypedArray.p.length behaves when the underlying resizable buffer is
+  backed by resizable buffers
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const rab = CreateResizableArrayBuffer(40, 80);
+for (let ctor of ctors) {
+  const ta = new ctor(rab, 0, 3);
+  assert.compareArray(ta.buffer, rab);
+  assert.sameValue(ta.length, 3);
+  const empty_ta = new ctor(rab, 0, 0);
+  assert.compareArray(empty_ta.buffer, rab);
+  assert.sameValue(empty_ta.length, 0);
+  const ta_with_offset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 3);
+  assert.compareArray(ta_with_offset.buffer, rab);
+  assert.sameValue(ta_with_offset.length, 3);
+  const empty_ta_with_offset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 0);
+  assert.compareArray(empty_ta_with_offset.buffer, rab);
+  assert.sameValue(empty_ta_with_offset.length, 0);
+  const length_tracking_ta = new ctor(rab);
+  assert.compareArray(length_tracking_ta.buffer, rab);
+  assert.sameValue(length_tracking_ta.length, 40 / ctor.BYTES_PER_ELEMENT);
+  const offset = 8;
+  const length_tracking_ta_with_offset = new ctor(rab, offset);
+  assert.compareArray(length_tracking_ta_with_offset.buffer, rab);
+  assert.sameValue(length_tracking_ta_with_offset.length, (40 - offset) / ctor.BYTES_PER_ELEMENT);
+  const empty_length_tracking_ta_with_offset = new ctor(rab, 40);
+  assert.compareArray(empty_length_tracking_ta_with_offset.buffer, rab);
+  assert.sameValue(empty_length_tracking_ta_with_offset.length, 0);
+}

--- a/test/built-ins/TypedArray/prototype/length/resizable-buffer-assorted.js
+++ b/test/built-ins/TypedArray/prototype/length/resizable-buffer-assorted.js
@@ -4,45 +4,11 @@
 /*---
 esid: sec-get-%typedarray%.prototype.length
 description: >
-  TypedArray.p.length behaves when the underlying resizable buffer is
-  backed by resizable buffers
-includes: [compareArray.js]
+  TypedArray.p.length behaves correctly on TypedArrays backed by resizable
+  buffers.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
-
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
 
 const rab = CreateResizableArrayBuffer(40, 80);
 for (let ctor of ctors) {

--- a/test/built-ins/TypedArray/prototype/length/resized-out-of-bounds-1.js
+++ b/test/built-ins/TypedArray/prototype/length/resized-out-of-bounds-1.js
@@ -1,0 +1,77 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-%typedarray%.prototype.length
+description: >
+  TypedArray.p.length behaves when the underlying resizable buffer is
+  resized such that the receiver becomes out of bounds
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const rab = CreateResizableArrayBuffer(16, 40);
+
+// Create TAs which cover the bytes 0-7.
+let tas_and_lengths = [];
+for (let ctor of ctors) {
+  const length = 8 / ctor.BYTES_PER_ELEMENT;
+  tas_and_lengths.push([
+    new ctor(rab, 0, length),
+    length
+  ]);
+}
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+}
+rab.resize(2);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteLength, 0);
+}
+// Resize the rab so that it just barely covers the needed 8 bytes.
+rab.resize(8);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+}
+rab.resize(40);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+}

--- a/test/built-ins/TypedArray/prototype/length/resized-out-of-bounds-2.js
+++ b/test/built-ins/TypedArray/prototype/length/resized-out-of-bounds-2.js
@@ -1,0 +1,83 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-%typedarray%.prototype.length
+description: >
+  TypedArray.p.length behaves when the underlying resizable buffer is
+  resized such that the receiver becomes out of bounds
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+// typed-array-length-when-resized-out-of-bounds-1 but with offsets.
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const rab = CreateResizableArrayBuffer(20, 40);
+
+// Create TAs which cover the bytes 8-15.
+let tas_and_lengths = [];
+for (let ctor of ctors) {
+  const length = 8 / ctor.BYTES_PER_ELEMENT;
+  tas_and_lengths.push([
+    new ctor(rab, 8, length),
+    length
+  ]);
+}
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteOffset, 8);
+}
+rab.resize(10);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteLength, 0);
+  assert.sameValue(ta.byteOffset, 0);
+}
+// Resize the rab so that it just barely covers the needed 8 bytes.
+rab.resize(16);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteOffset, 8);
+}
+rab.resize(40);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteOffset, 8);
+}

--- a/test/built-ins/TypedArray/prototype/length/resized-out-of-bounds-2.js
+++ b/test/built-ins/TypedArray/prototype/length/resized-out-of-bounds-2.js
@@ -4,51 +4,17 @@
 /*---
 esid: sec-get-%typedarray%.prototype.length
 description: >
-  TypedArray.p.length behaves when the underlying resizable buffer is
-  resized such that the receiver becomes out of bounds
-includes: [compareArray.js]
+  TypedArray.p.length behaves correctly when the underlying resizable buffer is
+  resized such that the TypedArray becomes out of bounds.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-// typed-array-length-when-resized-out-of-bounds-1 but with offsets.
-
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
+// Like resized-out-of-bounds-1.js but with offsets.
 
 const rab = CreateResizableArrayBuffer(20, 40);
 
-// Create TAs which cover the bytes 8-15.
+// Create TAs with offset, which cover the bytes 8-15.
 let tas_and_lengths = [];
 for (let ctor of ctors) {
   const length = 8 / ctor.BYTES_PER_ELEMENT;
@@ -59,25 +25,17 @@ for (let ctor of ctors) {
 }
 for (let [ta, length] of tas_and_lengths) {
   assert.sameValue(ta.length, length);
-  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
-  assert.sameValue(ta.byteOffset, 8);
 }
 rab.resize(10);
 for (let [ta, length] of tas_and_lengths) {
   assert.sameValue(ta.length, 0);
-  assert.sameValue(ta.byteLength, 0);
-  assert.sameValue(ta.byteOffset, 0);
 }
 // Resize the rab so that it just barely covers the needed 8 bytes.
 rab.resize(16);
 for (let [ta, length] of tas_and_lengths) {
   assert.sameValue(ta.length, length);
-  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
-  assert.sameValue(ta.byteOffset, 8);
 }
 rab.resize(40);
 for (let [ta, length] of tas_and_lengths) {
   assert.sameValue(ta.length, length);
-  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
-  assert.sameValue(ta.byteOffset, 8);
 }


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR #3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js