### PR TITLE
 RAB: Integrate staging tests for the .set method 

### DIFF
--- a/test/built-ins/TypedArray/prototype/set/target-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/set/target-grow-mid-iteration.js
@@ -1,0 +1,187 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.set
+description: >
+  TypedArray.p.set behaves correctly when the receiver is backed by a
+  resizable buffer is grown mid-iteration due to a Proxy source
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let rab;
+// Resizing will happen when we're calling Get for the `resizeAt`:th data
+// element, but we haven't yet written it to the target.
+let resizeAt;
+let resizeTo;
+function CreateSourceProxy(length) {
+  let requestedIndices = [];
+  return new Proxy({}, {
+    get(target, prop, receiver) {
+      if (prop == 'length') {
+        return length;
+      }
+      requestedIndices.push(prop);
+      if (requestedIndices.length == resizeAt) {
+        rab.resize(resizeTo);
+      }
+      return true; // Can be converted to both BigInt and Number.
+    }
+  });
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAt = 2;
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(4));
+  assert.compareArray(ToNumbers(fixedLength), [
+    1,
+    1,
+    1,
+    1
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    1,
+    1,
+    1,
+    1,
+    0,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAt = 1;
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+    1,
+    1
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    1,
+    1,
+    0,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAt = 2;
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(lengthTracking), [
+    1,
+    1,
+    4,
+    6,
+    0,
+    0
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    1,
+    1,
+    4,
+    6,
+    0,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAt = 1;
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+    1,
+    1,
+    0,
+    0
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    1,
+    1,
+    0,
+    0
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/set/target-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/set/target-grow-mid-iteration.js
@@ -4,89 +4,15 @@
 /*---
 esid: sec-%typedarray%.prototype.set
 description: >
-  TypedArray.p.set behaves correctly when the receiver is backed by a
-  resizable buffer is grown mid-iteration due to a Proxy source
-includes: [compareArray.js]
+  TypedArray.p.set behaves correctly on TypedArrays backed by resizable buffers
+  that are grown mid-iteration due to a Proxy source.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
-  }
-  return item;
-}
-
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
-  }
-  return result;
-}
-
-// Orig. array: [0, 2, 4, 6]
-//              [0, 2, 4, 6] << fixedLength
-//                    [4, 6] << fixedLengthWithOffset
-//              [0, 2, 4, 6, ...] << lengthTracking
-//                    [4, 6, ...] << lengthTrackingWithOffset
-function CreateRabForTest(ctor) {
-  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-  // Write some data into the array.
-  const taWrite = new ctor(rab);
-  for (let i = 0; i < 4; ++i) {
-    WriteToTypedArray(taWrite, i, 2 * i);
-  }
-  return rab;
-}
-let rab;
 // Resizing will happen when we're calling Get for the `resizeAt`:th data
 // element, but we haven't yet written it to the target.
-let resizeAt;
-let resizeTo;
-function CreateSourceProxy(length) {
+function CreateSourceProxy(length, rab, resizeAt, resizeTo) {
   let requestedIndices = [];
   return new Proxy({}, {
     get(target, prop, receiver) {
@@ -102,11 +28,11 @@ function CreateSourceProxy(length) {
   });
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  resizeAt = 2;
-  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
-  fixedLength.set(CreateSourceProxy(4));
+  const resizeAt = 2;
+  const resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(4, rab, resizeAt, resizeTo));
   assert.compareArray(ToNumbers(fixedLength), [
     1,
     1,
@@ -123,11 +49,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  resizeAt = 1;
-  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
-  fixedLengthWithOffset.set(CreateSourceProxy(2));
+  const resizeAt = 1;
+  const resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(2, rab, resizeAt, resizeTo));
   assert.compareArray(ToNumbers(fixedLengthWithOffset), [
     1,
     1
@@ -142,11 +68,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  resizeAt = 2;
-  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
-  lengthTracking.set(CreateSourceProxy(2));
+  const resizeAt = 2;
+  const resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(2, rab, resizeAt, resizeTo));
   assert.compareArray(ToNumbers(lengthTracking), [
     1,
     1,
@@ -165,11 +91,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  resizeAt = 1;
-  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
-  lengthTrackingWithOffset.set(CreateSourceProxy(2));
+  const resizeAt = 1;
+  const resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(2, rab, resizeAt, resizeTo));
   assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
     1,
     1,

--- a/test/built-ins/TypedArray/prototype/set/target-grow-source-length-getter.js
+++ b/test/built-ins/TypedArray/prototype/set/target-grow-source-length-getter.js
@@ -4,86 +4,18 @@
 /*---
 esid: sec-%typedarray%.prototype.set
 description: >
-  TypedArray.p.set behaves correctly when the receiver is backed by a
+  TypedArray.p.set behaves correctly on TypedArrays backed by a
   resizable buffer is grown due to the source's length getter
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
-
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
-  }
-  return item;
-}
-
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
-  }
-  return result;
-}
 
 // Orig. array: [0, 2, 4, 6]
 //              [0, 2, 4, 6] << fixedLength
 //                    [4, 6] << fixedLengthWithOffset
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
-function CreateRabForTest(ctor) {
-  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-  // Write some data into the array.
-  const taWrite = new ctor(rab);
-  for (let i = 0; i < 4; ++i) {
-    WriteToTypedArray(taWrite, i, 2 * i);
-  }
-  return rab;
-}
-let rab;
-let resizeTo;
-function CreateSourceProxy(length) {
+function CreateSourceProxy(length, rab, resizeTo) {
   return new Proxy({}, {
     get(target, prop, receiver) {
       if (prop == 'length') {
@@ -99,11 +31,11 @@ function CreateSourceProxy(length) {
 // too large, even though we resized in the length getter (we check against
 // the original length).
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  const resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
   assert.throws(RangeError, () => {
-    lengthTracking.set(CreateSourceProxy(6));
+    lengthTracking.set(CreateSourceProxy(6, rab, resizeTo));
   });
   assert.compareArray(ToNumbers(new ctor(rab)), [
     0,
@@ -115,11 +47,11 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  const resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
   assert.throws(RangeError, () => {
-    lengthTrackingWithOffset.set(CreateSourceProxy(4));
+    lengthTrackingWithOffset.set(CreateSourceProxy(4, rab, resizeTo));
   });
   assert.compareArray(ToNumbers(new ctor(rab)), [
     0,

--- a/test/built-ins/TypedArray/prototype/set/target-grow-source-length-getter.js
+++ b/test/built-ins/TypedArray/prototype/set/target-grow-source-length-getter.js
@@ -1,0 +1,132 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.set
+description: >
+  TypedArray.p.set behaves correctly when the receiver is backed by a
+  resizable buffer is grown due to the source's length getter
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let rab;
+let resizeTo;
+function CreateSourceProxy(length) {
+  return new Proxy({}, {
+    get(target, prop, receiver) {
+      if (prop == 'length') {
+        rab.resize(resizeTo);
+        return length;
+      }
+      return true; // Can be converted to both BigInt and Number.
+    }
+  });
+}
+
+// Test that we still throw for lengthTracking TAs if the source length is
+// too large, even though we resized in the length getter (we check against
+// the original length).
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  assert.throws(RangeError, () => {
+    lengthTracking.set(CreateSourceProxy(6));
+  });
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4,
+    6,
+    0,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  assert.throws(RangeError, () => {
+    lengthTrackingWithOffset.set(CreateSourceProxy(4));
+  });
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4,
+    6,
+    0,
+    0
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/set/target-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/set/target-shrink-mid-iteration.js
@@ -1,0 +1,167 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.set
+description: >
+  TypedArray.p.set behaves correctly when the receiver is backed by a
+  resizable buffer is shrunk mid-iteration due to a Proxy source
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let rab;
+// Resizing will happen when we're calling Get for the `resizeAt`:th data
+// element, but we haven't yet written it to the target.
+let resizeAt;
+let resizeTo;
+function CreateSourceProxy(length) {
+  let requestedIndices = [];
+  return new Proxy({}, {
+    get(target, prop, receiver) {
+      if (prop == 'length') {
+        return length;
+      }
+      requestedIndices.push(prop);
+      if (requestedIndices.length == resizeAt) {
+        rab.resize(resizeTo);
+      }
+      return true; // Can be converted to both BigInt and Number.
+    }
+  });
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAt = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(4));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    1,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAt = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    1
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAt = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(lengthTracking), [
+    1,
+    1,
+    4
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    1,
+    1,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAt = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [1]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    1
+  ]);
+}
+
+// Length-tracking TA goes OOB because of the offset.
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAt = 1;
+  resizeTo = 1 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(new ctor(rab)), [0]);
+}

--- a/test/built-ins/TypedArray/prototype/set/target-shrink-source-length-getter.js
+++ b/test/built-ins/TypedArray/prototype/set/target-shrink-source-length-getter.js
@@ -1,0 +1,214 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.set
+description: >
+  TypedArray.p.set behaves correctly when the receiver is backed by a
+  resizable buffer is shrunk due to the source's length getter
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let rab;
+let resizeTo;
+function CreateSourceProxy(length) {
+  return new Proxy({}, {
+    get(target, prop, receiver) {
+      if (prop == 'length') {
+        rab.resize(resizeTo);
+        return length;
+      }
+      return true; // Can be converted to both BigInt and Number.
+    }
+  });
+}
+
+// Tests where the length getter returns a non-zero value -> these are nop if
+// the TA went OOB.
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(1));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(1));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(1));
+  assert.compareArray(ToNumbers(lengthTracking), [
+    1,
+    2,
+    4
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    1,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(1));
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [1]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    1
+  ]);
+}
+
+// Length-tracking TA goes OOB because of the offset.
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeTo = 1 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(1));
+  assert.compareArray(ToNumbers(new ctor(rab)), [0]);
+}
+
+// Tests where the length getter returns a zero -> these don't throw even if
+// the TA went OOB.
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(0));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(0));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(0));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(0));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+
+// Length-tracking TA goes OOB because of the offset.
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeTo = 1 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(0));
+  assert.compareArray(ToNumbers(new ctor(rab)), [0]);
+}

--- a/test/built-ins/TypedArray/prototype/set/target-shrink-source-length-getter.js
+++ b/test/built-ins/TypedArray/prototype/set/target-shrink-source-length-getter.js
@@ -4,86 +4,19 @@
 /*---
 esid: sec-%typedarray%.prototype.set
 description: >
-  TypedArray.p.set behaves correctly when the receiver is backed by a
-  resizable buffer is shrunk due to the source's length getter
-includes: [compareArray.js]
+  TypedArray.p.set behaves correctly on TypedArrays backed by resizable buffers
+  that are shrunk due to the source's length getter.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
-
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
-  }
-  return item;
-}
-
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
-  }
-  return result;
-}
 
 // Orig. array: [0, 2, 4, 6]
 //              [0, 2, 4, 6] << fixedLength
 //                    [4, 6] << fixedLengthWithOffset
 //              [0, 2, 4, 6, ...] << lengthTracking
 //                    [4, 6, ...] << lengthTrackingWithOffset
-function CreateRabForTest(ctor) {
-  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-  // Write some data into the array.
-  const taWrite = new ctor(rab);
-  for (let i = 0; i < 4; ++i) {
-    WriteToTypedArray(taWrite, i, 2 * i);
-  }
-  return rab;
-}
-let rab;
-let resizeTo;
-function CreateSourceProxy(length) {
+
+function CreateSourceProxy(length, rab, resizeTo) {
   return new Proxy({}, {
     get(target, prop, receiver) {
       if (prop == 'length') {
@@ -98,10 +31,10 @@ function CreateSourceProxy(length) {
 // Tests where the length getter returns a non-zero value -> these are nop if
 // the TA went OOB.
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  fixedLength.set(CreateSourceProxy(1));
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(1, rab, resizeTo));
   assert.compareArray(ToNumbers(new ctor(rab)), [
     0,
     2,
@@ -109,10 +42,10 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  fixedLengthWithOffset.set(CreateSourceProxy(1));
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(1, rab, resizeTo));
   assert.compareArray(ToNumbers(new ctor(rab)), [
     0,
     2,
@@ -120,10 +53,10 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  lengthTracking.set(CreateSourceProxy(1));
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(1, rab, resizeTo));
   assert.compareArray(ToNumbers(lengthTracking), [
     1,
     2,
@@ -136,10 +69,10 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  lengthTrackingWithOffset.set(CreateSourceProxy(1));
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(1, rab, resizeTo));
   assert.compareArray(ToNumbers(lengthTrackingWithOffset), [1]);
   assert.compareArray(ToNumbers(new ctor(rab)), [
     0,
@@ -150,20 +83,20 @@ for (let ctor of ctors) {
 
 // Length-tracking TA goes OOB because of the offset.
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  resizeTo = 1 * ctor.BYTES_PER_ELEMENT;
-  lengthTrackingWithOffset.set(CreateSourceProxy(1));
+  const resizeTo = 1 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(1, rab, resizeTo));
   assert.compareArray(ToNumbers(new ctor(rab)), [0]);
 }
 
 // Tests where the length getter returns a zero -> these don't throw even if
 // the TA went OOB.
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLength = new ctor(rab, 0, 4);
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  fixedLength.set(CreateSourceProxy(0));
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(0, rab, resizeTo));
   assert.compareArray(ToNumbers(new ctor(rab)), [
     0,
     2,
@@ -171,10 +104,10 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  fixedLengthWithOffset.set(CreateSourceProxy(0));
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(0, rab, resizeTo));
   assert.compareArray(ToNumbers(new ctor(rab)), [
     0,
     2,
@@ -182,10 +115,10 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTracking = new ctor(rab, 0);
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  lengthTracking.set(CreateSourceProxy(0));
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(0, rab, resizeTo));
   assert.compareArray(ToNumbers(new ctor(rab)), [
     0,
     2,
@@ -193,10 +126,10 @@ for (let ctor of ctors) {
   ]);
 }
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
-  lengthTrackingWithOffset.set(CreateSourceProxy(0));
+  const resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(0, rab, resizeTo));
   assert.compareArray(ToNumbers(new ctor(rab)), [
     0,
     2,
@@ -206,9 +139,9 @@ for (let ctor of ctors) {
 
 // Length-tracking TA goes OOB because of the offset.
 for (let ctor of ctors) {
-  rab = CreateRabForTest(ctor);
+  const rab = CreateRabForTest(ctor);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-  resizeTo = 1 * ctor.BYTES_PER_ELEMENT;
-  lengthTrackingWithOffset.set(CreateSourceProxy(0));
+  const resizeTo = 1 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(0, rab, resizeTo));
   assert.compareArray(ToNumbers(new ctor(rab)), [0]);
 }

--- a/test/built-ins/TypedArray/prototype/set/this-backed-by-resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/set/this-backed-by-resizable-buffer.js
@@ -1,0 +1,575 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.set
+description: >
+  TypedArray.p.set behaves correctly when the receiver is backed by
+  resizable buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+function SetHelper(target, source, offset) {
+  if (target instanceof BigInt64Array || target instanceof BigUint64Array) {
+    const bigIntSource = [];
+    for (const s of source) {
+      bigIntSource.push(BigInt(s));
+    }
+    source = bigIntSource;
+  }
+  if (offset == undefined) {
+    return target.set(source);
+  }
+  return target.set(source, offset);
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  const taFull = new ctor(rab);
+
+  // Orig. array: [0, 0, 0, 0]
+  //              [0, 0, 0, 0] << fixedLength
+  //                    [0, 0] << fixedLengthWithOffset
+  //              [0, 0, 0, 0, ...] << lengthTracking
+  //                    [0, 0, ...] << lengthTrackingWithOffset
+
+  // For making sure we're not calling the source length or element getters
+  // if the target is OOB.
+  const throwingProxy = new Proxy({}, {
+    get(target, prop, receiver) {
+      throw new Error('Called getter for ' + prop);
+    }
+  });
+  SetHelper(fixedLength, [
+    1,
+    2
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    2,
+    0,
+    0
+  ]);
+  SetHelper(fixedLength, [
+    3,
+    4
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    3,
+    4,
+    0
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLength, [
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLength, [
+      0,
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    3,
+    4,
+    0
+  ]);
+  SetHelper(fixedLengthWithOffset, [
+    5,
+    6
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    3,
+    5,
+    6
+  ]);
+  SetHelper(fixedLengthWithOffset, [7], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    3,
+    5,
+    7
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLengthWithOffset, [
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLengthWithOffset, [
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    3,
+    5,
+    7
+  ]);
+  SetHelper(lengthTracking, [
+    8,
+    9
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    9,
+    5,
+    7
+  ]);
+  SetHelper(lengthTracking, [
+    10,
+    11
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    11,
+    7
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    11,
+    7
+  ]);
+  SetHelper(lengthTrackingWithOffset, [
+    12,
+    13
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    12,
+    13
+  ]);
+  SetHelper(lengthTrackingWithOffset, [14], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    12,
+    14
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    12,
+    14
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [8, 10, 12]
+  //              [8, 10, 12, ...] << lengthTracking
+  //                     [12, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLength, throwingProxy);
+  });
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLengthWithOffset, throwingProxy);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    12
+  ]);
+  SetHelper(lengthTracking, [
+    15,
+    16
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    15,
+    16,
+    12
+  ]);
+  SetHelper(lengthTracking, [
+    17,
+    18
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    15,
+    17,
+    18
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    15,
+    17,
+    18
+  ]);
+  SetHelper(lengthTrackingWithOffset, [19]);
+  assert.compareArray(ToNumbers(taFull), [
+    15,
+    17,
+    19
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [0], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    15,
+    17,
+    19
+  ]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLength, throwingProxy);
+  });
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLengthWithOffset, throwingProxy);
+  });
+  assert.throws(TypeError, () => {
+    SetHelper(lengthTrackingWithOffset, throwingProxy);
+  });
+  assert.compareArray(ToNumbers(taFull), [15]);
+  SetHelper(lengthTracking, [20]);
+  assert.compareArray(ToNumbers(taFull), [20]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLength, throwingProxy);
+  });
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLengthWithOffset, throwingProxy);
+  });
+  assert.throws(TypeError, () => {
+    SetHelper(lengthTrackingWithOffset, throwingProxy);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [0]);
+  });
+  assert.compareArray(ToNumbers(taFull), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 0, 0, 0, 0, 0]
+  //              [0, 0, 0, 0] << fixedLength
+  //                    [0, 0] << fixedLengthWithOffset
+  //              [0, 0, 0, 0, 0, 0, ...] << lengthTracking
+  //                    [0, 0, 0, 0, ...] << lengthTrackingWithOffset
+  SetHelper(fixedLength, [
+    21,
+    22
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    22,
+    0,
+    0,
+    0,
+    0
+  ]);
+  SetHelper(fixedLength, [
+    23,
+    24
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    23,
+    24,
+    0,
+    0,
+    0
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLength, [
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLength, [
+      0,
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    23,
+    24,
+    0,
+    0,
+    0
+  ]);
+  SetHelper(fixedLengthWithOffset, [
+    25,
+    26
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    23,
+    25,
+    26,
+    0,
+    0
+  ]);
+  SetHelper(fixedLengthWithOffset, [27], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    23,
+    25,
+    27,
+    0,
+    0
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLengthWithOffset, [
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLengthWithOffset, [
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    23,
+    25,
+    27,
+    0,
+    0
+  ]);
+  SetHelper(lengthTracking, [
+    28,
+    29,
+    30,
+    31,
+    32,
+    33
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    29,
+    30,
+    31,
+    32,
+    33
+  ]);
+  SetHelper(lengthTracking, [
+    34,
+    35,
+    36,
+    37,
+    38
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    34,
+    35,
+    36,
+    37,
+    38
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    34,
+    35,
+    36,
+    37,
+    38
+  ]);
+  SetHelper(lengthTrackingWithOffset, [
+    39,
+    40,
+    41,
+    42
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    34,
+    39,
+    40,
+    41,
+    42
+  ]);
+  SetHelper(lengthTrackingWithOffset, [
+    43,
+    44,
+    45
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    34,
+    39,
+    43,
+    44,
+    45
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [
+      0,
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    34,
+    39,
+    43,
+    44,
+    45
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/set/this-backed-by-resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/set/this-backed-by-resizable-buffer.js
@@ -4,62 +4,12 @@
 /*---
 esid: sec-%typedarray%.prototype.set
 description: >
-  TypedArray.p.set behaves correctly when the receiver is backed by
-  resizable buffer
-includes: [compareArray.js]
+  TypedArray.p.set behaves correctly on TypedArrays backed by resizable buffers.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function Convert(item) {
-  if (typeof item == 'bigint') {
-    return Number(item);
-  }
-  return item;
-}
-
-function ToNumbers(array) {
-  let result = [];
-  for (let item of array) {
-    result.push(Convert(item));
-  }
-  return result;
-}
-
-function SetHelper(target, source, offset) {
+function SetNumOrBigInt(target, source, offset) {
   if (target instanceof BigInt64Array || target instanceof BigUint64Array) {
     const bigIntSource = [];
     for (const s of source) {
@@ -94,7 +44,7 @@ for (let ctor of ctors) {
       throw new Error('Called getter for ' + prop);
     }
   });
-  SetHelper(fixedLength, [
+  SetNumOrBigInt(fixedLength, [
     1,
     2
   ]);
@@ -104,7 +54,7 @@ for (let ctor of ctors) {
     0,
     0
   ]);
-  SetHelper(fixedLength, [
+  SetNumOrBigInt(fixedLength, [
     3,
     4
   ], 1);
@@ -115,7 +65,7 @@ for (let ctor of ctors) {
     0
   ]);
   assert.throws(RangeError, () => {
-    SetHelper(fixedLength, [
+    SetNumOrBigInt(fixedLength, [
       0,
       0,
       0,
@@ -124,7 +74,7 @@ for (let ctor of ctors) {
     ]);
   });
   assert.throws(RangeError, () => {
-    SetHelper(fixedLength, [
+    SetNumOrBigInt(fixedLength, [
       0,
       0,
       0,
@@ -137,7 +87,7 @@ for (let ctor of ctors) {
     4,
     0
   ]);
-  SetHelper(fixedLengthWithOffset, [
+  SetNumOrBigInt(fixedLengthWithOffset, [
     5,
     6
   ]);
@@ -147,7 +97,7 @@ for (let ctor of ctors) {
     5,
     6
   ]);
-  SetHelper(fixedLengthWithOffset, [7], 1);
+  SetNumOrBigInt(fixedLengthWithOffset, [7], 1);
   assert.compareArray(ToNumbers(taFull), [
     1,
     3,
@@ -155,14 +105,14 @@ for (let ctor of ctors) {
     7
   ]);
   assert.throws(RangeError, () => {
-    SetHelper(fixedLengthWithOffset, [
+    SetNumOrBigInt(fixedLengthWithOffset, [
       0,
       0,
       0
     ]);
   });
   assert.throws(RangeError, () => {
-    SetHelper(fixedLengthWithOffset, [
+    SetNumOrBigInt(fixedLengthWithOffset, [
       0,
       0
     ], 1);
@@ -173,7 +123,7 @@ for (let ctor of ctors) {
     5,
     7
   ]);
-  SetHelper(lengthTracking, [
+  SetNumOrBigInt(lengthTracking, [
     8,
     9
   ]);
@@ -183,7 +133,7 @@ for (let ctor of ctors) {
     5,
     7
   ]);
-  SetHelper(lengthTracking, [
+  SetNumOrBigInt(lengthTracking, [
     10,
     11
   ], 1);
@@ -194,7 +144,7 @@ for (let ctor of ctors) {
     7
   ]);
   assert.throws(RangeError, () => {
-    SetHelper(lengthTracking, [
+    SetNumOrBigInt(lengthTracking, [
       0,
       0,
       0,
@@ -203,7 +153,7 @@ for (let ctor of ctors) {
     ]);
   });
   assert.throws(RangeError, () => {
-    SetHelper(lengthTracking, [
+    SetNumOrBigInt(lengthTracking, [
       0,
       0,
       0,
@@ -216,7 +166,7 @@ for (let ctor of ctors) {
     11,
     7
   ]);
-  SetHelper(lengthTrackingWithOffset, [
+  SetNumOrBigInt(lengthTrackingWithOffset, [
     12,
     13
   ]);
@@ -226,7 +176,7 @@ for (let ctor of ctors) {
     12,
     13
   ]);
-  SetHelper(lengthTrackingWithOffset, [14], 1);
+  SetNumOrBigInt(lengthTrackingWithOffset, [14], 1);
   assert.compareArray(ToNumbers(taFull), [
     8,
     10,
@@ -234,14 +184,14 @@ for (let ctor of ctors) {
     14
   ]);
   assert.throws(RangeError, () => {
-    SetHelper(lengthTrackingWithOffset, [
+    SetNumOrBigInt(lengthTrackingWithOffset, [
       0,
       0,
       0
     ]);
   });
   assert.throws(RangeError, () => {
-    SetHelper(lengthTrackingWithOffset, [
+    SetNumOrBigInt(lengthTrackingWithOffset, [
       0,
       0
     ], 1);
@@ -261,17 +211,17 @@ for (let ctor of ctors) {
   //                     [12, ...] << lengthTrackingWithOffset
 
   assert.throws(TypeError, () => {
-    SetHelper(fixedLength, throwingProxy);
+    SetNumOrBigInt(fixedLength, throwingProxy);
   });
   assert.throws(TypeError, () => {
-    SetHelper(fixedLengthWithOffset, throwingProxy);
+    SetNumOrBigInt(fixedLengthWithOffset, throwingProxy);
   });
   assert.compareArray(ToNumbers(taFull), [
     8,
     10,
     12
   ]);
-  SetHelper(lengthTracking, [
+  SetNumOrBigInt(lengthTracking, [
     15,
     16
   ]);
@@ -280,7 +230,7 @@ for (let ctor of ctors) {
     16,
     12
   ]);
-  SetHelper(lengthTracking, [
+  SetNumOrBigInt(lengthTracking, [
     17,
     18
   ], 1);
@@ -290,7 +240,7 @@ for (let ctor of ctors) {
     18
   ]);
   assert.throws(RangeError, () => {
-    SetHelper(lengthTracking, [
+    SetNumOrBigInt(lengthTracking, [
       0,
       0,
       0,
@@ -298,7 +248,7 @@ for (let ctor of ctors) {
     ]);
   });
   assert.throws(RangeError, () => {
-    SetHelper(lengthTracking, [
+    SetNumOrBigInt(lengthTracking, [
       0,
       0,
       0
@@ -309,20 +259,20 @@ for (let ctor of ctors) {
     17,
     18
   ]);
-  SetHelper(lengthTrackingWithOffset, [19]);
+  SetNumOrBigInt(lengthTrackingWithOffset, [19]);
   assert.compareArray(ToNumbers(taFull), [
     15,
     17,
     19
   ]);
   assert.throws(RangeError, () => {
-    SetHelper(lengthTrackingWithOffset, [
+    SetNumOrBigInt(lengthTrackingWithOffset, [
       0,
       0
     ]);
   });
   assert.throws(RangeError, () => {
-    SetHelper(lengthTrackingWithOffset, [0], 1);
+    SetNumOrBigInt(lengthTrackingWithOffset, [0], 1);
   });
   assert.compareArray(ToNumbers(taFull), [
     15,
@@ -333,31 +283,31 @@ for (let ctor of ctors) {
   // Shrink so that the TAs with offset go out of bounds.
   rab.resize(1 * ctor.BYTES_PER_ELEMENT);
   assert.throws(TypeError, () => {
-    SetHelper(fixedLength, throwingProxy);
+    SetNumOrBigInt(fixedLength, throwingProxy);
   });
   assert.throws(TypeError, () => {
-    SetHelper(fixedLengthWithOffset, throwingProxy);
+    SetNumOrBigInt(fixedLengthWithOffset, throwingProxy);
   });
   assert.throws(TypeError, () => {
-    SetHelper(lengthTrackingWithOffset, throwingProxy);
+    SetNumOrBigInt(lengthTrackingWithOffset, throwingProxy);
   });
   assert.compareArray(ToNumbers(taFull), [15]);
-  SetHelper(lengthTracking, [20]);
+  SetNumOrBigInt(lengthTracking, [20]);
   assert.compareArray(ToNumbers(taFull), [20]);
 
   // Shrink to zero.
   rab.resize(0);
   assert.throws(TypeError, () => {
-    SetHelper(fixedLength, throwingProxy);
+    SetNumOrBigInt(fixedLength, throwingProxy);
   });
   assert.throws(TypeError, () => {
-    SetHelper(fixedLengthWithOffset, throwingProxy);
+    SetNumOrBigInt(fixedLengthWithOffset, throwingProxy);
   });
   assert.throws(TypeError, () => {
-    SetHelper(lengthTrackingWithOffset, throwingProxy);
+    SetNumOrBigInt(lengthTrackingWithOffset, throwingProxy);
   });
   assert.throws(RangeError, () => {
-    SetHelper(lengthTracking, [0]);
+    SetNumOrBigInt(lengthTracking, [0]);
   });
   assert.compareArray(ToNumbers(taFull), []);
 
@@ -369,7 +319,7 @@ for (let ctor of ctors) {
   //                    [0, 0] << fixedLengthWithOffset
   //              [0, 0, 0, 0, 0, 0, ...] << lengthTracking
   //                    [0, 0, 0, 0, ...] << lengthTrackingWithOffset
-  SetHelper(fixedLength, [
+  SetNumOrBigInt(fixedLength, [
     21,
     22
   ]);
@@ -381,7 +331,7 @@ for (let ctor of ctors) {
     0,
     0
   ]);
-  SetHelper(fixedLength, [
+  SetNumOrBigInt(fixedLength, [
     23,
     24
   ], 1);
@@ -394,7 +344,7 @@ for (let ctor of ctors) {
     0
   ]);
   assert.throws(RangeError, () => {
-    SetHelper(fixedLength, [
+    SetNumOrBigInt(fixedLength, [
       0,
       0,
       0,
@@ -403,7 +353,7 @@ for (let ctor of ctors) {
     ]);
   });
   assert.throws(RangeError, () => {
-    SetHelper(fixedLength, [
+    SetNumOrBigInt(fixedLength, [
       0,
       0,
       0,
@@ -418,7 +368,7 @@ for (let ctor of ctors) {
     0,
     0
   ]);
-  SetHelper(fixedLengthWithOffset, [
+  SetNumOrBigInt(fixedLengthWithOffset, [
     25,
     26
   ]);
@@ -430,7 +380,7 @@ for (let ctor of ctors) {
     0,
     0
   ]);
-  SetHelper(fixedLengthWithOffset, [27], 1);
+  SetNumOrBigInt(fixedLengthWithOffset, [27], 1);
   assert.compareArray(ToNumbers(taFull), [
     21,
     23,
@@ -440,14 +390,14 @@ for (let ctor of ctors) {
     0
   ]);
   assert.throws(RangeError, () => {
-    SetHelper(fixedLengthWithOffset, [
+    SetNumOrBigInt(fixedLengthWithOffset, [
       0,
       0,
       0
     ]);
   });
   assert.throws(RangeError, () => {
-    SetHelper(fixedLengthWithOffset, [
+    SetNumOrBigInt(fixedLengthWithOffset, [
       0,
       0
     ], 1);
@@ -460,7 +410,7 @@ for (let ctor of ctors) {
     0,
     0
   ]);
-  SetHelper(lengthTracking, [
+  SetNumOrBigInt(lengthTracking, [
     28,
     29,
     30,
@@ -476,7 +426,7 @@ for (let ctor of ctors) {
     32,
     33
   ]);
-  SetHelper(lengthTracking, [
+  SetNumOrBigInt(lengthTracking, [
     34,
     35,
     36,
@@ -492,7 +442,7 @@ for (let ctor of ctors) {
     38
   ]);
   assert.throws(RangeError, () => {
-    SetHelper(lengthTracking, [
+    SetNumOrBigInt(lengthTracking, [
       0,
       0,
       0,
@@ -503,7 +453,7 @@ for (let ctor of ctors) {
     ]);
   });
   assert.throws(RangeError, () => {
-    SetHelper(lengthTracking, [
+    SetNumOrBigInt(lengthTracking, [
       0,
       0,
       0,
@@ -520,7 +470,7 @@ for (let ctor of ctors) {
     37,
     38
   ]);
-  SetHelper(lengthTrackingWithOffset, [
+  SetNumOrBigInt(lengthTrackingWithOffset, [
     39,
     40,
     41,
@@ -534,7 +484,7 @@ for (let ctor of ctors) {
     41,
     42
   ]);
-  SetHelper(lengthTrackingWithOffset, [
+  SetNumOrBigInt(lengthTrackingWithOffset, [
     43,
     44,
     45
@@ -548,7 +498,7 @@ for (let ctor of ctors) {
     45
   ]);
   assert.throws(RangeError, () => {
-    SetHelper(lengthTrackingWithOffset, [
+    SetNumOrBigInt(lengthTrackingWithOffset, [
       0,
       0,
       0,
@@ -557,7 +507,7 @@ for (let ctor of ctors) {
     ]);
   });
   assert.throws(RangeError, () => {
-    SetHelper(lengthTrackingWithOffset, [
+    SetNumOrBigInt(lengthTrackingWithOffset, [
       0,
       0,
       0,

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js
@@ -1,0 +1,287 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.set
+description: >
+  TypedArray.p.set behaves correctly when the source argument is a
+  TypedArray backed by a resizable buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function IsBigIntTypedArray(ta) {
+  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+function SetHelper(target, source, offset) {
+  if (target instanceof BigInt64Array || target instanceof BigUint64Array) {
+    const bigIntSource = [];
+    for (const s of source) {
+      bigIntSource.push(BigInt(s));
+    }
+    source = bigIntSource;
+  }
+  if (offset == undefined) {
+    return target.set(source);
+  }
+  return target.set(source, offset);
+}
+
+for (let targetIsResizable of [
+    false,
+    true
+  ]) {
+  for (let targetCtor of ctors) {
+    for (let sourceCtor of ctors) {
+      const rab = CreateResizableArrayBuffer(4 * sourceCtor.BYTES_PER_ELEMENT, 8 * sourceCtor.BYTES_PER_ELEMENT);
+      const fixedLength = new sourceCtor(rab, 0, 4);
+      const fixedLengthWithOffset = new sourceCtor(rab, 2 * sourceCtor.BYTES_PER_ELEMENT, 2);
+      const lengthTracking = new sourceCtor(rab, 0);
+      const lengthTrackingWithOffset = new sourceCtor(rab, 2 * sourceCtor.BYTES_PER_ELEMENT);
+
+      // Write some data into the array.
+      const taFull = new sourceCtor(rab);
+      for (let i = 0; i < 4; ++i) {
+        WriteToTypedArray(taFull, i, i + 1);
+      }
+
+      // Orig. array: [1, 2, 3, 4]
+      //              [1, 2, 3, 4] << fixedLength
+      //                    [3, 4] << fixedLengthWithOffset
+      //              [1, 2, 3, 4, ...] << lengthTracking
+      //                    [3, 4, ...] << lengthTrackingWithOffset
+
+      const targetAb = targetIsResizable ? new ArrayBuffer(6 * targetCtor.BYTES_PER_ELEMENT) : new ArrayBuffer(6 * targetCtor.BYTES_PER_ELEMENT, { maxByteLength: 8 * targetCtor.BYTES_PER_ELEMENT });
+      const target = new targetCtor(targetAb);
+      if (IsBigIntTypedArray(target) != IsBigIntTypedArray(taFull)) {
+        // Can't mix BigInt and non-BigInt types.
+        continue;
+      }
+      SetHelper(target, fixedLength);
+      assert.compareArray(ToNumbers(target), [
+        1,
+        2,
+        3,
+        4,
+        0,
+        0
+      ]);
+      SetHelper(target, fixedLengthWithOffset);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        4,
+        3,
+        4,
+        0,
+        0
+      ]);
+      SetHelper(target, lengthTracking, 1);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        1,
+        2,
+        3,
+        4,
+        0
+      ]);
+      SetHelper(target, lengthTrackingWithOffset, 1);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        3,
+        4,
+        3,
+        4,
+        0
+      ]);
+
+      // Shrink so that fixed length TAs go out of bounds.
+      rab.resize(3 * sourceCtor.BYTES_PER_ELEMENT);
+
+      // Orig. array: [1, 2, 3]
+      //              [1, 2, 3, ...] << lengthTracking
+      //                    [3, ...] << lengthTrackingWithOffset
+
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLengthWithOffset);
+      });
+      assert.compareArray(ToNumbers(target), [
+        3,
+        3,
+        4,
+        3,
+        4,
+        0
+      ]);
+      SetHelper(target, lengthTracking);
+      assert.compareArray(ToNumbers(target), [
+        1,
+        2,
+        3,
+        3,
+        4,
+        0
+      ]);
+      SetHelper(target, lengthTrackingWithOffset);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        2,
+        3,
+        3,
+        4,
+        0
+      ]);
+
+      // Shrink so that the TAs with offset go out of bounds.
+      rab.resize(1 * sourceCtor.BYTES_PER_ELEMENT);
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        SetHelper(target, lengthTrackingWithOffset);
+      });
+      SetHelper(target, lengthTracking, 3);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        2,
+        3,
+        1,
+        4,
+        0
+      ]);
+
+      // Shrink to zero.
+      rab.resize(0);
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        SetHelper(target, lengthTrackingWithOffset);
+      });
+      SetHelper(target, lengthTracking, 4);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        2,
+        3,
+        1,
+        4,
+        0
+      ]);
+
+      // Grow so that all TAs are back in-bounds.
+      rab.resize(6 * sourceCtor.BYTES_PER_ELEMENT);
+      for (let i = 0; i < 6; ++i) {
+        WriteToTypedArray(taFull, i, i + 1);
+      }
+
+      // Orig. array: [1, 2, 3, 4, 5, 6]
+      //              [1, 2, 3, 4] << fixedLength
+      //                    [3, 4] << fixedLengthWithOffset
+      //              [1, 2, 3, 4, 5, 6, ...] << lengthTracking
+      //                    [3, 4, 5, 6, ...] << lengthTrackingWithOffset
+
+      SetHelper(target, fixedLength);
+      assert.compareArray(ToNumbers(target), [
+        1,
+        2,
+        3,
+        4,
+        4,
+        0
+      ]);
+      SetHelper(target, fixedLengthWithOffset);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        4,
+        3,
+        4,
+        4,
+        0
+      ]);
+      SetHelper(target, lengthTracking, 0);
+      assert.compareArray(ToNumbers(target), [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]);
+      SetHelper(target, lengthTrackingWithOffset, 1);
+      assert.compareArray(ToNumbers(target), [
+        1,
+        3,
+        4,
+        5,
+        6,
+        6
+      ]);
+    }
+  }
+}


### PR DESCRIPTION
of TypedArray.prototype

This is part of PR https://github.com/tc39/test262/pull/3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js