### PR TITLE
Add tests for nullable quantifiers in RegExps

### DIFF
--- a/test/built-ins/RegExp/nullable-quantifier.js
+++ b/test/built-ins/RegExp/nullable-quantifier.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2024 Aurèle Barrière. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-repeatmatcher-abstract-operation
+description: JavaScript nullable quantifiers have special semantics: optional iterations are not allowed to match the empty string. Point 2.b below shows that after each optional (min=0) iteration of a quantifier, if the iteration matched the empty string (y.[[EndIndex]] = x.[[EndIndex]]), then the iteration is discarded. In particular, for (a?b??)* on "ab", it is possible to do two iterations of the star, one matching "a" and the other matching "b".
+info: |
+    RepeatMatcher ( m, min, max, greedy, x, c, parenIndex, parenCount )
+
+    2. Let d be a new MatcherContinuation with parameters (y) that captures m, min, max, greedy, x, c, parenIndex, and parenCount and performs the following steps when called:
+
+      b. If min = 0 and y.[[EndIndex]] = x.[[EndIndex]], return failure.
+author: Aurèle Barrière
+---*/
+
+let input = "ab";
+let regex = /(a?b??)*/;
+let match = regex.exec(input);
+let expected = "ab";
+
+assert.sameValue(match[0], expected, "The regex is expected to match the whole string");

--- a/test/built-ins/RegExp/nullable-quantifier.js
+++ b/test/built-ins/RegExp/nullable-quantifier.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-runtime-semantics-repeatmatcher-abstract-operation
-description: JavaScript nullable quantifiers have special semantics: optional iterations are not allowed to match the empty string. Point 2.b below shows that after each optional (min=0) iteration of a quantifier, if the iteration matched the empty string (y.[[EndIndex]] = x.[[EndIndex]]), then the iteration is discarded. In particular, for (a?b??)* on "ab", it is possible to do two iterations of the star, one matching "a" and the other matching "b".
+description: JavaScript nullable quantifiers have special semantics, optional iterations are not allowed to match the empty string. Point 2.b below shows that after each optional (min=0) iteration of a quantifier, if the iteration matched the empty string (y.[[EndIndex]] = x.[[EndIndex]]), then the iteration is discarded. In particular, for (a?b??)* on "ab", it is possible to do two iterations of the star, one matching "a" and the other matching "b".
 info: |
     RepeatMatcher ( m, min, max, greedy, x, c, parenIndex, parenCount )
 


### PR DESCRIPTION
The JavaScript regex quantifiers (star, plus, counted repetition) have unique semantics when it comes to matching the empty string.
Optional iterations of quantifiers that match the empty string are forbidden.
This is documented in [ECMAScript](https://262.ecma-international.org/15.0/index.html#sec-runtime-semantics-repeatmatcher-abstract-operation) (point 2.b)
and the PLDI2024 paper [Linear Matching of JavaScript Regular Expressions](https://dl.acm.org/doi/10.1145/3656431).

In many other regex languages however, the quantifier semantics are different.
Instead of only checking at the end of an iteration, it is forbidden to visit any part of the regex twice without having consumed a character.

In some rare cases, the two semantics give different results.
For instance, matching /(a?b??)*/ on string "ab" matches "ab" in JavaScript (two iterations of the star, each matching one character), but only "a" in other languages.
See for instance https://regex101.com/r/iuVSat/1

I don't believe this JavaScript-specific behavior has been documented in Test262. I suggest adding a test case for this.
Many classical algorithms for regex matching (like NFA simulation or lazy DFA) typically do not implement the JavaScript quantifier semantics.
This led to a bug in the linear engine of V8 (which uses NFA simulation):
[Bug Report](https://issues.chromium.org/issues/42204037), [Relevant test case in V8](https://chromium-review.googlesource.com/c/v8/v8/+/4661659), [V8 fix](https://chromium-review.googlesource.com/c/v8/v8/+/4755530), [Explanation of the fix](https://dl.acm.org/doi/10.1145/3656431) (section 4.1).
