### PR TITLE
Use spaces instead of tabs

### DIFF
--- a/test/built-ins/Array/prototype/every/15.4.4.16-3-23.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-3-23.js
@@ -33,8 +33,8 @@ var child = new Con();
 
 Object.defineProperty(child, "toString", {
   value: function() {
-	  toStringAccessed = true;
-	  return '1';
+    toStringAccessed = true;
+    return '1';
   }
 });
 

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-3-23.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-3-23.js
@@ -37,8 +37,8 @@ function callbackfn(prevVal, curVal, idx, obj) {
 
 Object.defineProperty(child, "toString", {
   value: function() {
-	  toStringAccessed = true;
-	  return '1';
+    toStringAccessed = true;
+    return '1';
   }
 });
 


### PR DESCRIPTION
When we update tesst262 for WebKit, WebKit style checker warns for tabs (context: https://github.com/WebKit/WebKit/pull/30940 ).

For consistency, I think we should use spaces instead of tabs.
