### PR TITLE
Run full test suite for non-PR builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "private": true,
   "homepage": "https://github.com/tc39/test262#readme",
   "devDependencies": {
-    "esvu": "^1.2.11",
-    "test262-harness": "^8.0.0"
+    "esvu": "^1.2.16",
+    "test262-harness": "^10.0.0"
   },
   "scripts": {
     "ci": "./tools/scripts/ci_test.sh",

--- a/tools/scripts/ci_test.sh
+++ b/tools/scripts/ci_test.sh
@@ -14,4 +14,8 @@ if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
 
   echo "Running the tests with test262-harness"
   test262-harness -t 1 --hostType=$hostType --hostPath=$hostPath --hostArgs="$hostArgs" -- $paths
+  exit 0
 fi
+
+# running full suite for non-PRs
+test262-harness -t 1 --hostType=$hostType --hostPath=$hostPath --hostArgs="$hostArgs" -- test/**/*.js


### PR DESCRIPTION
I'm proposing to run full suite of tests when running against `main` branch. This will give full listing of currently unsupported tests by engine. Also updating to latest NPM dependencies.

Test will still be green on CI like for PRs when errors are present, see https://github.com/tc39/test262/commit/1ebd34b53b59a5cb84bdfece8931e40c462747e0 for original reasoning not erroring.

I would argue that it would be better if the PRs would fail and maintainers would need to read the actual error output to figure out whether problems are correct. The test262-harness has a flag for this `--error-for-failures` which would break PR builds if there's a problem. Of course this would create noise for unsupported features per engine.