### PR TITLE
Add names for expected outcomes in compareArray.js

### DIFF
--- a/harness/compareArray.js
+++ b/harness/compareArray.js
@@ -37,14 +37,14 @@ assert.compareArray = function(actual, expected, message) {
     message = message.toString();
   }
 
-  assert(actual != null, `First argument shouldn't be nullish. ${message}`);
-  assert(expected != null, `Second argument shouldn't be nullish. ${message}`);
+  assert(actual != null, `Actual argument shouldn't be nullish. ${message}`);
+  assert(expected != null, `Expected argument shouldn't be nullish. ${message}`);
   var format = compareArray.format;
   var result = compareArray(actual, expected);
 
   // The following prevents actual and expected from being iterated and evaluated
   // more than once unless absolutely necessary.
   if (!result) {
-    assert(false, `Expected ${format(actual)} and ${format(expected)} to have the same contents. ${message}`);
+    assert(false, `Actual ${format(actual)} and expected ${format(expected)} should have the the same contents. ${message}`);
   }
 };


### PR DESCRIPTION
Just a small quality of life improvement. I usually can't wrap my head around which was the expected and which one was the actual outcome so a textual clue helps.