### PR TITLE
Make resizableArrayBufferUtils not depend on syntax that may not be supported

### DIFF
--- a/harness/resizableArrayBufferUtils.js
+++ b/harness/resizableArrayBufferUtils.js
@@ -18,14 +18,10 @@ defines:
 features: [BigInt]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
+// Using new Function()(); instead of just 'class x extends Y' as to not bomb out when `class` isn't supported
+const MyUint8Array = new Function('return class MyUint8Array extends Uint8Array {}')();
+const MyFloat32Array = new Function('return class MyFloat32Array extends Float32Array {}')();
+const MyBigInt64Array = new Function('return class MyBigInt64Array extends BigInt64Array {}')();
 
 const builtinCtors = [
   Uint8Array,
@@ -39,15 +35,18 @@ const builtinCtors = [
   Uint8ClampedArray,
 ];
 
-// BigInt and Float16Array are newer features adding them above unconditionally
+// Big(U)int64Array and Float16Array are newer features adding them above unconditionally
 // would cause implementations lacking it to fail every test which uses it.
 if (typeof Float16Array !== 'undefined') {
   builtinCtors.push(Float16Array);
 }
 
-if (typeof BigInt !== 'undefined') {
-    builtinCtors.push(BigUint64Array);
-    builtinCtors.push(BigInt64Array);
+if (typeof BigUint64Array !== 'undefined') {
+  builtinCtors.push(BigUint64Array);
+}
+
+if (typeof BigInt64Array !== 'undefined') {
+  builtinCtors.push(BigInt64Array);
 }
 
 const floatCtors = [
@@ -60,13 +59,9 @@ if (typeof Float16Array !== 'undefined') {
   floatCtors.push(Float16Array);
 }
 
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array
-];
+const ctors = builtinCtors.concat(MyUint8Array, MyFloat32Array);
 
-if (typeof BigInt !== 'undefined') {
+if (typeof MyBigInt64Array !== 'undefined') {
     ctors.push(MyBigInt64Array);
 }
 
@@ -125,7 +120,7 @@ function TestIterationAndResize(iterable, expected, rab, resizeAfter, newByteLen
   let resized = false;
   var arrayValues = false;
 
-  for (const value of iterable) {
+  for (let value of iterable) {
     if (Array.isArray(value)) {
       arrayValues = true;
       values.push([


### PR DESCRIPTION
In order to not fail because harness code fails to load due to using not-supported EcmaScript features while not needed 

Relates to ##3032