### PR TITLE
Compatibility with Hardened JavaScript - start of built-ins

### DIFF
--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -13,6 +13,7 @@ defines:
   - verifyNotEnumerable # deprecated
   - verifyConfigurable # deprecated
   - verifyNotConfigurable # deprecated
+  - verifyPrimordialProperty
 ---*/
 
 // @ts-check
@@ -280,3 +281,10 @@ function verifyNotConfigurable(obj, name) {
     throw new Test262Error("Expected obj[" + String(name) + "] NOT to be configurable, but was.");
   }
 }
+
+/**
+ * Use this function to verify the properties of a primordial object.
+ * For non-primordial objects, use verifyProperty.
+ * See: https://github.com/tc39/how-we-work/blob/main/terminology.md#primordial
+ */
+var verifyPrimordialProperty = verifyProperty;

--- a/test/built-ins/Array/prototype/every/prop-desc.js
+++ b/test/built-ins/Array/prototype/every/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.every, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "every");
-verifyWritable(Array.prototype, "every");
-verifyConfigurable(Array.prototype, "every");
+verifyPrimordialProperty(Array.prototype, "every", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DataView/prototype/getInt16/length.js
+++ b/test/built-ins/DataView/prototype/getInt16/length.js
@@ -23,7 +23,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(DataView.prototype.getInt16, "length", {
+verifyPrimordialProperty(DataView.prototype.getInt16, "length", {
   value: 1,
   writable: false,
   enumerable: false,

--- a/test/built-ins/Date/parse/S15.9.4.2_A1_T1.js
+++ b/test/built-ins/Date/parse/S15.9.4.2_A1_T1.js
@@ -5,14 +5,9 @@
 info: The Date property "parse" has { DontEnum } attributes
 esid: sec-date.parse
 description: Checking absence of ReadOnly attribute
+includes: [propertyHelper.js]
 ---*/
 
-var x = Date.parse;
-if (x === 1) {
-  Date.parse = 2;
-} else {
-  Date.parse = 1;
-}
-assert.notSameValue(Date.parse, x, 'The value of Date.parse is expected to not equal the value of `x`');
-
-// TODO: Convert to verifyProperty() format.
+verifyPrimordialProperty(Date, "parse", {
+  writable: true,
+});

--- a/tools/lint/lib/checks/harness.py
+++ b/tools/lint/lib/checks/harness.py
@@ -9,5 +9,7 @@ class CheckHarness(Check):
     def run(self, name, meta, source):
         if 'verifyConfigurable(' in source and 'verifyProperty(' in source:
             return 'verifyConfigurable & verifyProperty may not be used in the same file'
+        elif 'verifyConfigurable(' in source and 'verifyPrimordialProperty(' in source:
+            return 'verifyConfigurable & verifyPrimordialProperty may not be used in the same file'
         else:
             return

--- a/tools/lint/test/fixtures/harness/propertyHelper.js
+++ b/tools/lint/test/fixtures/harness/propertyHelper.js
@@ -13,6 +13,7 @@ defines:
   - verifyNotEnumerable
   - verifyConfigurable
   - verifyNotConfigurable
+  - verifyPrimordialProperty
 ---*/
 
 // @ts-check
@@ -227,3 +228,10 @@ function verifyNotConfigurable(obj, name) {
     throw new Test262Error("Expected obj[" + String(name) + "] NOT to be configurable, but was.");
   }
 }
+
+/**
+ * Use this function to verify the properties of a primordial object.
+ * For non-primordial objects, use verifyProperty.
+ * See: https://github.com/tc39/how-we-work/blob/main/terminology.md#primordial
+ */
+var verifyPrimordialProperty = verifyProperty;


### PR DESCRIPTION
This PR is a continuation of the effort to improve test262 compatibility with Hardened JavaScript after lockdown. The [initial PR](https://github.com/tc39/test262/pull/4088) focused on language tests. This one starts the work on built-in tests.

The approach is to modify the tests as little as possible to allow them to pass before and after lockdown. None of the changes so far require the tests themselves to have knowledge of Hardened JavaScript.

The Writable and Configurable attributes of built-ins are a significant source of failures under lockdown. Lockdown increases the integrity level of built-ins to `FROZEN`, causing over 1500 tests that verify the attributes of built-ins to fail.

There are three ways that the tests verify the attributes of built-ins:

- Using the `verifyProperty` helper function in `propertyHelper.js`. This is the preferred method, according to the test262 sources. Some test that do not use `verifyProperty` are [marked for update](https://github.com/tc39/test262/blob/474af832507d1f7183648a2ca875bd8570f21ec6/test/built-ins/Date/prototype/getUTCMonth/S15.9.5.13_A1_T1.js#L23).
- Using the `verifyConfigurable`, `verifyWritable`, `verifyEnumerable`, `verifyNotConfigurable`, `verifyNotWritable`, and `verifyMotEnumerable` helper functions. These are [marked as deprecated](https://github.com/tc39/test262/blob/474af832507d1f7183648a2ca875bd8570f21ec6/harness/propertyHelper.js#L10-L15) in the test262 sources. They perform more-or-less the same checks as `verifyProperty` as they use the same helper functions, `isWritable` and `isConfigurable`.
- Ad-hoc tests [in-line in the test code](https://github.com/tc39/test262/blob/main/test/built-ins/Date/prototype/getUTCMonth/S15.9.5.13_A1_T1.js#L10). This is done primarily by older tests.

The approach taken is to add the new `verifyBuiltinProperty` function to `propertyHelper.js`. This function calls through to `verifyProperty` after setting the `writable` and `configurable` options, when present, to `false` when running under lockdown. This accounts for the expected raised integrity level of built-ins. A new function is necessary because `verifyProperty` is used with objects created at runtime, not only built-ins.

With the new `verifyBuiltinProperty` function in place, the tests are modified as follows:

- Calls to `verifyProperty` that operate on a built-in are replaced with calls to `verifyBuiltinProperty`.
- Calls to the deprecated helper functions (`verifyConfigurable`, etc.) are replaced with calls to `verifyProperty` or `verifyBuiltinProperty` as appropriate.
- Ad-hoc checks for configurable and writable properties of built-ins are replaced with calls to `verifyBuiltinProperty`.

The benefits of these changes include:

- Many of the built-in test failures under lockdown are fixed
- The use of the deprecated property helper functions (`verifyConfigurable`, etc.) is significantly reduced (perhaps eliminated...) from test262
- The intention of the tests is clearer by expressly calling `verifyBuiltinProperty`, a function that expects a built-in object.

Having an explicit check for built-in properties may open the door to more extensive and consistent tests of built-in properties. For example, test262 is inconsistent in checking:

- Built-in functions [are native functions](https://github.com/tc39/test262/blob/474af832507d1f7183648a2ca875bd8570f21ec6/test/built-ins/Function/prototype/toString/built-in-function-object.js)
- The [order of enumeration](https://github.com/tc39/test262/blob/474af832507d1f7183648a2ca875bd8570f21ec6/test/built-ins/Promise/all/resolve-element-function-property-order.js#L25-L30) of `length` and `name` properties of built-in functions matches the order required by [`CreateBuiltinFunction`](https://tc39.es/ecma262/#sec-createbuiltinfunction) abstract operation
- Other [requirements for built-in functions](https://github.com/tc39/test262/blob/474af832507d1f7183648a2ca875bd8570f21ec6/test/built-ins/Set/prototype/symmetricDifference/builtins.js)

The `$262.isLockedDown()` function is introduced to determine if lockdown has completed. It is only invoked by `verifyBuiltinProperty` at this time and only if `isLockedDown` is present on `$262`.

There was a small bug in `verifyProperty`. When checking that the configurable attribute is `false`, `verifyProperty` is destructive - it deletes the property. The implementation of `verifyProperty` uses `Array.prototype.join`. Once the test for `Array.prototype.join` was updated to use `verifyProperty` the test harness failed. The solution is to cache `Array.prototype.join` in a local variable and invoke it using `.call`. This approach mirrors how `isConfigurable()` in `propertyHelper.js` [caches](https://github.com/tc39/test262/blob/474af832507d1f7183648a2ca875bd8570f21ec6/harness/propertyHelper.js#L120) `Object.prototype.hasOwnProperty`.
