### PR TITLE
Add staging source-phase-imports

### DIFF
--- a/test/staging/source-phase-imports/import-source-source-text-module.js
+++ b/test/staging/source-phase-imports/import-source-source-text-module.js
@@ -1,0 +1,24 @@
+// Copyright 2024 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+/*---
+description: >
+  GetModuleSource of SourceTextModule throws a ReferenceError.
+esid: sec-source-text-module-record-getmodulesource
+features: [source-phase-imports]
+flags: [async]
+includes: [asyncHelpers.js]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(
+    ReferenceError,
+    () => import.source('./module-simple_FIXTURE.js'),
+    "Promise should be rejected with ReferenceError");
+
+	// Import a module that has a source phase import.
+	await assert.throwsAsync(
+		ReferenceError,
+		() => import.source('./module-import-source_FIXTURE.js'),
+		"Promise should be rejected with ReferenceError");
+});

--- a/test/staging/source-phase-imports/modules-import-source_FIXTURE.js
+++ b/test/staging/source-phase-imports/modules-import-source_FIXTURE.js
@@ -1,0 +1,5 @@
+// Copyright 2024 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import source x from './modules-simple_FIXTURE.mjs';

--- a/test/staging/source-phase-imports/modules-simple_FIXTURE.mjs
+++ b/test/staging/source-phase-imports/modules-simple_FIXTURE.mjs
@@ -1,0 +1,6 @@
+// Copyright 2024 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Just a module file that does nothing.
+export const x = 42;


### PR DESCRIPTION
Even though https://github.com/tc39/proposal-esm-phase-imports will supersede this test case, as https://tc39.es/proposal-source-phase-imports/#sec-source-text-module-record-getmodulesource is defined in the spec, add a staging test to cover import a SourceTextModule source. 

Refs: https://github.com/tc39/test262/pull/3980#pullrequestreview-1822534491