### PR TITLE
Temporal: Add test coverage for canonicalizing era codes in from()

### DIFF
--- a/test/intl402/Temporal/PlainDate/from/canonicalize-era-codes.js
+++ b/test/intl402/Temporal/PlainDate/from/canonicalize-era-codes.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: Calendar era code is canonicalized
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const date1 = Temporal.PlainDate.from({
+  calendar: "gregory",
+  era: "ce",
+  eraYear: 2024,
+  year: 2024,
+  month: 1,
+  day: 1
+});
+TemporalHelpers.assertPlainDate(
+  date1,
+  2024, 1, "M01", 1,
+  "'ce' is accepted as alias for 'gregory'",
+  "gregory", 2024
+);
+
+const date2 = Temporal.PlainDate.from({
+  calendar: "gregory",
+  era: "bce",
+  eraYear: 44,
+  year: -43,
+  month: 3,
+  day: 15
+});
+TemporalHelpers.assertPlainDate(
+  date2,
+  -43, 3, "M03", 15,
+  "'bce' is accepted as alias for 'gregory-inverse'",
+  "gregory-inverse", 44
+);

--- a/test/intl402/Temporal/PlainDateTime/from/canonicalize-era-codes.js
+++ b/test/intl402/Temporal/PlainDateTime/from/canonicalize-era-codes.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: Calendar era code is canonicalized
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const date1 = Temporal.PlainDateTime.from({
+  calendar: "gregory",
+  era: "ce",
+  eraYear: 2024,
+  year: 2024,
+  month: 1,
+  day: 1
+});
+TemporalHelpers.assertPlainDateTime(
+  date1,
+  2024, 1, "M01", 1, 0, 0, 0, 0, 0, 0,
+  "'ce' is accepted as alias for 'gregory'",
+  "gregory", 2024
+);
+
+const date2 = Temporal.PlainDateTime.from({
+  calendar: "gregory",
+  era: "bce",
+  eraYear: 44,
+  year: -43,
+  month: 3,
+  day: 15
+});
+TemporalHelpers.assertPlainDateTime(
+  date2,
+  -43, 3, "M03", 15, 0, 0, 0, 0, 0, 0,
+  "'bce' is accepted as alias for 'gregory-inverse'",
+  "gregory-inverse", 44
+);

--- a/test/intl402/Temporal/PlainYearMonth/from/canonicalize-era-codes.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/canonicalize-era-codes.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: Calendar era code is canonicalized
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const date1 = Temporal.PlainYearMonth.from({
+  calendar: "gregory",
+  era: "ce",
+  eraYear: 2024,
+  year: 2024,
+  month: 1,
+});
+TemporalHelpers.assertPlainYearMonth(
+  date1,
+  2024, 1, "M01",
+  "'ce' is accepted as alias for 'gregory'",
+  "gregory", 2024
+);
+
+const date2 = Temporal.PlainYearMonth.from({
+  calendar: "gregory",
+  era: "bce",
+  eraYear: 44,
+  year: -43,
+  month: 3,
+});
+TemporalHelpers.assertPlainYearMonth(
+  date2,
+  -43, 3, "M03",
+  "'bce' is accepted as alias for 'gregory-inverse'",
+  "gregory-inverse", 44
+);

--- a/test/intl402/Temporal/ZonedDateTime/from/canonicalize-era-codes.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/canonicalize-era-codes.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Calendar era code is canonicalized
+features: [Temporal]
+---*/
+
+const date1 = Temporal.ZonedDateTime.from({
+  calendar: "gregory",
+  era: "ce",
+  eraYear: 2024,
+  year: 2024,
+  month: 1,
+  day: 1,
+  timeZone: "UTC",
+});
+assert.sameValue(date1.era, "gregory", "'ce' is accepted as alias for 'gregory'");
+
+const date2 = Temporal.ZonedDateTime.from({
+  calendar: "gregory",
+  era: "bce",
+  eraYear: 44,
+  year: -43,
+  month: 3,
+  day: 15,
+  timeZone: "Europe/Rome",
+});
+assert.sameValue(date2.era, "gregory-inverse", "'bce' is accepted as alias for 'gregory-inverse'");


### PR DESCRIPTION
There was a coverage gap for converting calendar fields to a date when the provided era was an alias.

See https://github.com/tc39/proposal-temporal/pull/2940#discussion_r1767508659