### PR TITLE
Revert "Prevent harness code not loading when async/generator/asyncGenerator not supported"

### DIFF
--- a/harness/hidden-constructors.js
+++ b/harness/hidden-constructors.js
@@ -10,18 +10,6 @@ defines:
   - GeneratorFunction
 ---*/
 
-var AsyncFunction;
-var AsyncGeneratorFunction;
-var GeneratorFunction;
-
-try {
-  AsyncFunction = Object.getPrototypeOf(new Function('async function () {}')).constructor;
-} catch(e) {}
-
-try {
-  AsyncGeneratorFunction = Object.getPrototypeOf(new Function('async function* () {}')).constructor;
-} catch(e) {}
-
-try {
-  GeneratorFunction = Object.getPrototypeOf(new Function('function* () {}')).constructor;
-} catch(e) {}
+var AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+var AsyncGeneratorFunction = Object.getPrototypeOf(async function* () {}).constructor;
+var GeneratorFunction = Object.getPrototypeOf(function* () {}).constructor;


### PR DESCRIPTION
Reverts tc39/test262#4164 because it added incorrect code:

```js
js> Object.getPrototypeOf(new Function('async function () {}')).constructor;
typein:3:16 SyntaxError: function statement requires a name:
typein:3:16 async function () {}
typein:3:16 ...............^
Stack:
  @typein:1:23
```