### PR TITLE
Function branding boilerplate tests from PR #3866

### DIFF
--- a/test/built-ins/AsyncDisposableStack/newtarget-prototype-is-not-object.js
+++ b/test/built-ins/AsyncDisposableStack/newtarget-prototype-is-not-object.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack
+description: >
+  [[Prototype]] defaults to %AsyncDisposableStack.prototype% if NewTarget.prototype is not an object.
+info: |
+  AsyncDisposableStack( target )
+
+  ...
+  2. Let asyncDisposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%AsyncDisposableStack.prototype%", « [[AsyncDisposableState]], [[DisposeCapability]] »).
+  3. Set asyncDisposableStack.[[AsyncDisposableState]] to pending.
+  4. Set asyncDisposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return asyncDisposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management, Reflect.construct, Symbol]
+---*/
+
+var stack;
+function newTarget() {}
+
+newTarget.prototype = undefined;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is undefined');
+
+newTarget.prototype = null;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is null');
+
+newTarget.prototype = true;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is a Boolean');
+
+newTarget.prototype = '';
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is a String');
+
+newTarget.prototype = Symbol();
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is a Symbol');
+
+newTarget.prototype = 1;
+stack = Reflect.construct(AsyncDisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), AsyncDisposableStack.prototype, 'newTarget.prototype is a Number');

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/this-does-not-have-internal-asyncdisposablestate-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/this-does-not-have-internal-asyncdisposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: Throws a TypeError if this does not have a [[AsyncDisposableState]] internal slot
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.adopt, 'function');
+
+var adopt = AsyncDisposableStack.prototype.adopt;
+
+assert.throws(TypeError, function() {
+  adopt.call({ ['[[AsyncDisposableState]]']: {} });
+}, 'Ordinary object without [[AsyncDisposableState]]');
+
+assert.throws(TypeError, function() {
+  adopt.call(AsyncDisposableStack.prototype);
+}, 'AsyncDisposableStack.prototype does not have a [[AsyncDisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  adopt.call(AsyncDisposableStack);
+}, 'AsyncDisposableStack does not have a [[AsyncDisposableState]] internal slot');
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  adopt.call(stack);
+}, 'DisposableStack instance');

--- a/test/built-ins/AsyncDisposableStack/prototype/adopt/this-not-object-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/adopt/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.adopt
+description: Throws a TypeError if this is not an Object
+info: |
+  AsyncDisposableStack.prototype.adopt ( value, onDisposeAsync )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.adopt, 'function');
+
+var adopt = AsyncDisposableStack.prototype.adopt;
+
+assert.throws(TypeError, function() {
+  adopt.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  adopt.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  adopt.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  adopt.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  adopt.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  adopt.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  adopt.call(s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/this-does-not-have-internal-asyncdisposablestate-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/this-does-not-have-internal-asyncdisposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: Throws a TypeError if this does not have a [[AsyncDisposableState]] internal slot
+info: |
+  AsyncDisposableStack.prototype.defer ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.defer, 'function');
+
+var defer = AsyncDisposableStack.prototype.defer;
+
+assert.throws(TypeError, function() {
+  defer.call({ ['[[AsyncDisposableState]]']: {} });
+}, 'Ordinary object without [[AsyncDisposableState]]');
+
+assert.throws(TypeError, function() {
+  defer.call(AsyncDisposableStack.prototype);
+}, 'AsyncDisposableStack.prototype does not have a [[AsyncDisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  defer.call(AsyncDisposableStack);
+}, 'AsyncDisposableStack does not have a [[AsyncDisposableState]] internal slot');
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  defer.call(stack);
+}, 'DisposableStack instance');

--- a/test/built-ins/AsyncDisposableStack/prototype/defer/this-not-object-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/defer/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.defer
+description: Throws a TypeError if this is not an Object
+info: |
+  AsyncDisposableStack.prototype.defer ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.defer, 'function');
+
+var defer = AsyncDisposableStack.prototype.defer;
+
+assert.throws(TypeError, function() {
+  defer.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  defer.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  defer.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  defer.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  defer.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  defer.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  defer.call(s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/this-does-not-have-internal-asyncdisposablestate-rejects.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/this-does-not-have-internal-asyncdisposablestate-rejects.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Throws a TypeError if this does not have a [[AsyncDisposableState]] internal slot
+info: |
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function() {
+  assert.sameValue(typeof AsyncDisposableStack.prototype.disposeAsync, 'function');
+  
+  var disposeAsync = AsyncDisposableStack.prototype.disposeAsync;
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call({ ['[[AsyncDisposableState]]']: {} });
+  }, 'Ordinary object without [[AsyncDisposableState]]');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(AsyncDisposableStack.prototype);
+  }, 'AsyncDisposableStack.prototype does not have a [[AsyncDisposableState]] internal slot');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(AsyncDisposableStack);
+  }, 'AsyncDisposableStack does not have a [[AsyncDisposableState]] internal slot');
+  
+  var stack = new DisposableStack();
+  await assert.throwsAsync(TypeError, function () {
+    return disposeAsync.call(stack);
+  }, 'DisposableStack instance');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/this-not-object-rejects.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposeAsync/this-not-object-rejects.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.disposeAsync
+description: Throws a TypeError if this is not an Object
+info: |
+  AsyncDisposableStack.prototype.disposeAsync ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.disposeAsync, 'function');
+
+var disposeAsync = AsyncDisposableStack.prototype.disposeAsync;
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(undefined);
+  }, 'undefined');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(null);
+  }, 'null');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(true);
+  }, 'true');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(false);
+  }, 'false');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(1);
+  }, 'number');
+  
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call('object');
+  }, 'string');
+  
+  var s = Symbol();
+  await assert.throwsAsync(TypeError, function() {
+    return disposeAsync.call(s);
+  }, 'symbol');
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/does-not-have-asyncdisposablestate-internal-slot.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/does-not-have-asyncdisposablestate-internal-slot.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  Throws a TypeError if `this` object does not have a [[AsyncDisposableState]] internal slot.
+info: |
+  get AsyncDisposableStack.prototype.disposed
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(AsyncDisposableStack.prototype, 'disposed');
+
+var stack = new AsyncDisposableStack();
+
+// Does not throw
+descriptor.get.call(stack);
+
+assert.throws(TypeError, function() {
+  descriptor.get.call([]);
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/this-not-object-throw.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/this-not-object-throw.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-asyncdisposablestack.prototype.disposed
+description: >
+  Throws a TypeError if `this` is not an Object.
+info: |
+  get AsyncDisposableStack.prototype.disposed
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management,Symbol]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(AsyncDisposableStack.prototype, 'disposed');
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(1);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(false);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(1);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call('');
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(undefined);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(null);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(Symbol());
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/move/this-does-not-have-internal-asyncdisposablestate-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/this-does-not-have-internal-asyncdisposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: Throws a TypeError if this does not have a [[AsyncDisposableState]] internal slot
+info: |
+  AsyncDisposableStack.prototype.move ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.move, 'function');
+
+var move = AsyncDisposableStack.prototype.move;
+
+assert.throws(TypeError, function() {
+  move.call({ ['[[AsyncDisposableState]]']: {} });
+}, 'Ordinary object without [[AsyncDisposableState]]');
+
+assert.throws(TypeError, function() {
+  move.call(AsyncDisposableStack.prototype);
+}, 'AsyncDisposableStack.prototype does not have a [[AsyncDisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  move.call(AsyncDisposableStack);
+}, 'AsyncDisposableStack does not have a [[AsyncDisposableState]] internal slot');
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  move.call(stack);
+}, 'DisposableStack instance');

--- a/test/built-ins/AsyncDisposableStack/prototype/move/this-not-object-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/move/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.move
+description: Throws a TypeError if this is not an Object
+info: |
+  AsyncDisposableStack.prototype.move ( )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.move, 'function');
+
+var move = AsyncDisposableStack.prototype.move;
+
+assert.throws(TypeError, function() {
+  move.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  move.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  move.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  move.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  move.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  move.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  move.call(s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/this-does-not-have-internal-asyncdisposablestate-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/this-does-not-have-internal-asyncdisposablestate-throws.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws a TypeError if this does not have a [[AsyncDisposableState]] internal slot
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  3. If asyncDisposableStack.[[AsyncDisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, sync-dispose).
+  5. Return value.
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.use, 'function');
+
+var use = AsyncDisposableStack.prototype.use;
+
+assert.throws(TypeError, function() {
+  use.call({ ['[[AsyncDisposableState]]']: {} });
+}, 'Ordinary object without [[AsyncDisposableState]]');
+
+assert.throws(TypeError, function() {
+  use.call(AsyncDisposableStack.prototype);
+}, 'AsyncDisposableStack.prototype does not have a [[AsyncDisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  use.call(AsyncDisposableStack);
+}, 'AsyncDisposableStack does not have a [[AsyncDisposableState]] internal slot');
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  use.call(stack);
+}, 'DisposableStack instance');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/this-not-object-throws.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws a TypeError if this is not an Object
+info: |
+  AsyncDisposableStack.prototype.use ()
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[AsyncDisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof AsyncDisposableStack.prototype.use, 'function');
+
+var use = AsyncDisposableStack.prototype.use;
+
+assert.throws(TypeError, function() {
+  use.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  use.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  use.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  use.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  use.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  use.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  use.call(s);
+}, 'symbol');

--- a/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-not-object.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/use/throws-if-value-not-object.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-asyncdisposablestack.prototype.use
+description: Throws if the argument is not an object and is neither null nor undefined.
+info: |
+  AsyncDisposableStack.prototype.use ( value )
+
+  1. Let asyncDisposableStack be the this value.
+  2. Perform ? RequireInternalSlot(asyncDisposableStack, [[DisposableState]]).
+  3. If asyncDisposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], value, async-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+    ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  stack.use(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.use(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.use(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.use('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.use(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/newtarget-prototype-is-not-object.js
+++ b/test/built-ins/DisposableStack/newtarget-prototype-is-not-object.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack
+description: >
+  [[Prototype]] defaults to %DisposableStack.prototype% if NewTarget.prototype is not an object.
+info: |
+  DisposableStack( target )
+
+  ...
+  2. Let disposableStack be ? OrdinaryCreateFromConstructor(NewTarget, "%DisposableStack.prototype%", « [[DisposableState]], [[DisposeCapability]] »).
+  3. Set disposableStack.[[DisposableState]] to pending.
+  4. Set disposableStack.[[DisposeCapability]] to NewDisposeCapability().
+  5. Return disposableStack.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [explicit-resource-management, Reflect.construct, Symbol]
+---*/
+
+var stack;
+function newTarget() {}
+
+newTarget.prototype = undefined;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is undefined');
+
+newTarget.prototype = null;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is null');
+
+newTarget.prototype = true;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is a Boolean');
+
+newTarget.prototype = '';
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is a String');
+
+newTarget.prototype = Symbol();
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is a Symbol');
+
+newTarget.prototype = 1;
+stack = Reflect.construct(DisposableStack, [], newTarget);
+assert.sameValue(Object.getPrototypeOf(stack), DisposableStack.prototype, 'newTarget.prototype is a Number');

--- a/test/built-ins/DisposableStack/prototype/adopt/this-does-not-have-internal-disposablestate-throws.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/this-does-not-have-internal-disposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: Throws a TypeError if this does not have a [[DisposableState]] internal slot
+info: |
+  DisposableStack.prototype.adopt ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.adopt, 'function');
+
+var adopt = DisposableStack.prototype.adopt;
+
+assert.throws(TypeError, function() {
+  adopt.call({ ['[[DisposableState]]']: {} });
+}, 'Ordinary object without [[DisposableState]]');
+
+assert.throws(TypeError, function() {
+  adopt.call(DisposableStack.prototype);
+}, 'DisposableStack.prototype does not have a [[DisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  adopt.call(DisposableStack);
+}, 'DisposableStack does not have a [[DisposableState]] internal slot');
+
+var asyncStack = new AsyncDisposableStack(function() {});
+assert.throws(TypeError, function() {
+  adopt.call(asyncStack);
+}, 'AsyncDisposableStack instance');

--- a/test/built-ins/DisposableStack/prototype/adopt/this-not-object-throws.js
+++ b/test/built-ins/DisposableStack/prototype/adopt/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.adopt
+description: Throws a TypeError if this is not an Object
+info: |
+  DisposableStack.prototype.adopt ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.adopt, 'function');
+
+var adopt = DisposableStack.prototype.adopt;
+
+assert.throws(TypeError, function() {
+  adopt.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  adopt.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  adopt.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  adopt.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  adopt.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  adopt.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  adopt.call(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/defer/this-does-not-have-internal-disposablestate-throws.js
+++ b/test/built-ins/DisposableStack/prototype/defer/this-does-not-have-internal-disposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: Throws a TypeError if this does not have a [[DisposableState]] internal slot
+info: |
+  DisposableStack.prototype.defer ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.defer, 'function');
+
+var defer = DisposableStack.prototype.defer;
+
+assert.throws(TypeError, function() {
+  defer.call({ ['[[DisposableState]]']: {} });
+}, 'Ordinary object without [[DisposableState]]');
+
+assert.throws(TypeError, function() {
+  defer.call(DisposableStack.prototype);
+}, 'DisposableStack.prototype does not have a [[DisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  defer.call(DisposableStack);
+}, 'DisposableStack does not have a [[DisposableState]] internal slot');
+
+var asyncStack = new AsyncDisposableStack(function() {});
+assert.throws(TypeError, function() {
+  defer.call(asyncStack);
+}, 'AsyncDisposableStack instance');

--- a/test/built-ins/DisposableStack/prototype/defer/this-not-object-throws.js
+++ b/test/built-ins/DisposableStack/prototype/defer/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.defer
+description: Throws a TypeError if this is not an Object
+info: |
+  DisposableStack.prototype.defer ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.defer, 'function');
+
+var defer = DisposableStack.prototype.defer;
+
+assert.throws(TypeError, function() {
+  defer.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  defer.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  defer.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  defer.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  defer.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  defer.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  defer.call(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/dispose/this-does-not-have-internal-disposablestate-throws.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/this-does-not-have-internal-disposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Throws a TypeError if this does not have a [[DisposableState]] internal slot
+info: |
+  DisposableStack.prototype.dispose ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.dispose, 'function');
+
+var dispose = DisposableStack.prototype.dispose;
+
+assert.throws(TypeError, function() {
+  dispose.call({ ['[[DisposableState]]']: {} });
+}, 'Ordinary object without [[DisposableState]]');
+
+assert.throws(TypeError, function() {
+  dispose.call(DisposableStack.prototype);
+}, 'DisposableStack.prototype does not have a [[DisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  dispose.call(DisposableStack);
+}, 'DisposableStack does not have a [[DisposableState]] internal slot');
+
+var asyncStack = new AsyncDisposableStack(function() {});
+assert.throws(TypeError, function() {
+  dispose.call(asyncStack);
+}, 'AsyncDisposableStack instance');

--- a/test/built-ins/DisposableStack/prototype/dispose/this-not-object-throws.js
+++ b/test/built-ins/DisposableStack/prototype/dispose/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.dispose
+description: Throws a TypeError if this is not an Object
+info: |
+  DisposableStack.prototype.dispose ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.dispose, 'function');
+
+var dispose = DisposableStack.prototype.dispose;
+
+assert.throws(TypeError, function() {
+  dispose.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  dispose.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  dispose.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  dispose.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  dispose.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  dispose.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  dispose.call(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/disposed/does-not-have-disposablestate-internal-slot.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/does-not-have-disposablestate-internal-slot.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  Throws a TypeError if `this` object does not have a [[DisposableState]] internal slot.
+info: |
+  get DisposableStack.prototype.disposed
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');
+
+var stack = new DisposableStack();
+
+// Does not throw
+descriptor.get.call(stack);
+
+assert.throws(TypeError, function() {
+  descriptor.get.call([]);
+});

--- a/test/built-ins/DisposableStack/prototype/disposed/this-not-object-throw.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/this-not-object-throw.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-disposablestack.prototype.disposed
+description: >
+  Throws a TypeError if `this` is not an Object.
+info: |
+  get DisposableStack.prototype.disposed
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management,Symbol]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(1);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(false);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(1);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call('');
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(undefined);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(null);
+});
+
+assert.throws(TypeError, function() {
+  descriptor.get.call(Symbol());
+});

--- a/test/built-ins/DisposableStack/prototype/move/this-does-not-have-internal-disposablestate-throws.js
+++ b/test/built-ins/DisposableStack/prototype/move/this-does-not-have-internal-disposablestate-throws.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: Throws a TypeError if this does not have a [[DisposableState]] internal slot
+info: |
+  DisposableStack.prototype.move ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.move, 'function');
+
+var move = DisposableStack.prototype.move;
+
+assert.throws(TypeError, function() {
+  move.call({ ['[[DisposableState]]']: {} });
+}, 'Ordinary object without [[DisposableState]]');
+
+assert.throws(TypeError, function() {
+  move.call(DisposableStack.prototype);
+}, 'DisposableStack.prototype does not have a [[DisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  move.call(DisposableStack);
+}, 'DisposableStack does not have a [[DisposableState]] internal slot');
+
+var asyncStack = new AsyncDisposableStack();
+assert.throws(TypeError, function() {
+  move.call(asyncStack);
+}, 'AsyncDisposableStack instance');

--- a/test/built-ins/DisposableStack/prototype/move/this-not-object-throws.js
+++ b/test/built-ins/DisposableStack/prototype/move/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.move
+description: Throws a TypeError if this is not an Object
+info: |
+  DisposableStack.prototype.move ( )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.move, 'function');
+
+var move = DisposableStack.prototype.move;
+
+assert.throws(TypeError, function() {
+  move.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  move.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  move.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  move.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  move.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  move.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  move.call(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/use/this-does-not-have-internal-disposablestate-throws.js
+++ b/test/built-ins/DisposableStack/prototype/use/this-does-not-have-internal-disposablestate-throws.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws a TypeError if this does not have a [[DisposableState]] internal slot
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  5. Return value.
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  2. If O does not have an internalSlot internal slot, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.use, 'function');
+
+var use = DisposableStack.prototype.use;
+
+assert.throws(TypeError, function() {
+  use.call({ ['[[DisposableState]]']: {} });
+}, 'Ordinary object without [[DisposableState]]');
+
+assert.throws(TypeError, function() {
+  use.call(DisposableStack.prototype);
+}, 'DisposableStack.prototype does not have a [[DisposableState]] internal slot');
+
+assert.throws(TypeError, function() {
+  use.call(DisposableStack);
+}, 'DisposableStack does not have a [[DisposableState]] internal slot');
+
+var asyncStack = new AsyncDisposableStack(function() {});
+assert.throws(TypeError, function() {
+  use.call(asyncStack);
+}, 'AsyncDisposableStack instance');

--- a/test/built-ins/DisposableStack/prototype/use/this-not-object-throws.js
+++ b/test/built-ins/DisposableStack/prototype/use/this-not-object-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws a TypeError if this is not an Object
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  ...
+
+  RequireInternalSlot ( O, internalSlot )
+
+  1. If O is not an Object, throw a TypeError exception.
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof DisposableStack.prototype.use, 'function');
+
+var use = DisposableStack.prototype.use;
+
+assert.throws(TypeError, function() {
+  use.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  use.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  use.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  use.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  use.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  use.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  use.call(s);
+}, 'symbol');

--- a/test/built-ins/DisposableStack/prototype/use/throws-if-value-not-object.js
+++ b/test/built-ins/DisposableStack/prototype/use/throws-if-value-not-object.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-disposablestack.prototype.use
+description: Throws if the argument is not an object and is neither null nor undefined.
+info: |
+  DisposableStack.prototype.use ( value )
+
+  1. Let disposableStack be the this value.
+  2. Perform ? RequireInternalSlot(disposableStack, [[DisposableState]]).
+  3. If disposableStack.[[DisposableState]] is disposed, throw a ReferenceError exception.
+  4. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], value, sync-dispose).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused
+    b. Let resource be ? CreateDisposableResource(V, hint).
+    ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+var stack = new DisposableStack();
+assert.throws(TypeError, function() {
+  stack.use(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  stack.use(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  stack.use(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  stack.use('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  stack.use(s);
+}, 'symbol');

--- a/test/built-ins/NativeErrors/SuppressedError/message-undefined-no-prop.js
+++ b/test/built-ins/NativeErrors/SuppressedError/message-undefined-no-prop.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  If message is undefined, no property will be set to the new instance
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+features: [explicit-resource-management]
+---*/
+
+var case1 = new SuppressedError(undefined, undefined, undefined);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(case1, 'message'),
+  false,
+  'explicit'
+);
+
+var case2 = new SuppressedError([]);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(case2, 'message'),
+  false,
+  'implicit'
+);

--- a/test/language/statements/await-using/throws-if-initializer-not-object.js
+++ b/test/language/statements/await-using/throws-if-initializer-not-object.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value is not an Object
+info: |
+  RS: Evaluation
+    AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument async-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ...
+  ...
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = true;
+  }, 'true');
+
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = false;
+  }, 'false');
+
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = 1;
+  }, 'number');
+
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = 'object';
+  }, 'string');
+
+  var s = Symbol();
+  await assert.throwsAsync(TypeError, async function() {
+    await using x = s;
+  }, 'symbol');
+});

--- a/test/language/statements/using/throws-if-initializer-not-object.js
+++ b/test/language/statements/using/throws-if-initializer-not-object.js
@@ -1,0 +1,71 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+description: Throws if initialized value is not an Object
+info: |
+  RS: Evaluation
+    UsingDeclaration : using BindingList ;
+
+    1. Perform ? BindingEvaluation of BindingList with argument sync-dispose.
+    2. Return empty.
+
+  RS: BindingEvaluation
+    LexicalBinding : BindingIdentifier Initializer
+
+    ...
+    5. Return ? InitializeReferencedBinding(lhs, value, hint).
+
+  InitializeReferencedBinding ( V, W )
+
+  ...
+  4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+
+  InitializeBinding ( N, V, hint )
+
+  ...
+  2. If hint is not normal, perform ? AddDisposableResource(envRec.[[DisposeCapability]], V, hint).
+  ...
+
+  AddDisposableResource ( disposeCapability, V, hint [, method ] )
+
+  1. If method is not present then,
+    a. If V is either null or undefined and hint is sync-dispose, then
+      i. Return unused.
+    b. Let resource be ? CreateDisposableResource(V, hint).
+  ...
+
+  CreateDisposableResource ( V, hint [ , method ] )
+
+  1. If method is not present, then
+    a. If V is either null or undefined, then
+      ...
+    b. Else,
+      i. If V is not an Object, throw a TypeError exception.
+      ...
+  ...
+
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function() {
+  using x = true;
+}, 'true');
+
+assert.throws(TypeError, function() {
+  using x = false;
+}, 'false');
+
+assert.throws(TypeError, function() {
+  using x = 1;
+}, 'number');
+
+assert.throws(TypeError, function() {
+  using x = 'object';
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  using x = s;
+}, 'symbol');


### PR DESCRIPTION
This PR splits some of the boilerplate tests from PR #3866  to make reviewing all those files a little easier.

This includes branding boilerplate tests for methods, as for example here: https://github.com/tc39/test262/blob/main/test/intl402/ListFormat/prototype/format/branding.js