### PR TITLE
RAB: fix reduce tests

### DIFF
--- a/test/built-ins/TypedArray/prototype/reduce/resizable-buffer-grow-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/reduce/resizable-buffer-grow-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
-function ResizeMidIteration(n) {
+function ResizeMidIteration(acc, n) {
   // Returns true by default.
   return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
 }

--- a/test/built-ins/TypedArray/prototype/reduce/resizable-buffer-shrink-mid-iteration.js
+++ b/test/built-ins/TypedArray/prototype/reduce/resizable-buffer-shrink-mid-iteration.js
@@ -19,7 +19,7 @@ let resizeTo;
 // resizeTo. To be called by a method of the view being collected.
 // Note that rab, values, resizeAfter, and resizeTo may need to be reset
 // before calling this.
-function ResizeMidIteration(n) {
+function ResizeMidIteration(acc, n) {
   return CollectValuesAndResize(n, values, rab, resizeAfter, resizeTo);
 }
 


### PR DESCRIPTION
Introduced in #4156 , `Array.prototype.reduce` had the correct signature for callback function, but typed array did not.

`reduce` callback has call signature `«accumulator, kValue, 𝔽(k), O»` earlier the collected values contained the accumalator instead of the actual value.
