### PR TITLE
Temporal: Tests for ignoring era and eraYear in calendars without eras

### DIFF
--- a/test/intl402/Temporal/PlainDate/from/calendar-not-supporting-eras.js
+++ b/test/intl402/Temporal/PlainDate/from/calendar-not-supporting-eras.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: era and eraYear are ignored (for calendars not using eras)
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const result = Temporal.PlainDate.from({
+  era: "foobar",
+  eraYear: 1,
+  year: 1970,
+  monthCode: "M01",
+  day: 1,
+  calendar: "iso8601",
+});
+TemporalHelpers.assertPlainDate(result, 1970, 1, "M01", 1,
+  "era and eraYear are ignored for calendar not using eras (iso8601)");
+
+assert.throws(TypeError, () => Temporal.PlainDate.from({
+  era: "foobar",
+  eraYear: 1,
+  monthCode: "M01",
+  day: 1,
+  calendar: "iso8601",
+}), "era and eraYear cannot replace year for calendar not using eras (iso8601)");
+
+const resultHebrew = Temporal.PlainDate.from({
+  era: "foobar",
+  eraYear: 1,
+  year: 5780,
+  monthCode: "M01",
+  day: 1,
+  calendar: "hebrew",
+});
+TemporalHelpers.assertPlainDate(resultHebrew, 5780, 1, "M01", 1,
+  "era and eraYear are ignored for calendar not using eras (Hebrew)");
+assert.sameValue(resultHebrew.calendarId, "hebrew");
+
+assert.throws(TypeError, () => Temporal.PlainDate.from({
+  era: "foobar",
+  eraYear: 1,
+  monthCode: "M01",
+  day: 1,
+  calendar: "hebrew",
+}), "era and eraYear cannot replace year for calendar not using eras (Hebrew)");

--- a/test/intl402/Temporal/PlainDateTime/from/calendar-not-supporting-eras.js
+++ b/test/intl402/Temporal/PlainDateTime/from/calendar-not-supporting-eras.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: era and eraYear are ignored (for calendars not using eras)
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const result = Temporal.PlainDateTime.from({
+  era: "foobar",
+  eraYear: 1,
+  year: 1970,
+  monthCode: "M01",
+  day: 1,
+  calendar: "iso8601",
+});
+TemporalHelpers.assertPlainDateTime(result, 1970, 1, "M01", 1, 0, 0, 0, 0, 0, 0,
+  "era and eraYear are ignored for calendar not using eras (iso8601)");
+
+assert.throws(TypeError, () => Temporal.PlainDateTime.from({
+  era: "foobar",
+  eraYear: 1,
+  monthCode: "M01",
+  day: 1,
+  calendar: "iso8601",
+}), "era and eraYear cannot replace year for calendar not using eras (iso8601)");
+
+const resultHebrew = Temporal.PlainDateTime.from({
+  era: "foobar",
+  eraYear: 1,
+  year: 5780,
+  monthCode: "M01",
+  day: 1,
+  calendar: "hebrew",
+});
+TemporalHelpers.assertPlainDateTime(resultHebrew, 5780, 1, "M01", 1, 0, 0, 0, 0, 0, 0,
+  "era and eraYear are ignored for calendar not using eras (Hebrew)");
+assert.sameValue(resultHebrew.calendarId, "hebrew");
+
+assert.throws(TypeError, () => Temporal.PlainDateTime.from({
+  era: "foobar",
+  eraYear: 1,
+  monthCode: "M01",
+  day: 1,
+  calendar: "hebrew",
+}), "era and eraYear cannot replace year for calendar not using eras (Hebrew)");

--- a/test/intl402/Temporal/PlainMonthDay/from/calendar-not-supporting-eras.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/calendar-not-supporting-eras.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: era and eraYear are ignored (for calendars not using eras)
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const result = Temporal.PlainMonthDay.from({
+  era: "foobar",
+  eraYear: 1,
+  monthCode: "M01",
+  day: 1,
+  calendar: "iso8601",
+});
+TemporalHelpers.assertPlainMonthDay(result, "M01", 1,
+  "era and eraYear are ignored for calendar not using eras (iso8601)");
+
+const resultHebrew = Temporal.PlainMonthDay.from({
+  era: "foobar",
+  eraYear: 1,
+  monthCode: "M01",
+  day: 1,
+  calendar: "hebrew",
+});
+TemporalHelpers.assertPlainMonthDay(resultHebrew, "M01", 1,
+  "era and eraYear are ignored for calendar not using eras (Hebrew)");
+assert.sameValue(resultHebrew.calendarId, "hebrew");

--- a/test/intl402/Temporal/PlainYearMonth/from/calendar-not-supporting-eras.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/calendar-not-supporting-eras.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: era and eraYear are ignored (for calendars not using eras)
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const result = Temporal.PlainYearMonth.from({
+  era: "foobar",
+  eraYear: 1,
+  year: 1970,
+  monthCode: "M01",
+  calendar: "iso8601",
+});
+TemporalHelpers.assertPlainYearMonth(result, 1970, 1, "M01",
+  "era and eraYear are ignored for calendar not using eras (iso8601)");
+
+assert.throws(TypeError, () => Temporal.PlainYearMonth.from({
+  era: "foobar",
+  eraYear: 1,
+  monthCode: "M01",
+  calendar: "iso8601",
+}), "era and eraYear cannot replace year for calendar not using eras (iso8601)");
+
+const resultHebrew = Temporal.PlainYearMonth.from({
+  era: "foobar",
+  eraYear: 1,
+  year: 5780,
+  monthCode: "M01",
+  calendar: "hebrew",
+});
+TemporalHelpers.assertPlainYearMonth(resultHebrew, 5780, 1, "M01",
+  "era and eraYear are ignored for calendar not using eras (Hebrew)",
+  undefined, undefined, 30);
+assert.sameValue(resultHebrew.calendarId, "hebrew");
+
+assert.throws(TypeError, () => Temporal.PlainYearMonth.from({
+  era: "foobar",
+  eraYear: 1,
+  monthCode: "M01",
+  day: 1,
+  calendar: "hebrew",
+}), "era and eraYear cannot replace year for calendar not using eras (Hebrew)");

--- a/test/intl402/Temporal/ZonedDateTime/from/calendar-not-supporting-eras.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/calendar-not-supporting-eras.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: era and eraYear are ignored (for calendars not using eras)
+features: [BigInt, Temporal]
+---*/
+
+const result = Temporal.ZonedDateTime.from({
+  era: "foobar",
+  eraYear: 1,
+  year: 1970,
+  monthCode: "M01",
+  day: 1,
+  timeZone: "UTC",
+  calendar: "iso8601",
+});
+assert.sameValue(result.epochNanoseconds, 0n,
+  "era and eraYear are ignored for calendar not using eras (iso8601)");
+
+assert.throws(TypeError, () => Temporal.ZonedDateTime.from({
+  era: "foobar",
+  eraYear: 1,
+  monthCode: "M01",
+  day: 1,
+  timeZone: "UTC",
+  calendar: "iso8601",
+}), "era and eraYear cannot replace year for calendar not using eras (iso8601)");
+
+const resultHebrew = Temporal.ZonedDateTime.from({
+  era: "foobar",
+  eraYear: 1,
+  year: 5730,
+  monthCode: "M04",
+  day: 23,
+  timeZone: "UTC",
+  calendar: "hebrew",
+});
+assert.sameValue(resultHebrew.epochNanoseconds, 0n,
+  "era and eraYear are ignored for calendar not using eras (Hebrew)");
+assert.sameValue(resultHebrew.calendarId, "hebrew");
+
+assert.throws(TypeError, () => Temporal.ZonedDateTime.from({
+  era: "foobar",
+  eraYear: 1,
+  monthCode: "M01",
+  day: 1,
+  timeZone: "UTC",
+  calendar: "hebrew",
+}), "era and eraYear cannot replace year for calendar not using eras (Hebrew)");

--- a/test/staging/Intl402/Temporal/old/japanese-before-era.js
+++ b/test/staging/Intl402/Temporal/old/japanese-before-era.js
@@ -59,5 +59,5 @@ date = Temporal.PlainDate.from({
   calendar: "japanese"
 });
 assert.sameValue(`${ date }`, "1868-01-01[u-ca=japanese]");
-assert.sameValue(date.era, "ce");
+assert.sameValue(date.era, "japanese");
 assert.sameValue(date.eraYear, 1868);


### PR DESCRIPTION
This tests some of the prose requirements of CalendarResolveFields, that previously didn't have any test coverage.

See https://github.com/tc39/proposal-temporal/issues/2870