### PR TITLE
[explicit-resource-management] some boilerplate tests from PR #3866

### DIFF
--- a/test/built-ins/AsyncDisposableStack/is-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/is-a-constructor.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The AsyncDisposableStack constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [explicit-resource-management, Reflect.construct]
+---*/
+
+assert.sameValue(isConstructor(AsyncDisposableStack), true, 'isConstructor(AsyncDisposableStack) must return true');
+new AsyncDisposableStack();

--- a/test/built-ins/AsyncDisposableStack/length.js
+++ b/test/built-ins/AsyncDisposableStack/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: AsyncDisposableStack.length property descriptor
+info: |
+  AsyncDisposableStack ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/name.js
+++ b/test/built-ins/AsyncDisposableStack/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: AsyncDisposableStack.name property descriptor
+info: |
+  AsyncDisposableStack ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack, 'name', {
+  value: 'AsyncDisposableStack',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prop-desc.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack-constructor
+description: >
+  Property descriptor of AsyncDisposableStack
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(this, 'AsyncDisposableStack', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: AsyncDisposableStack.prototype.adopt.length property descriptor
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.adopt, 'length', {
+  value: 2,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: AsyncDisposableStack.prototype.adopt.name property descriptor
+info: |
+  AsyncDisposableStack.prototype.adopt.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.adopt, 'name', {
+  value: 'adopt',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/not-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/not-a-constructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: >
+  AsyncDisposableStack.prototype.adopt does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(AsyncDisposableStack.prototype.adopt),
+  false,
+  'isConstructor(AsyncDisposableStack.prototype.adopt) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new AsyncDisposableStack({}); new stack.adopt();
+}, '`let stack = new AsyncDisposableStack({}); new stack.adopt()` throws TypeError');

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: >
+  Property descriptor of AsyncDisposableStack.prototype.adopt
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.adopt, 'function');
+
+verifyProperty(AsyncDisposableStack.prototype, 'adopt', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/length.js
@@ -5,7 +5,7 @@
 esid: sec-asyncdisposablestack.prototype.defer
 description: AsyncDisposableStack.prototype.defer.length property descriptor
 info: |
-  AsyncDisposableStack.prototype.defer ( )
+  AsyncDisposableStack.prototype.defer ( onDisposeAsync )
 
   17 ECMAScript Standard Built-in Objects
 

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: AsyncDisposableStack.prototype.defer.length property descriptor
+info: |
+  AsyncDisposableStack.prototype.defer ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.defer, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: AsyncDisposableStack.prototype.defer.name property descriptor
+info: |
+  AsyncDisposableStack.prototype.defer.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.defer, 'name', {
+  value: 'defer',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/not-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/not-a-constructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: >
+  AsyncDisposableStack.prototype.defer does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(AsyncDisposableStack.prototype.defer),
+  false,
+  'isConstructor(AsyncDisposableStack.prototype.defer) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new AsyncDisposableStack({}); new stack.defer();
+}, '`let stack = new AsyncDisposableStack({}); new stack.defer()` throws TypeError');

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: >
+  Property descriptor of AsyncDisposableStack.prototype.defer
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.defer, 'function');
+
+verifyProperty(AsyncDisposableStack.prototype, 'defer', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: AsyncDisposableStack.prototype.disposeAsync.length property descriptor
+info: |
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.disposeAsync, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: AsyncDisposableStack.prototype.disposeAsync.name property descriptor
+info: |
+  AsyncDisposableStack.prototype.disposeAsync.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.disposeAsync, 'name', {
+  value: 'disposeAsync',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/not-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/not-a-constructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: >
+  AsyncDisposableStack.prototype.disposeAsync does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(AsyncDisposableStack.prototype.disposeAsync),
+  false,
+  'isConstructor(AsyncDisposableStack.prototype.disposeAsync) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new AsyncDisposableStack({}); new stack.disposeAsync();
+}, '`let stack = new AsyncDisposableStack({}); new stack.disposeAsync()` throws TypeError');

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: >
+  Property descriptor of AsyncDisposableStack.prototype.disposeAsync
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.disposeAsync, 'function');
+
+verifyProperty(AsyncDisposableStack.prototype, 'disposeAsync', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/length.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  Map.prototype.size.length value and descriptor.
+info: |
+  get Map.prototype.size
+
+  17 ECMAScript Standard Built-in Objects
+includes: [propertyHelper.js]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+
+assert.sameValue(
+  descriptor.get.length, 0,
+  'The value of `Map.prototype.size.length` is `0`'
+);
+
+verifyNotEnumerable(descriptor.get, 'length');
+verifyNotWritable(descriptor.get, 'length');
+verifyConfigurable(descriptor.get, 'length');

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/length.js
@@ -3,19 +3,19 @@
 /*---
 esid: sec-get-asyncdisposablestack.prototype.disposed
 description: >
-  Map.prototype.size.length value and descriptor.
+  AsyncDisposableStack.prototype.disposed.length value and descriptor.
 info: |
-  get Map.prototype.size
+  get AsyncDisposableStack.prototype.disposed
 
   17 ECMAScript Standard Built-in Objects
 includes: [propertyHelper.js]
 ---*/
 
-var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+var descriptor = Object.getOwnPropertyDescriptor(AsyncDisposableStack.prototype, 'disposed');
 
 assert.sameValue(
   descriptor.get.length, 0,
-  'The value of `Map.prototype.size.length` is `0`'
+  'The value of `AsyncDisposableStack.prototype.disposed` is `0`'
 );
 
 verifyNotEnumerable(descriptor.get, 'length');

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/length.js
@@ -13,11 +13,9 @@ includes: [propertyHelper.js]
 
 var descriptor = Object.getOwnPropertyDescriptor(AsyncDisposableStack.prototype, 'disposed');
 
-assert.sameValue(
-  descriptor.get.length, 0,
-  'The value of `AsyncDisposableStack.prototype.disposed` is `0`'
-);
-
-verifyNotEnumerable(descriptor.get, 'length');
-verifyNotWritable(descriptor.get, 'length');
-verifyConfigurable(descriptor.get, 'length');
+verifyProperty(descriptor.get, 'length', {
+  value: 0;
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/length.js
@@ -9,6 +9,7 @@ info: |
 
   17 ECMAScript Standard Built-in Objects
 includes: [propertyHelper.js]
+features: [explicit-resource-management]
 ---*/
 
 var descriptor = Object.getOwnPropertyDescriptor(AsyncDisposableStack.prototype, 'disposed');

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/name.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  AsyncDisposableStack.prototype.disposed.name value and descriptor.
+info: |
+  get AsyncDisposableStack.prototype.size
+
+  17 ECMAScript Standard Built-in Objects
+
+  Functions that are specified as get or set accessor functions of built-in
+  properties have "get " or "set " prepended to the property name string.
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(AsyncDisposableStack.prototype, 'disposed');
+
+assert.sameValue(descriptor.get.name,
+  'get disposed',
+  'The value of `descriptor.get.name` is `get disposed`'
+);
+
+verifyNotEnumerable(descriptor.get, 'name');
+verifyNotWritable(descriptor.get, 'name');
+verifyConfigurable(descriptor.get, 'name');

--- a/test/built-ins/AsyncDisposableStack/prototype/move/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: AsyncDisposableStack.prototype.move.length property descriptor
+info: |
+  AsyncDisposableStack.prototype.move ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.move, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/move/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: AsyncDisposableStack.prototype.move.name property descriptor
+info: |
+  AsyncDisposableStack.prototype.move.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.move, 'name', {
+  value: 'move',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/move/not-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/not-a-constructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: >
+  AsyncDisposableStack.prototype.move does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(AsyncDisposableStack.prototype.move),
+  false,
+  'isConstructor(AsyncDisposableStack.prototype.move) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new AsyncDisposableStack({}); new stack.move();
+}, '`let stack = new AsyncDisposableStack({}); new stack.move()` throws TypeError');

--- a/test/built-ins/AsyncDisposableStack/prototype/move/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: >
+  Property descriptor of AsyncDisposableStack.prototype.move
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.move, 'function');
+
+verifyProperty(AsyncDisposableStack.prototype, 'move', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The property descriptor AsyncDisposableStack.prototype
+esid: sec-properties-of-the-asyncdisposablestack-constructor
+info: |
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: false }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(AsyncDisposableStack, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/length.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: AsyncDisposableStack.prototype.use.length property descriptor
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.use, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: AsyncDisposableStack.prototype.use.name property descriptor
+info: |
+  AsyncDisposableStack.prototype.use.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(AsyncDisposableStack.prototype.use, 'name', {
+  value: 'use',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/use/not-a-constructor.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/not-a-constructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: >
+  AsyncDisposableStack.prototype.use does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(AsyncDisposableStack.prototype.use),
+  false,
+  'isConstructor(AsyncDisposableStack.prototype.use) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new AsyncDisposableStack({}); new stack.use();
+}, '`let stack = new AsyncDisposableStack({}); new stack.use()` throws TypeError');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/prop-desc.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: >
+  Property descriptor of AsyncDisposableStack.prototype.use
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.use, 'function');
+
+verifyProperty(AsyncDisposableStack.prototype, 'use', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/length.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/length.js
@@ -4,6 +4,8 @@
 esid: sec-%asynciteratorprototype%-@@asyncDispose
 description: Length of %AsyncIteratorPrototype%[ @@asyncDispose ]
 info: |
+    %AsyncIteratorPrototype%[ @@asyncDispose ] ()
+
     ES6 Section 17:
     Every built-in Function object, including constructors, has a length
     property whose value is an integer. Unless otherwise specified, this value

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/length.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%asynciteratorprototype%-@@asyncDispose
+description: Length of %AsyncIteratorPrototype%[ @@asyncDispose ]
+info: |
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+async function* generator() {}
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+
+verifyProperty(AsyncIteratorPrototype[Symbol.asyncDispose], 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/name.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/name.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%asynciteratorprototype%-@@asyncDispose
+description: Descriptor for `name` property
+info: |
+  The value of the name property of this function is "[Symbol.asyncDispose]".
+
+  ES6 Section 17: ECMAScript Standard Built-in Objects
+
+  Every built-in Function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value is a
+  String. Unless otherwise specified, this value is the name that is given to
+  the function in this specification.
+
+  [...]
+
+  Unless otherwise specified, the name property of a built-in Function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+async function* generator() {}
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+
+verifyProperty(AsyncIteratorPrototype[Symbol.asyncDispose], 'name', {
+  value: '[Symbol.asyncDispose]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/name.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/name.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%asynciteratorprototype%-@@asyncDispose
-description: Descriptor for `name` property
+description: Descriptor for `name` property of %AsyncIteratorPrototype%[ @@asyncDispose ]
 info: |
   The value of the name property of this function is "[Symbol.asyncDispose]".
 

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/prop-desc.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/prop-desc.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%asynciteratorprototype%-@@asyncDispose
+description: Property descriptor
+info: |
+    ES6 Section 17
+
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+async function* generator() {}
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+
+verifyProperty(AsyncIteratorPrototype, Symbol.asyncDispose, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/prop-desc.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/prop-desc.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%asynciteratorprototype%-@@asyncDispose
-description: Property descriptor
+description: Property descriptor of %AsyncIteratorPrototype%[ @@asyncDispose ]
 info: |
     ES6 Section 17
 

--- a/test/built-ins/DisposableStack/is-a-constructor.js
+++ b/test/built-ins/DisposableStack/is-a-constructor.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The DisposableStack constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [explicit-resource-management, Reflect.construct]
+---*/
+
+assert.sameValue(isConstructor(DisposableStack), true, 'isConstructor(DisposableStack) must return true');
+new DisposableStack();

--- a/test/built-ins/DisposableStack/length.js
+++ b/test/built-ins/DisposableStack/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: DisposableStack.length property descriptor
+info: |
+  DisposableStack ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/name.js
+++ b/test/built-ins/DisposableStack/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: DisposableStack.name property descriptor
+info: |
+  DisposableStack ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack, 'name', {
+  value: 'DisposableStack',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prop-desc.js
+++ b/test/built-ins/DisposableStack/prop-desc.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack-constructor
+description: >
+  Property descriptor of DisposableStack
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(this, 'DisposableStack', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/adopt/length.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: DisposableStack.prototype.adopt.length property descriptor
+info: |
+  DisposableStack.prototype.adopt ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.adopt, 'length', {
+  value: 2,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/adopt/length.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/length.js
@@ -3,9 +3,9 @@
 
 /*---
 esid: sec-disposablestack.prototype.adopt
-description: DisposableStack.prototype.adopt.length property descriptor
+description: DisposableStack.prototype.adopt.length value and property descriptor
 info: |
-  DisposableStack.prototype.adopt ( )
+  DisposableStack.prototype.adopt ( value, onDispose )
 
   17 ECMAScript Standard Built-in Objects
 

--- a/test/built-ins/DisposableStack/prototype/adopt/name.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: DisposableStack.prototype.adopt.name property descriptor
+info: |
+  DisposableStack.prototype.adopt.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.adopt, 'name', {
+  value: 'adopt',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/adopt/not-a-constructor.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/not-a-constructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: >
+  DisposableStack.prototype.adopt does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(DisposableStack.prototype.adopt),
+  false,
+  'isConstructor(DisposableStack.prototype.adopt) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new DisposableStack({}); new stack.adopt();
+}, '`let stack = new DisposableStack({}); new stack.adopt()` throws TypeError');

--- a/test/built-ins/DisposableStack/prototype/adopt/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: >
+  Property descriptor of DisposableStack.prototype.adopt
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.adopt, 'function');
+
+verifyProperty(DisposableStack.prototype, 'adopt', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/defer/length.js
+++ b/test/built-ins/DisposableStack/prototype/defer/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: DisposableStack.prototype.defer.length property descriptor
+info: |
+  DisposableStack.prototype.defer ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.defer, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/defer/length.js
+++ b/test/built-ins/DisposableStack/prototype/defer/length.js
@@ -5,7 +5,7 @@
 esid: sec-disposablestack.prototype.defer
 description: DisposableStack.prototype.defer.length property descriptor
 info: |
-  DisposableStack.prototype.defer ( )
+  DisposableStack.prototype.defer ( onDispose )
 
   17 ECMAScript Standard Built-in Objects
 

--- a/test/built-ins/DisposableStack/prototype/defer/name.js
+++ b/test/built-ins/DisposableStack/prototype/defer/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: DisposableStack.prototype.defer.name property descriptor
+info: |
+  DisposableStack.prototype.defer.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.defer, 'name', {
+  value: 'defer',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/defer/not-a-constructor.js
+++ b/test/built-ins/DisposableStack/prototype/defer/not-a-constructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: >
+  DisposableStack.prototype.defer does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(DisposableStack.prototype.defer),
+  false,
+  'isConstructor(DisposableStack.prototype.defer) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new DisposableStack({}); new stack.defer();
+}, '`let stack = new DisposableStack({}); new stack.defer()` throws TypeError');

--- a/test/built-ins/DisposableStack/prototype/defer/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/defer/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: >
+  Property descriptor of DisposableStack.prototype.defer
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.defer, 'function');
+
+verifyProperty(DisposableStack.prototype, 'defer', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/dispose/length.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: DisposableStack.prototype.dispose.length property descriptor
+info: |
+  DisposableStack.prototype.dispose ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.dispose, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/dispose/name.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: DisposableStack.prototype.dispose.name property descriptor
+info: |
+  DisposableStack.prototype.dispose.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.dispose, 'name', {
+  value: 'dispose',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/dispose/not-a-constructor.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/not-a-constructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: >
+  DisposableStack.prototype.dispose does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(DisposableStack.prototype.dispose),
+  false,
+  'isConstructor(DisposableStack.prototype.dispose) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new DisposableStack({}); new stack.dispose();
+}, '`let stack = new DisposableStack({}); new stack.dispose()` throws TypeError');

--- a/test/built-ins/DisposableStack/prototype/dispose/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: >
+  Property descriptor of DisposableStack.prototype.dispose
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.dispose, 'function');
+
+verifyProperty(DisposableStack.prototype, 'dispose', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/disposed/length.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/length.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  Map.prototype.size.length value and descriptor.
+info: |
+  get Map.prototype.size
+
+  17 ECMAScript Standard Built-in Objects
+includes: [propertyHelper.js]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+
+assert.sameValue(
+  descriptor.get.length, 0,
+  'The value of `Map.prototype.size.length` is `0`'
+);
+
+verifyNotEnumerable(descriptor.get, 'length');
+verifyNotWritable(descriptor.get, 'length');
+verifyConfigurable(descriptor.get, 'length');

--- a/test/built-ins/DisposableStack/prototype/disposed/length.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/length.js
@@ -3,19 +3,19 @@
 /*---
 esid: sec-get-disposablestack.prototype.disposed
 description: >
-  Map.prototype.size.length value and descriptor.
+  DisposableStack.prototype.disposed.length value and descriptor.
 info: |
-  get Map.prototype.size
+  get DisposableStack.prototype.disposed
 
   17 ECMAScript Standard Built-in Objects
 includes: [propertyHelper.js]
 ---*/
 
-var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+var descriptor = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');
 
 assert.sameValue(
   descriptor.get.length, 0,
-  'The value of `Map.prototype.size.length` is `0`'
+  'The value of `DisposableStack.prototype.disposed.length` is `0`'
 );
 
 verifyNotEnumerable(descriptor.get, 'length');

--- a/test/built-ins/DisposableStack/prototype/disposed/length.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/length.js
@@ -13,11 +13,9 @@ includes: [propertyHelper.js]
 
 var descriptor = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');
 
-assert.sameValue(
-  descriptor.get.length, 0,
-  'The value of `DisposableStack.prototype.disposed.length` is `0`'
-);
-
-verifyNotEnumerable(descriptor.get, 'length');
-verifyNotWritable(descriptor.get, 'length');
-verifyConfigurable(descriptor.get, 'length');
+verifyProperty(descriptor.get, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/disposed/length.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/length.js
@@ -9,6 +9,7 @@ info: |
 
   17 ECMAScript Standard Built-in Objects
 includes: [propertyHelper.js]
+features: [explicit-resource-management]
 ---*/
 
 var descriptor = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');

--- a/test/built-ins/DisposableStack/prototype/disposed/name.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/name.js
@@ -5,7 +5,7 @@ esid: sec-get-disposablestack.prototype.disposed
 description: >
   DisposableStack.prototype.disposed.name value and descriptor.
 info: |
-  get DisposableStack.prototype.size
+  get DisposableStack.prototype.disposed
 
   17 ECMAScript Standard Built-in Objects
 

--- a/test/built-ins/DisposableStack/prototype/disposed/name.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/name.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  DisposableStack.prototype.disposed.name value and descriptor.
+info: |
+  get DisposableStack.prototype.size
+
+  17 ECMAScript Standard Built-in Objects
+
+  Functions that are specified as get or set accessor functions of built-in
+  properties have "get " or "set " prepended to the property name string.
+
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');
+
+assert.sameValue(descriptor.get.name,
+  'get disposed',
+  'The value of `descriptor.get.name` is `get disposed`'
+);
+
+verifyNotEnumerable(descriptor.get, 'name');
+verifyNotWritable(descriptor.get, 'name');
+verifyConfigurable(descriptor.get, 'name');

--- a/test/built-ins/DisposableStack/prototype/move/length.js
+++ b/test/built-ins/DisposableStack/prototype/move/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: DisposableStack.prototype.move.length property descriptor
+info: |
+  DisposableStack.prototype.move ( )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.move, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/move/name.js
+++ b/test/built-ins/DisposableStack/prototype/move/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: DisposableStack.prototype.move.name property descriptor
+info: |
+  DisposableStack.prototype.move.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.move, 'name', {
+  value: 'move',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/move/not-a-constructor.js
+++ b/test/built-ins/DisposableStack/prototype/move/not-a-constructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: >
+  DisposableStack.prototype.move does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(DisposableStack.prototype.move),
+  false,
+  'isConstructor(DisposableStack.prototype.move) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new DisposableStack({}); new stack.move();
+}, '`let stack = new DisposableStack({}); new stack.move()` throws TypeError');

--- a/test/built-ins/DisposableStack/prototype/move/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/move/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: >
+  Property descriptor of DisposableStack.prototype.move
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.move, 'function');
+
+verifyProperty(DisposableStack.prototype, 'move', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The property descriptor DisposableStack.prototype
+esid: sec-properties-of-the-disposablestack-constructor
+info: |
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: false }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(DisposableStack, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false
+});

--- a/test/built-ins/DisposableStack/prototype/use/length.js
+++ b/test/built-ins/DisposableStack/prototype/use/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: DisposableStack.prototype.use.length property descriptor
+info: |
+  DisposableStack.prototype.use ( value )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.use, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/use/name.js
+++ b/test/built-ins/DisposableStack/prototype/use/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: DisposableStack.prototype.use.name property descriptor
+info: |
+  DisposableStack.prototype.use.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(DisposableStack.prototype.use, 'name', {
+  value: 'use',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DisposableStack/prototype/use/not-a-constructor.js
+++ b/test/built-ins/DisposableStack/prototype/use/not-a-constructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: >
+  DisposableStack.prototype.use does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(DisposableStack.prototype.use),
+  false,
+  'isConstructor(DisposableStack.prototype.use) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let stack = new DisposableStack({}); new stack.use();
+}, '`let stack = new DisposableStack({}); new stack.use()` throws TypeError');

--- a/test/built-ins/DisposableStack/prototype/use/prop-desc.js
+++ b/test/built-ins/DisposableStack/prototype/use/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: >
+  Property descriptor of DisposableStack.prototype.use
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.use, 'function');
+
+verifyProperty(DisposableStack.prototype, 'use', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/length.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/length.js
@@ -4,6 +4,8 @@
 esid: sec-%iteratorprototype%-@@dispose
 description: Length of %IteratorPrototype%[ @@dispose ]
 info: |
+    %IteratorPrototype% [ @@dispose ] ( )
+
     ES6 Section 17:
     Every built-in Function object, including constructors, has a length
     property whose value is an integer. Unless otherwise specified, this value

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/length.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%iteratorprototype%-@@dispose
+description: Length of %IteratorPrototype%[ @@dispose ]
+info: |
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+const IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+verifyProperty(IteratorPrototype[Symbol.dispose], 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/name.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/name.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%iteratorprototype%-@@dispose
+description: Descriptor for `name` property
+info: |
+  The value of the name property of this function is "[Symbol.dispose]".
+
+  ES6 Section 17: ECMAScript Standard Built-in Objects
+
+  Every built-in Function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value is a
+  String. Unless otherwise specified, this value is the name that is given to
+  the function in this specification.
+
+  [...]
+
+  Unless otherwise specified, the name property of a built-in Function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+const IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+verifyProperty(IteratorPrototype[Symbol.dispose], 'name', {
+  value: '[Symbol.dispose]',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/name.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/name.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%iteratorprototype%-@@dispose
-description: Descriptor for `name` property
+description: Descriptor for `name` property of %IteratorPrototype%[ @@dispose ]
 info: |
   The value of the name property of this function is "[Symbol.dispose]".
 

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/prop-desc.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/prop-desc.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%iteratorprototype%-@@dispose
-description: Property descriptor
+description: Property descriptor of %IteratorPrototype%[ @@dispose ]
 info: |
     ES6 Section 17
 

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/prop-desc.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/prop-desc.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%iteratorprototype%-@@dispose
+description: Property descriptor
+info: |
+    ES6 Section 17
+
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+const IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+verifyProperty(IteratorPrototype, Symbol.dispose, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/SuppressedError/is-a-constructor.js
+++ b/test/built-ins/NativeErrors/SuppressedError/is-a-constructor.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The SuppressedError constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management]
+---*/
+
+assert.sameValue(isConstructor(SuppressedError), true, 'isConstructor(SuppressedError) must return true');
+new SuppressedError();
+

--- a/test/built-ins/NativeErrors/SuppressedError/length.js
+++ b/test/built-ins/NativeErrors/SuppressedError/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-suppressederror-constructors
+description: SuppressedError.length property descriptor
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError, 'length', {
+  value: 3,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SuppressedError/name.js
+++ b/test/built-ins/NativeErrors/SuppressedError/name.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-suppressederror-constructor
+description: SuppressedError.name property descriptor
+info: |
+  Properties of the SuppressedError Constructor
+
+  - has a name property whose value is the String value "SuppressedError".
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError, 'name', {
+  value: 'SuppressedError',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SuppressedError/prop-desc.js
+++ b/test/built-ins/NativeErrors/SuppressedError/prop-desc.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-objects
+description: >
+  Property descriptor of SuppressedError
+info: |
+  SuppressedError Objects
+
+  ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof SuppressedError, 'function');
+
+verifyProperty(this, 'SuppressedError', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SuppressedError/prototype/name.js
+++ b/test/built-ins/NativeErrors/SuppressedError/prototype/name.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype.name
+description: >
+  The `SuppressedError.prototype.name` property descriptor.
+info: |
+  The initial value of SuppressedError.prototype.name is "SuppressedError".
+
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described (...) has the attributes { [[Writable]]: true,
+    [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError.prototype, 'name', {
+  value: 'SuppressedError',
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SuppressedError/prototype/prop-desc.js
+++ b/test/built-ins/NativeErrors/SuppressedError/prototype/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype
+description: >
+  Property descriptor of SuppressedError.prototype
+info: |
+  SuppressedError.prototype
+
+  The initial value of SuppressedError.prototype is the intrinsic object %AggregateErrorPrototype%.
+
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof SuppressedError.prototype, 'object');
+
+verifyProperty(SuppressedError, 'prototype', {
+  enumerable: false,
+  writable: false,
+  configurable: false
+});

--- a/test/built-ins/Symbol/asyncDispose/prop-desc.js
+++ b/test/built-ins/Symbol/asyncDispose/prop-desc.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: pending
+esid: sec-symbol.asyncdispose
 description: >
     `Symbol.asyncDispose` property descriptor
 info: |

--- a/test/built-ins/Symbol/asyncDispose/prop-desc.js
+++ b/test/built-ins/Symbol/asyncDispose/prop-desc.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    `Symbol.asyncDispose` property descriptor
+info: |
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof Symbol.asyncDispose, 'symbol');
+verifyNotEnumerable(Symbol, 'asyncDispose');
+verifyNotWritable(Symbol, 'asyncDispose');
+verifyNotConfigurable(Symbol, 'asyncDispose');

--- a/test/built-ins/Symbol/dispose/prop-desc.js
+++ b/test/built-ins/Symbol/dispose/prop-desc.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: pending
+esid: sec-symbol.dispose
 description: >
     `Symbol.dispose` property descriptor
 info: |

--- a/test/built-ins/Symbol/dispose/prop-desc.js
+++ b/test/built-ins/Symbol/dispose/prop-desc.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    `Symbol.dispose` property descriptor
+info: |
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof Symbol.dispose, 'symbol');
+verifyNotEnumerable(Symbol, 'dispose');
+verifyNotWritable(Symbol, 'dispose');
+verifyNotConfigurable(Symbol, 'dispose');


### PR DESCRIPTION
This PR splits some of the boilerplate tests from PR #3866 to make reviewing all those files a little easier.

Includes the boilerplate tests mentioned in [this comment](https://github.com/tc39/test262/pull/3816#issuecomment-1515072120) except brand checks for functions and tests for object prototypes and extensibility.

In particular this PR adds the following tests from #3866 (links from the comment above): 
- [Property descriptor of the object/method/whatever](https://github.com/tc39/test262/blob/main/test/built-ins/String/prototype/at/prop-desc.js)
- [Function length property](https://github.com/tc39/test262/blob/main/test/built-ins/String/prototype/at/length.js) (although note that new tests should use `verifyProperty()` instead)
- [Function name property](https://github.com/tc39/test262/blob/main/test/built-ins/String/prototype/at/name.js)
- [Function is a constructor (or not a constructor)](https://github.com/tc39/test262/blob/main/test/built-ins/Number/isNaN/not-a-constructor.js)

Each of these bullet points is a separate commit.

cc. @rbuckton 