### PR TITLE
Prevent harness code not loading when async/generator/asyncGenerator not supported

### DIFF
--- a/harness/hidden-constructors.js
+++ b/harness/hidden-constructors.js
@@ -10,6 +10,18 @@ defines:
   - GeneratorFunction
 ---*/
 
-var AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-var AsyncGeneratorFunction = Object.getPrototypeOf(async function* () {}).constructor;
-var GeneratorFunction = Object.getPrototypeOf(function* () {}).constructor;
+var AsyncFunction;
+var AsyncGeneratorFunction;
+var GeneratorFunction;
+
+try {
+  AsyncFunction = Object.getPrototypeOf(new Function('async function () {}')).constructor;
+} catch(e) {}
+
+try {
+  Object.getPrototypeOf(new Function('async function* () {}')).constructor;
+} catch(e) {}
+
+try {
+  Object.getPrototypeOf(new Function('function* () {}')).constructor;
+} catch(e) {}

--- a/harness/hidden-constructors.js
+++ b/harness/hidden-constructors.js
@@ -19,9 +19,9 @@ try {
 } catch(e) {}
 
 try {
-  Object.getPrototypeOf(new Function('async function* () {}')).constructor;
+  AsyncGeneratorFunction = Object.getPrototypeOf(new Function('async function* () {}')).constructor;
 } catch(e) {}
 
 try {
-  Object.getPrototypeOf(new Function('function* () {}')).constructor;
+  GeneratorFunction = Object.getPrototypeOf(new Function('function* () {}')).constructor;
 } catch(e) {}


### PR DESCRIPTION
In order to not fail because harness code fails to load due to using not-supported EcmaScript features while not needed

Relates to ##3032 