### PR TITLE
chore: convert many tests to use verifyProperty

### DIFF
--- a/test/built-ins/Array/from/Array.from-descriptor.js
+++ b/test/built-ins/Array/from/Array.from-descriptor.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 esid: sec-array.from
 ---*/
 
-verifyWritable(Array, "from");
-verifyNotEnumerable(Array, "from");
-verifyConfigurable(Array, "from");
+verifyProperty(Array, "from", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/isArray/descriptor.js
+++ b/test/built-ins/Array/isArray/descriptor.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 esid: sec-array.isarray
 ---*/
 
-verifyWritable(Array, "isArray");
-verifyNotEnumerable(Array, "isArray");
-verifyConfigurable(Array, "isArray");
+verifyProperty(Array, "isArray", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/of/of.js
+++ b/test/built-ins/Array/of/of.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Array, 'of');
-verifyWritable(Array, 'of');
-verifyConfigurable(Array, 'of');
+verifyProperty(Array, "of", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/Symbol.iterator.js
+++ b/test/built-ins/Array/prototype/Symbol.iterator.js
@@ -15,6 +15,9 @@ esid: sec-array.prototype-@@iterator
 ---*/
 
 assert.sameValue(Array.prototype[Symbol.iterator], Array.prototype.values);
-verifyNotEnumerable(Array.prototype, Symbol.iterator);
-verifyWritable(Array.prototype, Symbol.iterator);
-verifyConfigurable(Array.prototype, Symbol.iterator);
+
+verifyProperty(Array.prototype, Symbol.iterator, {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/Symbol.unscopables/array-find-from-last.js
+++ b/test/built-ins/Array/prototype/Symbol.unscopables/array-find-from-last.js
@@ -31,6 +31,6 @@ verifyProperty(unscopables, "findLast", {
 assert.sameValue(unscopables.findLastIndex, true, '`findLastIndex` property value');
 verifyProperty(unscopables, "findLastIndex", {
   writable: true,
-  enumerable: false,
+  enumerable: true,
   configurable: true
 });

--- a/test/built-ins/Array/prototype/Symbol.unscopables/array-find-from-last.js
+++ b/test/built-ins/Array/prototype/Symbol.unscopables/array-find-from-last.js
@@ -21,11 +21,16 @@ var unscopables = Array.prototype[Symbol.unscopables];
 assert.sameValue(Object.getPrototypeOf(unscopables), null);
 
 assert.sameValue(unscopables.findLast, true, '`findLast` property value');
-verifyEnumerable(unscopables, 'findLast');
-verifyWritable(unscopables, 'findLast');
-verifyConfigurable(unscopables, 'findLast');
+verifyProperty(unscopables, "findLast", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
+
 
 assert.sameValue(unscopables.findLastIndex, true, '`findLastIndex` property value');
-verifyEnumerable(unscopables, 'findLastIndex');
-verifyWritable(unscopables, 'findLastIndex');
-verifyConfigurable(unscopables, 'findLastIndex');
+verifyProperty(unscopables, "findLastIndex", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/Symbol.unscopables/prop-desc.js
+++ b/test/built-ins/Array/prototype/Symbol.unscopables/prop-desc.js
@@ -11,6 +11,8 @@ includes: [propertyHelper.js]
 features: [Symbol.unscopables]
 ---*/
 
-verifyNotEnumerable(Array.prototype, Symbol.unscopables);
-verifyNotWritable(Array.prototype, Symbol.unscopables);
-verifyConfigurable(Array.prototype, Symbol.unscopables);
+verifyProperty(Array.prototype, Symbol.unscopables, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Array/prototype/Symbol.unscopables/value.js
+++ b/test/built-ins/Array/prototype/Symbol.unscopables/value.js
@@ -30,51 +30,71 @@ var unscopables = Array.prototype[Symbol.unscopables];
 assert.sameValue(Object.getPrototypeOf(unscopables), null);
 
 assert.sameValue(unscopables.copyWithin, true, '`copyWithin` property value');
-verifyEnumerable(unscopables, 'copyWithin');
-verifyWritable(unscopables, 'copyWithin');
-verifyConfigurable(unscopables, 'copyWithin');
+verifyProperty(unscopables, "copyWithin", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
 
 assert.sameValue(unscopables.entries, true, '`entries` property value');
-verifyEnumerable(unscopables, 'entries');
-verifyWritable(unscopables, 'entries');
-verifyConfigurable(unscopables, 'entries');
+verifyProperty(unscopables, "entries", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
 
 assert.sameValue(unscopables.fill, true, '`fill` property value');
-verifyEnumerable(unscopables, 'fill');
-verifyWritable(unscopables, 'fill');
-verifyConfigurable(unscopables, 'fill');
+verifyProperty(unscopables, "fill", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
 
 assert.sameValue(unscopables.find, true, '`find` property value');
-verifyEnumerable(unscopables, 'find');
-verifyWritable(unscopables, 'find');
-verifyConfigurable(unscopables, 'find');
+verifyProperty(unscopables, "find", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
 
 assert.sameValue(unscopables.findIndex, true, '`findIndex` property value');
-verifyEnumerable(unscopables, 'findIndex');
-verifyWritable(unscopables, 'findIndex');
-verifyConfigurable(unscopables, 'findIndex');
+verifyProperty(unscopables, "findIndex", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
 
 assert.sameValue(unscopables.flat, true, '`flat` property value');
-verifyEnumerable(unscopables, 'flat');
-verifyWritable(unscopables, 'flat');
-verifyConfigurable(unscopables, 'flat');
+verifyProperty(unscopables, "flat", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
 
 assert.sameValue(unscopables.flatMap, true, '`flatMap` property value');
-verifyEnumerable(unscopables, 'flatMap');
-verifyWritable(unscopables, 'flatMap');
-verifyConfigurable(unscopables, 'flatMap');
+verifyProperty(unscopables, "flatMap", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
 
 assert.sameValue(unscopables.includes, true, '`includes` property value');
-verifyEnumerable(unscopables, 'includes');
-verifyWritable(unscopables, 'includes');
-verifyConfigurable(unscopables, 'includes');
+verifyProperty(unscopables, "includes", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
 
 assert.sameValue(unscopables.keys, true, '`keys` property value');
-verifyEnumerable(unscopables, 'keys');
-verifyWritable(unscopables, 'keys');
-verifyConfigurable(unscopables, 'keys');
+verifyProperty(unscopables, "keys", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
 
 assert.sameValue(unscopables.values, true, '`values` property value');
-verifyEnumerable(unscopables, 'values');
-verifyWritable(unscopables, 'values');
-verifyConfigurable(unscopables, 'values');
+verifyProperty(unscopables, "values", {
+  writable: true,
+  enumerable: true,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/concat/prop-desc.js
+++ b/test/built-ins/Array/prototype/concat/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.concat, 'function', 'The value of `typeof Array.prototype.concat` is expected to be "function"');
 
-verifyNotEnumerable(Array.prototype, "concat");
-verifyWritable(Array.prototype, "concat");
-verifyConfigurable(Array.prototype, "concat");
+verifyProperty(Array.prototype, "concat", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/constructor.js
+++ b/test/built-ins/Array/prototype/constructor.js
@@ -20,6 +20,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(Array.prototype.constructor, Array);
 
-verifyNotEnumerable(Array.prototype, 'constructor');
-verifyWritable(Array.prototype, 'constructor');
-verifyConfigurable(Array.prototype, 'constructor');
+verifyProperty(Array.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/copyWithin/prop-desc.js
+++ b/test/built-ins/Array/prototype/copyWithin/prop-desc.js
@@ -16,6 +16,8 @@ assert.sameValue(
   '`typeof Array.prototype.copyWithin` is `function`'
 );
 
-verifyNotEnumerable(Array.prototype, 'copyWithin');
-verifyWritable(Array.prototype, 'copyWithin');
-verifyConfigurable(Array.prototype, 'copyWithin');
+verifyProperty(Array.prototype, "copyWithin", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/entries/prop-desc.js
+++ b/test/built-ins/Array/prototype/entries/prop-desc.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof Array.prototype.entries` is `function`'
 );
 
-verifyNotEnumerable(Array.prototype, 'entries');
-verifyWritable(Array.prototype, 'entries');
-verifyConfigurable(Array.prototype, 'entries');
+verifyProperty(Array.prototype, "entries", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/every/prop-desc.js
+++ b/test/built-ins/Array/prototype/every/prop-desc.js
@@ -7,7 +7,7 @@ description: >
   "every" property of Array.prototype
 info: |
   17 ECMAScript Standard Built-in Objects
-  
+
   Every other data property described in clauses 18 through 26 and in Annex B.2
   has the attributes { [[Writable]]: true, [[Enumerable]]: false,
     [[Configurable]]: true } unless otherwise specified.

--- a/test/built-ins/Array/prototype/fill/prop-desc.js
+++ b/test/built-ins/Array/prototype/fill/prop-desc.js
@@ -14,6 +14,8 @@ assert.sameValue(
   '`typeof Array.prototype.fill` is `function`'
 );
 
-verifyNotEnumerable(Array.prototype, 'fill');
-verifyWritable(Array.prototype, 'fill');
-verifyConfigurable(Array.prototype, 'fill');
+verifyProperty(Array.prototype, "fill", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/filter/prop-desc.js
+++ b/test/built-ins/Array/prototype/filter/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.filter, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "filter");
-verifyWritable(Array.prototype, "filter");
-verifyConfigurable(Array.prototype, "filter");
+verifyProperty(Array.prototype, "filter", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/find/prop-desc.js
+++ b/test/built-ins/Array/prototype/find/prop-desc.js
@@ -14,6 +14,8 @@ assert.sameValue(
   '`typeof Array.prototype.find` is `function`'
 );
 
-verifyNotEnumerable(Array.prototype, 'find');
-verifyWritable(Array.prototype, 'find');
-verifyConfigurable(Array.prototype, 'find');
+verifyProperty(Array.prototype, "find", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/findIndex/prop-desc.js
+++ b/test/built-ins/Array/prototype/findIndex/prop-desc.js
@@ -14,6 +14,8 @@ assert.sameValue(
   '`typeof Array.prototype.findIndex` is `function`'
 );
 
-verifyNotEnumerable(Array.prototype, 'findIndex');
-verifyWritable(Array.prototype, 'findIndex');
-verifyConfigurable(Array.prototype, 'findIndex');
+verifyProperty(Array.prototype, "findIndex", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/forEach/prop-desc.js
+++ b/test/built-ins/Array/prototype/forEach/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.forEach, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "forEach");
-verifyWritable(Array.prototype, "forEach");
-verifyConfigurable(Array.prototype, "forEach");
+verifyProperty(Array.prototype, "forEach", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/includes/prop-desc.js
+++ b/test/built-ins/Array/prototype/includes/prop-desc.js
@@ -12,6 +12,8 @@ includes: [propertyHelper.js]
 features: [Array.prototype.includes]
 ---*/
 
-verifyNotEnumerable(Array.prototype, "includes");
-verifyWritable(Array.prototype, "includes");
-verifyConfigurable(Array.prototype, "includes");
+verifyProperty(Array.prototype, "includes", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/indexOf/prop-desc.js
+++ b/test/built-ins/Array/prototype/indexOf/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.indexOf, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "indexOf");
-verifyWritable(Array.prototype, "indexOf");
-verifyConfigurable(Array.prototype, "indexOf");
+verifyProperty(Array.prototype, "indexOf", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/join/prop-desc.js
+++ b/test/built-ins/Array/prototype/join/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.join, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "join");
-verifyWritable(Array.prototype, "join");
-verifyConfigurable(Array.prototype, "join");
+verifyProperty(Array.prototype, "join", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/keys/prop-desc.js
+++ b/test/built-ins/Array/prototype/keys/prop-desc.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof Array.prototype.keys` is `function`'
 );
 
-verifyNotEnumerable(Array.prototype, 'keys');
-verifyWritable(Array.prototype, 'keys');
-verifyConfigurable(Array.prototype, 'keys');
+verifyProperty(Array.prototype, "keys", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/lastIndexOf/prop-desc.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.lastIndexOf, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "lastIndexOf");
-verifyWritable(Array.prototype, "lastIndexOf");
-verifyConfigurable(Array.prototype, "lastIndexOf");
+verifyProperty(Array.prototype, "lastIndexOf", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/map/prop-desc.js
+++ b/test/built-ins/Array/prototype/map/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.map, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "map");
-verifyWritable(Array.prototype, "map");
-verifyConfigurable(Array.prototype, "map");
+verifyProperty(Array.prototype, "map", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/pop/prop-desc.js
+++ b/test/built-ins/Array/prototype/pop/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.pop, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "pop");
-verifyWritable(Array.prototype, "pop");
-verifyConfigurable(Array.prototype, "pop");
+verifyProperty(Array.prototype, "pop", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/prop-desc.js
+++ b/test/built-ins/Array/prototype/prop-desc.js
@@ -15,6 +15,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Array, 'prototype');
-verifyNotWritable(Array, 'prototype');
-verifyNotConfigurable(Array, 'prototype');
+verifyProperty(Array, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Array/prototype/push/prop-desc.js
+++ b/test/built-ins/Array/prototype/push/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.push, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "push");
-verifyWritable(Array.prototype, "push");
-verifyConfigurable(Array.prototype, "push");
+verifyProperty(Array.prototype, "push", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/reduce/prop-desc.js
+++ b/test/built-ins/Array/prototype/reduce/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.reduce, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "reduce");
-verifyWritable(Array.prototype, "reduce");
-verifyConfigurable(Array.prototype, "reduce");
+verifyProperty(Array.prototype, "reduce", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/reduceRight/prop-desc.js
+++ b/test/built-ins/Array/prototype/reduceRight/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.reduceRight, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "reduceRight");
-verifyWritable(Array.prototype, "reduceRight");
-verifyConfigurable(Array.prototype, "reduceRight");
+verifyProperty(Array.prototype, "reduceRight", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/reverse/prop-desc.js
+++ b/test/built-ins/Array/prototype/reverse/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.reverse, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "reverse");
-verifyWritable(Array.prototype, "reverse");
-verifyConfigurable(Array.prototype, "reverse");
+verifyProperty(Array.prototype, "reverse", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/shift/prop-desc.js
+++ b/test/built-ins/Array/prototype/shift/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.shift, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "shift");
-verifyWritable(Array.prototype, "shift");
-verifyConfigurable(Array.prototype, "shift");
+verifyProperty(Array.prototype, "shift", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/slice/prop-desc.js
+++ b/test/built-ins/Array/prototype/slice/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.slice, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "slice");
-verifyWritable(Array.prototype, "slice");
-verifyConfigurable(Array.prototype, "slice");
+verifyProperty(Array.prototype, "slice", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/some/prop-desc.js
+++ b/test/built-ins/Array/prototype/some/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.some, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "some");
-verifyWritable(Array.prototype, "some");
-verifyConfigurable(Array.prototype, "some");
+verifyProperty(Array.prototype, "some", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/sort/prop-desc.js
+++ b/test/built-ins/Array/prototype/sort/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.sort, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "sort");
-verifyWritable(Array.prototype, "sort");
-verifyConfigurable(Array.prototype, "sort");
+verifyProperty(Array.prototype, "sort", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/splice/prop-desc.js
+++ b/test/built-ins/Array/prototype/splice/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.splice, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "splice");
-verifyWritable(Array.prototype, "splice");
-verifyConfigurable(Array.prototype, "splice");
+verifyProperty(Array.prototype, "splice", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/toLocaleString/prop-desc.js
+++ b/test/built-ins/Array/prototype/toLocaleString/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.toLocaleString, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "toLocaleString");
-verifyWritable(Array.prototype, "toLocaleString");
-verifyConfigurable(Array.prototype, "toLocaleString");
+verifyProperty(Array.prototype, "toLocaleString", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/toString/prop-desc.js
+++ b/test/built-ins/Array/prototype/toString/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.toString, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "toString");
-verifyWritable(Array.prototype, "toString");
-verifyConfigurable(Array.prototype, "toString");
+verifyProperty(Array.prototype, "toString", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/unshift/prop-desc.js
+++ b/test/built-ins/Array/prototype/unshift/prop-desc.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.unshift, 'function', 'typeof');
 
-verifyNotEnumerable(Array.prototype, "unshift");
-verifyWritable(Array.prototype, "unshift");
-verifyConfigurable(Array.prototype, "unshift");
+verifyProperty(Array.prototype, "unshift", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Array/prototype/values/prop-desc.js
+++ b/test/built-ins/Array/prototype/values/prop-desc.js
@@ -12,6 +12,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Array.prototype.values, 'function');
 
-verifyNotEnumerable(Array.prototype, 'values');
-verifyWritable(Array.prototype, 'values');
-verifyConfigurable(Array.prototype, 'values');
+verifyProperty(Array.prototype, "values", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/ArrayBuffer/isView/prop-desc.js
+++ b/test/built-ins/ArrayBuffer/isView/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(ArrayBuffer, "isView");
-verifyWritable(ArrayBuffer, "isView");
-verifyConfigurable(ArrayBuffer, "isView");
+verifyProperty(ArrayBuffer, "isView", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/ArrayBuffer/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/ArrayBuffer/prototype/Symbol.toStringTag.js
@@ -16,6 +16,8 @@ features: [Symbol.toStringTag]
 
 assert.sameValue(ArrayBuffer.prototype[Symbol.toStringTag], 'ArrayBuffer');
 
-verifyNotEnumerable(ArrayBuffer.prototype, Symbol.toStringTag);
-verifyNotWritable(ArrayBuffer.prototype, Symbol.toStringTag);
-verifyConfigurable(ArrayBuffer.prototype, Symbol.toStringTag);
+verifyProperty(ArrayBuffer.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/ArrayBuffer/prototype/constructor.js
+++ b/test/built-ins/ArrayBuffer/prototype/constructor.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(ArrayBuffer.prototype.constructor, ArrayBuffer);
 
-verifyNotEnumerable(ArrayBuffer.prototype, "constructor");
-verifyWritable(ArrayBuffer.prototype, "constructor");
-verifyConfigurable(ArrayBuffer.prototype, "constructor");
+verifyProperty(ArrayBuffer.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/ArrayBuffer/prototype/slice/descriptor.js
+++ b/test/built-ins/ArrayBuffer/prototype/slice/descriptor.js
@@ -15,6 +15,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(ArrayBuffer.prototype, "slice");
-verifyWritable(ArrayBuffer.prototype, "slice");
-verifyConfigurable(ArrayBuffer.prototype, "slice");
+verifyProperty(ArrayBuffer.prototype, "slice", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/ArrayIteratorPrototype/Symbol.toStringTag/property-descriptor.js
+++ b/test/built-ins/ArrayIteratorPrototype/Symbol.toStringTag/property-descriptor.js
@@ -20,6 +20,8 @@ var ArrayIteratorProto = Object.getPrototypeOf([][Symbol.iterator]());
 
 assert.sameValue("Array Iterator", ArrayIteratorProto[Symbol.toStringTag]);
 
-verifyNotEnumerable(ArrayIteratorProto, Symbol.toStringTag);
-verifyNotWritable(ArrayIteratorProto, Symbol.toStringTag);
-verifyConfigurable(ArrayIteratorProto, Symbol.toStringTag);
+verifyProperty(ArrayIteratorProto, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/ArrayIteratorPrototype/next/property-descriptor.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/property-descriptor.js
@@ -12,6 +12,8 @@ features: [Symbol.iterator]
 
 var ArrayIteratorProto = Object.getPrototypeOf([][Symbol.iterator]());
 
-verifyNotEnumerable(ArrayIteratorProto, 'next');
-verifyWritable(ArrayIteratorProto, 'next');
-verifyConfigurable(ArrayIteratorProto, 'next');
+verifyProperty(ArrayIteratorProto, "next", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/AsyncDisposableStack/prototype/disposed/name.js
+++ b/test/built-ins/AsyncDisposableStack/prototype/disposed/name.js
@@ -23,6 +23,8 @@ assert.sameValue(descriptor.get.name,
   'The value of `descriptor.get.name` is `get disposed`'
 );
 
-verifyNotEnumerable(descriptor.get, 'name');
-verifyNotWritable(descriptor.get, 'name');
-verifyConfigurable(descriptor.get, 'name');
+verifyProperty(descriptor.get, 'name', {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/AsyncFunction/instance-length.js
+++ b/test/built-ins/AsyncFunction/instance-length.js
@@ -17,6 +17,8 @@ assert.sameValue(l0.length, 0);
 assert.sameValue(l1.length, 1);
 assert.sameValue(l2.length, 2)
 
-verifyNotWritable(l0, 'length');
-verifyNotEnumerable(l0, 'length');
-verifyConfigurable(l0, 'length');
+verifyProperty(l0, 'length', {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Atomics/Symbol.toStringTag.js
+++ b/test/built-ins/Atomics/Symbol.toStringTag.js
@@ -20,6 +20,8 @@ assert.sameValue(
   'The value of Atomics[Symbol.toStringTag] is "Atomics"'
 );
 
-verifyNotEnumerable(Atomics, Symbol.toStringTag);
-verifyNotWritable(Atomics, Symbol.toStringTag);
-verifyConfigurable(Atomics, Symbol.toStringTag);
+verifyProperty(Atomics, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Boolean/prop-desc.js
+++ b/test/built-ins/Boolean/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "Boolean");
-verifyWritable(this, "Boolean");
-verifyConfigurable(this, "Boolean");
+verifyProperty(this, "Boolean", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DataView/dataview.js
+++ b/test/built-ins/DataView/dataview.js
@@ -8,6 +8,8 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "DataView");
-verifyWritable(this, "DataView");
-verifyConfigurable(this, "DataView");
+verifyProperty(this, "DataView", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/DataView/prototype.js
+++ b/test/built-ins/DataView/prototype.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(DataView, "prototype");
-verifyNotWritable(DataView, "prototype");
-verifyNotConfigurable(DataView, "prototype");
+verifyProperty(DataView, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/DataView/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/DataView/prototype/Symbol.toStringTag.js
@@ -20,6 +20,8 @@ assert.sameValue(
   'The value of DataView.prototype[Symbol.toStringTag] is expected to be "DataView"'
 );
 
-verifyNotEnumerable(DataView.prototype, Symbol.toStringTag);
-verifyNotWritable(DataView.prototype, Symbol.toStringTag);
-verifyConfigurable(DataView.prototype, Symbol.toStringTag);
+verifyProperty(DataView.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Date/prop-desc.js
+++ b/test/built-ins/Date/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "Date");
-verifyWritable(this, "Date");
-verifyConfigurable(this, "Date");
+verifyProperty(this, "Date", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Date/prototype/Symbol.toPrimitive/prop-desc.js
+++ b/test/built-ins/Date/prototype/Symbol.toPrimitive/prop-desc.js
@@ -11,6 +11,8 @@ includes: [propertyHelper.js]
 features: [Symbol.toPrimitive]
 ---*/
 
-verifyNotEnumerable(Date.prototype, Symbol.toPrimitive);
-verifyNotWritable(Date.prototype, Symbol.toPrimitive);
-verifyConfigurable(Date.prototype, Symbol.toPrimitive);
+verifyProperty(Date.prototype, Symbol.toPrimitive, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/DisposableStack/prototype/disposed/name.js
+++ b/test/built-ins/DisposableStack/prototype/disposed/name.js
@@ -23,6 +23,8 @@ assert.sameValue(descriptor.get.name,
   'The value of `descriptor.get.name` is `get disposed`'
 );
 
-verifyNotEnumerable(descriptor.get, 'name');
-verifyNotWritable(descriptor.get, 'name');
-verifyConfigurable(descriptor.get, 'name');
+verifyProperty(descriptor.get, 'name', {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Error/instance-prototype.js
+++ b/test/built-ins/Error/instance-prototype.js
@@ -18,6 +18,8 @@ assert.sameValue(
   'Error.prototype.isPrototypeOf(Error()) returns true'
 );
 
-verifyNotEnumerable(Error, 'prototype');
-verifyNotWritable(Error, 'prototype');
-verifyNotConfigurable(Error, 'prototype');
+verifyProperty(Error, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Error/message_property.js
+++ b/test/built-ins/Error/message_property.js
@@ -19,6 +19,8 @@ var message = "my-message";
 var error = new Error(message);
 
 verifyEqualTo(error, "message", message);
-verifyNotEnumerable(error, "message");
-verifyWritable(error, "message");
-verifyConfigurable(error, "message");
+verifyProperty(error, "message", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Error/prop-desc.js
+++ b/test/built-ins/Error/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "Error");
-verifyWritable(this, "Error");
-verifyConfigurable(this, "Error");
+verifyProperty(this, "Error", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Function/prop-desc.js
+++ b/test/built-ins/Function/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "Function");
-verifyWritable(this, "Function");
-verifyConfigurable(this, "Function");
+verifyProperty(this, "Function", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Function/prototype/Symbol.hasInstance/prop-desc.js
+++ b/test/built-ins/Function/prototype/Symbol.hasInstance/prop-desc.js
@@ -12,6 +12,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Function.prototype[Symbol.hasInstance], 'function');
 
-verifyNotEnumerable(Function.prototype, Symbol.hasInstance);
-verifyNotWritable(Function.prototype, Symbol.hasInstance);
-verifyNotConfigurable(Function.prototype, Symbol.hasInstance);
+verifyProperty(Function.prototype, Symbol.hasInstance, {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/GeneratorFunction/instance-prototype.js
+++ b/test/built-ins/GeneratorFunction/instance-prototype.js
@@ -30,6 +30,8 @@ assert.sameValue(
   Object.getPrototypeOf(instance).prototype
 );
 
-verifyNotEnumerable(instance, 'prototype');
-verifyWritable(instance, 'prototype');
-verifyNotConfigurable(instance, 'prototype');
+verifyProperty(instance, 'prototype', {
+  writable: true,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/GeneratorFunction/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/GeneratorFunction/prototype/Symbol.toStringTag.js
@@ -21,6 +21,8 @@ assert.sameValue(
   GeneratorFunctionPrototype[Symbol.toStringTag], 'GeneratorFunction'
 );
 
-verifyNotEnumerable(GeneratorFunctionPrototype, Symbol.toStringTag);
-verifyNotWritable(GeneratorFunctionPrototype, Symbol.toStringTag);
-verifyConfigurable(GeneratorFunctionPrototype, Symbol.toStringTag);
+verifyProperty(GeneratorFunctionPrototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/GeneratorFunction/prototype/constructor.js
+++ b/test/built-ins/GeneratorFunction/prototype/constructor.js
@@ -18,6 +18,8 @@ var GeneratorFunction = Object.getPrototypeOf(function*() {}).constructor;
 
 assert.sameValue(GeneratorFunction.prototype.constructor, GeneratorFunction);
 
-verifyNotEnumerable(GeneratorFunction.prototype, 'constructor');
-verifyNotWritable(GeneratorFunction.prototype, 'constructor');
-verifyConfigurable(GeneratorFunction.prototype, 'constructor');
+verifyProperty(GeneratorFunction.prototype, 'constructor', {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/GeneratorFunction/prototype/prop-desc.js
+++ b/test/built-ins/GeneratorFunction/prototype/prop-desc.js
@@ -12,6 +12,8 @@ features: [generators]
 
 var GeneratorFunction = Object.getPrototypeOf(function*() {}).constructor;
 
-verifyNotEnumerable(GeneratorFunction, 'prototype');
-verifyNotWritable(GeneratorFunction, 'prototype');
-verifyNotConfigurable(GeneratorFunction, 'prototype');
+verifyProperty(GeneratorFunction, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/GeneratorFunction/prototype/prototype.js
+++ b/test/built-ins/GeneratorFunction/prototype/prototype.js
@@ -18,6 +18,8 @@ assert.sameValue(
   Object.getPrototypeOf(function*() {}.prototype)
 );
 
-verifyNotEnumerable(GeneratorFunctionPrototype, 'prototype');
-verifyNotWritable(GeneratorFunctionPrototype, 'prototype');
-verifyConfigurable(GeneratorFunctionPrototype, 'prototype');
+verifyProperty(GeneratorFunctionPrototype, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/GeneratorPrototype/Symbol.toStringTag.js
+++ b/test/built-ins/GeneratorPrototype/Symbol.toStringTag.js
@@ -21,6 +21,8 @@ var GeneratorPrototype = Object.getPrototypeOf(
 
 assert.sameValue(GeneratorPrototype[Symbol.toStringTag], 'Generator');
 
-verifyNotEnumerable(GeneratorPrototype, Symbol.toStringTag);
-verifyNotWritable(GeneratorPrototype, Symbol.toStringTag);
-verifyConfigurable(GeneratorPrototype, Symbol.toStringTag);
+verifyProperty(GeneratorPrototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/GeneratorPrototype/constructor.js
+++ b/test/built-ins/GeneratorPrototype/constructor.js
@@ -16,6 +16,8 @@ var GeneratorPrototype = Generator.prototype;
 
 assert.sameValue(GeneratorPrototype.constructor, Generator);
 
-verifyNotEnumerable(GeneratorPrototype, 'constructor');
-verifyNotWritable(GeneratorPrototype, 'constructor');
-verifyConfigurable(GeneratorPrototype, 'constructor');
+verifyProperty(GeneratorPrototype, 'constructor', {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/GeneratorPrototype/next/property-descriptor.js
+++ b/test/built-ins/GeneratorPrototype/next/property-descriptor.js
@@ -13,6 +13,8 @@ features: [generators]
 function* g() {}
 var GeneratorPrototype = Object.getPrototypeOf(g).prototype;
 
-verifyNotEnumerable(GeneratorPrototype, 'next');
-verifyWritable(GeneratorPrototype, 'next');
-verifyConfigurable(GeneratorPrototype, 'next');
+verifyProperty(GeneratorPrototype, 'next', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/GeneratorPrototype/return/property-descriptor.js
+++ b/test/built-ins/GeneratorPrototype/return/property-descriptor.js
@@ -13,6 +13,8 @@ features: [generators]
 function* g() {}
 var GeneratorPrototype = Object.getPrototypeOf(g).prototype;
 
-verifyNotEnumerable(GeneratorPrototype, 'return');
-verifyWritable(GeneratorPrototype, 'return');
-verifyConfigurable(GeneratorPrototype, 'return');
+verifyProperty(GeneratorPrototype, 'return', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/GeneratorPrototype/throw/property-descriptor.js
+++ b/test/built-ins/GeneratorPrototype/throw/property-descriptor.js
@@ -13,6 +13,8 @@ features: [generators]
 function* g() {}
 var GeneratorPrototype = Object.getPrototypeOf(g).prototype;
 
-verifyNotEnumerable(GeneratorPrototype, 'throw');
-verifyWritable(GeneratorPrototype, 'throw');
-verifyConfigurable(GeneratorPrototype, 'throw');
+verifyProperty(GeneratorPrototype, 'throw', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/JSON/Symbol.toStringTag.js
+++ b/test/built-ins/JSON/Symbol.toStringTag.js
@@ -16,6 +16,8 @@ features: [Symbol.toStringTag]
 
 assert.sameValue(JSON[Symbol.toStringTag], 'JSON');
 
-verifyNotEnumerable(JSON, Symbol.toStringTag);
-verifyNotWritable(JSON, Symbol.toStringTag);
-verifyConfigurable(JSON, Symbol.toStringTag);
+verifyProperty(JSON, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/map.js
+++ b/test/built-ins/Map/map.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, 'Map');
-verifyWritable(this, 'Map');
-verifyConfigurable(this, 'Map');
+verifyProperty(this, 'Map', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Map/prototype/Symbol.iterator.js
+++ b/test/built-ins/Map/prototype/Symbol.iterator.js
@@ -14,6 +14,8 @@ features: [Symbol.iterator]
 ---*/
 
 assert.sameValue(Map.prototype[Symbol.iterator], Map.prototype.entries);
-verifyNotEnumerable(Map.prototype, Symbol.iterator);
-verifyWritable(Map.prototype, Symbol.iterator);
-verifyConfigurable(Map.prototype, Symbol.iterator);
+verifyProperty(Map.prototype, Symbol.iterator, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/Map/prototype/Symbol.toStringTag.js
@@ -16,6 +16,8 @@ features: [Symbol.toStringTag]
 
 assert.sameValue(Map.prototype[Symbol.toStringTag], 'Map');
 
-verifyNotEnumerable(Map.prototype, Symbol.toStringTag);
-verifyNotWritable(Map.prototype, Symbol.toStringTag);
-verifyConfigurable(Map.prototype, Symbol.toStringTag);
+verifyProperty(Map.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/clear/clear.js
+++ b/test/built-ins/Map/prototype/clear/clear.js
@@ -16,6 +16,8 @@ assert.sameValue(
   'typeof Map.prototype.clear is "function"'
 );
 
-verifyNotEnumerable(Map.prototype, 'clear');
-verifyWritable(Map.prototype, 'clear');
-verifyConfigurable(Map.prototype, 'clear');
+verifyProperty(Map.prototype, 'clear', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/constructor.js
+++ b/test/built-ins/Map/prototype/constructor.js
@@ -11,6 +11,8 @@ includes: [propertyHelper.js]
 assert.sameValue(Map.prototype.constructor, Map);
 assert.sameValue((new Map()).constructor, Map);
 
-verifyNotEnumerable(Map.prototype, 'constructor');
-verifyWritable(Map.prototype, 'constructor');
-verifyConfigurable(Map.prototype, 'constructor');
+verifyProperty(Map.prototype, 'constructor', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/delete/delete.js
+++ b/test/built-ins/Map/prototype/delete/delete.js
@@ -16,6 +16,8 @@ assert.sameValue(
   'typeof Map.prototype.delete is "function"'
 );
 
-verifyNotEnumerable(Map.prototype, 'delete');
-verifyWritable(Map.prototype, 'delete');
-verifyConfigurable(Map.prototype, 'delete');
+verifyProperty(Map.prototype, 'delete', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/descriptor.js
+++ b/test/built-ins/Map/prototype/descriptor.js
@@ -9,6 +9,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Map, 'prototype');
-verifyNotWritable(Map, 'prototype');
-verifyNotConfigurable(Map, 'prototype');
+verifyProperty(Map, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Map/prototype/entries/entries.js
+++ b/test/built-ins/Map/prototype/entries/entries.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof Map.prototype.entries` is `function`'
 );
 
-verifyNotEnumerable(Map.prototype, 'entries');
-verifyWritable(Map.prototype, 'entries');
-verifyConfigurable(Map.prototype, 'entries');
+verifyProperty(Map.prototype, 'entries', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/forEach/forEach.js
+++ b/test/built-ins/Map/prototype/forEach/forEach.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof Map.prototype.forEach` is `function`'
 );
 
-verifyNotEnumerable(Map.prototype, 'forEach');
-verifyWritable(Map.prototype, 'forEach');
-verifyConfigurable(Map.prototype, 'forEach');
+verifyProperty(Map.prototype, 'forEach', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/get/get.js
+++ b/test/built-ins/Map/prototype/get/get.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof Map.prototype.get` is `function`'
 );
 
-verifyNotEnumerable(Map.prototype, 'get');
-verifyWritable(Map.prototype, 'get');
-verifyConfigurable(Map.prototype, 'get');
+verifyProperty(Map.prototype, 'get', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/has/has.js
+++ b/test/built-ins/Map/prototype/has/has.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof Map.prototype.has` is `function`'
 );
 
-verifyNotEnumerable(Map.prototype, 'has');
-verifyWritable(Map.prototype, 'has');
-verifyConfigurable(Map.prototype, 'has');
+verifyProperty(Map.prototype, 'has', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/keys/keys.js
+++ b/test/built-ins/Map/prototype/keys/keys.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof Map.prototype.keys` is `function`'
 );
 
-verifyNotEnumerable(Map.prototype, 'keys');
-verifyWritable(Map.prototype, 'keys');
-verifyConfigurable(Map.prototype, 'keys');
+verifyProperty(Map.prototype, 'keys', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/set/set.js
+++ b/test/built-ins/Map/prototype/set/set.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof Map.prototype.set` is `function`'
 );
 
-verifyNotEnumerable(Map.prototype, 'set');
-verifyWritable(Map.prototype, 'set');
-verifyConfigurable(Map.prototype, 'set');
+verifyProperty(Map.prototype, 'set', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Map/prototype/values/values.js
+++ b/test/built-ins/Map/prototype/values/values.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof Map.prototype.values` is `function`'
 );
 
-verifyNotEnumerable(Map.prototype, 'values');
-verifyWritable(Map.prototype, 'values');
-verifyConfigurable(Map.prototype, 'values');
+verifyProperty(Map.prototype, 'values', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/MapIteratorPrototype/Symbol.toStringTag.js
+++ b/test/built-ins/MapIteratorPrototype/Symbol.toStringTag.js
@@ -18,6 +18,8 @@ var MapIteratorProto = Object.getPrototypeOf(new Map()[Symbol.iterator]());
 
 assert.sameValue('Map Iterator', MapIteratorProto[Symbol.toStringTag]);
 
-verifyNotEnumerable(MapIteratorProto, Symbol.toStringTag);
-verifyNotWritable(MapIteratorProto, Symbol.toStringTag);
-verifyConfigurable(MapIteratorProto, Symbol.toStringTag);
+verifyProperty(MapIteratorProto, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Math/E/prop-desc.js
+++ b/test/built-ins/Math/E/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, 'E');
-verifyNotWritable(Math, 'E');
-verifyNotConfigurable(Math, 'E');
+verifyProperty(Math, 'E', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Math/LN10/prop-desc.js
+++ b/test/built-ins/Math/LN10/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, 'LN10');
-verifyNotWritable(Math, 'LN10');
-verifyNotConfigurable(Math, 'LN10');
+verifyProperty(Math, 'LN10', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Math/LN2/prop-desc.js
+++ b/test/built-ins/Math/LN2/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, 'LN2');
-verifyNotWritable(Math, 'LN2');
-verifyNotConfigurable(Math, 'LN2');
+verifyProperty(Math, 'LN2', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Math/LOG10E/prop-desc.js
+++ b/test/built-ins/Math/LOG10E/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, 'LOG10E');
-verifyNotWritable(Math, 'LOG10E');
-verifyNotConfigurable(Math, 'LOG10E');
+verifyProperty(Math, 'LOG10E', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Math/LOG2E/prop-desc.js
+++ b/test/built-ins/Math/LOG2E/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, 'LOG2E');
-verifyNotWritable(Math, 'LOG2E');
-verifyNotConfigurable(Math, 'LOG2E');
+verifyProperty(Math, 'LOG2E', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Math/PI/prop-desc.js
+++ b/test/built-ins/Math/PI/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, 'PI');
-verifyNotWritable(Math, 'PI');
-verifyNotConfigurable(Math, 'PI');
+verifyProperty(Math, 'PI', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Math/SQRT2/prop-desc.js
+++ b/test/built-ins/Math/SQRT2/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, 'SQRT2');
-verifyNotWritable(Math, 'SQRT2');
-verifyNotConfigurable(Math, 'SQRT2');
+verifyProperty(Math, 'SQRT2', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Math/Symbol.toStringTag.js
+++ b/test/built-ins/Math/Symbol.toStringTag.js
@@ -16,6 +16,8 @@ features: [Symbol.toStringTag]
 
 assert.sameValue(Math[Symbol.toStringTag], 'Math');
 
-verifyNotEnumerable(Math, Symbol.toStringTag);
-verifyNotWritable(Math, Symbol.toStringTag);
-verifyConfigurable(Math, Symbol.toStringTag);
+verifyProperty(Math, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Math/abs/prop-desc.js
+++ b/test/built-ins/Math/abs/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "abs");
-verifyWritable(Math, "abs");
-verifyConfigurable(Math, "abs");
+verifyProperty(Math, "abs", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/acos/prop-desc.js
+++ b/test/built-ins/Math/acos/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "acos");
-verifyWritable(Math, "acos");
-verifyConfigurable(Math, "acos");
+verifyProperty(Math, "acos", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/acosh/prop-desc.js
+++ b/test/built-ins/Math/acosh/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.3
 ---*/
 
-verifyNotEnumerable(Math, "acosh");
-verifyWritable(Math, "acosh");
-verifyConfigurable(Math, "acosh");
+verifyProperty(Math, "acosh", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/asin/prop-desc.js
+++ b/test/built-ins/Math/asin/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "asin");
-verifyWritable(Math, "asin");
-verifyConfigurable(Math, "asin");
+verifyProperty(Math, "asin", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/asinh/prop-desc.js
+++ b/test/built-ins/Math/asinh/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.5
 ---*/
 
-verifyNotEnumerable(Math, "asinh");
-verifyWritable(Math, "asinh");
-verifyConfigurable(Math, "asinh");
+verifyProperty(Math, "asinh", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/atan/prop-desc.js
+++ b/test/built-ins/Math/atan/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "atan");
-verifyWritable(Math, "atan");
-verifyConfigurable(Math, "atan");
+verifyProperty(Math, "atan", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/atan2/prop-desc.js
+++ b/test/built-ins/Math/atan2/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "atan2");
-verifyWritable(Math, "atan2");
-verifyConfigurable(Math, "atan2");
+verifyProperty(Math, "atan2", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Math/atanh/prop-desc.js
+++ b/test/built-ins/Math/atanh/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.7
 ---*/
 
-verifyNotEnumerable(Math, "atanh");
-verifyWritable(Math, "atanh");
-verifyConfigurable(Math, "atanh");
+verifyProperty(Math, "atanh", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/cbrt/prop-desc.js
+++ b/test/built-ins/Math/cbrt/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.9
 ---*/
 
-verifyNotEnumerable(Math, "cbrt");
-verifyWritable(Math, "cbrt");
-verifyConfigurable(Math, "cbrt");
+verifyProperty(Math, "cbrt", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/ceil/prop-desc.js
+++ b/test/built-ins/Math/ceil/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "ceil");
-verifyWritable(Math, "ceil");
-verifyConfigurable(Math, "ceil");
+verifyProperty(Math, "ceil", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/clz32/prop-desc.js
+++ b/test/built-ins/Math/clz32/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "clz32");
-verifyWritable(Math, "clz32");
-verifyConfigurable(Math, "clz32");
+verifyProperty(Math, "clz32", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Math/cos/prop-desc.js
+++ b/test/built-ins/Math/cos/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "cos");
-verifyWritable(Math, "cos");
-verifyConfigurable(Math, "cos");
+verifyProperty(Math, "cos", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/cosh/prop-desc.js
+++ b/test/built-ins/Math/cosh/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.13
 ---*/
 
-verifyNotEnumerable(Math, "cosh");
-verifyWritable(Math, "cosh");
-verifyConfigurable(Math, "cosh");
+verifyProperty(Math, "cosh", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/exp/prop-desc.js
+++ b/test/built-ins/Math/exp/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "exp");
-verifyWritable(Math, "exp");
-verifyConfigurable(Math, "exp");
+verifyProperty(Math, "exp", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/expm1/prop-desc.js
+++ b/test/built-ins/Math/expm1/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.15
 ---*/
 
-verifyNotEnumerable(Math, "expm1");
-verifyWritable(Math, "expm1");
-verifyConfigurable(Math, "expm1");
+verifyProperty(Math, "expm1", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/f16round/prop-desc.js
+++ b/test/built-ins/Math/f16round/prop-desc.js
@@ -9,6 +9,8 @@ features: [Float16Array]
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "f16round");
-verifyWritable(Math, "f16round");
-verifyConfigurable(Math, "f16round");
+verifyProperty(Math, "f16round", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Math/floor/prop-desc.js
+++ b/test/built-ins/Math/floor/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "floor");
-verifyWritable(Math, "floor");
-verifyConfigurable(Math, "floor");
+verifyProperty(Math, "floor", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/fround/prop-desc.js
+++ b/test/built-ins/Math/fround/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "fround");
-verifyWritable(Math, "fround");
-verifyConfigurable(Math, "fround");
+verifyProperty(Math, "fround", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/hypot/prop-desc.js
+++ b/test/built-ins/Math/hypot/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.18
 ---*/
 
-verifyNotEnumerable(Math, "hypot");
-verifyWritable(Math, "hypot");
-verifyConfigurable(Math, "hypot");
+verifyProperty(Math, "hypot", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/imul/prop-desc.js
+++ b/test/built-ins/Math/imul/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.19
 ---*/
 
-verifyNotEnumerable(Math, "imul");
-verifyWritable(Math, "imul");
-verifyConfigurable(Math, "imul");
+verifyProperty(Math, "imul", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/log/prop-desc.js
+++ b/test/built-ins/Math/log/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "log");
-verifyWritable(Math, "log");
-verifyConfigurable(Math, "log");
+verifyProperty(Math, "log", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/log10/prop-desc.js
+++ b/test/built-ins/Math/log10/prop-desc.js
@@ -8,6 +8,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.20
 ---*/
 
-verifyNotEnumerable(Math, "log10");
-verifyWritable(Math, "log10");
-verifyConfigurable(Math, "log10");
+verifyProperty(Math, "log10", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Math/log1p/prop-desc.js
+++ b/test/built-ins/Math/log1p/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.21
 ---*/
 
-verifyNotEnumerable(Math, "log1p");
-verifyWritable(Math, "log1p");
-verifyConfigurable(Math, "log1p");
+verifyProperty(Math, "log1p", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Math/log2/prop-desc.js
+++ b/test/built-ins/Math/log2/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.23
 ---*/
 
-verifyNotEnumerable(Math, "log2");
-verifyWritable(Math, "log2");
-verifyConfigurable(Math, "log2");
+verifyProperty(Math, "log2", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Math/max/prop-desc.js
+++ b/test/built-ins/Math/max/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "max");
-verifyWritable(Math, "max");
-verifyConfigurable(Math, "max");
+verifyProperty(Math, "max", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/min/prop-desc.js
+++ b/test/built-ins/Math/min/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "min");
-verifyWritable(Math, "min");
-verifyConfigurable(Math, "min");
+verifyProperty(Math, "min", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/pow/prop-desc.js
+++ b/test/built-ins/Math/pow/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "pow");
-verifyWritable(Math, "pow");
-verifyConfigurable(Math, "pow");
+verifyProperty(Math, "pow", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/random/prop-desc.js
+++ b/test/built-ins/Math/random/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "random");
-verifyWritable(Math, "random");
-verifyConfigurable(Math, "random");
+verifyProperty(Math, "random", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/round/prop-desc.js
+++ b/test/built-ins/Math/round/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "round");
-verifyWritable(Math, "round");
-verifyConfigurable(Math, "round");
+verifyProperty(Math, "round", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/sign/prop-desc.js
+++ b/test/built-ins/Math/sign/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.29
 ---*/
 
-verifyNotEnumerable(Math, "sign");
-verifyWritable(Math, "sign");
-verifyConfigurable(Math, "sign");
+verifyProperty(Math, "sign", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/sin/prop-desc.js
+++ b/test/built-ins/Math/sin/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "sin");
-verifyWritable(Math, "sin");
-verifyConfigurable(Math, "sin");
+verifyProperty(Math, "sin", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/sinh/prop-desc.js
+++ b/test/built-ins/Math/sinh/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.31
 ---*/
 
-verifyNotEnumerable(Math, "sinh");
-verifyWritable(Math, "sinh");
-verifyConfigurable(Math, "sinh");
+verifyProperty(Math, "sinh", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/sqrt/prop-desc.js
+++ b/test/built-ins/Math/sqrt/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "sqrt");
-verifyWritable(Math, "sqrt");
-verifyConfigurable(Math, "sqrt");
+verifyProperty(Math, "sqrt", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/tan/prop-desc.js
+++ b/test/built-ins/Math/tan/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Math, "tan");
-verifyWritable(Math, "tan");
-verifyConfigurable(Math, "tan");
+verifyProperty(Math, "tan", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/tanh/prop-desc.js
+++ b/test/built-ins/Math/tanh/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.34
 ---*/
 
-verifyNotEnumerable(Math, "tanh");
-verifyWritable(Math, "tanh");
-verifyConfigurable(Math, "tanh");
+verifyProperty(Math, "tanh", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Math/trunc/prop-desc.js
+++ b/test/built-ins/Math/trunc/prop-desc.js
@@ -7,6 +7,8 @@ includes: [propertyHelper.js]
 es6id: 20.2.2.35
 ---*/
 
-verifyNotEnumerable(Math, "trunc");
-verifyWritable(Math, "trunc");
-verifyConfigurable(Math, "trunc");
+verifyProperty(Math, "trunc", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/EvalError/prop-desc.js
+++ b/test/built-ins/NativeErrors/EvalError/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "EvalError");
-verifyWritable(this, "EvalError");
-verifyConfigurable(this, "EvalError");
+verifyProperty(this, "EvalError", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/EvalError/prototype.js
+++ b/test/built-ins/NativeErrors/EvalError/prototype.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(EvalError.prototype, Object.getPrototypeOf(new EvalError));
 
-verifyNotEnumerable(EvalError, "prototype");
-verifyNotWritable(EvalError, "prototype");
-verifyNotConfigurable(EvalError, "prototype");
+verifyProperty(EvalError, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/NativeErrors/EvalError/prototype/constructor.js
+++ b/test/built-ins/NativeErrors/EvalError/prototype/constructor.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(EvalError.prototype.constructor, EvalError);
 
-verifyNotEnumerable(EvalError.prototype, "constructor");
-verifyWritable(EvalError.prototype, "constructor");
-verifyConfigurable(EvalError.prototype, "constructor");
+verifyProperty(EvalError.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/EvalError/prototype/message.js
+++ b/test/built-ins/NativeErrors/EvalError/prototype/message.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(EvalError.prototype.message, "");
 
-verifyNotEnumerable(EvalError.prototype, "message");
-verifyWritable(EvalError.prototype, "message");
-verifyConfigurable(EvalError.prototype, "message");
+verifyProperty(EvalError.prototype, "message", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/RangeError/prop-desc.js
+++ b/test/built-ins/NativeErrors/RangeError/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "RangeError");
-verifyWritable(this, "RangeError");
-verifyConfigurable(this, "RangeError");
+verifyProperty(this, "RangeError", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/RangeError/prototype.js
+++ b/test/built-ins/NativeErrors/RangeError/prototype.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(RangeError.prototype, Object.getPrototypeOf(new RangeError));
 
-verifyNotEnumerable(RangeError, "prototype");
-verifyNotWritable(RangeError, "prototype");
-verifyNotConfigurable(RangeError, "prototype");
+verifyProperty(RangeError, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/NativeErrors/RangeError/prototype/constructor.js
+++ b/test/built-ins/NativeErrors/RangeError/prototype/constructor.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(RangeError.prototype.constructor, RangeError);
 
-verifyNotEnumerable(RangeError.prototype, "constructor");
-verifyWritable(RangeError.prototype, "constructor");
-verifyConfigurable(RangeError.prototype, "constructor");
+verifyProperty(RangeError.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/RangeError/prototype/message.js
+++ b/test/built-ins/NativeErrors/RangeError/prototype/message.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(RangeError.prototype.message, "");
 
-verifyNotEnumerable(RangeError.prototype, "message");
-verifyWritable(RangeError.prototype, "message");
-verifyConfigurable(RangeError.prototype, "message");
+verifyProperty(RangeError.prototype, "message", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/ReferenceError/prop-desc.js
+++ b/test/built-ins/NativeErrors/ReferenceError/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "ReferenceError");
-verifyWritable(this, "ReferenceError");
-verifyConfigurable(this, "ReferenceError");
+verifyProperty(this, "ReferenceError", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/ReferenceError/prototype.js
+++ b/test/built-ins/NativeErrors/ReferenceError/prototype.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(ReferenceError.prototype, Object.getPrototypeOf(new ReferenceError));
 
-verifyNotEnumerable(ReferenceError, "prototype");
-verifyNotWritable(ReferenceError, "prototype");
-verifyNotConfigurable(ReferenceError, "prototype");
+verifyProperty(ReferenceError, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/NativeErrors/ReferenceError/prototype/constructor.js
+++ b/test/built-ins/NativeErrors/ReferenceError/prototype/constructor.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(ReferenceError.prototype.constructor, ReferenceError);
 
-verifyNotEnumerable(ReferenceError.prototype, "constructor");
-verifyWritable(ReferenceError.prototype, "constructor");
-verifyConfigurable(ReferenceError.prototype, "constructor");
+verifyProperty(ReferenceError.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/ReferenceError/prototype/message.js
+++ b/test/built-ins/NativeErrors/ReferenceError/prototype/message.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(ReferenceError.prototype.message, "");
 
-verifyNotEnumerable(ReferenceError.prototype, "message");
-verifyWritable(ReferenceError.prototype, "message");
-verifyConfigurable(ReferenceError.prototype, "message");
+verifyProperty(ReferenceError.prototype, "message", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/SyntaxError/prop-desc.js
+++ b/test/built-ins/NativeErrors/SyntaxError/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "SyntaxError");
-verifyWritable(this, "SyntaxError");
-verifyConfigurable(this, "SyntaxError");
+verifyProperty(this, "SyntaxError", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/SyntaxError/prototype.js
+++ b/test/built-ins/NativeErrors/SyntaxError/prototype.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(SyntaxError.prototype, Object.getPrototypeOf(new SyntaxError));
 
-verifyNotEnumerable(SyntaxError, "prototype");
-verifyNotWritable(SyntaxError, "prototype");
-verifyNotConfigurable(SyntaxError, "prototype");
+verifyProperty(SyntaxError, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/NativeErrors/SyntaxError/prototype/constructor.js
+++ b/test/built-ins/NativeErrors/SyntaxError/prototype/constructor.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(SyntaxError.prototype.constructor, SyntaxError);
 
-verifyNotEnumerable(SyntaxError.prototype, "constructor");
-verifyWritable(SyntaxError.prototype, "constructor");
-verifyConfigurable(SyntaxError.prototype, "constructor");
+verifyProperty(SyntaxError.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/SyntaxError/prototype/message.js
+++ b/test/built-ins/NativeErrors/SyntaxError/prototype/message.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(SyntaxError.prototype.message, "");
 
-verifyNotEnumerable(SyntaxError.prototype, "message");
-verifyWritable(SyntaxError.prototype, "message");
-verifyConfigurable(SyntaxError.prototype, "message");
+verifyProperty(SyntaxError.prototype, "message", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/TypeError/prop-desc.js
+++ b/test/built-ins/NativeErrors/TypeError/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "TypeError");
-verifyWritable(this, "TypeError");
-verifyConfigurable(this, "TypeError");
+verifyProperty(this, "TypeError", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/TypeError/prototype.js
+++ b/test/built-ins/NativeErrors/TypeError/prototype.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(TypeError.prototype, Object.getPrototypeOf(new TypeError));
 
-verifyNotEnumerable(TypeError, "prototype");
-verifyNotWritable(TypeError, "prototype");
-verifyNotConfigurable(TypeError, "prototype");
+verifyProperty(TypeError, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/NativeErrors/TypeError/prototype/constructor.js
+++ b/test/built-ins/NativeErrors/TypeError/prototype/constructor.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(TypeError.prototype.constructor, TypeError);
 
-verifyNotEnumerable(TypeError.prototype, "constructor");
-verifyWritable(TypeError.prototype, "constructor");
-verifyConfigurable(TypeError.prototype, "constructor");
+verifyProperty(TypeError.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/TypeError/prototype/message.js
+++ b/test/built-ins/NativeErrors/TypeError/prototype/message.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(TypeError.prototype.message, "");
 
-verifyNotEnumerable(TypeError.prototype, "message");
-verifyWritable(TypeError.prototype, "message");
-verifyConfigurable(TypeError.prototype, "message");
+verifyProperty(TypeError.prototype, "message", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/URIError/prop-desc.js
+++ b/test/built-ins/NativeErrors/URIError/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "URIError");
-verifyWritable(this, "URIError");
-verifyConfigurable(this, "URIError");
+verifyProperty(this, "URIError", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/NativeErrors/URIError/prototype.js
+++ b/test/built-ins/NativeErrors/URIError/prototype.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(URIError.prototype, Object.getPrototypeOf(new URIError));
 
-verifyNotEnumerable(URIError, "prototype");
-verifyNotWritable(URIError, "prototype");
-verifyNotConfigurable(URIError, "prototype");
+verifyProperty(URIError, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/NativeErrors/URIError/prototype/constructor.js
+++ b/test/built-ins/NativeErrors/URIError/prototype/constructor.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(URIError.prototype.constructor, URIError);
 
-verifyNotEnumerable(URIError.prototype, "constructor");
-verifyWritable(URIError.prototype, "constructor");
-verifyConfigurable(URIError.prototype, "constructor");
+verifyProperty(URIError.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/NativeErrors/URIError/prototype/message.js
+++ b/test/built-ins/NativeErrors/URIError/prototype/message.js
@@ -18,6 +18,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(URIError.prototype.message, "");
 
-verifyNotEnumerable(URIError.prototype, "message");
-verifyWritable(URIError.prototype, "message");
-verifyConfigurable(URIError.prototype, "message");
+verifyProperty(URIError.prototype, "message", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Number/EPSILON.js
+++ b/test/built-ins/Number/EPSILON.js
@@ -26,6 +26,8 @@ assert(
   "value is smaller than 0.000001"
 );
 
-verifyNotEnumerable(Number, "EPSILON");
-verifyNotWritable(Number, "EPSILON");
-verifyNotConfigurable(Number, "EPSILON");
+verifyProperty(Number, "EPSILON", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Number/NaN.js
+++ b/test/built-ins/Number/NaN.js
@@ -17,6 +17,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(Number.NaN, NaN);
 
-verifyNotEnumerable(Number, "NaN");
-verifyNotWritable(Number, "NaN");
-verifyNotConfigurable(Number, "NaN");
+verifyProperty(Number, "NaN", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Number/isFinite/prop-desc.js
+++ b/test/built-ins/Number/isFinite/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number, "isFinite");
-verifyWritable(Number, "isFinite");
-verifyConfigurable(Number, "isFinite");
+verifyProperty(Number, "isFinite", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Number/isInteger/prop-desc.js
+++ b/test/built-ins/Number/isInteger/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number, "isInteger");
-verifyWritable(Number, "isInteger");
-verifyConfigurable(Number, "isInteger");
+verifyProperty(Number, "isInteger", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Number/isNaN/prop-desc.js
+++ b/test/built-ins/Number/isNaN/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number, "isNaN");
-verifyWritable(Number, "isNaN");
-verifyConfigurable(Number, "isNaN");
+verifyProperty(Number, "isNaN", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Number/isSafeInteger/prop-desc.js
+++ b/test/built-ins/Number/isSafeInteger/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number, "isSafeInteger");
-verifyWritable(Number, "isSafeInteger");
-verifyConfigurable(Number, "isSafeInteger");
+verifyProperty(Number, "isSafeInteger", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Number/parseFloat.js
+++ b/test/built-ins/Number/parseFloat.js
@@ -22,6 +22,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(Number.parseFloat, parseFloat);
 
-verifyNotEnumerable(Number, "parseFloat");
-verifyWritable(Number, "parseFloat");
-verifyConfigurable(Number, "parseFloat");
+verifyProperty(Number, "parseFloat", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Number/parseInt.js
+++ b/test/built-ins/Number/parseInt.js
@@ -22,6 +22,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(Number.parseInt, parseInt);
 
-verifyNotEnumerable(Number, "parseInt");
-verifyWritable(Number, "parseInt");
-verifyConfigurable(Number, "parseInt");
+verifyProperty(Number, "parseInt", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Number/prop-desc.js
+++ b/test/built-ins/Number/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "Number");
-verifyWritable(this, "Number");
-verifyConfigurable(this, "Number");
+verifyProperty(this, "Number", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Number/prototype/constructor.js
+++ b/test/built-ins/Number/prototype/constructor.js
@@ -15,6 +15,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(Number.prototype.constructor, Number);
 
-verifyNotEnumerable(Number.prototype, "constructor");
-verifyWritable(Number.prototype, "constructor");
-verifyConfigurable(Number.prototype, "constructor");
+verifyProperty(Number.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Number/prototype/prop-desc.js
+++ b/test/built-ins/Number/prototype/prop-desc.js
@@ -13,6 +13,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number, "prototype");
-verifyNotWritable(Number, "prototype");
-verifyNotConfigurable(Number, "prototype");
+verifyProperty(Number, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Number/prototype/toExponential/prop-desc.js
+++ b/test/built-ins/Number/prototype/toExponential/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number.prototype, "toExponential");
-verifyWritable(Number.prototype, "toExponential");
-verifyConfigurable(Number.prototype, "toExponential");
+verifyProperty(Number.prototype, "toExponential", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Number/prototype/toFixed/prop-desc.js
+++ b/test/built-ins/Number/prototype/toFixed/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number.prototype, "toFixed");
-verifyWritable(Number.prototype, "toFixed");
-verifyConfigurable(Number.prototype, "toFixed");
+verifyProperty(Number.prototype, "toFixed", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Number/prototype/toLocaleString/prop-desc.js
+++ b/test/built-ins/Number/prototype/toLocaleString/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number.prototype, "toLocaleString");
-verifyWritable(Number.prototype, "toLocaleString");
-verifyConfigurable(Number.prototype, "toLocaleString");
+verifyProperty(Number.prototype, "toLocaleString", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Number/prototype/toPrecision/prop-desc.js
+++ b/test/built-ins/Number/prototype/toPrecision/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number.prototype, "toPrecision");
-verifyWritable(Number.prototype, "toPrecision");
-verifyConfigurable(Number.prototype, "toPrecision");
+verifyProperty(Number.prototype, "toPrecision", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Number/prototype/toString/prop-desc.js
+++ b/test/built-ins/Number/prototype/toString/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number.prototype, "toString");
-verifyWritable(Number.prototype, "toString");
-verifyConfigurable(Number.prototype, "toString");
+verifyProperty(Number.prototype, "toString", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Number/prototype/valueOf/prop-desc.js
+++ b/test/built-ins/Number/prototype/valueOf/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Number.prototype, "valueOf");
-verifyWritable(Number.prototype, "valueOf");
-verifyConfigurable(Number.prototype, "valueOf");
+verifyProperty(Number.prototype, "valueOf", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Promise/all/prop-desc.js
+++ b/test/built-ins/Promise/all/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Promise, 'all');
-verifyWritable(Promise, 'all');
-verifyConfigurable(Promise, 'all');
+verifyProperty(Promise, 'all', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Promise/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/Promise/prototype/Symbol.toStringTag.js
@@ -16,6 +16,8 @@ features: [Symbol.toStringTag]
 
 assert.sameValue(Promise.prototype[Symbol.toStringTag], 'Promise');
 
-verifyNotEnumerable(Promise.prototype, Symbol.toStringTag);
-verifyNotWritable(Promise.prototype, Symbol.toStringTag);
-verifyConfigurable(Promise.prototype, Symbol.toStringTag);
+verifyProperty(Promise.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Promise/prototype/catch/prop-desc.js
+++ b/test/built-ins/Promise/prototype/catch/prop-desc.js
@@ -12,6 +12,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Promise.prototype.catch, 'function');
 
-verifyNotEnumerable(Promise.prototype, 'catch');
-verifyWritable(Promise.prototype, 'catch');
-verifyConfigurable(Promise.prototype, 'catch');
+verifyProperty(Promise.prototype, 'catch', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Promise/prototype/finally/prop-desc.js
+++ b/test/built-ins/Promise/prototype/finally/prop-desc.js
@@ -14,6 +14,8 @@ features: [Promise.prototype.finally]
 
 assert.sameValue(typeof Promise.prototype.finally, 'function');
 
-verifyNotEnumerable(Promise.prototype, 'finally');
-verifyWritable(Promise.prototype, 'finally');
-verifyConfigurable(Promise.prototype, 'finally');
+verifyProperty(Promise.prototype, 'finally', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Promise/prototype/prop-desc.js
+++ b/test/built-ins/Promise/prototype/prop-desc.js
@@ -9,6 +9,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Promise, 'prototype');
-verifyNotWritable(Promise, 'prototype');
-verifyNotConfigurable(Promise, 'prototype');
+verifyProperty(Promise, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Promise/prototype/then/prop-desc.js
+++ b/test/built-ins/Promise/prototype/then/prop-desc.js
@@ -12,6 +12,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(typeof Promise.prototype.then, 'function');
 
-verifyNotEnumerable(Promise.prototype, 'then');
-verifyWritable(Promise.prototype, 'then');
-verifyConfigurable(Promise.prototype, 'then');
+verifyProperty(Promise.prototype, 'then', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Promise/race/prop-desc.js
+++ b/test/built-ins/Promise/race/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Promise, 'race');
-verifyWritable(Promise, 'race');
-verifyConfigurable(Promise, 'race');
+verifyProperty(Promise, 'race', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Promise/reject/prop-desc.js
+++ b/test/built-ins/Promise/reject/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Promise, 'reject');
-verifyWritable(Promise, 'reject');
-verifyConfigurable(Promise, 'reject');
+verifyProperty(Promise, 'reject', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Promise/resolve/prop-desc.js
+++ b/test/built-ins/Promise/resolve/prop-desc.js
@@ -14,6 +14,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Promise, 'resolve');
-verifyWritable(Promise, 'resolve');
-verifyConfigurable(Promise, 'resolve');
+verifyProperty(Promise, 'resolve', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Proxy/defineProperty/return-boolean-and-define-target.js
+++ b/test/built-ins/Proxy/defineProperty/return-boolean-and-define-target.js
@@ -27,9 +27,11 @@ var result = Reflect.defineProperty(p, "attr", {
 assert.sameValue(result, true, "result === true");
 
 verifyEqualTo(target, "attr", 1);
-verifyWritable(target, "attr");
-verifyEnumerable(target, "attr");
-verifyConfigurable(target, "attr");
+verifyProperty(target, "attr", {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
 
 result = Reflect.defineProperty(p, "attr", {
   configurable: false,
@@ -41,6 +43,8 @@ result = Reflect.defineProperty(p, "attr", {
 assert.sameValue(result, true, "result === true");
 
 verifyEqualTo(target, "attr", 2);
-verifyNotWritable(target, "attr");
-verifyNotEnumerable(target, "attr");
-verifyNotConfigurable(target, "attr");
+verifyProperty(target, "attr", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Proxy/defineProperty/trap-is-undefined.js
+++ b/test/built-ins/Proxy/defineProperty/trap-is-undefined.js
@@ -26,9 +26,11 @@ Object.defineProperty(p, "attr", {
 });
 
 verifyEqualTo(target, "attr", 1);
-verifyWritable(target, "attr");
-verifyEnumerable(target, "attr");
-verifyConfigurable(target, "attr");
+verifyProperty(target, "attr", {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
 
 Object.defineProperty(p, "attr", {
   configurable: false,
@@ -38,6 +40,8 @@ Object.defineProperty(p, "attr", {
 });
 
 verifyEqualTo(target, "attr", 2);
-verifyNotWritable(target, "attr");
-verifyNotEnumerable(target, "attr");
-verifyNotConfigurable(target, "attr");
+verifyProperty(target, "attr", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-undefined.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-undefined.js
@@ -23,6 +23,8 @@ var p = new Proxy(target, {});
 var proxyDesc = Object.getOwnPropertyDescriptor(p, "attr");
 
 verifyEqualTo(p, "attr", 1);
-verifyWritable(p, "attr");
-verifyEnumerable(p, "attr");
-verifyConfigurable(p, "attr");
+verifyProperty(p, "attr", {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});

--- a/test/built-ins/Proxy/proxy.js
+++ b/test/built-ins/Proxy/proxy.js
@@ -10,6 +10,8 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "Proxy");
-verifyWritable(this, "Proxy");
-verifyConfigurable(this, "Proxy");
+verifyProperty(this, "Proxy", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/apply/apply.js
+++ b/test/built-ins/Reflect/apply/apply.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'apply');
-verifyWritable(Reflect, 'apply');
-verifyConfigurable(Reflect, 'apply');
+verifyProperty(Reflect, 'apply', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/construct/construct.js
+++ b/test/built-ins/Reflect/construct/construct.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'construct');
-verifyWritable(Reflect, 'construct');
-verifyConfigurable(Reflect, 'construct');
+verifyProperty(Reflect, 'construct', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/defineProperty/defineProperty.js
+++ b/test/built-ins/Reflect/defineProperty/defineProperty.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'defineProperty');
-verifyWritable(Reflect, 'defineProperty');
-verifyConfigurable(Reflect, 'defineProperty');
+verifyProperty(Reflect, 'defineProperty', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/deleteProperty/deleteProperty.js
+++ b/test/built-ins/Reflect/deleteProperty/deleteProperty.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'deleteProperty');
-verifyWritable(Reflect, 'deleteProperty');
-verifyConfigurable(Reflect, 'deleteProperty');
+verifyProperty(Reflect, 'deleteProperty', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/get/get.js
+++ b/test/built-ins/Reflect/get/get.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'get');
-verifyWritable(Reflect, 'get');
-verifyConfigurable(Reflect, 'get');
+verifyProperty(Reflect, 'get', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/getOwnPropertyDescriptor.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/getOwnPropertyDescriptor.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'getOwnPropertyDescriptor');
-verifyWritable(Reflect, 'getOwnPropertyDescriptor');
-verifyConfigurable(Reflect, 'getOwnPropertyDescriptor');
+verifyProperty(Reflect, 'getOwnPropertyDescriptor', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/getPrototypeOf/getPrototypeOf.js
+++ b/test/built-ins/Reflect/getPrototypeOf/getPrototypeOf.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'getPrototypeOf');
-verifyWritable(Reflect, 'getPrototypeOf');
-verifyConfigurable(Reflect, 'getPrototypeOf');
+verifyProperty(Reflect, 'getPrototypeOf', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/has/has.js
+++ b/test/built-ins/Reflect/has/has.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'has');
-verifyWritable(Reflect, 'has');
-verifyConfigurable(Reflect, 'has');
+verifyProperty(Reflect, 'has', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/isExtensible/isExtensible.js
+++ b/test/built-ins/Reflect/isExtensible/isExtensible.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'isExtensible');
-verifyWritable(Reflect, 'isExtensible');
-verifyConfigurable(Reflect, 'isExtensible');
+verifyProperty(Reflect, 'isExtensible', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/ownKeys/ownKeys.js
+++ b/test/built-ins/Reflect/ownKeys/ownKeys.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'ownKeys');
-verifyWritable(Reflect, 'ownKeys');
-verifyConfigurable(Reflect, 'ownKeys');
+verifyProperty(Reflect, 'ownKeys', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/preventExtensions/preventExtensions.js
+++ b/test/built-ins/Reflect/preventExtensions/preventExtensions.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'preventExtensions');
-verifyWritable(Reflect, 'preventExtensions');
-verifyConfigurable(Reflect, 'preventExtensions');
+verifyProperty(Reflect, 'preventExtensions', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/set/creates-a-data-descriptor.js
+++ b/test/built-ins/Reflect/set/creates-a-data-descriptor.js
@@ -73,6 +73,8 @@ assert.sameValue(
   desc.value, 43,
   'sets a data descriptor on the receiver object to set a new property'
 );
-verifyWritable(receiver, 'p');
-verifyEnumerable(receiver, 'p');
-verifyConfigurable(receiver, 'p');
+verifyProperty(receiver, 'p', {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});

--- a/test/built-ins/Reflect/set/creates-a-data-descriptor.js
+++ b/test/built-ins/Reflect/set/creates-a-data-descriptor.js
@@ -52,9 +52,11 @@ assert.sameValue(
   desc.value, 42,
   'sets a data descriptor to set a new property'
 );
-verifyWritable(o1, 'p');
-verifyEnumerable(o1, 'p');
-verifyConfigurable(o1, 'p');
+verifyProperty(o1, 'p', {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
 
 var o2 = {};
 var receiver = {};

--- a/test/built-ins/Reflect/set/set.js
+++ b/test/built-ins/Reflect/set/set.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'set');
-verifyWritable(Reflect, 'set');
-verifyConfigurable(Reflect, 'set');
+verifyProperty(Reflect, 'set', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Reflect/setPrototypeOf/setPrototypeOf.js
+++ b/test/built-ins/Reflect/setPrototypeOf/setPrototypeOf.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js]
 features: [Reflect]
 ---*/
 
-verifyNotEnumerable(Reflect, 'setPrototypeOf');
-verifyWritable(Reflect, 'setPrototypeOf');
-verifyConfigurable(Reflect, 'setPrototypeOf');
+verifyProperty(Reflect, 'setPrototypeOf', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/RegExp/lastIndex.js
+++ b/test/built-ins/RegExp/lastIndex.js
@@ -27,6 +27,8 @@ var re = new RegExp('');
 
 assert.sameValue(re.lastIndex, 0);
 
-verifyNotEnumerable(re, 'lastIndex');
-verifyWritable(re, 'lastIndex');
-verifyNotConfigurable(re, 'lastIndex');
+verifyProperty(re, 'lastIndex', {
+  writable: true,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/RegExp/named-groups/groups-properties.js
+++ b/test/built-ins/RegExp/named-groups/groups-properties.js
@@ -27,6 +27,8 @@ assert.sameValue(counter, 0);
 
 // Properties are writable, enumerable and configurable
 // (from CreateDataProperty)
-verifyWritable(groups, "x");
-verifyEnumerable(groups, "x");
-verifyConfigurable(groups, "x");
+verifyProperty(groups, "x", {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});

--- a/test/built-ins/RegExp/prop-desc.js
+++ b/test/built-ins/RegExp/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "RegExp");
-verifyWritable(this, "RegExp");
-verifyConfigurable(this, "RegExp");
+verifyProperty(this, "RegExp", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/RegExp/prototype/Symbol.match/prop-desc.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/prop-desc.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 features: [Symbol.match]
 ---*/
 
-verifyNotEnumerable(RegExp.prototype, Symbol.match);
-verifyWritable(RegExp.prototype, Symbol.match);
-verifyConfigurable(RegExp.prototype, Symbol.match);
+verifyProperty(RegExp.prototype, Symbol.match, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/RegExp/prototype/Symbol.matchAll/prop-desc.js
+++ b/test/built-ins/RegExp/prototype/Symbol.matchAll/prop-desc.js
@@ -17,6 +17,8 @@ features: [Symbol.matchAll]
 
 assert.sameValue(typeof RegExp.prototype[Symbol.matchAll], 'function');
 
-verifyNotEnumerable(RegExp.prototype, Symbol.matchAll);
-verifyWritable(RegExp.prototype, Symbol.matchAll);
-verifyConfigurable(RegExp.prototype, Symbol.matchAll);
+verifyProperty(RegExp.prototype, Symbol.matchAll, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/RegExp/prototype/Symbol.replace/prop-desc.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/prop-desc.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 features: [Symbol.replace]
 ---*/
 
-verifyNotEnumerable(RegExp.prototype, Symbol.replace);
-verifyWritable(RegExp.prototype, Symbol.replace);
-verifyConfigurable(RegExp.prototype, Symbol.replace);
+verifyProperty(RegExp.prototype, Symbol.replace, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/RegExp/prototype/Symbol.search/prop-desc.js
+++ b/test/built-ins/RegExp/prototype/Symbol.search/prop-desc.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 features: [Symbol.search]
 ---*/
 
-verifyNotEnumerable(RegExp.prototype, Symbol.search);
-verifyWritable(RegExp.prototype, Symbol.search);
-verifyConfigurable(RegExp.prototype, Symbol.search);
+verifyProperty(RegExp.prototype, Symbol.search, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/prop-desc.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/prop-desc.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 features: [Symbol.split]
 ---*/
 
-verifyNotEnumerable(RegExp.prototype, Symbol.split);
-verifyWritable(RegExp.prototype, Symbol.split);
-verifyConfigurable(RegExp.prototype, Symbol.split);
+verifyProperty(RegExp.prototype, Symbol.split, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/RegExpStringIteratorPrototype/Symbol.toStringTag.js
+++ b/test/built-ins/RegExpStringIteratorPrototype/Symbol.toStringTag.js
@@ -18,6 +18,8 @@ var RegExpStringIteratorProto = Object.getPrototypeOf(/./[Symbol.matchAll](''));
 
 assert.sameValue(RegExpStringIteratorProto[Symbol.toStringTag], 'RegExp String Iterator');
 
-verifyNotEnumerable(RegExpStringIteratorProto, Symbol.toStringTag);
-verifyNotWritable(RegExpStringIteratorProto, Symbol.toStringTag);
-verifyConfigurable(RegExpStringIteratorProto, Symbol.toStringTag);
+verifyProperty(RegExpStringIteratorProto, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/RegExpStringIteratorPrototype/next/prop-desc.js
+++ b/test/built-ins/RegExpStringIteratorPrototype/next/prop-desc.js
@@ -20,6 +20,8 @@ var RegExpStringIteratorProto = Object.getPrototypeOf(/./[Symbol.matchAll](''));
 
 assert.sameValue(typeof RegExpStringIteratorProto.next, 'function');
 
-verifyNotEnumerable(RegExpStringIteratorProto, 'next');
-verifyWritable(RegExpStringIteratorProto, 'next');
-verifyConfigurable(RegExpStringIteratorProto, 'next');
+verifyProperty(RegExpStringIteratorProto, 'next', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Set/prototype/Symbol.iterator.js
+++ b/test/built-ins/Set/prototype/Symbol.iterator.js
@@ -15,6 +15,8 @@ features: [Symbol.iterator]
 ---*/
 
 assert.sameValue(Set.prototype[Symbol.iterator], Set.prototype.values);
-verifyNotEnumerable(Set.prototype, Symbol.iterator);
-verifyWritable(Set.prototype, Symbol.iterator);
-verifyConfigurable(Set.prototype, Symbol.iterator);
+verifyProperty(Set.prototype, Symbol.iterator, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/Set/prototype/Symbol.toStringTag.js
@@ -16,6 +16,8 @@ features: [Symbol.toStringTag]
 
 assert.sameValue(Set.prototype[Symbol.toStringTag], 'Set');
 
-verifyNotEnumerable(Set.prototype, Symbol.toStringTag);
-verifyNotWritable(Set.prototype, Symbol.toStringTag);
-verifyConfigurable(Set.prototype, Symbol.toStringTag);
+verifyProperty(Set.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/prototype/Symbol.toStringTag/property-descriptor.js
+++ b/test/built-ins/Set/prototype/Symbol.toStringTag/property-descriptor.js
@@ -18,6 +18,8 @@ assert.sameValue(
   "The value of `SetProto[Symbol.toStringTag]` is `'Set'`"
 );
 
-verifyNotEnumerable(SetProto, Symbol.toStringTag);
-verifyNotWritable(SetProto, Symbol.toStringTag);
-verifyConfigurable(SetProto, Symbol.toStringTag);
+verifyProperty(SetProto, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/prototype/add/add.js
+++ b/test/built-ins/Set/prototype/add/add.js
@@ -16,6 +16,8 @@ assert.sameValue(
   "`typeof Set.prototype.add` is `'function'`"
 );
 
-verifyNotEnumerable(Set.prototype, "add");
-verifyWritable(Set.prototype, "add");
-verifyConfigurable(Set.prototype, "add");
+verifyProperty(Set.prototype, "add", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/prototype/clear/clear.js
+++ b/test/built-ins/Set/prototype/clear/clear.js
@@ -16,6 +16,8 @@ assert.sameValue(
   "`typeof Set.prototype.clear` is `'function'`"
 );
 
-verifyNotEnumerable(Set.prototype, "clear");
-verifyWritable(Set.prototype, "clear");
-verifyConfigurable(Set.prototype, "clear");
+verifyProperty(Set.prototype, "clear", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/prototype/constructor/set-prototype-constructor.js
+++ b/test/built-ins/Set/prototype/constructor/set-prototype-constructor.js
@@ -10,6 +10,8 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Set.prototype, "constructor");
-verifyWritable(Set.prototype, "constructor");
-verifyConfigurable(Set.prototype, "constructor");
+verifyProperty(Set.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/prototype/delete/delete.js
+++ b/test/built-ins/Set/prototype/delete/delete.js
@@ -16,6 +16,8 @@ assert.sameValue(
   "`typeof Set.prototype.delete` is `'function'`"
 );
 
-verifyNotEnumerable(Set.prototype, "delete");
-verifyWritable(Set.prototype, "delete");
-verifyConfigurable(Set.prototype, "delete");
+verifyProperty(Set.prototype, "delete", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/prototype/entries/entries.js
+++ b/test/built-ins/Set/prototype/entries/entries.js
@@ -16,6 +16,8 @@ assert.sameValue(
   "`typeof Set.prototype.entries` is `'function'`"
 );
 
-verifyNotEnumerable(Set.prototype, "entries");
-verifyWritable(Set.prototype, "entries");
-verifyConfigurable(Set.prototype, "entries");
+verifyProperty(Set.prototype, "entries", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/prototype/forEach/forEach.js
+++ b/test/built-ins/Set/prototype/forEach/forEach.js
@@ -16,6 +16,8 @@ assert.sameValue(
   "`typeof Set.prototype.forEach` is `'function'`"
 );
 
-verifyNotEnumerable(Set.prototype, "forEach");
-verifyWritable(Set.prototype, "forEach");
-verifyConfigurable(Set.prototype, "forEach");
+verifyProperty(Set.prototype, "forEach", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/prototype/has/has.js
+++ b/test/built-ins/Set/prototype/has/has.js
@@ -16,6 +16,8 @@ assert.sameValue(
   "`typeof Set.prototype.has` is `'function'`"
 );
 
-verifyNotEnumerable(Set.prototype, "has");
-verifyWritable(Set.prototype, "has");
-verifyConfigurable(Set.prototype, "has");
+verifyProperty(Set.prototype, "has", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/prototype/values/values.js
+++ b/test/built-ins/Set/prototype/values/values.js
@@ -16,6 +16,8 @@ assert.sameValue(
   "`typeof Set.prototype.values` is `'function'`"
 );
 
-verifyNotEnumerable(Set.prototype, "values");
-verifyWritable(Set.prototype, "values");
-verifyConfigurable(Set.prototype, "values");
+verifyProperty(Set.prototype, "values", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Set/set.js
+++ b/test/built-ins/Set/set.js
@@ -10,6 +10,8 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "Set");
-verifyWritable(this, "Set");
-verifyConfigurable(this, "Set");
+verifyProperty(this, "Set", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/SetIteratorPrototype/Symbol.toStringTag.js
+++ b/test/built-ins/SetIteratorPrototype/Symbol.toStringTag.js
@@ -24,6 +24,8 @@ assert.sameValue(
   '`Set Iterator` is `SetIteratorProto[Symbol.toStringTag]`'
 );
 
-verifyNotEnumerable(SetIteratorProto, Symbol.toStringTag);
-verifyNotWritable(SetIteratorProto, Symbol.toStringTag);
-verifyConfigurable(SetIteratorProto, Symbol.toStringTag);
+verifyProperty(SetIteratorProto, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/SharedArrayBuffer/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/SharedArrayBuffer/prototype/Symbol.toStringTag.js
@@ -16,6 +16,8 @@ features: [SharedArrayBuffer, Symbol.toStringTag]
 
 assert.sameValue(SharedArrayBuffer.prototype[Symbol.toStringTag], 'SharedArrayBuffer');
 
-verifyNotEnumerable(SharedArrayBuffer.prototype, Symbol.toStringTag);
-verifyNotWritable(SharedArrayBuffer.prototype, Symbol.toStringTag);
-verifyConfigurable(SharedArrayBuffer.prototype, Symbol.toStringTag);
+verifyProperty(SharedArrayBuffer.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/SharedArrayBuffer/prototype/constructor.js
+++ b/test/built-ins/SharedArrayBuffer/prototype/constructor.js
@@ -11,6 +11,8 @@ features: [SharedArrayBuffer]
 
 assert.sameValue(SharedArrayBuffer.prototype.constructor, SharedArrayBuffer);
 
-verifyNotEnumerable(SharedArrayBuffer.prototype, "constructor");
-verifyWritable(SharedArrayBuffer.prototype, "constructor");
-verifyConfigurable(SharedArrayBuffer.prototype, "constructor");
+verifyProperty(SharedArrayBuffer.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/SharedArrayBuffer/prototype/slice/descriptor.js
+++ b/test/built-ins/SharedArrayBuffer/prototype/slice/descriptor.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 features: [SharedArrayBuffer]
 ---*/
 
-verifyNotEnumerable(SharedArrayBuffer.prototype, "slice");
-verifyWritable(SharedArrayBuffer.prototype, "slice");
-verifyConfigurable(SharedArrayBuffer.prototype, "slice");
+verifyProperty(SharedArrayBuffer.prototype, "slice", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/fromCodePoint/fromCodePoint.js
+++ b/test/built-ins/String/fromCodePoint/fromCodePoint.js
@@ -12,6 +12,8 @@ includes: [propertyHelper.js]
 features: [String.fromCodePoint]
 ---*/
 
-verifyNotEnumerable(String, 'fromCodePoint');
-verifyWritable(String, 'fromCodePoint');
-verifyConfigurable(String, 'fromCodePoint');
+verifyProperty(String, 'fromCodePoint', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/String/length.js
+++ b/test/built-ins/String/length.js
@@ -12,9 +12,11 @@ includes: [propertyHelper.js]
 
 var str = new String('');
 
-verifyNotEnumerable(str, 'length');
-verifyNotWritable(str, 'length');
-verifyNotConfigurable(str, 'length');
+verifyProperty(str, 'length', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});
 
 assert.sameValue(str.length, 0, 'empty string');
 

--- a/test/built-ins/String/numeric-properties.js
+++ b/test/built-ins/String/numeric-properties.js
@@ -16,16 +16,22 @@ includes: [propertyHelper.js]
 var str = new String('abc');
 
 assert.sameValue(str[0], 'a');
-verifyEnumerable(str, '0');
-verifyNotWritable(str, '0');
-verifyNotConfigurable(str, '0');
+verifyProperty(str, '0', {
+  writable: false,
+  enumerable: true,
+  configurable: false,
+});
 
 assert.sameValue(str[1], 'b');
-verifyEnumerable(str, '1');
-verifyNotWritable(str, '1');
-verifyNotConfigurable(str, '1');
+verifyProperty(str, '1', {
+  writable: false,
+  enumerable: true,
+  configurable: false,
+});
 
 assert.sameValue(str[2], 'c');
-verifyEnumerable(str, '2');
-verifyNotWritable(str, '2');
-verifyNotConfigurable(str, '2');
+verifyProperty(str, '2', {
+  writable: false,
+  enumerable: true,
+  configurable: false,
+});

--- a/test/built-ins/String/prop-desc.js
+++ b/test/built-ins/String/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "String");
-verifyWritable(this, "String");
-verifyConfigurable(this, "String");
+verifyProperty(this, "String", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/String/prototype/Symbol.iterator/prop-desc.js
+++ b/test/built-ins/String/prototype/Symbol.iterator/prop-desc.js
@@ -14,6 +14,8 @@ includes: [propertyHelper.js]
 ---*/
 
 assert.sameValue(typeof String.prototype[Symbol.iterator], 'function');
-verifyNotEnumerable(String.prototype, Symbol.iterator);
-verifyWritable(String.prototype, Symbol.iterator);
-verifyConfigurable(String.prototype, Symbol.iterator);
+verifyProperty(String.prototype, Symbol.iterator, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/prototype/codePointAt/codePointAt.js
+++ b/test/built-ins/String/prototype/codePointAt/codePointAt.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof String.prototype.codePointAt` is `function`'
 );
 
-verifyNotEnumerable(String.prototype, 'codePointAt');
-verifyWritable(String.prototype, 'codePointAt');
-verifyConfigurable(String.prototype, 'codePointAt');
+verifyProperty(String.prototype, 'codePointAt', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/prototype/endsWith/endsWith.js
+++ b/test/built-ins/String/prototype/endsWith/endsWith.js
@@ -18,6 +18,8 @@ assert.sameValue(
   '`typeof String.prototype.endsWith` is `function`'
 );
 
-verifyNotEnumerable(String.prototype, 'endsWith');
-verifyWritable(String.prototype, 'endsWith');
-verifyConfigurable(String.prototype, 'endsWith');
+verifyProperty(String.prototype, 'endsWith', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/prototype/includes/includes.js
+++ b/test/built-ins/String/prototype/includes/includes.js
@@ -18,6 +18,8 @@ assert.sameValue(
   '`typeof String.prototype.includes` is `function`'
 );
 
-verifyNotEnumerable(String.prototype, 'includes');
-verifyWritable(String.prototype, 'includes');
-verifyConfigurable(String.prototype, 'includes');
+verifyProperty(String.prototype, 'includes', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/prototype/match/length.js
+++ b/test/built-ins/String/prototype/match/length.js
@@ -38,6 +38,8 @@ if (String.prototype.match.length !== 1) {
 //
 //////////////////////////////////////////////////////////////////////////////
 
-verifyNotEnumerable(String.prototype.match, 'length');
-verifyNotWritable(String.prototype.match, 'length');
-verifyConfigurable(String.prototype.match, 'length');
+verifyProperty(String.prototype.match, 'length', {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/prototype/matchAll/prop-desc.js
+++ b/test/built-ins/String/prototype/matchAll/prop-desc.js
@@ -17,6 +17,8 @@ features: [String.prototype.matchAll]
 
 assert.sameValue(typeof String.prototype.matchAll, 'function');
 
-verifyNotEnumerable(String.prototype, 'matchAll');
-verifyWritable(String.prototype, 'matchAll');
-verifyConfigurable(String.prototype, 'matchAll');
+verifyProperty(String.prototype, 'matchAll', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/prototype/normalize/normalize.js
+++ b/test/built-ins/String/prototype/normalize/normalize.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof String.prototype.normalize` is `function`'
 );
 
-verifyNotEnumerable(String.prototype, 'normalize');
-verifyWritable(String.prototype, 'normalize');
-verifyConfigurable(String.prototype, 'normalize');
+verifyProperty(String.prototype, 'normalize', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/prototype/padEnd/function-property-descriptor.js
+++ b/test/built-ins/String/prototype/padEnd/function-property-descriptor.js
@@ -8,6 +8,8 @@ author: Jordan Harband
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(String.prototype, 'padEnd');
-verifyWritable(String.prototype, 'padEnd');
-verifyConfigurable(String.prototype, 'padEnd');
+verifyProperty(String.prototype, 'padEnd', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/prototype/padStart/function-property-descriptor.js
+++ b/test/built-ins/String/prototype/padStart/function-property-descriptor.js
@@ -8,6 +8,8 @@ author: Jordan Harband
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(String.prototype, 'padStart');
-verifyWritable(String.prototype, 'padStart');
-verifyConfigurable(String.prototype, 'padStart');
+verifyProperty(String.prototype, 'padStart', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/prototype/repeat/repeat.js
+++ b/test/built-ins/String/prototype/repeat/repeat.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof String.prototype.repeat` is `function`'
 );
 
-verifyNotEnumerable(String.prototype, 'repeat');
-verifyWritable(String.prototype, 'repeat');
-verifyConfigurable(String.prototype, 'repeat');
+verifyProperty(String.prototype, 'repeat', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/prototype/startsWith/startsWith.js
+++ b/test/built-ins/String/prototype/startsWith/startsWith.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof String.prototype.startsWith` is `function`'
 );
 
-verifyNotEnumerable(String.prototype, 'startsWith');
-verifyWritable(String.prototype, 'startsWith');
-verifyConfigurable(String.prototype, 'startsWith');
+verifyProperty(String.prototype, 'startsWith', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/String/raw/raw.js
+++ b/test/built-ins/String/raw/raw.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(String, 'raw');
-verifyWritable(String, 'raw');
-verifyConfigurable(String, 'raw');
+verifyProperty(String, 'raw', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/StringIteratorPrototype/Symbol.toStringTag.js
+++ b/test/built-ins/StringIteratorPrototype/Symbol.toStringTag.js
@@ -18,6 +18,8 @@ var StringIteratorProto = Object.getPrototypeOf(''[Symbol.iterator]());
 
 assert.sameValue(StringIteratorProto[Symbol.toStringTag], 'String Iterator');
 
-verifyNotEnumerable(StringIteratorProto, Symbol.toStringTag);
-verifyNotWritable(StringIteratorProto, Symbol.toStringTag);
-verifyConfigurable(StringIteratorProto, Symbol.toStringTag);
+verifyProperty(StringIteratorProto, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Symbol/asyncDispose/prop-desc.js
+++ b/test/built-ins/Symbol/asyncDispose/prop-desc.js
@@ -12,6 +12,8 @@ features: [explicit-resource-management]
 ---*/
 
 assert.sameValue(typeof Symbol.asyncDispose, 'symbol');
-verifyNotEnumerable(Symbol, 'asyncDispose');
-verifyNotWritable(Symbol, 'asyncDispose');
-verifyNotConfigurable(Symbol, 'asyncDispose');
+verifyProperty(Symbol, 'asyncDispose', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/dispose/prop-desc.js
+++ b/test/built-ins/Symbol/dispose/prop-desc.js
@@ -12,6 +12,8 @@ features: [explicit-resource-management]
 ---*/
 
 assert.sameValue(typeof Symbol.dispose, 'symbol');
-verifyNotEnumerable(Symbol, 'dispose');
-verifyNotWritable(Symbol, 'dispose');
-verifyNotConfigurable(Symbol, 'dispose');
+verifyProperty(Symbol, 'dispose', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/for/prop-desc.js
+++ b/test/built-ins/Symbol/for/prop-desc.js
@@ -13,6 +13,8 @@ features: [Symbol]
 
 assert.sameValue(typeof Symbol.for, 'function');
 
-verifyNotEnumerable(Symbol, 'for');
-verifyWritable(Symbol, 'for');
-verifyConfigurable(Symbol, 'for');
+verifyProperty(Symbol, 'for', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Symbol/hasInstance/prop-desc.js
+++ b/test/built-ins/Symbol/hasInstance/prop-desc.js
@@ -11,6 +11,8 @@ features: [Symbol.hasInstance]
 ---*/
 
 assert.sameValue(typeof Symbol.hasInstance, 'symbol');
-verifyNotEnumerable(Symbol, 'hasInstance');
-verifyNotWritable(Symbol, 'hasInstance');
-verifyNotConfigurable(Symbol, 'hasInstance');
+verifyProperty(Symbol, 'hasInstance', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/isConcatSpreadable/prop-desc.js
+++ b/test/built-ins/Symbol/isConcatSpreadable/prop-desc.js
@@ -11,6 +11,8 @@ features: [Symbol.isConcatSpreadable]
 ---*/
 
 assert.sameValue(typeof Symbol.isConcatSpreadable, 'symbol');
-verifyNotEnumerable(Symbol, 'isConcatSpreadable');
-verifyNotWritable(Symbol, 'isConcatSpreadable');
-verifyNotConfigurable(Symbol, 'isConcatSpreadable');
+verifyProperty(Symbol, 'isConcatSpreadable', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/iterator/prop-desc.js
+++ b/test/built-ins/Symbol/iterator/prop-desc.js
@@ -12,6 +12,8 @@ features: [Symbol.iterator]
 ---*/
 
 assert.sameValue(typeof Symbol.iterator, 'symbol');
-verifyNotEnumerable(Symbol, 'iterator');
-verifyNotWritable(Symbol, 'iterator');
-verifyNotConfigurable(Symbol, 'iterator');
+verifyProperty(Symbol, 'iterator', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/keyFor/prop-desc.js
+++ b/test/built-ins/Symbol/keyFor/prop-desc.js
@@ -13,6 +13,8 @@ features: [Symbol]
 
 assert.sameValue(typeof Symbol.keyFor, 'function');
 
-verifyNotEnumerable(Symbol, 'keyFor');
-verifyWritable(Symbol, 'keyFor');
-verifyConfigurable(Symbol, 'keyFor');
+verifyProperty(Symbol, 'keyFor', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Symbol/match/prop-desc.js
+++ b/test/built-ins/Symbol/match/prop-desc.js
@@ -12,6 +12,8 @@ features: [Symbol.match]
 ---*/
 
 assert.sameValue(typeof Symbol.match, 'symbol');
-verifyNotEnumerable(Symbol, 'match');
-verifyNotWritable(Symbol, 'match');
-verifyNotConfigurable(Symbol, 'match');
+verifyProperty(Symbol, 'match', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/matchAll/prop-desc.js
+++ b/test/built-ins/Symbol/matchAll/prop-desc.js
@@ -12,6 +12,8 @@ features: [Symbol.matchAll]
 ---*/
 
 assert.sameValue(typeof Symbol.matchAll, 'symbol');
-verifyNotEnumerable(Symbol, 'matchAll');
-verifyNotWritable(Symbol, 'matchAll');
-verifyNotConfigurable(Symbol, 'matchAll');
+verifyProperty(Symbol, 'matchAll', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/prototype/Symbol.toPrimitive/prop-desc.js
+++ b/test/built-ins/Symbol/prototype/Symbol.toPrimitive/prop-desc.js
@@ -11,6 +11,8 @@ includes: [propertyHelper.js]
 features: [Symbol.toPrimitive]
 ---*/
 
-verifyNotEnumerable(Symbol.prototype, Symbol.toPrimitive);
-verifyNotWritable(Symbol.prototype, Symbol.toPrimitive);
-verifyConfigurable(Symbol.prototype, Symbol.toPrimitive);
+verifyProperty(Symbol.prototype, Symbol.toPrimitive, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Symbol/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/Symbol/prototype/Symbol.toStringTag.js
@@ -16,6 +16,8 @@ features: [Symbol.toStringTag]
 
 assert.sameValue(Symbol.prototype[Symbol.toStringTag], 'Symbol');
 
-verifyNotEnumerable(Symbol.prototype, Symbol.toStringTag);
-verifyNotWritable(Symbol.prototype, Symbol.toStringTag);
-verifyConfigurable(Symbol.prototype, Symbol.toStringTag);
+verifyProperty(Symbol.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Symbol/prototype/constructor.js
+++ b/test/built-ins/Symbol/prototype/constructor.js
@@ -13,6 +13,8 @@ features: [Symbol]
 
 assert.sameValue(Symbol.prototype.constructor, Symbol);
 
-verifyNotEnumerable(Symbol.prototype, 'constructor');
-verifyWritable(Symbol.prototype, 'constructor');
-verifyConfigurable(Symbol.prototype, 'constructor');
+verifyProperty(Symbol.prototype, 'constructor', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Symbol/prototype/toString/prop-desc.js
+++ b/test/built-ins/Symbol/prototype/toString/prop-desc.js
@@ -13,6 +13,8 @@ features: [Symbol]
 
 assert.sameValue(typeof Symbol.prototype.toString, 'function');
 
-verifyNotEnumerable(Symbol.prototype, 'toString');
-verifyWritable(Symbol.prototype, 'toString');
-verifyConfigurable(Symbol.prototype, 'toString');
+verifyProperty(Symbol.prototype, 'toString', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Symbol/prototype/valueOf/prop-desc.js
+++ b/test/built-ins/Symbol/prototype/valueOf/prop-desc.js
@@ -13,6 +13,8 @@ features: [Symbol]
 
 assert.sameValue(typeof Symbol.prototype.valueOf, 'function');
 
-verifyNotEnumerable(Symbol.prototype, 'valueOf');
-verifyWritable(Symbol.prototype, 'valueOf');
-verifyConfigurable(Symbol.prototype, 'valueOf');
+verifyProperty(Symbol.prototype, 'valueOf', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Symbol/replace/prop-desc.js
+++ b/test/built-ins/Symbol/replace/prop-desc.js
@@ -12,6 +12,8 @@ features: [Symbol.replace]
 ---*/
 
 assert.sameValue(typeof Symbol.replace, 'symbol');
-verifyNotEnumerable(Symbol, 'replace');
-verifyNotWritable(Symbol, 'replace');
-verifyNotConfigurable(Symbol, 'replace');
+verifyProperty(Symbol, 'replace', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/search/prop-desc.js
+++ b/test/built-ins/Symbol/search/prop-desc.js
@@ -12,6 +12,8 @@ features: [Symbol.search]
 ---*/
 
 assert.sameValue(typeof Symbol.search, 'symbol');
-verifyNotEnumerable(Symbol, 'search');
-verifyNotWritable(Symbol, 'search');
-verifyNotConfigurable(Symbol, 'search');
+verifyProperty(Symbol, 'search', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/species/basic.js
+++ b/test/built-ins/Symbol/species/basic.js
@@ -14,6 +14,8 @@ features: [Symbol.species]
 assert(Symbol !== undefined, "Symbol exists");
 assert(Symbol.species !== undefined, "Symbol.species exists");
 
-verifyNotWritable(Symbol, "species");
-verifyNotEnumerable(Symbol, "species");
-verifyNotConfigurable(Symbol, "species");
+verifyProperty(Symbol, "species", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/split/prop-desc.js
+++ b/test/built-ins/Symbol/split/prop-desc.js
@@ -12,6 +12,8 @@ features: [Symbol.split]
 ---*/
 
 assert.sameValue(typeof Symbol.split, 'symbol');
-verifyNotEnumerable(Symbol, 'split');
-verifyNotWritable(Symbol, 'split');
-verifyNotConfigurable(Symbol, 'split');
+verifyProperty(Symbol, 'split', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/symbol.js
+++ b/test/built-ins/Symbol/symbol.js
@@ -11,6 +11,8 @@ includes: [propertyHelper.js]
 features: [Symbol]
 ---*/
 
-verifyNotEnumerable(this, "Symbol");
-verifyWritable(this, "Symbol");
-verifyConfigurable(this, "Symbol");
+verifyProperty(this, "Symbol", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/Symbol/toPrimitive/prop-desc.js
+++ b/test/built-ins/Symbol/toPrimitive/prop-desc.js
@@ -12,6 +12,8 @@ features: [Symbol.toPrimitive]
 ---*/
 
 assert.sameValue(typeof Symbol.toPrimitive, 'symbol');
-verifyNotEnumerable(Symbol, 'toPrimitive');
-verifyNotWritable(Symbol, 'toPrimitive');
-verifyNotConfigurable(Symbol, 'toPrimitive');
+verifyProperty(Symbol, 'toPrimitive', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/toStringTag/prop-desc.js
+++ b/test/built-ins/Symbol/toStringTag/prop-desc.js
@@ -12,6 +12,8 @@ features: [Symbol.toStringTag]
 ---*/
 
 assert.sameValue(typeof Symbol.toStringTag, 'symbol');
-verifyNotEnumerable(Symbol, 'toStringTag');
-verifyNotWritable(Symbol, 'toStringTag');
-verifyNotConfigurable(Symbol, 'toStringTag');
+verifyProperty(Symbol, 'toStringTag', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Symbol/unscopables/prop-desc.js
+++ b/test/built-ins/Symbol/unscopables/prop-desc.js
@@ -12,6 +12,8 @@ features: [Symbol.unscopables]
 ---*/
 
 assert.sameValue(typeof Symbol.unscopables, 'symbol');
-verifyNotEnumerable(Symbol, 'unscopables');
-verifyNotWritable(Symbol, 'unscopables');
-verifyNotConfigurable(Symbol, 'unscopables');
+verifyProperty(Symbol, 'unscopables', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/TypedArray/from/prop-desc.js
+++ b/test/built-ins/TypedArray/from/prop-desc.js
@@ -12,6 +12,8 @@ includes: [propertyHelper.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-verifyNotEnumerable(TypedArray, 'from');
-verifyWritable(TypedArray, 'from');
-verifyConfigurable(TypedArray, 'from');
+verifyProperty(TypedArray, 'from', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/of/prop-desc.js
+++ b/test/built-ins/TypedArray/of/prop-desc.js
@@ -12,6 +12,8 @@ includes: [propertyHelper.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-verifyNotEnumerable(TypedArray, 'of');
-verifyWritable(TypedArray, 'of');
-verifyConfigurable(TypedArray, 'of');
+verifyProperty(TypedArray, 'of', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype.js
+++ b/test/built-ins/TypedArray/prototype.js
@@ -13,6 +13,8 @@ includes: [propertyHelper.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-verifyNotEnumerable(TypedArray, 'prototype');
-verifyNotWritable(TypedArray, 'prototype');
-verifyNotConfigurable(TypedArray, 'prototype');
+verifyProperty(TypedArray, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/TypedArray/prototype/Symbol.iterator.js
+++ b/test/built-ins/TypedArray/prototype/Symbol.iterator.js
@@ -17,6 +17,8 @@ features: [Symbol.iterator]
 
 assert.sameValue(TypedArray.prototype[Symbol.iterator], TypedArray.prototype.values);
 
-verifyNotEnumerable(TypedArray.prototype, Symbol.iterator);
-verifyWritable(TypedArray.prototype, Symbol.iterator);
-verifyConfigurable(TypedArray.prototype, Symbol.iterator);
+verifyProperty(TypedArray.prototype, Symbol.iterator, {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/TypedArray/prototype/constructor.js
+++ b/test/built-ins/TypedArray/prototype/constructor.js
@@ -16,6 +16,8 @@ features: [TypedArray]
 
 assert.sameValue(TypedArray.prototype.constructor, TypedArray);
 
-verifyNotEnumerable(TypedArray.prototype, "constructor");
-verifyWritable(TypedArray.prototype, "constructor");
-verifyConfigurable(TypedArray.prototype, "constructor");
+verifyProperty(TypedArray.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/TypedArray/prototype/copyWithin/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'copyWithin');
-verifyWritable(TypedArrayPrototype, 'copyWithin');
-verifyConfigurable(TypedArrayPrototype, 'copyWithin');
+verifyProperty(TypedArrayPrototype, 'copyWithin', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/entries/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/entries/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'entries');
-verifyWritable(TypedArrayPrototype, 'entries');
-verifyConfigurable(TypedArrayPrototype, 'entries');
+verifyProperty(TypedArrayPrototype, 'entries', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/every/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/every/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'every');
-verifyWritable(TypedArrayPrototype, 'every');
-verifyConfigurable(TypedArrayPrototype, 'every');
+verifyProperty(TypedArrayPrototype, 'every', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/fill/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/fill/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'fill');
-verifyWritable(TypedArrayPrototype, 'fill');
-verifyConfigurable(TypedArrayPrototype, 'fill');
+verifyProperty(TypedArrayPrototype, 'fill', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/filter/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/filter/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'filter');
-verifyWritable(TypedArrayPrototype, 'filter');
-verifyConfigurable(TypedArrayPrototype, 'filter');
+verifyProperty(TypedArrayPrototype, 'filter', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/find/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/find/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'find');
-verifyWritable(TypedArrayPrototype, 'find');
-verifyConfigurable(TypedArrayPrototype, 'find');
+verifyProperty(TypedArrayPrototype, 'find', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/findIndex/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'findIndex');
-verifyWritable(TypedArrayPrototype, 'findIndex');
-verifyConfigurable(TypedArrayPrototype, 'findIndex');
+verifyProperty(TypedArrayPrototype, 'findIndex', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/forEach/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/forEach/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'forEach');
-verifyWritable(TypedArrayPrototype, 'forEach');
-verifyConfigurable(TypedArrayPrototype, 'forEach');
+verifyProperty(TypedArrayPrototype, 'forEach', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/includes/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/includes/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, "includes");
-verifyWritable(TypedArrayPrototype, "includes");
-verifyConfigurable(TypedArrayPrototype, "includes");
+verifyProperty(TypedArrayPrototype, "includes", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/indexOf/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'indexOf');
-verifyWritable(TypedArrayPrototype, 'indexOf');
-verifyConfigurable(TypedArrayPrototype, 'indexOf');
+verifyProperty(TypedArrayPrototype, 'indexOf', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/join/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/join/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'join');
-verifyWritable(TypedArrayPrototype, 'join');
-verifyConfigurable(TypedArrayPrototype, 'join');
+verifyProperty(TypedArrayPrototype, 'join', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/keys/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/keys/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'keys');
-verifyWritable(TypedArrayPrototype, 'keys');
-verifyConfigurable(TypedArrayPrototype, 'keys');
+verifyProperty(TypedArrayPrototype, 'keys', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'lastIndexOf');
-verifyWritable(TypedArrayPrototype, 'lastIndexOf');
-verifyConfigurable(TypedArrayPrototype, 'lastIndexOf');
+verifyProperty(TypedArrayPrototype, 'lastIndexOf', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/map/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/map/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'map');
-verifyWritable(TypedArrayPrototype, 'map');
-verifyConfigurable(TypedArrayPrototype, 'map');
+verifyProperty(TypedArrayPrototype, 'map', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/reduce/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/reduce/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'reduce');
-verifyWritable(TypedArrayPrototype, 'reduce');
-verifyConfigurable(TypedArrayPrototype, 'reduce');
+verifyProperty(TypedArrayPrototype, 'reduce', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/reduceRight/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'reduceRight');
-verifyWritable(TypedArrayPrototype, 'reduceRight');
-verifyConfigurable(TypedArrayPrototype, 'reduceRight');
+verifyProperty(TypedArrayPrototype, 'reduceRight', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/reverse/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/reverse/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'reverse');
-verifyWritable(TypedArrayPrototype, 'reverse');
-verifyConfigurable(TypedArrayPrototype, 'reverse');
+verifyProperty(TypedArrayPrototype, 'reverse', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/set/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/set/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'set');
-verifyWritable(TypedArrayPrototype, 'set');
-verifyConfigurable(TypedArrayPrototype, 'set');
+verifyProperty(TypedArrayPrototype, 'set', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/slice/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/slice/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'slice');
-verifyWritable(TypedArrayPrototype, 'slice');
-verifyConfigurable(TypedArrayPrototype, 'slice');
+verifyProperty(TypedArrayPrototype, 'slice', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/some/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/some/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'some');
-verifyWritable(TypedArrayPrototype, 'some');
-verifyConfigurable(TypedArrayPrototype, 'some');
+verifyProperty(TypedArrayPrototype, 'some', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/sort/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/sort/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'sort');
-verifyWritable(TypedArrayPrototype, 'sort');
-verifyConfigurable(TypedArrayPrototype, 'sort');
+verifyProperty(TypedArrayPrototype, 'sort', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/subarray/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/subarray/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'subarray');
-verifyWritable(TypedArrayPrototype, 'subarray');
-verifyConfigurable(TypedArrayPrototype, 'subarray');
+verifyProperty(TypedArrayPrototype, 'subarray', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'toLocaleString');
-verifyWritable(TypedArrayPrototype, 'toLocaleString');
-verifyConfigurable(TypedArrayPrototype, 'toLocaleString');
+verifyProperty(TypedArrayPrototype, 'toLocaleString', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/toString.js
+++ b/test/built-ins/TypedArray/prototype/toString.js
@@ -22,6 +22,8 @@ var TypedArrayPrototype = TypedArray.prototype;
 
 assert.sameValue(TypedArrayPrototype.toString, Array.prototype.toString);
 
-verifyNotEnumerable(TypedArrayPrototype, 'toString');
-verifyWritable(TypedArrayPrototype, 'toString');
-verifyConfigurable(TypedArrayPrototype, 'toString');
+verifyProperty(TypedArrayPrototype, 'toString', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArray/prototype/values/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/values/prop-desc.js
@@ -14,6 +14,8 @@ features: [TypedArray]
 
 var TypedArrayPrototype = TypedArray.prototype;
 
-verifyNotEnumerable(TypedArrayPrototype, 'values');
-verifyWritable(TypedArrayPrototype, 'values');
-verifyConfigurable(TypedArrayPrototype, 'values');
+verifyProperty(TypedArrayPrototype, 'values', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/TypedArrayConstructors/Float32Array/prototype.js
+++ b/test/built-ins/TypedArrayConstructors/Float32Array/prototype.js
@@ -15,6 +15,8 @@ features: [TypedArray]
 
 assert.sameValue(Float32Array.prototype, Object.getPrototypeOf(new Float32Array(0)));
 
-verifyNotEnumerable(Float32Array, "prototype");
-verifyNotWritable(Float32Array, "prototype");
-verifyNotConfigurable(Float32Array, "prototype");
+verifyProperty(Float32Array, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/TypedArrayConstructors/Float64Array/prototype.js
+++ b/test/built-ins/TypedArrayConstructors/Float64Array/prototype.js
@@ -15,6 +15,8 @@ features: [TypedArray]
 
 assert.sameValue(Float64Array.prototype, Object.getPrototypeOf(new Float64Array(0)));
 
-verifyNotEnumerable(Float64Array, "prototype");
-verifyNotWritable(Float64Array, "prototype");
-verifyNotConfigurable(Float64Array, "prototype");
+verifyProperty(Float64Array, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/TypedArrayConstructors/Int16Array/prototype.js
+++ b/test/built-ins/TypedArrayConstructors/Int16Array/prototype.js
@@ -15,6 +15,8 @@ features: [TypedArray]
 
 assert.sameValue(Int16Array.prototype, Object.getPrototypeOf(new Int16Array(0)));
 
-verifyNotEnumerable(Int16Array, "prototype");
-verifyNotWritable(Int16Array, "prototype");
-verifyNotConfigurable(Int16Array, "prototype");
+verifyProperty(Int16Array, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/TypedArrayConstructors/Int32Array/prototype.js
+++ b/test/built-ins/TypedArrayConstructors/Int32Array/prototype.js
@@ -15,6 +15,8 @@ features: [TypedArray]
 
 assert.sameValue(Int32Array.prototype, Object.getPrototypeOf(new Int32Array(0)));
 
-verifyNotEnumerable(Int32Array, "prototype");
-verifyNotWritable(Int32Array, "prototype");
-verifyNotConfigurable(Int32Array, "prototype");
+verifyProperty(Int32Array, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/TypedArrayConstructors/Int8Array/prototype.js
+++ b/test/built-ins/TypedArrayConstructors/Int8Array/prototype.js
@@ -15,6 +15,8 @@ features: [TypedArray]
 
 assert.sameValue(Int8Array.prototype, Object.getPrototypeOf(new Int8Array(0)));
 
-verifyNotEnumerable(Int8Array, "prototype");
-verifyNotWritable(Int8Array, "prototype");
-verifyNotConfigurable(Int8Array, "prototype");
+verifyProperty(Int8Array, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/TypedArrayConstructors/Uint16Array/prototype.js
+++ b/test/built-ins/TypedArrayConstructors/Uint16Array/prototype.js
@@ -15,6 +15,8 @@ features: [TypedArray]
 
 assert.sameValue(Uint16Array.prototype, Object.getPrototypeOf(new Uint16Array(0)));
 
-verifyNotEnumerable(Uint16Array, "prototype");
-verifyNotWritable(Uint16Array, "prototype");
-verifyNotConfigurable(Uint16Array, "prototype");
+verifyProperty(Uint16Array, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/TypedArrayConstructors/Uint32Array/prototype.js
+++ b/test/built-ins/TypedArrayConstructors/Uint32Array/prototype.js
@@ -15,6 +15,8 @@ features: [TypedArray]
 
 assert.sameValue(Uint32Array.prototype, Object.getPrototypeOf(new Uint32Array(0)));
 
-verifyNotEnumerable(Uint32Array, "prototype");
-verifyNotWritable(Uint32Array, "prototype");
-verifyNotConfigurable(Uint32Array, "prototype");
+verifyProperty(Uint32Array, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/TypedArrayConstructors/Uint8Array/prototype.js
+++ b/test/built-ins/TypedArrayConstructors/Uint8Array/prototype.js
@@ -15,6 +15,8 @@ features: [TypedArray]
 
 assert.sameValue(Uint8Array.prototype, Object.getPrototypeOf(new Uint8Array(0)));
 
-verifyNotEnumerable(Uint8Array, "prototype");
-verifyNotWritable(Uint8Array, "prototype");
-verifyNotConfigurable(Uint8Array, "prototype");
+verifyProperty(Uint8Array, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/TypedArrayConstructors/Uint8ClampedArray/prototype.js
+++ b/test/built-ins/TypedArrayConstructors/Uint8ClampedArray/prototype.js
@@ -15,6 +15,8 @@ features: [TypedArray]
 
 assert.sameValue(Uint8ClampedArray.prototype, Object.getPrototypeOf(new Uint8ClampedArray(0)));
 
-verifyNotEnumerable(Uint8ClampedArray, "prototype");
-verifyNotWritable(Uint8ClampedArray, "prototype");
-verifyNotConfigurable(Uint8ClampedArray, "prototype");
+verifyProperty(Uint8ClampedArray, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/WeakMap/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/WeakMap/prototype/Symbol.toStringTag.js
@@ -16,6 +16,8 @@ features: [Symbol.toStringTag]
 
 assert.sameValue(WeakMap.prototype[Symbol.toStringTag], 'WeakMap');
 
-verifyNotEnumerable(WeakMap.prototype, Symbol.toStringTag);
-verifyNotWritable(WeakMap.prototype, Symbol.toStringTag);
-verifyConfigurable(WeakMap.prototype, Symbol.toStringTag);
+verifyProperty(WeakMap.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakMap/prototype/constructor.js
+++ b/test/built-ins/WeakMap/prototype/constructor.js
@@ -16,6 +16,8 @@ includes: [propertyHelper.js]
 assert.sameValue(WeakMap.prototype.constructor, WeakMap);
 assert.sameValue((new WeakMap()).constructor, WeakMap);
 
-verifyNotEnumerable(WeakMap.prototype, 'constructor');
-verifyWritable(WeakMap.prototype, 'constructor');
-verifyConfigurable(WeakMap.prototype, 'constructor');
+verifyProperty(WeakMap.prototype, 'constructor', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakMap/prototype/delete/delete.js
+++ b/test/built-ins/WeakMap/prototype/delete/delete.js
@@ -18,6 +18,8 @@ assert.sameValue(
   'typeof WeakMap.prototype.delete is "function"'
 );
 
-verifyNotEnumerable(WeakMap.prototype, 'delete');
-verifyWritable(WeakMap.prototype, 'delete');
-verifyConfigurable(WeakMap.prototype, 'delete');
+verifyProperty(WeakMap.prototype, 'delete', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakMap/prototype/get/get.js
+++ b/test/built-ins/WeakMap/prototype/get/get.js
@@ -17,6 +17,8 @@ assert.sameValue(
   '`typeof WeakMap.prototype.get` is `function`'
 );
 
-verifyNotEnumerable(WeakMap.prototype, 'get');
-verifyWritable(WeakMap.prototype, 'get');
-verifyConfigurable(WeakMap.prototype, 'get');
+verifyProperty(WeakMap.prototype, 'get', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakMap/prototype/has/has.js
+++ b/test/built-ins/WeakMap/prototype/has/has.js
@@ -18,6 +18,8 @@ assert.sameValue(
   'typeof WeakMap.prototype.has is "function"'
 );
 
-verifyNotEnumerable(WeakMap.prototype, 'has');
-verifyWritable(WeakMap.prototype, 'has');
-verifyConfigurable(WeakMap.prototype, 'has');
+verifyProperty(WeakMap.prototype, 'has', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakMap/prototype/prototype-attributes.js
+++ b/test/built-ins/WeakMap/prototype/prototype-attributes.js
@@ -7,6 +7,8 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(WeakMap, 'prototype');
-verifyNotWritable(WeakMap, 'prototype');
-verifyNotConfigurable(WeakMap, 'prototype');
+verifyProperty(WeakMap, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/WeakMap/prototype/set/set.js
+++ b/test/built-ins/WeakMap/prototype/set/set.js
@@ -17,6 +17,8 @@ assert.sameValue(
   'typeof WeakMap.prototype.set is "function"'
 );
 
-verifyNotEnumerable(WeakMap.prototype, 'set');
-verifyWritable(WeakMap.prototype, 'set');
-verifyConfigurable(WeakMap.prototype, 'set');
+verifyProperty(WeakMap.prototype, 'set', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakMap/weakmap.js
+++ b/test/built-ins/WeakMap/weakmap.js
@@ -9,6 +9,8 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, 'WeakMap');
-verifyWritable(this, 'WeakMap');
-verifyConfigurable(this, 'WeakMap');
+verifyProperty(this, 'WeakMap', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/WeakSet/prototype/Symbol.toStringTag.js
+++ b/test/built-ins/WeakSet/prototype/Symbol.toStringTag.js
@@ -16,6 +16,8 @@ features: [Symbol.toStringTag]
 
 assert.sameValue(WeakSet.prototype[Symbol.toStringTag], 'WeakSet');
 
-verifyNotEnumerable(WeakSet.prototype, Symbol.toStringTag);
-verifyNotWritable(WeakSet.prototype, Symbol.toStringTag);
-verifyConfigurable(WeakSet.prototype, Symbol.toStringTag);
+verifyProperty(WeakSet.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakSet/prototype/add/add.js
+++ b/test/built-ins/WeakSet/prototype/add/add.js
@@ -17,6 +17,8 @@ assert.sameValue(
   'typeof WeakSet.prototype.add is "function"'
 );
 
-verifyNotEnumerable(WeakSet.prototype, 'add');
-verifyWritable(WeakSet.prototype, 'add');
-verifyConfigurable(WeakSet.prototype, 'add');
+verifyProperty(WeakSet.prototype, 'add', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakSet/prototype/constructor/weakset-prototype-constructor.js
+++ b/test/built-ins/WeakSet/prototype/constructor/weakset-prototype-constructor.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(WeakSet.prototype, 'constructor');
-verifyWritable(WeakSet.prototype, 'constructor');
-verifyConfigurable(WeakSet.prototype, 'constructor');
+verifyProperty(WeakSet.prototype, 'constructor', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakSet/prototype/delete/delete.js
+++ b/test/built-ins/WeakSet/prototype/delete/delete.js
@@ -18,6 +18,8 @@ assert.sameValue(
   'typeof WeakSet.prototype.delete is "function"'
 );
 
-verifyNotEnumerable(WeakSet.prototype, 'delete');
-verifyWritable(WeakSet.prototype, 'delete');
-verifyConfigurable(WeakSet.prototype, 'delete');
+verifyProperty(WeakSet.prototype, 'delete', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakSet/prototype/has/has.js
+++ b/test/built-ins/WeakSet/prototype/has/has.js
@@ -18,6 +18,8 @@ assert.sameValue(
   'typeof WeakSet.prototype.has is "function"'
 );
 
-verifyNotEnumerable(WeakSet.prototype, 'has');
-verifyWritable(WeakSet.prototype, 'has');
-verifyConfigurable(WeakSet.prototype, 'has');
+verifyProperty(WeakSet.prototype, 'has', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/WeakSet/prototype/prototype-attributes.js
+++ b/test/built-ins/WeakSet/prototype/prototype-attributes.js
@@ -7,6 +7,8 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(WeakSet, 'prototype');
-verifyNotWritable(WeakSet, 'prototype');
-verifyNotConfigurable(WeakSet, 'prototype');
+verifyProperty(WeakSet, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/WeakSet/weakset.js
+++ b/test/built-ins/WeakSet/weakset.js
@@ -9,6 +9,8 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, 'WeakSet');
-verifyWritable(this, 'WeakSet');
-verifyConfigurable(this, 'WeakSet');
+verifyProperty(this, 'WeakSet', {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/decodeURI/prop-desc.js
+++ b/test/built-ins/decodeURI/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "decodeURI");
-verifyWritable(this, "decodeURI");
-verifyConfigurable(this, "decodeURI");
+verifyProperty(this, "decodeURI", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/decodeURIComponent/prop-desc.js
+++ b/test/built-ins/decodeURIComponent/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "decodeURIComponent");
-verifyWritable(this, "decodeURIComponent");
-verifyConfigurable(this, "decodeURIComponent");
+verifyProperty(this, "decodeURIComponent", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/encodeURI/prop-desc.js
+++ b/test/built-ins/encodeURI/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "encodeURI");
-verifyWritable(this, "encodeURI");
-verifyConfigurable(this, "encodeURI");
+verifyProperty(this, "encodeURI", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/encodeURIComponent/prop-desc.js
+++ b/test/built-ins/encodeURIComponent/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "encodeURIComponent");
-verifyWritable(this, "encodeURIComponent");
-verifyConfigurable(this, "encodeURIComponent");
+verifyProperty(this, "encodeURIComponent", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/eval/prop-desc.js
+++ b/test/built-ins/eval/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "eval");
-verifyWritable(this, "eval");
-verifyConfigurable(this, "eval");
+verifyProperty(this, "eval", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/isFinite/prop-desc.js
+++ b/test/built-ins/isFinite/prop-desc.js
@@ -8,6 +8,8 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "isFinite");
-verifyWritable(this, "isFinite");
-verifyConfigurable(this, "isFinite");
+verifyProperty(this, "isFinite", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/isNaN/prop-desc.js
+++ b/test/built-ins/isNaN/prop-desc.js
@@ -8,6 +8,8 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "isNaN");
-verifyWritable(this, "isNaN");
-verifyConfigurable(this, "isNaN");
+verifyProperty(this, "isNaN", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/parseFloat/prop-desc.js
+++ b/test/built-ins/parseFloat/prop-desc.js
@@ -12,6 +12,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "parseFloat");
-verifyWritable(this, "parseFloat");
-verifyConfigurable(this, "parseFloat");
+verifyProperty(this, "parseFloat", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/parseInt/prop-desc.js
+++ b/test/built-ins/parseInt/prop-desc.js
@@ -11,6 +11,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(this, "parseInt");
-verifyWritable(this, "parseInt");
-verifyConfigurable(this, "parseInt");
+verifyProperty(this, "parseInt", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/test/staging/explicit-resource-management/Symbol/dispose/prop-desc.js
+++ b/test/staging/explicit-resource-management/Symbol/dispose/prop-desc.js
@@ -12,6 +12,8 @@ features: [explicit-resource-management]
 ---*/
 
 assert.sameValue(typeof Symbol.dispose, 'symbol');
-verifyNotEnumerable(Symbol, 'dispose');
-verifyNotWritable(Symbol, 'dispose');
-verifyNotConfigurable(Symbol, 'dispose');
+verifyProperty(Symbol, 'dispose', {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});


### PR DESCRIPTION
edit: i see `verifyPrimordialProperty` got added recently, if any of these should use that instead lmk