### PR TITLE
RAB: Integrate staging tests for the .reduceRight method

### DIFF
--- a/test/built-ins/Array/prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,145 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.reduceright
+description: >
+  Array.p.reduceRight behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const ArrayReduceRightHelper = (ta, ...rest) => {
+  return Array.prototype.reduceRight.call(ta, ...rest);
+};
+
+function TestReduceRight() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return true;
+  }
+  function ReduceRightHelper(array) {
+    values = [];
+    ArrayReduceRightHelper(array, (acc, n) => {
+      CollectValuesAndResize(n);
+    }, 'initial value');
+    return values;
+  }
+
+  // Test for reduceRight.
+
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(fixedLength), [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(fixedLengthWithOffset), [
+      6,
+      4
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(lengthTracking), [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(lengthTrackingWithOffset), [
+      6,
+      4
+    ]);
+  }
+}
+
+TestReduceRight();

--- a/test/built-ins/Array/prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,95 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%array%.prototype.reduceright
+description: >
+  Array.p.reduceRight behaves correctly when the backing resizable buffer is
+  shrunk mid-iteration.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
+features: [resizable-arraybuffer]
+---*/
+
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset before
+// calling this.
+function ResizeMidIteration(acc, n) {
+  return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.reduceRight.call(fixedLength, ResizeMidIteration, 'initial value');
+  assert.compareArray(values, [
+    6,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.reduceRight.call(fixedLengthWithOffset, ResizeMidIteration, 'initial value');
+  assert.compareArray(values, [
+    6
+  ]);
+}
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  // Unaffected by the shrinking, since we've already iterated past the point.
+  Array.prototype.reduceRight.call(lengthTracking, ResizeMidIteration, 'initial value');
+  assert.compareArray(values, [
+    6,
+    4,
+    2,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 1;
+  resizeTo = 2 * ctor.BYTES_PER_ELEMENT;
+  Array.prototype.reduceRight.call(lengthTracking, ResizeMidIteration, 'initial value');
+  assert.compareArray(values, [
+    6,
+    2,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  // Unaffected by the shrinking, since we've already iterated past the point.
+  Array.prototype.reduceRight.call(lengthTrackingWithOffset, ResizeMidIteration, 'initial value');
+  assert.compareArray(values, [
+    6,
+    4
+  ]);
+}

--- a/test/built-ins/Array/prototype/reduceRight/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/reduceRight/resizable-buffer.js
@@ -1,0 +1,194 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.reduceright
+description: >
+  Array.p.reduceRight behaves correctly when receiver is backed by resizable
+  buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const ArrayReduceRightHelper = (ta, ...rest) => {
+  return Array.prototype.reduceRight.call(ta, ...rest);
+};
+
+function TestReduceRight() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function Helper(array) {
+      const reduceRightValues = [];
+      ArrayReduceRightHelper(array, (acc, n) => {
+        reduceRightValues.push(n);
+      }, 'initial value');
+      reduceRightValues.reverse();
+      return ToNumbers(reduceRightValues);
+    }
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Helper(fixedLength), []);
+    assert.compareArray(Helper(fixedLengthWithOffset), []);
+
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.compareArray(Helper(fixedLength), []);
+    assert.compareArray(Helper(fixedLengthWithOffset), []);
+
+    assert.compareArray(Helper(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.compareArray(Helper(fixedLength), []);
+    assert.compareArray(Helper(fixedLengthWithOffset), []);
+    assert.compareArray(Helper(lengthTrackingWithOffset), []);
+
+    assert.compareArray(Helper(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+  }
+}
+
+TestReduceRight();

--- a/test/built-ins/Array/prototype/reduceRight/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/reduceRight/resizable-buffer.js
@@ -4,191 +4,126 @@
 /*---
 esid: sec-array.prototype.reduceright
 description: >
-  Array.p.reduceRight behaves correctly when receiver is backed by resizable
-  buffer
-includes: [compareArray.js]
+  Array.p.reduceRight behaves correctly on TypedArrays backed by resizable
+  buffers.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  function ReduceRightCollecting(array) {
+    const reduceRightValues = [];
+    Array.prototype.reduceRight.call(array, (acc, n) => {
+      reduceRightValues.push(n);
+    }, 'initial value');
+    reduceRightValues.reverse();
+    return ToNumbers(reduceRightValues);
   }
-  return item;
-}
+  assert.compareArray(ReduceRightCollecting(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ReduceRightCollecting(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(ReduceRightCollecting(lengthTracking), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ReduceRightCollecting(lengthTrackingWithOffset), [
+    4,
+    6
+  ]);
 
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ReduceRightCollecting(fixedLength), []);
+  assert.compareArray(ReduceRightCollecting(fixedLengthWithOffset), []);
+
+  assert.compareArray(ReduceRightCollecting(lengthTracking), [
+    0,
+    2,
+    4
+  ]);
+  assert.compareArray(ReduceRightCollecting(lengthTrackingWithOffset), [4]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.compareArray(ReduceRightCollecting(fixedLength), []);
+  assert.compareArray(ReduceRightCollecting(fixedLengthWithOffset), []);
+
+  assert.compareArray(ReduceRightCollecting(lengthTracking), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.compareArray(ReduceRightCollecting(fixedLength), []);
+  assert.compareArray(ReduceRightCollecting(fixedLengthWithOffset), []);
+  assert.compareArray(ReduceRightCollecting(lengthTrackingWithOffset), []);
+
+  assert.compareArray(ReduceRightCollecting(lengthTracking), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-  return result;
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ReduceRightCollecting(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ReduceRightCollecting(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(ReduceRightCollecting(lengthTracking), [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10
+  ]);
+  assert.compareArray(ReduceRightCollecting(lengthTrackingWithOffset), [
+    4,
+    6,
+    8,
+    10
+  ]);
 }
-
-const ArrayReduceRightHelper = (ta, ...rest) => {
-  return Array.prototype.reduceRight.call(ta, ...rest);
-};
-
-function TestReduceRight() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    function Helper(array) {
-      const reduceRightValues = [];
-      ArrayReduceRightHelper(array, (acc, n) => {
-        reduceRightValues.push(n);
-      }, 'initial value');
-      reduceRightValues.reverse();
-      return ToNumbers(reduceRightValues);
-    }
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      6
-    ]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(Helper(fixedLength), []);
-    assert.compareArray(Helper(fixedLengthWithOffset), []);
-
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.compareArray(Helper(fixedLength), []);
-    assert.compareArray(Helper(fixedLengthWithOffset), []);
-
-    assert.compareArray(Helper(lengthTracking), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.compareArray(Helper(fixedLength), []);
-    assert.compareArray(Helper(fixedLengthWithOffset), []);
-    assert.compareArray(Helper(lengthTrackingWithOffset), []);
-
-    assert.compareArray(Helper(lengthTracking), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      6,
-      8,
-      10
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      6,
-      8,
-      10
-    ]);
-  }
-}
-
-TestReduceRight();

--- a/test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
@@ -4,142 +4,82 @@
 /*---
 esid: sec-%typedarray%.prototype.reduceright
 description: >
-  TypedArray.p.reduceRight behaves correctly when receiver is backed by resizable
-  buffer that is grown mid-iteration
-includes: [compareArray.js]
+  TypedArray.p.reduceRight behaves correctly on TypedArrays backed by resizable
+  buffers that are grown mid-iteration.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+// Collects the view of the resizable array buffer rab into values, with an
+// iteration during which, after resizeAfter steps, rab is resized to length
+// resizeTo. To be called by a method of the view being collected.
+// Note that rab, values, resizeAfter, and resizeTo may need to be reset before
+// calling this.
+function ResizeMidIteration(acc, n) {
+  return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
 }
 
-class MyFloat32Array extends Float32Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+// Test for reduceRight.
+
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.reduceRight(ResizeMidIteration, 'initial value');
+  assert.compareArray(values, [
+    6,
+    4,
+    2,
+    0
+  ]);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.reduceRight(ResizeMidIteration, 'initial value');
+  assert.compareArray(values, [
+    6,
+    4
+  ]);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 2;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.reduceRight(ResizeMidIteration, 'initial value');
+  assert.compareArray(values, [
+    6,
+    4,
+    2,
+    0
+  ]);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
+for (let ctor of ctors) {
+  values = [];
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAfter = 1;
+  resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.reduceRight(ResizeMidIteration, 'initial value');
+  assert.compareArray(values, [
+    6,
+    4
+  ]);
 }
-
-const TypedArrayReduceRightHelper = (ta, ...rest) => {
-  return ta.reduceRight(...rest);
-};
-
-function TestReduceRight() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-  let values;
-  let rab;
-  let resizeAfter;
-  let resizeTo;
-  function CollectValuesAndResize(n) {
-    if (typeof n == 'bigint') {
-      values.push(Number(n));
-    } else {
-      values.push(n);
-    }
-    if (values.length == resizeAfter) {
-      rab.resize(resizeTo);
-    }
-    return true;
-  }
-  function ReduceRightHelper(array) {
-    values = [];
-    TypedArrayReduceRightHelper(array, (acc, n) => {
-      CollectValuesAndResize(n);
-    }, 'initial value');
-    return values;
-  }
-
-  // Test for reduceRight.
-
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ReduceRightHelper(fixedLength), [
-      6,
-      4,
-      2,
-      0
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ReduceRightHelper(fixedLengthWithOffset), [
-      6,
-      4
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    resizeAfter = 2;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ReduceRightHelper(lengthTracking), [
-      6,
-      4,
-      2,
-      0
-    ]);
-  }
-  for (let ctor of ctors) {
-    rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    resizeAfter = 1;
-    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
-    assert.compareArray(ReduceRightHelper(lengthTrackingWithOffset), [
-      6,
-      4
-    ]);
-  }
-}
-
-TestReduceRight();

--- a/test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,145 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.reduceright
+description: >
+  TypedArray.p.reduceRight behaves correctly when receiver is backed by resizable
+  buffer that is grown mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayReduceRightHelper = (ta, ...rest) => {
+  return ta.reduceRight(...rest);
+};
+
+function TestReduceRight() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return true;
+  }
+  function ReduceRightHelper(array) {
+    values = [];
+    TypedArrayReduceRightHelper(array, (acc, n) => {
+      CollectValuesAndResize(n);
+    }, 'initial value');
+    return values;
+  }
+
+  // Test for reduceRight.
+
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(fixedLength), [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(fixedLengthWithOffset), [
+      6,
+      4
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(lengthTracking), [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(lengthTrackingWithOffset), [
+      6,
+      4
+    ]);
+  }
+}
+
+TestReduceRight();

--- a/test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,151 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.reduceright
+description: >
+  TypedArray.p.reduceRight behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+function CollectValuesAndResize(n) {
+  if (typeof n == 'bigint') {
+    values.push(Number(n));
+  } else {
+    values.push(n);
+  }
+  if (values.length == resizeAfter) {
+    rab.resize(resizeTo);
+  }
+  return true;
+}
+function ReduceRightHelper(array) {
+  values = [];
+  array.reduceRight((acc, n) => {
+    CollectValuesAndResize(n);
+  }, 'initial value');
+  return values;
+}
+
+// Tests for reduceRight.
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ReduceRightHelper(fixedLength), [
+    6,
+    4,
+    undefined,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ReduceRightHelper(fixedLengthWithOffset), [
+    6,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  // Unaffected by the shrinking, since we've already iterated past the point.
+  assert.compareArray(ReduceRightHelper(lengthTracking), [
+    6,
+    4,
+    2,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 1;
+  resizeTo = 2 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ReduceRightHelper(lengthTracking), [
+    6,
+    undefined,
+    2,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  // Unaffected by the shrinking, since we've already iterated past the point.
+  assert.compareArray(ReduceRightHelper(lengthTrackingWithOffset), [
+    6,
+    4
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer.js
@@ -1,0 +1,211 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.reduceright
+description: >
+  TypedArray.p.reduceRight behaves correctly when receiver is backed by resizable
+  buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArrayReduceRightHelper = (ta, ...rest) => {
+  return ta.reduceRight(...rest);
+};
+
+function TestReduceRight() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function Helper(array) {
+      const reduceRightValues = [];
+      TypedArrayReduceRightHelper(array, (acc, n) => {
+        reduceRightValues.push(n);
+      }, 'initial value');
+      reduceRightValues.reverse();
+      return ToNumbers(reduceRightValues);
+    }
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      Helper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      Helper(fixedLengthWithOffset);
+    });
+
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      Helper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      Helper(fixedLengthWithOffset);
+    });
+    assert.throws(TypeError, () => {
+      Helper(lengthTrackingWithOffset);
+    });
+
+    assert.compareArray(Helper(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      Helper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      Helper(fixedLengthWithOffset);
+    });
+    assert.throws(TypeError, () => {
+      Helper(lengthTrackingWithOffset);
+    });
+
+    assert.compareArray(Helper(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+  }
+}
+
+TestReduceRight();

--- a/test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer.js
@@ -4,208 +4,143 @@
 /*---
 esid: sec-%typedarray%.prototype.reduceright
 description: >
-  TypedArray.p.reduceRight behaves correctly when receiver is backed by resizable
-  buffer
-includes: [compareArray.js]
+  TypedArray.p.reduceRight behaves correctly on TypedArrays backed by resizable
+  buffers.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  function ReduceRightCollecting(array) {
+    const reduceRightValues = [];
+    array.reduceRight((acc, n) => {
+      reduceRightValues.push(n);
+    }, 'initial value');
+    reduceRightValues.reverse();
+    return ToNumbers(reduceRightValues);
   }
-  return item;
-}
+  assert.compareArray(ReduceRightCollecting(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ReduceRightCollecting(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(ReduceRightCollecting(lengthTracking), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ReduceRightCollecting(lengthTrackingWithOffset), [
+    4,
+    6
+  ]);
 
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    ReduceRightCollecting(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    ReduceRightCollecting(fixedLengthWithOffset);
+  });
+
+  assert.compareArray(ReduceRightCollecting(lengthTracking), [
+    0,
+    2,
+    4
+  ]);
+  assert.compareArray(ReduceRightCollecting(lengthTrackingWithOffset), [4]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    ReduceRightCollecting(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    ReduceRightCollecting(fixedLengthWithOffset);
+  });
+  assert.throws(TypeError, () => {
+    ReduceRightCollecting(lengthTrackingWithOffset);
+  });
+
+  assert.compareArray(ReduceRightCollecting(lengthTracking), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    ReduceRightCollecting(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    ReduceRightCollecting(fixedLengthWithOffset);
+  });
+  assert.throws(TypeError, () => {
+    ReduceRightCollecting(lengthTrackingWithOffset);
+  });
+
+  assert.compareArray(ReduceRightCollecting(lengthTracking), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-  return result;
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ReduceRightCollecting(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ReduceRightCollecting(fixedLengthWithOffset), [
+    4,
+    6
+  ]);
+  assert.compareArray(ReduceRightCollecting(lengthTracking), [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10
+  ]);
+  assert.compareArray(ReduceRightCollecting(lengthTrackingWithOffset), [
+    4,
+    6,
+    8,
+    10
+  ]);
 }
-
-const TypedArrayReduceRightHelper = (ta, ...rest) => {
-  return ta.reduceRight(...rest);
-};
-
-function TestReduceRight() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    function Helper(array) {
-      const reduceRightValues = [];
-      TypedArrayReduceRightHelper(array, (acc, n) => {
-        reduceRightValues.push(n);
-      }, 'initial value');
-      reduceRightValues.reverse();
-      return ToNumbers(reduceRightValues);
-    }
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      6
-    ]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    assert.throws(TypeError, () => {
-      Helper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      Helper(fixedLengthWithOffset);
-    });
-
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      Helper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      Helper(fixedLengthWithOffset);
-    });
-    assert.throws(TypeError, () => {
-      Helper(lengthTrackingWithOffset);
-    });
-
-    assert.compareArray(Helper(lengthTracking), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      Helper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      Helper(fixedLengthWithOffset);
-    });
-    assert.throws(TypeError, () => {
-      Helper(lengthTrackingWithOffset);
-    });
-
-    assert.compareArray(Helper(lengthTracking), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(Helper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(Helper(lengthTracking), [
-      0,
-      2,
-      4,
-      6,
-      8,
-      10
-    ]);
-    assert.compareArray(Helper(lengthTrackingWithOffset), [
-      4,
-      6,
-      8,
-      10
-    ]);
-  }
-}
-
-TestReduceRight();


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR #3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js

This is very similar as PR #4156 for `.reduce`.