### PR TITLE
Temporal: Fix Japanese era test

### DIFF
--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -127,7 +127,7 @@ var TemporalHelpers = {
    * Return the canonical era code.
    */
   canonicalizeCalendarEra(calendarId, eraName) {
-    assert.sameValue(typeof calendarId, "string");
+    assert.sameValue(typeof calendarId, "string", "calendar must be string in canonicalizeCalendarEra");
 
     if (calendarId === "iso8601") {
       assert.sameValue(eraName, undefined);
@@ -138,7 +138,7 @@ var TemporalHelpers = {
     if (eraName === undefined) {
       return undefined;
     }
-    assert.sameValue(typeof eraName, "string");
+    assert.sameValue(typeof eraName, "string", "eraName must be string or undefined in canonicalizeCalendarEra");
 
     for (let {era, aliases = []} of TemporalHelpers.CalendarEras[calendarId]) {
       if (era === eraName || aliases.includes(eraName)) {

--- a/test/staging/Intl402/Temporal/old/japanese-era.js
+++ b/test/staging/Intl402/Temporal/old/japanese-era.js
@@ -69,8 +69,8 @@ date = Temporal.PlainDate.from({
 });
 assert.sameValue(`${date}`, "1000-01-01[u-ca=japanese]");
 assert.sameValue(
-  TemporalHelpers.canonicalizeEraInCalendar(date, date.era),
-  TemporalHelpers.canonicalizeEraInCalendar(date, "ce"),
+  TemporalHelpers.canonicalizeCalendarEra(date.calendarId, date.era),
+  TemporalHelpers.canonicalizeCalendarEra(date.calendarId, "ce"),
 );
 assert.sameValue(date.eraYear, 1000);
 
@@ -83,7 +83,7 @@ date = Temporal.PlainDate.from({
 });
 assert.sameValue(`${date}`, "0000-01-01[u-ca=japanese]");
 assert.sameValue(
-  TemporalHelpers.canonicalizeEraInCalendar(date, date.era),
-  TemporalHelpers.canonicalizeEraInCalendar(date, "bce"),
+  TemporalHelpers.canonicalizeCalendarEra(date.calendarId, date.era),
+  TemporalHelpers.canonicalizeCalendarEra(date.calendarId, "bce"),
 );
 assert.sameValue(date.eraYear, 1);


### PR DESCRIPTION
This mistakenly used a previous name for the helper function. Also adds a couple of debugging messages.

(Regression from #4102)