### PR TITLE
harness/deepEqual.js: Improve formatting and align with base assert

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -101,18 +101,30 @@ assert.throws = function (expectedErrorConstructor, func, message) {
   throw new Test262Error(message);
 };
 
-assert._toString = function (value) {
-  try {
-    if (value === 0 && 1 / value === -Infinity) {
-      return '-0';
-    }
+assert._formatIdentityFreeValue = function formatIdentityFreeValue(value) {
+  switch (typeof value) {
+    case 'string':
+      return typeof JSON !== "undefined" ? JSON.stringify(value) : `"${value}"`;
+    case 'bigint':
+      return `${value}n`;
+    case 'boolean':
+    case 'undefined':
+    case 'number':
+      return value === 0 && 1 / value === -Infinity ? '-0' : String(value);
+    default:
+      if (value === null) return 'null';
+  }
+};
 
+assert._toString = function (value) {
+  var basic = assert._formatIdentityFreeValue(value);
+  if (basic) return basic;
+  try {
     return String(value);
   } catch (err) {
     if (err.name === 'TypeError') {
       return Object.prototype.toString.call(value);
     }
-
     throw err;
   }
 };

--- a/harness/assert.js
+++ b/harness/assert.js
@@ -102,17 +102,18 @@ assert.throws = function (expectedErrorConstructor, func, message) {
 };
 
 assert._formatIdentityFreeValue = function formatIdentityFreeValue(value) {
-  switch (typeof value) {
+  switch (value === null ? 'null' : typeof value) {
     case 'string':
       return typeof JSON !== "undefined" ? JSON.stringify(value) : `"${value}"`;
     case 'bigint':
       return `${value}n`;
+    case 'number':
+      if (value === 0 && 1 / value === -Infinity) return '-0';
+      // falls through
     case 'boolean':
     case 'undefined':
-    case 'number':
-      return value === 0 && 1 / value === -Infinity ? '-0' : String(value);
-    default:
-      if (value === null) return 'null';
+    case 'null':
+      return String(value);
   }
 };
 

--- a/harness/deepEqual.js
+++ b/harness/deepEqual.js
@@ -85,6 +85,8 @@ assert.deepEqual.format = function(value, seen) {
     return acceptMappers;
   }
 
+  let format = assert.deepEqual.format;
+
   if (typeof value === 'function') {
     return lazyOutput`function${value.name ? ` ${String(value.name)}` : ''}`;
   }
@@ -92,31 +94,31 @@ assert.deepEqual.format = function(value, seen) {
     return lazyOutput`${value}`;
   }
   if (Array.isArray ? Array.isArray(value) : value instanceof Array) {
-    return lazyOutput`[${value.map(value => assert.deepEqual.format(value, seen))}]`(join);
+    return lazyOutput`[${value.map(value => format(value, seen))}]`(join);
   }
   if (value instanceof Date) {
-    return lazyOutput`Date(${assert.deepEqual.format(value.toISOString(), seen)})`;
+    return lazyOutput`Date(${format(value.toISOString(), seen)})`;
   }
   if (value instanceof Error) {
-    return lazyOutput`error ${value.name || 'Error'}(${assert.deepEqual.format(value.message, seen)})`;
+    return lazyOutput`error ${value.name || 'Error'}(${format(value.message, seen)})`;
   }
   if (value instanceof RegExp) {
     return lazyOutput`${value}`;
   }
   if (typeof Map !== "undefined" && value instanceof Map) {
-    return lazyOutput`Map {${Array.from(value).map(pair => `${assert.deepEqual.format(pair[0], seen)} => ${assert.deepEqual.format(pair[1], seen)}`)}}`(join);
+    let contents = Array.from(value).map(pair => `${format(pair[0], seen)} => ${format(pair[1], seen)}`);
+    return lazyOutput`Map {${contents}}`(join);
   }
   if (typeof Set !== "undefined" && value instanceof Set) {
-    return lazyOutput`Set {${Array.from(value).map(value => assert.deepEqual.format(value, seen))}}`(join);
+    let contents = Array.from(value).map(value => format(value, seen));
+    return lazyOutput`Set {${contents}}`(join);
   }
 
   let tag = Symbol.toStringTag && Symbol.toStringTag in value
     ? value[Symbol.toStringTag]
-    : 'Object';
-  if (tag === 'Object' && Object.getPrototypeOf(value) === null) {
-    tag = '[Object: null prototype]';
-  }
-  return lazyOutput`${tag ? `${tag} ` : ''}{${Object.keys(value).map(key => `${key.toString()}: ${assert.deepEqual.format(value[key], seen)}`)}}`(String, join);
+    : Object.getPrototypeOf(value) === null ? '[Object: null prototype]' : 'Object';
+  let contents = Object.keys(value).map(key => `${String(key)}: ${format(value[key], seen)}`);
+  return lazyOutput`${tag ? `${tag} ` : ''}{${contents}}`(String, join);
 };
 
 assert.deepEqual._compare = (function () {

--- a/harness/deepEqual.js
+++ b/harness/deepEqual.js
@@ -16,110 +16,108 @@ assert.deepEqual = function(actual, expected, message) {
 
 let join = arr => arr.join(', ');
 
-assert.deepEqual.format = (function () {
-  return function format(value, seen) {
-    let basic = assert._formatIdentityFreeValue(value);
-    if (basic) return basic;
-    switch (value === null ? 'null' : typeof value) {
-      case 'string':
-      case 'bigint':
-      case 'number':
-      case 'boolean':
-      case 'undefined':
-      case 'null':
-        assert(false, 'values without identity should use basic formatting');
-        break;
-      case 'symbol':
-      case 'function':
-      case 'object':
-        break;
-      default:
-        return typeof value;
-    }
+assert.deepEqual.format = function(value, seen) {
+  let basic = assert._formatIdentityFreeValue(value);
+  if (basic) return basic;
+  switch (value === null ? 'null' : typeof value) {
+    case 'string':
+    case 'bigint':
+    case 'number':
+    case 'boolean':
+    case 'undefined':
+    case 'null':
+      assert(false, 'values without identity should use basic formatting');
+      break;
+    case 'symbol':
+    case 'function':
+    case 'object':
+      break;
+    default:
+      return typeof value;
+  }
 
-    if (!seen) {
-      seen = {
-        counter: 0,
-        map: new Map()
-      };
-    }
-    let usage = seen.map.get(value);
-    if (usage) {
-      usage.used = true;
-      return `ref #${usage.id}`;
-    }
-    usage = { id: ++seen.counter, used: false };
-    seen.map.set(value, usage);
+  if (!seen) {
+    seen = {
+      counter: 0,
+      map: new Map()
+    };
+  }
+  let usage = seen.map.get(value);
+  if (usage) {
+    usage.used = true;
+    return `ref #${usage.id}`;
+  }
+  usage = { id: ++seen.counter, used: false };
+  seen.map.set(value, usage);
 
-    // Properly communicating multiple references requires deferred rendering of
-    // all identity-bearing values until the outermost format call finishes,
-    // because the current value can also in appear in a not-yet-visited part of
-    // the object graph (which, when visited, will update the usage object).
-    //
-    // To preserve readability of the desired output formatting, we accomplish
-    // this deferral using tagged template literals.
-    // Evaluation closes over the usage object and returns a function that accepts
-    // "mapper" arguments for rendering the corresponding substitution values and
-    // returns an object with only a toString method which will itself be invoked
-    // when trying to use the result as a string in assert.deepEqual.
-    //
-    // For convenience, any absent mapper is presumed to be `String`, and the
-    // function itself has a toString method that self-invokes with no mappers
-    // (allowing returning the function directly when every mapper is `String`).
-    function lazyOutput(strings, ...subs) {
-      function acceptMappers(...mappers) {
-        function toString() {
-          let renderings = subs.map((sub, i) => (mappers[i] || String)(sub));
-          let parts = strings.map((str, i) => {
-            if (i === 0) return `${str}`;
-            return `${renderings[i - 1]}${str}`;
-          });
-          let rendered = parts.join('');
-          if (usage.used) rendered += ` as #${usage.id}`;
-          return rendered;
-        }
-
-        return { toString };
+  // Properly communicating multiple references requires deferred rendering of
+  // all identity-bearing values until the outermost format call finishes,
+  // because the current value can also in appear in a not-yet-visited part of
+  // the object graph (which, when visited, will update the usage object).
+  //
+  // To preserve readability of the desired output formatting, we accomplish
+  // this deferral using tagged template literals.
+  // Evaluation closes over the usage object and returns a function that accepts
+  // "mapper" arguments for rendering the corresponding substitution values and
+  // returns an object with only a toString method which will itself be invoked
+  // when trying to use the result as a string in assert.deepEqual.
+  //
+  // For convenience, any absent mapper is presumed to be `String`, and the
+  // function itself has a toString method that self-invokes with no mappers
+  // (allowing returning the function directly when every mapper is `String`).
+  function lazyOutput(strings, ...subs) {
+    function acceptMappers(...mappers) {
+      function toString() {
+        let renderings = subs.map((sub, i) => (mappers[i] || String)(sub));
+        let parts = strings.map((str, i) => {
+          if (i === 0) return `${str}`;
+          return `${renderings[i - 1]}${str}`;
+        });
+        let rendered = parts.join('');
+        if (usage.used) rendered += ` as #${usage.id}`;
+        return rendered;
       }
 
-      acceptMappers.toString = () => String(acceptMappers());
-      return acceptMappers;
+      return { toString };
     }
 
-    if (typeof value === 'function') {
-      return lazyOutput`function${value.name ? ` ${String(value.name)}` : ''}`;
-    }
-    if (typeof value !== 'object') {
-      return lazyOutput`${value}`;
-    }
-    if (Array.isArray ? Array.isArray(value) : value instanceof Array) {
-      return lazyOutput`[${value.map(value => assert.deepEqual.format(value, seen))}]`(join);
-    }
-    if (value instanceof Date) {
-      return lazyOutput`Date(${assert.deepEqual.format(value.toISOString(), seen)})`;
-    }
-    if (value instanceof Error) {
-      return lazyOutput`error ${value.name || 'Error'}(${assert.deepEqual.format(value.message, seen)})`;
-    }
-    if (value instanceof RegExp) {
-      return lazyOutput`${value}`;
-    }
-    if (typeof Map !== "undefined" && value instanceof Map) {
-      return lazyOutput`Map {${Array.from(value).map(pair => `${assert.deepEqual.format(pair[0], seen)} => ${assert.deepEqual.format(pair[1], seen)}`)}}`(join);
-    }
-    if (typeof Set !== "undefined" && value instanceof Set) {
-      return lazyOutput`Set {${Array.from(value).map(value => assert.deepEqual.format(value, seen))}}`(join);
-    }
+    acceptMappers.toString = () => String(acceptMappers());
+    return acceptMappers;
+  }
 
-    let tag = Symbol.toStringTag && Symbol.toStringTag in value
-      ? value[Symbol.toStringTag]
-      : 'Object';
-    if (tag === 'Object' && Object.getPrototypeOf(value) === null) {
-      tag = '[Object: null prototype]';
-    }
-    return lazyOutput`${tag ? `${tag} ` : ''}{${Object.keys(value).map(key => `${key.toString()}: ${assert.deepEqual.format(value[key], seen)}`)}}`(String, join);
-  };
-})();
+  if (typeof value === 'function') {
+    return lazyOutput`function${value.name ? ` ${String(value.name)}` : ''}`;
+  }
+  if (typeof value !== 'object') {
+    return lazyOutput`${value}`;
+  }
+  if (Array.isArray ? Array.isArray(value) : value instanceof Array) {
+    return lazyOutput`[${value.map(value => assert.deepEqual.format(value, seen))}]`(join);
+  }
+  if (value instanceof Date) {
+    return lazyOutput`Date(${assert.deepEqual.format(value.toISOString(), seen)})`;
+  }
+  if (value instanceof Error) {
+    return lazyOutput`error ${value.name || 'Error'}(${assert.deepEqual.format(value.message, seen)})`;
+  }
+  if (value instanceof RegExp) {
+    return lazyOutput`${value}`;
+  }
+  if (typeof Map !== "undefined" && value instanceof Map) {
+    return lazyOutput`Map {${Array.from(value).map(pair => `${assert.deepEqual.format(pair[0], seen)} => ${assert.deepEqual.format(pair[1], seen)}`)}}`(join);
+  }
+  if (typeof Set !== "undefined" && value instanceof Set) {
+    return lazyOutput`Set {${Array.from(value).map(value => assert.deepEqual.format(value, seen))}}`(join);
+  }
+
+  let tag = Symbol.toStringTag && Symbol.toStringTag in value
+    ? value[Symbol.toStringTag]
+    : 'Object';
+  if (tag === 'Object' && Object.getPrototypeOf(value) === null) {
+    tag = '[Object: null prototype]';
+  }
+  return lazyOutput`${tag ? `${tag} ` : ''}{${Object.keys(value).map(key => `${key.toString()}: ${assert.deepEqual.format(value[key], seen)}`)}}`(String, join);
+};
 
 assert.deepEqual._compare = (function () {
   var EQUAL = 1;

--- a/harness/deepEqual.js
+++ b/harness/deepEqual.js
@@ -30,17 +30,18 @@ assert.deepEqual.format = (function () {
   return function format(value, seen) {
     let basic = assert._formatIdentityFreeValue(value);
     if (basic) return basic;
-    switch (typeof value) {
+    switch (value === null ? 'null' : typeof value) {
       case 'string':
       case 'bigint':
+      case 'number':
       case 'boolean':
       case 'undefined':
-      case 'number':
+      case 'null':
         assert(false, 'values without identity should use basic formatting');
+        break;
       case 'symbol':
       case 'function':
       case 'object':
-        if (value === null) return 'null';
         break;
       default:
         return typeof value;

--- a/harness/deepEqual.js
+++ b/harness/deepEqual.js
@@ -28,15 +28,15 @@ assert.deepEqual.format = (function () {
   let renderUsage = usage => usage.used ? ` as #${usage.id}` : '';
 
   return function format(value, seen) {
+    let basic = assert._formatIdentityFreeValue(value);
+    if (basic) return basic;
     switch (typeof value) {
       case 'string':
-        return typeof JSON !== "undefined" ? JSON.stringify(value) : `"${value}"`;
       case 'bigint':
-        return `${value}n`;
       case 'boolean':
       case 'undefined':
       case 'number':
-        return value === 0 && 1 / value === -Infinity ? '-0' : String(value);
+        assert(false, 'values without identity should use basic formatting');
       case 'symbol':
       case 'function':
       case 'object':

--- a/harness/deepEqual.js
+++ b/harness/deepEqual.js
@@ -15,6 +15,18 @@ assert.deepEqual = function(actual, expected, message) {
 };
 
 assert.deepEqual.format = (function () {
+  function lazyStringFactory(strings, ...subs) {
+    return function(...mappers) {
+      assert(mappers.length === subs.length, 'mappers must be paired with substitutions');
+      let toString = () => {
+        let mappedSubs = subs.map((sub, i) => mappers[i](sub));
+        return strings.map((str, i) => `${i === 0 ? '' : mappedSubs[i - 1]}${str}`).join('');
+      };
+      return { toString };
+    };
+  }
+  let renderUsage = usage => usage.used ? ` as #${usage.id}` : '';
+
   return function format(value, seen) {
     switch (typeof value) {
       case 'string':
@@ -22,52 +34,57 @@ assert.deepEqual.format = (function () {
       case 'bigint':
         return `${value}n`;
       case 'boolean':
-      case 'symbol':
       case 'undefined':
       case 'number':
         return value === 0 && 1 / value === -Infinity ? '-0' : String(value);
+      case 'symbol':
       case 'function':
-        return `function${value.name ? ` ${String(value.name)}` : ''}`;
       case 'object':
         if (value === null) return 'null';
-        if (value instanceof Date) return `Date("${value.toISOString()}")`;
-        if (value instanceof Error) return `error ${value.name || 'Error'}("${value.message}")`;
-        if (value instanceof RegExp) return value.toString();
-        if (!seen) {
-          seen = {
-            counter: 0,
-            map: new Map()
-          };
-        }
-
-        let usage = seen.map.get(value);
-        if (usage) {
-          usage.used = true;
-          return `ref #${usage.id}`;
-        }
-
-        usage = { id: ++seen.counter, used: false };
-        seen.map.set(value, usage);
-
-        if (typeof Set !== "undefined" && value instanceof Set) {
-          return `Set {${Array.from(value).map(value => assert.deepEqual.format(value, seen)).join(', ')}}${usage.used ? ` as #${usage.id}` : ''}`;
-        }
-        if (typeof Map !== "undefined" && value instanceof Map) {
-          return `Map {${Array.from(value).map(pair => `${assert.deepEqual.format(pair[0], seen)} => ${assert.deepEqual.format(pair[1], seen)}`).join(', ')}}${usage.used ? ` as #${usage.id}` : ''}`;
-        }
-        if (Array.isArray ? Array.isArray(value) : value instanceof Array) {
-          return `[${value.map(value => assert.deepEqual.format(value, seen)).join(', ')}]${usage.used ? ` as #${usage.id}` : ''}`;
-        }
-        let tag = Symbol.toStringTag && Symbol.toStringTag in value
-          ? value[Symbol.toStringTag]
-          : 'Object';
-        if (tag === 'Object' && Object.getPrototypeOf(value) === null) {
-          tag = '[Object: null prototype]';
-        }
-        return `${tag ? `${tag} ` : ''}{${Object.keys(value).map(key => `${key.toString()}: ${assert.deepEqual.format(value[key], seen)}`).join(', ')}}${usage.used ? ` as #${usage.id}` : ''}`;
+        break;
       default:
         return typeof value;
     }
+
+    if (!seen) {
+      seen = {
+        counter: 0,
+        map: new Map()
+      };
+    }
+    let usage = seen.map.get(value);
+    if (usage) {
+      usage.used = true;
+      return `ref #${usage.id}`;
+    }
+    usage = { id: ++seen.counter, used: false };
+    seen.map.set(value, usage);
+
+    if (typeof value === 'function') {
+      return lazyStringFactory`function${value.name ? ` ${String(value.name)}` : ''}${usage}`(String, renderUsage);
+    } else if (typeof value !== 'object') {
+      return lazyStringFactory`${value}${usage}`(String, renderUsage);
+    } else if (Array.isArray ? Array.isArray(value) : value instanceof Array) {
+      return lazyStringFactory`[${value.map(value => assert.deepEqual.format(value, seen))}]${usage}`(arr => arr.join(', '), renderUsage);
+    } else if (value instanceof Date) {
+      return lazyStringFactory`Date(${assert.deepEqual.format(value.toISOString(), seen)})${usage}`(String, renderUsage);
+    } else if (value instanceof Error) {
+      return lazyStringFactory`error ${value.name || 'Error'}(${assert.deepEqual.format(value.message, seen)})${usage}`(String, String, renderUsage);
+    } else if (value instanceof RegExp) {
+      return lazyStringFactory`${value}${usage}`(String, renderUsage);
+    } else if (typeof Map !== "undefined" && value instanceof Map) {
+      return lazyStringFactory`Map {${Array.from(value).map(pair => `${assert.deepEqual.format(pair[0], seen)} => ${assert.deepEqual.format(pair[1], seen)}`)}}${usage}`(arr => arr.join(', '), renderUsage);
+    } else if (typeof Set !== "undefined" && value instanceof Set) {
+      return lazyStringFactory`Set {${Array.from(value).map(value => assert.deepEqual.format(value, seen))}}${usage}`(arr => arr.join(', '), renderUsage);
+    }
+
+    let tag = Symbol.toStringTag && Symbol.toStringTag in value
+      ? value[Symbol.toStringTag]
+      : 'Object';
+    if (tag === 'Object' && Object.getPrototypeOf(value) === null) {
+      tag = '[Object: null prototype]';
+    }
+    return lazyStringFactory`${tag ? `${tag} ` : ''}{${Object.keys(value).map(key => `${key.toString()}: ${assert.deepEqual.format(value[key], seen)}`)}}${usage}`(String, arr => arr.join(', '), renderUsage);
   };
 })();
 

--- a/harness/deepEqual.js
+++ b/harness/deepEqual.js
@@ -20,6 +20,11 @@ function stringFromTemplate(strings, ...subs) {
   let parts = strings.map((str, i) => `${i === 0 ? '' : subs[i - 1]}${str}`);
   return parts.join('');
 }
+function escapeKey(key) {
+  if (typeof key === 'symbol') return `[${String(key)}]`;
+  if (/^[a-zA-Z0-9_$]+$/.test(key)) return key;
+  return assert._formatIdentityFreeValue(key);
+}
 
 assert.deepEqual.format = function(value, seen) {
   let basic = assert._formatIdentityFreeValue(value);
@@ -123,7 +128,7 @@ assert.deepEqual.format = function(value, seen) {
     ? value[Symbol.toStringTag]
     : Object.getPrototypeOf(value) === null ? '[Object: null prototype]' : 'Object';
   let keys = Reflect.ownKeys(value).filter(key => getOwnPropertyDescriptor(value, key).enumerable);
-  let contents = keys.map(key => lazyString`${String(key)}: ${format(value[key], seen)}`);
+  let contents = keys.map(key => lazyString`${escapeKey(key)}: ${format(value[key], seen)}`);
   return lazyResult`${tag ? `${tag} ` : ''}{${contents}}`(String, join);
 };
 

--- a/harness/deepEqual.js
+++ b/harness/deepEqual.js
@@ -14,6 +14,7 @@ assert.deepEqual = function(actual, expected, message) {
   );
 };
 
+let getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 let join = arr => arr.join(', ');
 function stringFromTemplate(strings, ...subs) {
   let parts = strings.map((str, i) => `${i === 0 ? '' : subs[i - 1]}${str}`);
@@ -121,7 +122,8 @@ assert.deepEqual.format = function(value, seen) {
   let tag = Symbol.toStringTag && Symbol.toStringTag in value
     ? value[Symbol.toStringTag]
     : Object.getPrototypeOf(value) === null ? '[Object: null prototype]' : 'Object';
-  let contents = Object.keys(value).map(key => lazyString`${String(key)}: ${format(value[key], seen)}`);
+  let keys = Reflect.ownKeys(value).filter(key => getOwnPropertyDescriptor(value, key).enumerable);
+  let contents = keys.map(key => lazyString`${String(key)}: ${format(value[key], seen)}`);
   return lazyResult`${tag ? `${tag} ` : ''}{${contents}}`(String, join);
 };
 


### PR DESCRIPTION
Consolidates handling of identity-bearing values via a lazy multi-use indication.

<details open><summary>comparison</summary>

```js
const v = [];
v.push(v);
const values = [
  '',
  Symbol('foo'),
  /./gui,
  [-0, 0, 0n],
  ((a, b) => [a, b, a, b, {}])({}, {}),
  new Date(0),
  { [Symbol.toStringTag]: 'errors', error: Error(), typeError: TypeError('foo') },
  function fn(){},
  new Set([v, {}, {}]),
  Object.create(null),
];
for (const x of values) v.push(x, x, 'NL');
String(assert.deepEqual.format(v)).replace(/ "NL",/g, '\n');
```

<details><summary>before</summary>

Note the frequently missing "as #*N*" and the total lack of indication for referentially-identical symbols/regular expressions/dates/etc., not to mention the inability to differentiate signed zeros from each other or numbers from bigints.

```
[[Ref: #1], "", "",
 Symbol(foo), Symbol(foo),
 /./giu, /./giu,
 [0, 0, 0], [Ref: #2],
 [Object {  }, Object {  }, [Ref: #4], [Ref: #5], Object {  }], [Ref: #3],
 Date "1970-01-01T00:00:00.000Z", Date "1970-01-01T00:00:00.000Z",
 errors { error: Object {  }, typeError: Object {  } }, [Ref: #7],
 [Function: fn], [Function: fn],
 Set {[Ref: #1], Object {  }, Object {  }}, [Ref: #10],
 [Object: null prototype] {  }, [Ref: #13], "NL"] as #1
```

</details>
<details><summary>after</summary>

```
[ref #1, "", "",
 Symbol(foo) as #2, ref #2,
 /./giu as #3, ref #3,
 [-0, 0, 0n] as #4, ref #4,
 [Object {} as #6, Object {} as #7, ref #6, ref #7, Object {}] as #5, ref #5,
 Date("1970-01-01T00:00:00.000Z") as #9, ref #9,
 errors {error: error Error(""), typeError: error TypeError("foo")} as #10, ref #10,
 function fn as #13, ref #13,
 Set {ref #1, Object {}, Object {}} as #14, ref #14,
 [Object: null prototype] {} as #17, ref #17, "NL"] as #1
```

</details>
</details>