### PR TITLE
Fix syntax error from #4164

### DIFF
--- a/harness/hidden-constructors.js
+++ b/harness/hidden-constructors.js
@@ -15,13 +15,13 @@ var AsyncGeneratorFunction;
 var GeneratorFunction;
 
 try {
-  AsyncFunction = Object.getPrototypeOf(new Function('async function () {}')).constructor;
+  AsyncFunction = Object.getPrototypeOf(new Function('async function dummy() {}')).constructor;
 } catch(e) {}
 
 try {
-  AsyncGeneratorFunction = Object.getPrototypeOf(new Function('async function* () {}')).constructor;
+  AsyncGeneratorFunction = Object.getPrototypeOf(new Function('async function* dummy() {}')).constructor;
 } catch(e) {}
 
 try {
-  GeneratorFunction = Object.getPrototypeOf(new Function('function* () {}')).constructor;
+  GeneratorFunction = Object.getPrototypeOf(new Function('function* dummy() {}')).constructor;
 } catch(e) {}

--- a/harness/hidden-constructors.js
+++ b/harness/hidden-constructors.js
@@ -15,13 +15,13 @@ var AsyncGeneratorFunction;
 var GeneratorFunction;
 
 try {
-  AsyncFunction = Object.getPrototypeOf(new Function('async function dummy() {}')).constructor;
+  AsyncFunction = Object.getPrototypeOf(new Function('return async function dummy() {}')()).constructor;
 } catch(e) {}
 
 try {
-  AsyncGeneratorFunction = Object.getPrototypeOf(new Function('async function* dummy() {}')).constructor;
+  AsyncGeneratorFunction = Object.getPrototypeOf(new Function('return async function* dummy() {}')()).constructor;
 } catch(e) {}
 
 try {
-  GeneratorFunction = Object.getPrototypeOf(new Function('function* dummy() {}')).constructor;
+  GeneratorFunction = Object.getPrototypeOf(new Function('return function* dummy() {}')()).constructor;
 } catch(e) {}


### PR DESCRIPTION
Function statements require a name.

See #4166