### PR TITLE
Add tests for `%WrapForValidIteratorPrototype%.return()` from Iterator Helpers Proposal

### DIFF
--- a/test/built-ins/Iterator/from/get-return-method-when-call-return.js
+++ b/test/built-ins/Iterator/from/get-return-method-when-call-return.js
@@ -10,20 +10,26 @@ info: |
     5. Let returnMethod be ? GetMethod(iterator, "return").
 
 features: [iterator-helpers]
-flags: []
+includes: [temporalHelpers.js, compareArray.js]
 ---*/
 
-let returnGetCount = 0;
-const iter = {
-    get return() {
-        returnGetCount++;
-        return function () {
-            return { value: 5, done: true };
-        };
-    },
-};
+const calls = [];
+
+const iter = TemporalHelpers.propertyBagObserver(calls, {
+  return () {
+    return { value: 5, done: true };
+  },
+}, "originalIter");
+
 const wrapper = Iterator.from(iter);
-assert.sameValue(returnGetCount, 0);
+assert.compareArray(calls, [
+  "get originalIter[Symbol.iterator]",
+  "get originalIter.next",
+]);
 
 wrapper.return();
-assert.sameValue(returnGetCount, 1);
+assert.compareArray(calls, [
+  "get originalIter[Symbol.iterator]",
+  "get originalIter.next",
+  "get originalIter.return"
+]);

--- a/test/built-ins/Iterator/from/get-return-method-when-call-return.js
+++ b/test/built-ins/Iterator/from/get-return-method-when-call-return.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2024 Sosuke Suzuki. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.from
+description: >
+  Gets the base iterator return method when the wrapper return method is called.
+info: |
+  %WrapForValidIteratorPrototype%.return ( )
+    ...
+    5. Let returnMethod be ? GetMethod(iterator, "return").
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let returnGetCount = 0;
+const iter = {
+    get return() {
+        returnGetCount++;
+        return function () {
+            return { value: 5, done: true };
+        };
+    },
+};
+const wrapper = Iterator.from(iter);
+assert.sameValue(returnGetCount, 0);
+
+wrapper.return();
+assert.sameValue(returnGetCount, 1);

--- a/test/built-ins/Iterator/from/return-method-calls-base-return-method.js
+++ b/test/built-ins/Iterator/from/return-method-calls-base-return-method.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2024 Sosuke Suzuki. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.from
+description: >
+  %WrapForValidIteratorPrototype%.return() call base iterator's return method when it exists.
+info: |
+  %WrapForValidIteratorPrototype%.return ( )
+    5. Let returnMethod be ? GetMethod(iterator, "return").
+    6. If returnMethod is undefined, then
+      ...
+    7. Return ? Call(returnMethod, iterator).
+
+includes: [deepEqual.js]
+features: [iterator-helpers]
+flags: []
+---*/
+
+let returnCallCount = 0;
+const iter = {
+    return () {
+        returnCallCount++;
+        return { value: 5, done: true };
+    },
+};
+const wrapper = Iterator.from(iter);
+
+assert.deepEqual(wrapper.return(), { value: 5, done: true });
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/from/return-method-calls-base-return-method.js
+++ b/test/built-ins/Iterator/from/return-method-calls-base-return-method.js
@@ -11,19 +11,31 @@ info: |
       ...
     7. Return ? Call(returnMethod, iterator).
 
-includes: [deepEqual.js]
 features: [iterator-helpers]
-flags: []
+includes: [temporalHelpers.js, compareArray.js]
 ---*/
 
-let returnCallCount = 0;
-const iter = {
+const calls = [];
+
+const expectedIteratorResult = { value: 5, done: true };
+const originalIter = {
     return () {
-        returnCallCount++;
-        return { value: 5, done: true };
+        return expectedIteratorResult;
     },
 };
-const wrapper = Iterator.from(iter);
+TemporalHelpers.observeMethod(calls, originalIter, "return", "originalIter");
+const iter = TemporalHelpers.propertyBagObserver(calls, originalIter, "originalIter");
 
-assert.deepEqual(wrapper.return(), { value: 5, done: true });
-assert.sameValue(returnCallCount, 1);
+const wrapper = Iterator.from(iter);
+assert.compareArray(calls, [
+  "get originalIter[Symbol.iterator]",
+  "get originalIter.next",
+]);
+
+assert.sameValue(wrapper.return(), expectedIteratorResult);
+assert.compareArray(calls, [
+  "get originalIter[Symbol.iterator]",
+  "get originalIter.next",
+  "get originalIter.return",
+  "call originalIter.return",
+]);

--- a/test/built-ins/Iterator/from/return-method-returns-iterator-result.js
+++ b/test/built-ins/Iterator/from/return-method-returns-iterator-result.js
@@ -11,12 +11,13 @@ info: |
     6. If returnMethod is undefined, then
       a. Return CreateIterResultObject(undefined, true).
 
-includes: [deepEqual.js]
 features: [iterator-helpers]
-flags: []
 ---*/
 
 const iter = {};
 const wrapper = Iterator.from(iter);
 
-assert.deepEqual(wrapper.return(), { value: undefined, done: true });
+const result = wrapper.return();
+assert(result.hasOwnProperty("value"));
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/built-ins/Iterator/from/return-method-returns-iterator-result.js
+++ b/test/built-ins/Iterator/from/return-method-returns-iterator-result.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2024 Sosuke Suzuki. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.from
+description: >
+  %WrapForValidIteratorPrototype%.return() should return an iterator result object that value is undefined when base object does not have return method.
+info: |
+  %WrapForValidIteratorPrototype%.return ( )
+    ...
+    5. Let returnMethod be ? GetMethod(iterator, "return").
+    6. If returnMethod is undefined, then
+      a. Return CreateIterResultObject(undefined, true).
+
+includes: [deepEqual.js]
+features: [iterator-helpers]
+flags: []
+---*/
+
+const iter = {};
+const wrapper = Iterator.from(iter);
+
+assert.deepEqual(wrapper.return(), { value: undefined, done: true });

--- a/test/built-ins/Iterator/from/return-method-throws-for-invalid-this.js
+++ b/test/built-ins/Iterator/from/return-method-throws-for-invalid-this.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2024 Sosuke Suzuki. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.from
+description: >
+  %WrapForValidIteratorPrototype%.return() requires [[iterated]] internal slot
+info: |
+  %WrapForValidIteratorPrototype%.return ( )
+    ...
+    2. Perform ? RequireInternalSlot(O, [[Iterated]]).
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+const iter = {};
+const WrapForValidIteratorPrototype = Object.getPrototypeOf(Iterator.from(iter));
+
+assert.throws(TypeError, function() {
+    WrapForValidIteratorPrototype.return.call({});
+});
+
+let returnCallCount = 0;
+assert.throws(TypeError, function() {
+    WrapForValidIteratorPrototype.return.call({
+      return () {
+        returnCallCount++;
+        return { value: 5, done: true };
+      }
+    });
+});
+assert.sameValue(returnCallCount, 0);


### PR DESCRIPTION
While implementing `Iterator.from` in WebKit[^1], I noticed that nearly all test262 test cases pass without implementing `%WrapForValidIteratorPrototype%.return()`[^2].

Although this method is not particularly complex, I believe there should be minimal tests for it.

This PR adds tests for `%WrapForValidIteratorPrototype%.return()`.

[^1]: https://github.com/WebKit/WebKit/pull/32741
[^2]: https://tc39.es/proposal-iterator-helpers/#sec-wrapforvaliditeratorprototype.return
