### PR TITLE
Fix test regression in asyncHelpers.js

### DIFF
--- a/test/harness/asyncHelpers-throwsAsync-func-never-settles.js
+++ b/test/harness/asyncHelpers-throwsAsync-func-never-settles.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2024 Julián Espina. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: |
+    assert.throwsAsync returns a promise that never settles if func returns a thenable that never settles.
+flags: [async]
+includes: [asyncHelpers.js]
+---*/
+
+var realDone = $DONE;
+var doneCalls = 0
+globalThis.$DONE = function () {
+  doneCalls++;
+}
+
+function delay() {
+  var later = Promise.resolve();
+  for (var i = 0; i < 100; i++) {
+    later = later.then();
+  }
+  return later;
+}
+
+(async function () {
+  // Spy on the promise returned by an invocation of assert.throwsAsync
+  // with a function that returns a thenable which never settles.
+  var neverSettlingThenable = { then: function () { } };
+  const p = assert.throwsAsync(TypeError, function () { return neverSettlingThenable });
+  assert(p instanceof Promise, "assert.throwsAsync should return a promise");
+  p.then($DONE, $DONE);
+})()
+  // Give it a long time to try.
+  .then(delay, delay)
+  .then(function () {
+    assert.sameValue(doneCalls, 0, "$DONE should not have been called")
+  })
+  .then(realDone, realDone);


### PR DESCRIPTION
Some recent changes to `harness/asyncHelpers.js` regressed some harness tests; `test/harness/asyncHelpers-throwsAsync-func-throws-sync.js` and `test/harness/asyncHelpers-throwsAsync-no-arg.js` to be more specific. The cause of this was fa3d0246e74da7844843ebfb4c71453c616b923a and feb400c68598138b4e5a056c69b94bc1108d8a51, which made some changes that broke those two tests.

This PR fixes this by slightly modifying `asyncHelpers.js` so that it passes the two tests, and also adds a new test to ensure #4186 is still fixed even with the new changes.