### PR TITLE
RAB: Integrate staging tests for the .map method

### DIFF
--- a/test/built-ins/Array/prototype/map/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/map/resizable-buffer-grow-mid-iteration.js
@@ -4,137 +4,79 @@
 /*---
 esid: sec-array.prototype.map
 description: >
-  Array.p.map behaves correctly when receiver is backed by resizable
-  buffer that is grown mid-iteration
-includes: [compareArray.js]
+  Array.p.map behaves correctly when the resizable buffer is grown mid-iteration.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
+// before calling this.
+function ResizeMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return n;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.map.call(fixedLength, ResizeMidIteration);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.map.call(fixedLengthWithOffset, ResizeMidIteration);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.map.call(lengthTracking, ResizeMidIteration);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.map.call(lengthTrackingWithOffset, ResizeMidIteration);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-const ArrayMapHelper = (ta, ...rest) => {
-  return Array.prototype.map.call(ta, ...rest);
-};
-
-function MapGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return n;
-  }
-  function Helper(array) {
-    values = [];
-    ArrayMapHelper(array, CollectValuesAndResize);
-    return values;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      6
-    ]);
-  }
-}
-
-MapGrowMidIteration();

--- a/test/built-ins/Array/prototype/map/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/map/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,140 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.map
+description: >
+  Array.p.map behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const ArrayMapHelper = (ta, ...rest) => {
+  return Array.prototype.map.call(ta, ...rest);
+};
+
+function MapGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return n;
+  }
+  function Helper(array) {
+    values = [];
+    ArrayMapHelper(array, CollectValuesAndResize);
+    return values;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+  }
+}
+
+MapGrowMidIteration();

--- a/test/built-ins/Array/prototype/map/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/map/resizable-buffer-shrink-mid-iteration.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-array.prototype.map
 description: >
-  Array.p.map behaves correctly when the resizable buffer is grown mid-iteration.
+  Array.p.map behaves correctly when the resizable buffer is shrunk mid-iteration.
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/

--- a/test/built-ins/Array/prototype/map/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/map/resizable-buffer-shrink-mid-iteration.js
@@ -4,137 +4,76 @@
 /*---
 esid: sec-array.prototype.map
 description: >
-  Array.p.map behaves correctly when receiver is backed by resizable
-  buffer that is grown mid-iteration
-includes: [compareArray.js]
+  Array.p.map behaves correctly when the resizable buffer is grown mid-iteration.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
+// before calling this. This version can deal with the undefined values
+// resulting by shrinking rab.
+function ShrinkMidIteration(n, ix, ta) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  // We still need to return a valid BigInt / non-BigInt, even if
+  // n is `undefined`.
+  if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+    return 0n;
+  }
+  return 0;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.map.call(fixedLength, ShrinkMidIteration);
+  assert.compareArray(values, [
+    0,
+    2
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.map.call(fixedLengthWithOffset, ShrinkMidIteration);
+  assert.compareArray(values, [4]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.map.call(lengthTracking, ShrinkMidIteration);
+  assert.compareArray(values, [
+    0,
+    2,
+    4
+  ]);
 }
-
-function IsBigIntTypedArray(ta) {
-  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.map.call(lengthTrackingWithOffset, ShrinkMidIteration);
+  assert.compareArray(values, [4]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-const ArrayMapHelper = (ta, ...rest) => {
-  return Array.prototype.map.call(ta, ...rest);
-};
-
-function MapShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n, ix, ta) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    // We still need to return a valid BigInt / non-BigInt, even if
-    // n is `undefined`.
-    if (IsBigIntTypedArray(ta)) {
-      return 0n;
-    }
-    return 0;
-  }
-  function Helper(array) {
-    values = [];
-    ArrayMapHelper(array, CollectValuesAndResize);
-    return values;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(fixedLengthWithOffset), [4]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
-  }
-}
-
-MapShrinkMidIteration();

--- a/test/built-ins/Array/prototype/map/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/map/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,140 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.map
+description: >
+  Array.p.map behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function IsBigIntTypedArray(ta) {
+  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const ArrayMapHelper = (ta, ...rest) => {
+  return Array.prototype.map.call(ta, ...rest);
+};
+
+function MapShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n, ix, ta) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    // We still need to return a valid BigInt / non-BigInt, even if
+    // n is `undefined`.
+    if (IsBigIntTypedArray(ta)) {
+      return 0n;
+    }
+    return 0;
+  }
+  function Helper(array) {
+    values = [];
+    ArrayMapHelper(array, CollectValuesAndResize);
+    return values;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(fixedLengthWithOffset), [4]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
+  }
+}
+
+MapShrinkMidIteration();

--- a/test/built-ins/Array/prototype/map/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/map/resizable-buffer.js
@@ -1,0 +1,207 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.map
+description: >
+  Array.p.map behaves as expected when the receiver is backed by
+  resizable buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const ArrayMapHelper = (ta, ...rest) => {
+  return Array.prototype.map.call(ta, ...rest);
+};
+
+function TestMap() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < taWrite.length; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function Helper(array) {
+      const values = [];
+      function GatherValues(n, ix) {
+        assert.sameValue(ix, values.length);
+        values.push(n);
+        if (typeof n == 'bigint') {
+          return n + 1n;
+        }
+        return n + 1;
+      }
+      const newValues = ArrayMapHelper(array, GatherValues);
+      for (let i = 0; i < values.length; ++i) {
+        if (typeof values[i] == 'bigint') {
+          assert.sameValue(values[i] + 1n, newValues[i]);
+        } else {
+          assert.sameValue(values[i] + 1, newValues[i]);
+        }
+      }
+      return ToNumbers(values);
+    }
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Helper(fixedLength), []);
+    assert.compareArray(Helper(fixedLengthWithOffset), []);
+
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.compareArray(Helper(fixedLength), []);
+    assert.compareArray(Helper(fixedLengthWithOffset), []);
+    assert.compareArray(Helper(lengthTrackingWithOffset), []);
+
+    assert.compareArray(Helper(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.compareArray(Helper(fixedLength), []);
+    assert.compareArray(Helper(fixedLengthWithOffset), []);
+    assert.compareArray(Helper(lengthTrackingWithOffset), []);
+
+    assert.compareArray(Helper(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+  }
+}
+
+TestMap();

--- a/test/built-ins/Array/prototype/map/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/map/resizable-buffer.js
@@ -4,204 +4,138 @@
 /*---
 esid: sec-array.prototype.map
 description: >
-  Array.p.map behaves as expected when the receiver is backed by
-  resizable buffer
-includes: [compareArray.js]
+  Array.p.map behaves as expected on TypedArrays backed by resizable buffers.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < taWrite.length; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
-  }
-  return item;
-}
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
 
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
-  }
-  return result;
-}
-
-const ArrayMapHelper = (ta, ...rest) => {
-  return Array.prototype.map.call(ta, ...rest);
-};
-
-function TestMap() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < taWrite.length; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    function Helper(array) {
-      const values = [];
-      function GatherValues(n, ix) {
-        assert.sameValue(ix, values.length);
-        values.push(n);
-        if (typeof n == 'bigint') {
-          return n + 1n;
-        }
-        return n + 1;
+  function MapGatherCompare(array) {
+    const values = [];
+    function GatherValues(n, ix) {
+      assert.sameValue(ix, values.length);
+      values.push(n);
+      if (typeof n == 'bigint') {
+        return n + 1n;
       }
-      const newValues = ArrayMapHelper(array, GatherValues);
-      for (let i = 0; i < values.length; ++i) {
-        if (typeof values[i] == 'bigint') {
-          assert.sameValue(values[i] + 1n, newValues[i]);
-        } else {
-          assert.sameValue(values[i] + 1, newValues[i]);
-        }
+      return n + 1;
+    }
+    const newValues = Array.prototype.map.call(array, GatherValues);
+    for (let i = 0; i < values.length; ++i) {
+      if (typeof values[i] == 'bigint') {
+        assert.sameValue(values[i] + 1n, newValues[i]);
+      } else {
+        assert.sameValue(values[i] + 1, newValues[i]);
       }
-      return ToNumbers(values);
     }
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      6
-    ]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(Helper(fixedLength), []);
-    assert.compareArray(Helper(fixedLengthWithOffset), []);
-
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.compareArray(Helper(fixedLength), []);
-    assert.compareArray(Helper(fixedLengthWithOffset), []);
-    assert.compareArray(Helper(lengthTrackingWithOffset), []);
-
-    assert.compareArray(Helper(lengthTracking), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.compareArray(Helper(fixedLength), []);
-    assert.compareArray(Helper(fixedLengthWithOffset), []);
-    assert.compareArray(Helper(lengthTrackingWithOffset), []);
-
-    assert.compareArray(Helper(lengthTracking), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      6,
-      8,
-      10
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      6,
-      8,
-      10
-    ]);
+    return ToNumbers(values);
   }
-}
+  assert.compareArray(MapGatherCompare(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(MapGatherCompare(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(MapGatherCompare(lengthTracking), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(MapGatherCompare(lengthTrackingWithOffset), [
+    4,
+    6
+  ]);
 
-TestMap();
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(MapGatherCompare(fixedLength), []);
+  assert.compareArray(MapGatherCompare(fixedLengthWithOffset), []);
+
+  assert.compareArray(MapGatherCompare(lengthTracking), [
+    0,
+    2,
+    4
+  ]);
+  assert.compareArray(MapGatherCompare(lengthTrackingWithOffset), [4]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.compareArray(MapGatherCompare(fixedLength), []);
+  assert.compareArray(MapGatherCompare(fixedLengthWithOffset), []);
+  assert.compareArray(MapGatherCompare(lengthTrackingWithOffset), []);
+
+  assert.compareArray(MapGatherCompare(lengthTracking), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.compareArray(MapGatherCompare(fixedLength), []);
+  assert.compareArray(MapGatherCompare(fixedLengthWithOffset), []);
+  assert.compareArray(MapGatherCompare(lengthTrackingWithOffset), []);
+
+  assert.compareArray(MapGatherCompare(lengthTracking), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(MapGatherCompare(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(MapGatherCompare(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(MapGatherCompare(lengthTracking), [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10
+  ]);
+  assert.compareArray(MapGatherCompare(lengthTrackingWithOffset), [
+    4,
+    6,
+    8,
+    10
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/map/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/map/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,140 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  TypedArray.p.map behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayMapHelper = (ta, ...rest) => {
+  return ta.map(...rest);
+};
+
+function MapGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return n;
+  }
+  function Helper(array) {
+    values = [];
+    TypedArrayMapHelper(array, CollectValuesAndResize);
+    return values;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+  }
+}
+
+MapGrowMidIteration();

--- a/test/built-ins/TypedArray/prototype/map/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/map/resizable-buffer-grow-mid-iteration.js
@@ -4,137 +4,80 @@
 /*---
 esid: sec-%typedarray%.prototype.map
 description: >
-  TypedArray.p.map behaves correctly when receiver is backed by resizable
-  buffer that is grown mid-iteration
-includes: [compareArray.js]
+  TypedArray.p.map behaves correctly on TypedArrays backed by resizable buffers
+  that are grown mid-iteration.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
+// before calling this.
+function ResizeMidIteration(n) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  return n;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.map(ResizeMidIteration);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.map(ResizeMidIteration);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.map(ResizeMidIteration);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    6
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.map(ResizeMidIteration);
+  assert.compareArray(values, [
+    4,
+    6
+  ]);
 }
-
-const TypedArrayMapHelper = (ta, ...rest) => {
-  return ta.map(...rest);
-};
-
-function MapGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return n;
-  }
-  function Helper(array) {
-    values = [];
-    TypedArrayMapHelper(array, CollectValuesAndResize);
-    return values;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      6
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      6
-    ]);
-  }
-}
-
-MapGrowMidIteration();

--- a/test/built-ins/TypedArray/prototype/map/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/map/resizable-buffer-shrink-mid-iteration.js
@@ -5,7 +5,7 @@
 esid: sec-%typedarray%.prototype.map
 description: >
   TypedArray.p.map behaves correctly on TypedArrays backed by resizable buffers
-  that are grown mid-iteration.
+  that are shrunk mid-iteration.
 includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/

--- a/test/built-ins/TypedArray/prototype/map/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/map/resizable-buffer-shrink-mid-iteration.js
@@ -4,146 +4,86 @@
 /*---
 esid: sec-%typedarray%.prototype.map
 description: >
-  TypedArray.p.map behaves correctly when receiver is backed by resizable
-  buffer that is grown mid-iteration
-includes: [compareArray.js]
+  TypedArray.p.map behaves correctly on TypedArrays backed by resizable buffers
+  that are grown mid-iteration.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset
+// before calling this. This version can deal with the undefined values
+// resulting by shrinking rab.
+function ShrinkMidIteration(n, ix, ta) {
+  CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+  // We still need to return a valid BigInt / non-BigInt, even if
+  // n is `undefined`.
+  if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+    return 0n;
+  }
+  return 0;
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.map(ShrinkMidIteration);
+  assert.compareArray(values, [
+    0,
+    2,
+    undefined,
+    undefined
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.map(ShrinkMidIteration);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.map(ShrinkMidIteration);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    undefined
+  ]);
 }
-
-function IsBigIntTypedArray(ta) {
-  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.map(ShrinkMidIteration);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-const TypedArrayMapHelper = (ta, ...rest) => {
-  return ta.map(...rest);
-};
-
-function MapShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n, ix, ta) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    // We still need to return a valid BigInt / non-BigInt, even if
-    // n is `undefined`.
-    if (IsBigIntTypedArray(ta)) {
-      return 0n;
-    }
-    return 0;
-  }
-  function Helper(array) {
-    values = [];
-    TypedArrayMapHelper(array, CollectValuesAndResize);
-    return values;
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      undefined,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    resizeAfter = 2;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      undefined
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    resizeAfter = 1;
-    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      undefined
-    ]);
-  }
-}
-
-MapShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/map/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/map/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,149 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  TypedArray.p.map behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function IsBigIntTypedArray(ta) {
+  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayMapHelper = (ta, ...rest) => {
+  return ta.map(...rest);
+};
+
+function MapShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n, ix, ta) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    // We still need to return a valid BigInt / non-BigInt, even if
+    // n is `undefined`.
+    if (IsBigIntTypedArray(ta)) {
+      return 0n;
+    }
+    return 0;
+  }
+  function Helper(array) {
+    values = [];
+    TypedArrayMapHelper(array, CollectValuesAndResize);
+    return values;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      undefined,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      undefined
+    ]);
+  }
+}
+
+MapShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/map/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/map/resizable-buffer.js
@@ -1,0 +1,223 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  TypedArray.p.map behaves as expected when the receiver is backed by
+  resizable buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArrayMapHelper = (ta, ...rest) => {
+  return ta.map(...rest);
+};
+
+function TestMap() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < taWrite.length; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function Helper(array) {
+      const values = [];
+      function GatherValues(n, ix) {
+        assert.sameValue(ix, values.length);
+        values.push(n);
+        if (typeof n == 'bigint') {
+          return n + 1n;
+        }
+        return n + 1;
+      }
+      const newValues = TypedArrayMapHelper(array, GatherValues);
+      for (let i = 0; i < values.length; ++i) {
+        if (typeof values[i] == 'bigint') {
+          assert.sameValue(values[i] + 1n, newValues[i]);
+        } else {
+          assert.sameValue(values[i] + 1, newValues[i]);
+        }
+      }
+      return ToNumbers(values);
+    }
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      Helper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      Helper(fixedLengthWithOffset);
+    });
+
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      Helper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      Helper(fixedLengthWithOffset);
+    });
+    assert.throws(TypeError, () => {
+      Helper(lengthTrackingWithOffset);
+    });
+
+    assert.compareArray(Helper(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      Helper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      Helper(fixedLengthWithOffset);
+    });
+    assert.throws(TypeError, () => {
+      Helper(lengthTrackingWithOffset);
+    });
+
+    assert.compareArray(Helper(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+  }
+}
+
+TestMap();

--- a/test/built-ins/TypedArray/prototype/map/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/map/resizable-buffer.js
@@ -4,220 +4,155 @@
 /*---
 esid: sec-%typedarray%.prototype.map
 description: >
-  TypedArray.p.map behaves as expected when the receiver is backed by
-  resizable buffer
-includes: [compareArray.js]
+  TypedArray.p.map behaves as expected on TypedArrays backed by resizable
+  buffers.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < taWrite.length; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
-  }
-  return item;
-}
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
 
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
-  }
-  return result;
-}
-
-const TypedArrayMapHelper = (ta, ...rest) => {
-  return ta.map(...rest);
-};
-
-function TestMap() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < taWrite.length; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    function Helper(array) {
-      const values = [];
-      function GatherValues(n, ix) {
-        assert.sameValue(ix, values.length);
-        values.push(n);
-        if (typeof n == 'bigint') {
-          return n + 1n;
-        }
-        return n + 1;
+  function MapGathering(array) {
+    const values = [];
+    function GatherValues(n, ix) {
+      assert.sameValue(ix, values.length);
+      values.push(n);
+      if (typeof n == 'bigint') {
+        return n + 1n;
       }
-      const newValues = TypedArrayMapHelper(array, GatherValues);
-      for (let i = 0; i < values.length; ++i) {
-        if (typeof values[i] == 'bigint') {
-          assert.sameValue(values[i] + 1n, newValues[i]);
-        } else {
-          assert.sameValue(values[i] + 1, newValues[i]);
-        }
+      return n + 1;
+    }
+    const newValues = array.map(GatherValues);
+    for (let i = 0; i < values.length; ++i) {
+      if (typeof values[i] == 'bigint') {
+        assert.sameValue(values[i] + 1n, newValues[i]);
+      } else {
+        assert.sameValue(values[i] + 1, newValues[i]);
       }
-      return ToNumbers(values);
     }
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      6
-    ]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert.throws(TypeError, () => {
-      Helper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      Helper(fixedLengthWithOffset);
-    });
-
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      Helper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      Helper(fixedLengthWithOffset);
-    });
-    assert.throws(TypeError, () => {
-      Helper(lengthTrackingWithOffset);
-    });
-
-    assert.compareArray(Helper(lengthTracking), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      Helper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      Helper(fixedLengthWithOffset);
-    });
-    assert.throws(TypeError, () => {
-      Helper(lengthTrackingWithOffset);
-    });
-
-    assert.compareArray(Helper(lengthTracking), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      6,
-      8,
-      10
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      6,
-      8,
-      10
-    ]);
+    return ToNumbers(values);
   }
-}
+  assert.compareArray(MapGathering(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(MapGathering(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(MapGathering(lengthTracking), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(MapGathering(lengthTrackingWithOffset), [
+    4,
+    6
+  ]);
 
-TestMap();
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    MapGathering(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    MapGathering(fixedLengthWithOffset);
+  });
+
+  assert.compareArray(MapGathering(lengthTracking), [
+    0,
+    2,
+    4
+  ]);
+  assert.compareArray(MapGathering(lengthTrackingWithOffset), [4]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    MapGathering(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    MapGathering(fixedLengthWithOffset);
+  });
+  assert.throws(TypeError, () => {
+    MapGathering(lengthTrackingWithOffset);
+  });
+
+  assert.compareArray(MapGathering(lengthTracking), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    MapGathering(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    MapGathering(fixedLengthWithOffset);
+  });
+  assert.throws(TypeError, () => {
+    MapGathering(lengthTrackingWithOffset);
+  });
+
+  assert.compareArray(MapGathering(lengthTracking), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(MapGathering(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(MapGathering(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(MapGathering(lengthTracking), [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10
+  ]);
+  assert.compareArray(MapGathering(lengthTrackingWithOffset), [
+    4,
+    6,
+    8,
+    10
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-resizable-buffer-grow.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-resizable-buffer-grow.js
@@ -1,0 +1,129 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  TypedArray.p.map behaves correctly when the receiver is grown by the
+  species constructor
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function IsBigIntTypedArray(ta) {
+  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+let values;
+let rab;
+function CollectValues(n, ix, ta) {
+  if (typeof n == 'bigint') {
+    values.push(Number(n));
+  } else {
+    values.push(n);
+  }
+  // We still need to return a valid BigInt / non-BigInt, even if
+  // n is `undefined`.
+  if (IsBigIntTypedArray(ta)) {
+    return 0n;
+  }
+  return 0;
+}
+function Helper(array) {
+  values = [];
+  array.map(CollectValues);
+  return values;
+}
+for (let ctor of ctors) {
+  rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  };
+  const fixedLength = new MyArray(rab, 0, 4);
+  resizeWhenConstructorCalled = true;
+  assert.compareArray(Helper(fixedLength), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.sameValue(rab.byteLength, 6 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  }
+  ;
+  const lengthTracking = new MyArray(rab);
+  resizeWhenConstructorCalled = true;
+  assert.compareArray(Helper(lengthTracking), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.sameValue(rab.byteLength, 6 * ctor.BYTES_PER_ELEMENT);
+}

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-resizable-buffer-shrink.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-resizable-buffer-shrink.js
@@ -1,0 +1,126 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  TypedArray.p.map behaves correctly when the receiver is shrunk by the
+  species constructor
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function IsBigIntTypedArray(ta) {
+  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+let values;
+let rab;
+function CollectValues(n, ix, ta) {
+  if (typeof n == 'bigint') {
+    values.push(Number(n));
+  } else {
+    values.push(n);
+  }
+  if (IsBigIntTypedArray(ta)) {
+    // We still need to return a valid BigInt / non-BigInt, even if
+    // n is `undefined`.
+    return 0n;
+  }
+  return 0;
+}
+function Helper(array) {
+  values = [];
+  array.map(CollectValues);
+  return values;
+}
+for (let ctor of ctors) {
+  rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  }
+  ;
+  const fixedLength = new MyArray(rab, 0, 4);
+  resizeWhenConstructorCalled = true;
+  assert.compareArray(Helper(fixedLength), [
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  ]);
+  assert.sameValue(rab.byteLength, 2 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  }
+  ;
+  const lengthTracking = new MyArray(rab);
+  resizeWhenConstructorCalled = true;
+  assert.compareArray(Helper(lengthTracking), [
+    0,
+    1,
+    undefined,
+    undefined
+  ]);
+  assert.sameValue(rab.byteLength, 2 * ctor.BYTES_PER_ELEMENT);
+}

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-resizable-buffer-shrink.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-resizable-buffer-shrink.js
@@ -4,80 +4,32 @@
 /*---
 esid: sec-%typedarray%.prototype.map
 description: >
-  TypedArray.p.map behaves correctly when the receiver is shrunk by the
-  species constructor
-includes: [compareArray.js]
+  TypedArray.p.map behaves correctly on TypedArrays backed by resizable buffers
+  that are shrunk by the species constructor.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function IsBigIntTypedArray(ta) {
-  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+// Returns a function that collects an appropriate typed array into values. Such
+// a result can be used as an argument to .map.
+function CollectWithUndefined(values) {
+  return (n, ix, ta) => {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+      // We still need to return a valid BigInt / non-BigInt, even if
+      // n is `undefined`.
+      return 0n;
+    }
+    return 0;
   }
 }
 
-let values;
-let rab;
-function CollectValues(n, ix, ta) {
-  if (typeof n == 'bigint') {
-    values.push(Number(n));
-  } else {
-    values.push(n);
-  }
-  if (IsBigIntTypedArray(ta)) {
-    // We still need to return a valid BigInt / non-BigInt, even if
-    // n is `undefined`.
-    return 0n;
-  }
-  return 0;
-}
-function Helper(array) {
-  values = [];
-  array.map(CollectValues);
-  return values;
-}
 for (let ctor of ctors) {
-  rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
   let resizeWhenConstructorCalled = false;
   class MyArray extends ctor {
     constructor(...params) {
@@ -90,7 +42,9 @@ for (let ctor of ctors) {
   ;
   const fixedLength = new MyArray(rab, 0, 4);
   resizeWhenConstructorCalled = true;
-  assert.compareArray(Helper(fixedLength), [
+  const values = [];
+  fixedLength.map(CollectWithUndefined(values));
+  assert.compareArray(values, [
     undefined,
     undefined,
     undefined,
@@ -99,7 +53,7 @@ for (let ctor of ctors) {
   assert.sameValue(rab.byteLength, 2 * ctor.BYTES_PER_ELEMENT);
 }
 for (let ctor of ctors) {
-  rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
   const taWrite = new ctor(rab);
   for (let i = 0; i < 4; ++i) {
     WriteToTypedArray(taWrite, i, i);
@@ -116,7 +70,9 @@ for (let ctor of ctors) {
   ;
   const lengthTracking = new MyArray(rab);
   resizeWhenConstructorCalled = true;
-  assert.compareArray(Helper(lengthTracking), [
+  const values = [];
+  lengthTracking.map(CollectWithUndefined(values));
+  assert.compareArray(values, [
     0,
     1,
     undefined,


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR #3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js
