### PR TITLE
RAB: Integrate staging tests for the .values method

### DIFF
--- a/test/built-ins/Array/prototype/values/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/values/resizable-buffer-grow-mid-iteration.js
@@ -4,138 +4,57 @@
 /*---
 esid: sec-array.prototype.values
 description: >
-  Array.p.values behaves correctly when receiver is backed by a resizable
-  buffer and resized mid-iteration
+  Array.p.values behaves correctly on TypedArrays backed by resizable buffers and
+  resized mid-iteration.
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(Array.prototype.values.call(fixedLength), [
+    0,
+    2,
+    4,
+    6
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-class MyFloat32Array extends Float32Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(Array.prototype.values.call(fixedLengthWithOffset), [
+    4,
+    6
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(Array.prototype.values.call(lengthTracking), [
+    0,
+    2,
+    4,
+    6,
+    0,
+    0
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  TestIterationAndResize(Array.prototype.values.call(lengthTrackingWithOffset), [
+    4,
+    6,
+    0,
+    0
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayValuesHelper(ta) {
-  return Array.prototype.values.call(ta);
-}
-
-function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
-  let values = [];
-  let resized = false;
-  for (const value of ta) {
-    if (value instanceof Array) {
-      values.push([
-        value[0],
-        Number(value[1])
-      ]);
-    } else {
-      values.push(Number(value));
-    }
-    if (!resized && values.length == resize_after) {
-      rab.resize(new_byte_length);
-      resized = true;
-    }
-  }
-  assert.compareArray(values.flat(), expected.flat());
-  assert(resized);
-}
-
-function ValuesGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-
-  // Iterating with values() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(ArrayValuesHelper(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(ArrayValuesHelper(fixedLengthWithOffset), [
-      4,
-      6
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(ArrayValuesHelper(lengthTracking), [
-      0,
-      2,
-      4,
-      6,
-      0,
-      0
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    TestIterationAndResize(ArrayValuesHelper(lengthTrackingWithOffset), [
-      4,
-      6,
-      0,
-      0
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-}
-
-ValuesGrowMidIteration();

--- a/test/built-ins/Array/prototype/values/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/Array/prototype/values/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,141 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.values
+description: >
+  Array.p.values behaves correctly when receiver is backed by a resizable
+  buffer and resized mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayValuesHelper(ta) {
+  return Array.prototype.values.call(ta);
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values.flat(), expected.flat());
+  assert(resized);
+}
+
+function ValuesGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+
+  // Iterating with values() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(ArrayValuesHelper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(ArrayValuesHelper(fixedLengthWithOffset), [
+      4,
+      6
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(ArrayValuesHelper(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      0,
+      0
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(ArrayValuesHelper(lengthTrackingWithOffset), [
+      4,
+      6,
+      0,
+      0
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+ValuesGrowMidIteration();

--- a/test/built-ins/Array/prototype/values/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/values/resizable-buffer-shrink-mid-iteration.js
@@ -4,130 +4,49 @@
 /*---
 esid: sec-array.prototype.values
 description: >
-  Array.p.values behaves correctly when receiver is backed by resizable
-  buffer that is shrunk mid-iteration
+  Array.p.values behaves correctly on TypedArrays backed by resizable buffers
+  that are shrunk mid-iteration.
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+
+  // The fixed length array goes out of bounds when the RAB is resized.
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(Array.prototype.values.call(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  });
 }
-
-class MyFloat32Array extends Float32Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(Array.prototype.values.call(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  });
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(Array.prototype.values.call(lengthTracking), [
+    0,
+    2,
+    4
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
 }
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+  // The fixed length array goes out of bounds when the RAB is resized.
+  TestIterationAndResize(Array.prototype.values.call(lengthTrackingWithOffset), [
+    4,
+    6
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayValuesHelper(ta) {
-  return Array.prototype.values.call(ta);
-}
-
-function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
-  let values = [];
-  let resized = false;
-  for (const value of ta) {
-    if (value instanceof Array) {
-      values.push([
-        value[0],
-        Number(value[1])
-      ]);
-    } else {
-      values.push(Number(value));
-    }
-    if (!resized && values.length == resize_after) {
-      rab.resize(new_byte_length);
-      resized = true;
-    }
-  }
-  assert.compareArray(values.flat(), expected.flat());
-  assert(resized);
-}
-
-function ValuesShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-
-  // Iterating with values() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-
-    // The fixed length array goes out of bounds when the RAB is resized.
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(ArrayValuesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(ArrayValuesHelper(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(ArrayValuesHelper(lengthTracking), [
-      0,
-      2,
-      4
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // The fixed length array goes out of bounds when the RAB is resized.
-    TestIterationAndResize(ArrayValuesHelper(lengthTrackingWithOffset), [
-      4,
-      6
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
-}
-
-ValuesShrinkMidIteration();

--- a/test/built-ins/Array/prototype/values/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/Array/prototype/values/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,133 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.values
+description: >
+  Array.p.values behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayValuesHelper(ta) {
+  return Array.prototype.values.call(ta);
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values.flat(), expected.flat());
+  assert(resized);
+}
+
+function ValuesShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+
+  // Iterating with values() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(ArrayValuesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(ArrayValuesHelper(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(ArrayValuesHelper(lengthTracking), [
+      0,
+      2,
+      4
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    TestIterationAndResize(ArrayValuesHelper(lengthTrackingWithOffset), [
+      4,
+      6
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+ValuesShrinkMidIteration();

--- a/test/built-ins/Array/prototype/values/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/values/resizable-buffer.js
@@ -1,0 +1,207 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.values
+description: >
+  Array.p.values behaves correctly when receiver is backed by resizable
+  buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function ArrayValuesHelper(ta) {
+  return Array.prototype.values.call(ta);
+}
+
+function ValuesFromArrayValues(ta) {
+  const result = [];
+  for (let value of Array.prototype.values.call(ta)) {
+    result.push(Number(value));
+  }
+  return result;
+}
+
+function TestValues() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ValuesFromArrayValues(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromArrayValues(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromArrayValues(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromArrayValues(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    // TypedArray.prototype.{entries, keys, values} throw right away when
+    // called. Array.prototype.{entries, keys, values} don't throw, but when
+    // we try to iterate the returned ArrayIterator, that throws.
+    ArrayValuesHelper(fixedLength);
+    ArrayValuesHelper(fixedLengthWithOffset);
+
+    assert.throws(TypeError, () => {
+      Array.from(ArrayValuesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayValuesHelper(fixedLengthWithOffset));
+    });
+    assert.compareArray(ValuesFromArrayValues(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(ValuesFromArrayValues(lengthTrackingWithOffset), [4]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    ArrayValuesHelper(fixedLength);
+    ArrayValuesHelper(fixedLengthWithOffset);
+    ArrayValuesHelper(lengthTrackingWithOffset);
+
+    assert.throws(TypeError, () => {
+      Array.from(ArrayValuesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayValuesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayValuesHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(ValuesFromArrayValues(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    ArrayValuesHelper(fixedLength);
+    ArrayValuesHelper(fixedLengthWithOffset);
+    ArrayValuesHelper(lengthTrackingWithOffset);
+
+    assert.throws(TypeError, () => {
+      Array.from(ArrayValuesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayValuesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(ArrayValuesHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(ValuesFromArrayValues(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ValuesFromArrayValues(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromArrayValues(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromArrayValues(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(ValuesFromArrayValues(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+  }
+}
+
+TestValues();

--- a/test/built-ins/Array/prototype/values/resizable-buffer.js
+++ b/test/built-ins/Array/prototype/values/resizable-buffer.js
@@ -4,204 +4,153 @@
 /*---
 esid: sec-array.prototype.values
 description: >
-  Array.p.values behaves correctly when receiver is backed by resizable
-  buffer
-includes: [compareArray.js]
+  Array.p.values behaves correctly on TypedArrays backed by resizable buffers.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function ArrayValuesHelper(ta) {
-  return Array.prototype.values.call(ta);
-}
-
-function ValuesFromArrayValues(ta) {
+function IteratorToNumbers(iterator) {
   const result = [];
-  for (let value of Array.prototype.values.call(ta)) {
+  for (let value of iterator) {
     result.push(Number(value));
   }
   return result;
 }
 
-function TestValues() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(ValuesFromArrayValues(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromArrayValues(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromArrayValues(lengthTracking), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromArrayValues(lengthTrackingWithOffset), [
-      4,
-      6
-    ]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    // TypedArray.prototype.{entries, keys, values} throw right away when
-    // called. Array.prototype.{entries, keys, values} don't throw, but when
-    // we try to iterate the returned ArrayIterator, that throws.
-    ArrayValuesHelper(fixedLength);
-    ArrayValuesHelper(fixedLengthWithOffset);
-
-    assert.throws(TypeError, () => {
-      Array.from(ArrayValuesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayValuesHelper(fixedLengthWithOffset));
-    });
-    assert.compareArray(ValuesFromArrayValues(lengthTracking), [
-      0,
-      2,
-      4
-    ]);
-    assert.compareArray(ValuesFromArrayValues(lengthTrackingWithOffset), [4]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    ArrayValuesHelper(fixedLength);
-    ArrayValuesHelper(fixedLengthWithOffset);
-    ArrayValuesHelper(lengthTrackingWithOffset);
-
-    assert.throws(TypeError, () => {
-      Array.from(ArrayValuesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayValuesHelper(fixedLengthWithOffset));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayValuesHelper(lengthTrackingWithOffset));
-    });
-    assert.compareArray(ValuesFromArrayValues(lengthTracking), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    ArrayValuesHelper(fixedLength);
-    ArrayValuesHelper(fixedLengthWithOffset);
-    ArrayValuesHelper(lengthTrackingWithOffset);
-
-    assert.throws(TypeError, () => {
-      Array.from(ArrayValuesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayValuesHelper(fixedLengthWithOffset));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(ArrayValuesHelper(lengthTrackingWithOffset));
-    });
-    assert.compareArray(ValuesFromArrayValues(lengthTracking), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(ValuesFromArrayValues(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromArrayValues(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromArrayValues(lengthTracking), [
-      0,
-      2,
-      4,
-      6,
-      8,
-      10
-    ]);
-    assert.compareArray(ValuesFromArrayValues(lengthTrackingWithOffset), [
-      4,
-      6,
-      8,
-      10
-    ]);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-TestValues();
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(fixedLength)), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(fixedLengthWithOffset)), [
+    4,
+    6
+  ]);
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(lengthTracking)), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(lengthTrackingWithOffset)), [
+    4,
+    6
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  // TypedArray.prototype.{entries, keys, values} throw right away when
+  // called. Array.prototype.{entries, keys, values} don't throw, but when
+  // we try to iterate the returned ArrayIterator, that throws.
+  Array.prototype.values.call(fixedLength);
+  Array.prototype.values.call(fixedLengthWithOffset);
+
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.values.call(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.values.call(fixedLengthWithOffset));
+  });
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(lengthTracking)), [
+    0,
+    2,
+    4
+  ]);
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(lengthTrackingWithOffset)), [4]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  Array.prototype.values.call(fixedLength);
+  Array.prototype.values.call(fixedLengthWithOffset);
+  Array.prototype.values.call(lengthTrackingWithOffset);
+
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.values.call(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.values.call(fixedLengthWithOffset));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.values.call(lengthTrackingWithOffset));
+  });
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(lengthTracking)), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  Array.prototype.values.call(fixedLength);
+  Array.prototype.values.call(fixedLengthWithOffset);
+  Array.prototype.values.call(lengthTrackingWithOffset);
+
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.values.call(fixedLength));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.values.call(fixedLengthWithOffset));
+  });
+  assert.throws(TypeError, () => {
+    Array.from(Array.prototype.values.call(lengthTrackingWithOffset));
+  });
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(lengthTracking)), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(fixedLength)), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(fixedLengthWithOffset)), [
+    4,
+    6
+  ]);
+  assert.compareArray(IteratorToNumbers(Array.prototype.values.call(lengthTracking)), [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10
+  ]);
+                      assert.compareArray(IteratorToNumbers(Array.prototype.values.call(lengthTrackingWithOffset)), [
+    4,
+    6,
+    8,
+    10
+  ]);
+}

--- a/test/built-ins/TypedArray/prototype/values/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/values/resizable-buffer-grow-mid-iteration.js
@@ -1,0 +1,137 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.values
+description: >
+  TypedArray.p.values behaves correctly when receiver is backed by a resizable
+  buffer and resized mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values.flat(), expected.flat());
+  assert(resized);
+}
+
+function ValuesGrowMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+
+  // Iterating with values() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(fixedLength.values(), [
+      0,
+      2,
+      4,
+      6
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(fixedLengthWithOffset.values(), [
+      4,
+      6
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(lengthTracking.values(), [
+      0,
+      2,
+      4,
+      6,
+      0,
+      0
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(lengthTrackingWithOffset.values(), [
+      4,
+      6,
+      0,
+      0
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+ValuesGrowMidIteration();

--- a/test/built-ins/TypedArray/prototype/values/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/values/resizable-buffer-grow-mid-iteration.js
@@ -4,134 +4,57 @@
 /*---
 esid: sec-%typedarray%.prototype.values
 description: >
-  TypedArray.p.values behaves correctly when receiver is backed by a resizable
-  buffer and resized mid-iteration
+  TypedArray.p.values behaves correctly on TypedArrays backed by resizable
+  buffers and resized mid-iteration.
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(fixedLength.values(), [
+    0,
+    2,
+    4,
+    6
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-class MyFloat32Array extends Float32Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  // The fixed length array is not affected by resizing.
+  TestIterationAndResize(fixedLengthWithOffset.values(), [
+    4,
+    6
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(lengthTracking.values(), [
+    0,
+    2,
+    4,
+    6,
+    0,
+    0
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  TestIterationAndResize(lengthTrackingWithOffset.values(), [
+    4,
+    6,
+    0,
+    0
+  ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
-  let values = [];
-  let resized = false;
-  for (const value of ta) {
-    if (value instanceof Array) {
-      values.push([
-        value[0],
-        Number(value[1])
-      ]);
-    } else {
-      values.push(Number(value));
-    }
-    if (!resized && values.length == resize_after) {
-      rab.resize(new_byte_length);
-      resized = true;
-    }
-  }
-  assert.compareArray(values.flat(), expected.flat());
-  assert(resized);
-}
-
-function ValuesGrowMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-
-  // Iterating with values() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(fixedLength.values(), [
-      0,
-      2,
-      4,
-      6
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    // The fixed length array is not affected by resizing.
-    TestIterationAndResize(fixedLengthWithOffset.values(), [
-      4,
-      6
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(lengthTracking.values(), [
-      0,
-      2,
-      4,
-      6,
-      0,
-      0
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-    TestIterationAndResize(lengthTrackingWithOffset.values(), [
-      4,
-      6,
-      0,
-      0
-    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
-  }
-}
-
-ValuesGrowMidIteration();

--- a/test/built-ins/TypedArray/prototype/values/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/values/resizable-buffer-shrink-mid-iteration.js
@@ -1,0 +1,133 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.values
+description: >
+  TypedArray.p.values behaves correctly when receiver is backed by resizable
+  buffer that is shrunk mid-iteration
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayValuesHelper(ta) {
+  return ta.values();
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values.flat(), expected.flat());
+  assert(resized);
+}
+
+function ValuesShrinkMidIteration() {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+
+  // Iterating with values() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(TypedArrayValuesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(TypedArrayValuesHelper(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(TypedArrayValuesHelper(lengthTracking), [
+      0,
+      2,
+      4
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    TestIterationAndResize(TypedArrayValuesHelper(lengthTrackingWithOffset), [
+      4,
+      6
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+ValuesShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/values/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/values/resizable-buffer-shrink-mid-iteration.js
@@ -4,130 +4,49 @@
 /*---
 esid: sec-%typedarray%.prototype.values
 description: >
-  TypedArray.p.values behaves correctly when receiver is backed by resizable
-  buffer that is shrunk mid-iteration
+  TypedArray.p.values behaves correctly on TypedArrays backed by resizable
+  buffers that are shrunk mid-iteration.
 features: [resizable-arraybuffer]
-includes: [compareArray.js]
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 ---*/
 
-class MyUint8Array extends Uint8Array {
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+
+  // The fixed length array goes out of bounds when the RAB is resized.
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(fixedLength.values(), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  });
 }
-
-class MyFloat32Array extends Float32Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(fixedLengthWithOffset.values(), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  });
 }
-
-class MyBigInt64Array extends BigInt64Array {
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  TestIterationAndResize(lengthTracking.values(), [
+    0,
+    2,
+    4
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
 }
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+  // The fixed length array goes out of bounds when the RAB is resized.
+  TestIterationAndResize(lengthTrackingWithOffset.values(), [
+    4,
+    6
+  ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
 }
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayValuesHelper(ta) {
-  return ta.values();
-}
-
-function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
-  let values = [];
-  let resized = false;
-  for (const value of ta) {
-    if (value instanceof Array) {
-      values.push([
-        value[0],
-        Number(value[1])
-      ]);
-    } else {
-      values.push(Number(value));
-    }
-    if (!resized && values.length == resize_after) {
-      rab.resize(new_byte_length);
-      resized = true;
-    }
-  }
-  assert.compareArray(values.flat(), expected.flat());
-  assert(resized);
-}
-
-function ValuesShrinkMidIteration() {
-  // Orig. array: [0, 2, 4, 6]
-  //              [0, 2, 4, 6] << fixedLength
-  //                    [4, 6] << fixedLengthWithOffset
-  //              [0, 2, 4, 6, ...] << lengthTracking
-  //                    [4, 6, ...] << lengthTrackingWithOffset
-  function CreateRabForTest(ctor) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-    return rab;
-  }
-
-  // Iterating with values() (the 4 loops below).
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLength = new ctor(rab, 0, 4);
-
-    // The fixed length array goes out of bounds when the RAB is resized.
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(TypedArrayValuesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    assert.throws(TypeError, () => {
-      TestIterationAndResize(TypedArrayValuesHelper(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-    });
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTracking = new ctor(rab, 0);
-    TestIterationAndResize(TypedArrayValuesHelper(lengthTracking), [
-      0,
-      2,
-      4
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
-  for (let ctor of ctors) {
-    const rab = CreateRabForTest(ctor);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
-
-    // The fixed length array goes out of bounds when the RAB is resized.
-    TestIterationAndResize(TypedArrayValuesHelper(lengthTrackingWithOffset), [
-      4,
-      6
-    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
-  }
-}
-
-ValuesShrinkMidIteration();

--- a/test/built-ins/TypedArray/prototype/values/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/values/resizable-buffer.js
@@ -75,12 +75,6 @@ for (let ctor of ctors) {
     fixedLengthWithOffset.values();
   });
 
-  assert.throws(TypeError, () => {
-    Array.from(fixedLength.values());
-  });
-  assert.throws(TypeError, () => {
-    Array.from(fixedLengthWithOffset.values());
-  });
   assert.compareArray(IteratorToNumbers(lengthTracking.values()), [
     0,
     2,
@@ -100,15 +94,6 @@ for (let ctor of ctors) {
     lengthTrackingWithOffset.values();
   });
 
-  assert.throws(TypeError, () => {
-    Array.from(fixedLength.values());
-  });
-  assert.throws(TypeError, () => {
-    Array.from(fixedLengthWithOffset.values());
-  });
-  assert.throws(TypeError, () => {
-    Array.from(lengthTrackingWithOffset.values());
-  });
   assert.compareArray(IteratorToNumbers(lengthTracking.values()), [0]);
 
   // Shrink to zero.
@@ -123,15 +108,6 @@ for (let ctor of ctors) {
     lengthTrackingWithOffset.values();
   });
 
-  assert.throws(TypeError, () => {
-    Array.from(fixedLength.values());
-  });
-  assert.throws(TypeError, () => {
-    Array.from(fixedLengthWithOffset.values());
-  });
-  assert.throws(TypeError, () => {
-    Array.from(lengthTrackingWithOffset.values());
-  });
   assert.compareArray(IteratorToNumbers(lengthTracking.values()), []);
 
   // Grow so that all TAs are back in-bounds.

--- a/test/built-ins/TypedArray/prototype/values/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/values/resizable-buffer.js
@@ -1,0 +1,223 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.values
+description: >
+  TypedArray.p.values behaves correctly when receiver is backed by resizable
+  buffer
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayValuesHelper(ta) {
+  return ta.values();
+}
+
+function ValuesFromTypedArrayValues(ta) {
+  let result = [];
+  for (let value of ta.values()) {
+    result.push(Number(value));
+  }
+  return result;
+}
+
+function TestValues() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ValuesFromTypedArrayValues(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromTypedArrayValues(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromTypedArrayValues(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromTypedArrayValues(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    // TypedArray.prototype.{entries, keys, values} throw right away when
+    // called. Array.prototype.{entries, keys, values} don't throw, but when
+    // we try to iterate the returned ArrayIterator, that throws.
+    assert.throws(TypeError, () => {
+      TypedArrayValuesHelper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayValuesHelper(fixedLengthWithOffset);
+    });
+
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayValuesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayValuesHelper(fixedLengthWithOffset));
+    });
+    assert.compareArray(ValuesFromTypedArrayValues(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(ValuesFromTypedArrayValues(lengthTrackingWithOffset), [4]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      TypedArrayValuesHelper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayValuesHelper(fixedLengthWithOffset);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayValuesHelper(lengthTrackingWithOffset);
+    });
+
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayValuesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayValuesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayValuesHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(ValuesFromTypedArrayValues(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      TypedArrayValuesHelper(fixedLength);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayValuesHelper(fixedLengthWithOffset);
+    });
+    assert.throws(TypeError, () => {
+      TypedArrayValuesHelper(lengthTrackingWithOffset);
+    });
+
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayValuesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayValuesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(TypedArrayValuesHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(ValuesFromTypedArrayValues(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ValuesFromTypedArrayValues(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromTypedArrayValues(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(ValuesFromTypedArrayValues(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(ValuesFromTypedArrayValues(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+  }
+}
+
+TestValues();

--- a/test/built-ins/TypedArray/prototype/values/resizable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/values/resizable-buffer.js
@@ -4,220 +4,170 @@
 /*---
 esid: sec-%typedarray%.prototype.values
 description: >
-  TypedArray.p.values behaves correctly when receiver is backed by resizable
-  buffer
-includes: [compareArray.js]
+  TypedArray.p.values behaves correctly on TypedArrays backed by resizable
+  buffers.
+includes: [compareArray.js, resizableArrayBufferUtils.js]
 features: [resizable-arraybuffer]
 ---*/
 
-class MyUint8Array extends Uint8Array {
-}
-
-class MyFloat32Array extends Float32Array {
-}
-
-class MyBigInt64Array extends BigInt64Array {
-}
-
-const builtinCtors = [
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-  Float32Array,
-  Float64Array,
-  Uint8ClampedArray,
-  BigUint64Array,
-  BigInt64Array
-];
-
-const ctors = [
-  ...builtinCtors,
-  MyUint8Array,
-  MyFloat32Array,
-  MyBigInt64Array
-];
-
-function CreateResizableArrayBuffer(byteLength, maxByteLength) {
-  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
-}
-
-function WriteToTypedArray(array, index, value) {
-  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
-    array[index] = BigInt(value);
-  } else {
-    array[index] = value;
-  }
-}
-
-function TypedArrayValuesHelper(ta) {
-  return ta.values();
-}
-
-function ValuesFromTypedArrayValues(ta) {
+function IteratorToNumbers(iterator) {
   let result = [];
-  for (let value of ta.values()) {
+  for (let value of iterator) {
     result.push(Number(value));
   }
   return result;
 }
 
-function TestValues() {
-  for (let ctor of ctors) {
-    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
-    const fixedLength = new ctor(rab, 0, 4);
-    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
-    const lengthTracking = new ctor(rab, 0);
-    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
 
-    // Write some data into the array.
-    const taWrite = new ctor(rab);
-    for (let i = 0; i < 4; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, ...] << lengthTracking
-    //                    [4, 6, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(ValuesFromTypedArrayValues(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromTypedArrayValues(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromTypedArrayValues(lengthTracking), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromTypedArrayValues(lengthTrackingWithOffset), [
-      4,
-      6
-    ]);
-
-    // Shrink so that fixed length TAs go out of bounds.
-    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
-
-    // Orig. array: [0, 2, 4]
-    //              [0, 2, 4, ...] << lengthTracking
-    //                    [4, ...] << lengthTrackingWithOffset
-
-    // TypedArray.prototype.{entries, keys, values} throw right away when
-    // called. Array.prototype.{entries, keys, values} don't throw, but when
-    // we try to iterate the returned ArrayIterator, that throws.
-    assert.throws(TypeError, () => {
-      TypedArrayValuesHelper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayValuesHelper(fixedLengthWithOffset);
-    });
-
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayValuesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayValuesHelper(fixedLengthWithOffset));
-    });
-    assert.compareArray(ValuesFromTypedArrayValues(lengthTracking), [
-      0,
-      2,
-      4
-    ]);
-    assert.compareArray(ValuesFromTypedArrayValues(lengthTrackingWithOffset), [4]);
-
-    // Shrink so that the TAs with offset go out of bounds.
-    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
-    assert.throws(TypeError, () => {
-      TypedArrayValuesHelper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayValuesHelper(fixedLengthWithOffset);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayValuesHelper(lengthTrackingWithOffset);
-    });
-
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayValuesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayValuesHelper(fixedLengthWithOffset));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayValuesHelper(lengthTrackingWithOffset));
-    });
-    assert.compareArray(ValuesFromTypedArrayValues(lengthTracking), [0]);
-
-    // Shrink to zero.
-    rab.resize(0);
-    assert.throws(TypeError, () => {
-      TypedArrayValuesHelper(fixedLength);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayValuesHelper(fixedLengthWithOffset);
-    });
-    assert.throws(TypeError, () => {
-      TypedArrayValuesHelper(lengthTrackingWithOffset);
-    });
-
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayValuesHelper(fixedLength));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayValuesHelper(fixedLengthWithOffset));
-    });
-    assert.throws(TypeError, () => {
-      Array.from(TypedArrayValuesHelper(lengthTrackingWithOffset));
-    });
-    assert.compareArray(ValuesFromTypedArrayValues(lengthTracking), []);
-
-    // Grow so that all TAs are back in-bounds.
-    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
-    for (let i = 0; i < 6; ++i) {
-      WriteToTypedArray(taWrite, i, 2 * i);
-    }
-
-    // Orig. array: [0, 2, 4, 6, 8, 10]
-    //              [0, 2, 4, 6] << fixedLength
-    //                    [4, 6] << fixedLengthWithOffset
-    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
-    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
-
-    assert.compareArray(ValuesFromTypedArrayValues(fixedLength), [
-      0,
-      2,
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromTypedArrayValues(fixedLengthWithOffset), [
-      4,
-      6
-    ]);
-    assert.compareArray(ValuesFromTypedArrayValues(lengthTracking), [
-      0,
-      2,
-      4,
-      6,
-      8,
-      10
-    ]);
-    assert.compareArray(ValuesFromTypedArrayValues(lengthTrackingWithOffset), [
-      4,
-      6,
-      8,
-      10
-    ]);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
   }
-}
 
-TestValues();
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(IteratorToNumbers(fixedLength.values()), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(IteratorToNumbers(fixedLengthWithOffset.values()), [
+    4,
+    6
+  ]);
+  assert.compareArray(IteratorToNumbers(lengthTracking.values()), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(IteratorToNumbers(lengthTrackingWithOffset.values()), [
+    4,
+    6
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  // TypedArray.prototype.{entries, keys, values} throw right away when
+  // called. Array.prototype.{entries, keys, values} don't throw, but when
+  // we try to iterate the returned ArrayIterator, that throws.
+  assert.throws(TypeError, () => {
+    fixedLength.values();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.values();
+  });
+
+  assert.throws(TypeError, () => {
+    Array.from(fixedLength.values());
+  });
+  assert.throws(TypeError, () => {
+    Array.from(fixedLengthWithOffset.values());
+  });
+  assert.compareArray(IteratorToNumbers(lengthTracking.values()), [
+    0,
+    2,
+    4
+  ]);
+  assert.compareArray(IteratorToNumbers(lengthTrackingWithOffset.values()), [4]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.values();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.values();
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.values();
+  });
+
+  assert.throws(TypeError, () => {
+    Array.from(fixedLength.values());
+  });
+  assert.throws(TypeError, () => {
+    Array.from(fixedLengthWithOffset.values());
+  });
+  assert.throws(TypeError, () => {
+    Array.from(lengthTrackingWithOffset.values());
+  });
+  assert.compareArray(IteratorToNumbers(lengthTracking.values()), [0]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    fixedLength.values();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.values();
+  });
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.values();
+  });
+
+  assert.throws(TypeError, () => {
+    Array.from(fixedLength.values());
+  });
+  assert.throws(TypeError, () => {
+    Array.from(fixedLengthWithOffset.values());
+  });
+  assert.throws(TypeError, () => {
+    Array.from(lengthTrackingWithOffset.values());
+  });
+  assert.compareArray(IteratorToNumbers(lengthTracking.values()), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(IteratorToNumbers(fixedLength.values()), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(IteratorToNumbers(fixedLengthWithOffset.values()), [
+    4,
+    6
+  ]);
+  assert.compareArray(IteratorToNumbers(lengthTracking.values()), [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10
+  ]);
+  assert.compareArray(IteratorToNumbers(lengthTrackingWithOffset.values()), [
+    4,
+    6,
+    8,
+    10
+  ]);
+}


### PR DESCRIPTION
of Array.prototype and TypedArray.prototype

This is part of PR https://github.com/tc39/test262/pull/3888 to make reviewing easier. Includes changes to use the helper ./harness/resizableArrayBufferUtils.js