### PR TITLE
Add test for asi between `get`/`set` field and generator

### DIFF
--- a/test/language/statements/class/elements/syntax/valid/grammar-field-named-get-followed-by-generator-asi.js
+++ b/test/language/statements/class/elements/syntax/valid/grammar-field-named-get-followed-by-generator-asi.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: ASI between a field named "get" and a generator method
+esid: prod-ClassElement
+features: [class-fields-public, class]
+info: |
+    ClassElement :
+      MethodDefinition
+      FieldDefinition ;
+      static FieldDefinition ;
+      ;
+
+    MethodDefinition :
+      GeneratorMethod
+      get ClassElementName () { FunctionBody }
+
+    GeneratorMethod :
+       * ClassElementName ( UniqueFormalParameters ) { GeneratorBody }
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PropertyName :
+      LiteralPropertyName
+      ComputedPropertyName
+
+    LiteralPropertyName :
+      IdentifierName
+      StringLiteral
+      NumericLiteral
+---*/
+
+class A {
+  get
+  *a() {}
+}
+
+class B {
+  static get
+  *a() {}
+}
+
+assert(
+  A.prototype.hasOwnProperty("a"),
+  "(A) The generator is installed on the prototype"
+);
+assert(
+  new A().hasOwnProperty("get"),
+  "(A) The field is installed on class instances"
+);
+assert(
+  B.prototype.hasOwnProperty("a"),
+  "(B) The generator is installed on the prototype"
+);
+assert(
+  B.hasOwnProperty("get"),
+  "(B) The field is installed on class"
+);

--- a/test/language/statements/class/elements/syntax/valid/grammar-field-named-get-followed-by-generator-asi.js
+++ b/test/language/statements/class/elements/syntax/valid/grammar-field-named-get-followed-by-generator-asi.js
@@ -3,7 +3,7 @@
 /*---
 description: ASI between a field named "get" and a generator method
 esid: prod-ClassElement
-features: [class-fields-public, class]
+features: [class-fields-public, class-static-fields-public, class, generators]
 info: |
     ClassElement :
       MethodDefinition

--- a/test/language/statements/class/elements/syntax/valid/grammar-field-named-set-followed-by-generator-asi.js
+++ b/test/language/statements/class/elements/syntax/valid/grammar-field-named-set-followed-by-generator-asi.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2024 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-description: ASI between a field named "get" and a generator method
+description: ASI between a field named "set" and a generator method
 esid: prod-ClassElement
 features: [class-fields-public, class]
 info: |

--- a/test/language/statements/class/elements/syntax/valid/grammar-field-named-set-followed-by-generator-asi.js
+++ b/test/language/statements/class/elements/syntax/valid/grammar-field-named-set-followed-by-generator-asi.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: ASI between a field named "get" and a generator method
+esid: prod-ClassElement
+features: [class-fields-public, class]
+info: |
+    ClassElement :
+      MethodDefinition
+      FieldDefinition ;
+      static FieldDefinition ;
+      ;
+
+    MethodDefinition :
+      GeneratorMethod
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    GeneratorMethod :
+       * ClassElementName ( UniqueFormalParameters ) { GeneratorBody }
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PropertyName :
+      LiteralPropertyName
+      ComputedPropertyName
+
+    LiteralPropertyName :
+      IdentifierName
+      StringLiteral
+      NumericLiteral
+---*/
+
+class A {
+  set
+  *a(x) {}
+}
+
+class B {
+  static set
+  *a(x) {}
+}
+
+assert(
+  A.prototype.hasOwnProperty("a"),
+  "(A) The generator is installed on the prototype"
+);
+assert(
+  new A().hasOwnProperty("set"),
+  "(A) The field is installed on class instances"
+);
+assert(
+  B.prototype.hasOwnProperty("a"),
+  "(B) The generator is installed on the prototype"
+);
+assert(
+  B.hasOwnProperty("set"),
+  "(B) The field is installed on class"
+);


### PR DESCRIPTION
Currently both SpiderMonkey and TypeScript fail parsing this code. V8, Babel and ESLint all pass the test.