### PR TITLE
fix: heritage-arrow-function.js

### DIFF
--- a/test/language/expressions/class/heritage-arrow-function.js
+++ b/test/language/expressions/class/heritage-arrow-function.js
@@ -26,6 +26,6 @@ features: [class]
 
 
 assert.throws(TypeError, () => {
-  var C = class extends (async () => {}) {};
+  var C = class extends (() => {}) {};
 });
 

--- a/test/language/expressions/class/heritage-arrow-function.js
+++ b/test/language/expressions/class/heritage-arrow-function.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-runtime-semantics-classdefinitionevaluation
 description: >
-  Throw a TypeError exception if IsConstructor(superclass) is false (async arrow)
+  Throw a TypeError exception if IsConstructor(superclass) is false (arrow)
 info: |
   Runtime Semantics: ClassDefinitionEvaluation
 


### PR DESCRIPTION
Previously this test was the exact same as https://github.com/tc39/test262/tree/main/test/language/expressions/class/heritage-async-arrow-function.js, which I think is wrong.