### PR TITLE
Update expected formatting for CLDR 46

### DIFF
--- a/test/staging/Intl402/Temporal/old/non-iso-calendars.js
+++ b/test/staging/Intl402/Temporal/old/non-iso-calendars.js
@@ -54,8 +54,8 @@ function compareFormatToPartsSnapshot(isoString, expected) {
 compareFormatToPartsSnapshot("2000-01-01T00:00Z", {
   iso8601: {
     year: 2000,
-    month: 1,
-    day: 1,
+    month: "01",
+    day: "01",
   },
   buddhist: {
     year: 2543,
@@ -178,8 +178,8 @@ const yearOneDay = new Map(
 compareFormatToPartsSnapshot("0001-01-01T00:00Z", {
   iso8601: {
     year: 1,
-    month: 1,
-    day: yearOneDay.get("iso8601"),
+    month: "01",
+    day: "0" + yearOneDay.get("iso8601"),
   },
   buddhist: {
     year: 544,


### PR DESCRIPTION
<https://github.com/unicode-org/cldr/pull/4037/> added a new entry for the ISO-8601 calendar.