### PR TITLE
Import and modernize bocoup/test262-regexp-generator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{README.md,package.json,*.yml,*.sh,*.js,*.case,*.template}]
+[{README.md,package.json,*.yml,*.sh,*.js,*.mjs,*.case,*.template}]
 indent_style = space
 indent_size = 2
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -72,6 +72,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r tools/generation/requirements.txt
 
+      - name: Install dependencies for regexp-generator tool
+        run: |
+          cd tools/regexp-generator
+          npm install
+
       - name: Build tests
         run: |
           ./make.py clean >/dev/null

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
@@ -40,7 +40,7 @@ includes: [regExpUtils.js]
 const str = buildString({
     loneCodePoints: [],
     ranges: [
-        [0x0030, 0x0039],
+        [0x000030, 0x000039],
     ],
 });
 

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for digit class escape \d with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for digit class escape \d with flags ug
+  Compare range for digit class escape \d with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -57,16 +57,16 @@ const re = /\d/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for digit class escape \d+ with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
@@ -40,7 +40,7 @@ includes: [regExpUtils.js]
 const str = buildString({
     loneCodePoints: [],
     ranges: [
-        [0x0030, 0x0039],
+        [0x000030, 0x000039],
     ],
 });
 

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for digit class escape \d+ with flags ug
+  Compare range for digit class escape \d+ with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -57,16 +57,16 @@ const re = /\d+/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
@@ -40,7 +40,7 @@ includes: [regExpUtils.js]
 const str = buildString({
     loneCodePoints: [],
     ranges: [
-        [0x0030, 0x0039],
+        [0x000030, 0x000039],
     ],
 });
 

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
@@ -7,7 +7,7 @@ description: >
     Compare range for digit class escape \d+ with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for digit class escape \d+ with flags g
+  Compare range for digit class escape \d+ with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -57,16 +57,16 @@ const re = /\d+/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
@@ -7,7 +7,7 @@ description: >
     Compare range for digit class escape \d with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for digit class escape \d with flags g
+  Compare range for digit class escape \d with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -57,16 +57,16 @@ const re = /\d/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
@@ -40,7 +40,7 @@ includes: [regExpUtils.js]
 const str = buildString({
     loneCodePoints: [],
     ranges: [
-        [0x0030, 0x0039],
+        [0x000030, 0x000039],
     ],
 });
 

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-digit class escape \D with flags ug
+  Compare range for non-digit class escape \D with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -60,16 +60,16 @@ const re = /\D/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-digit class escape \D with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
@@ -40,8 +40,10 @@ includes: [regExpUtils.js]
 const str = buildString({
     loneCodePoints: [],
     ranges: [
+        [0x00DC00, 0x00DFFF],
         [0x000000, 0x00002F],
-        [0x00003A, 0x10FFFF],
+        [0x00003A, 0x00DBFF],
+        [0x00E000, 0x10FFFF],
     ],
 });
 

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-digit class escape \D+ with flags ug
+  Compare range for non-digit class escape \D+ with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -60,16 +60,16 @@ const re = /\D+/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-digit class escape \D+ with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
@@ -38,11 +38,13 @@ includes: [regExpUtils.js]
 ---*/
 
 const str = buildString({
-  loneCodePoints: [],
-  ranges: [
-      [0x000000, 0x00002F],
-      [0x00003A, 0x10FFFF],
-  ],
+    loneCodePoints: [],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x00002F],
+        [0x00003A, 0x00DBFF],
+        [0x00E000, 0x10FFFF],
+    ],
 });
 
 const re = /\D+/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-digit class escape \D+ with flags g
+  Compare range for non-digit class escape \D+ with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -60,16 +60,16 @@ const re = /\D+/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
@@ -38,11 +38,13 @@ includes: [regExpUtils.js]
 ---*/
 
 const str = buildString({
-  loneCodePoints: [],
-  ranges: [
-      [0x000000, 0x00002F],
-      [0x00003A, 0x00FFFF],
-  ],
+    loneCodePoints: [],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x00002F],
+        [0x00003A, 0x00DBFF],
+        [0x00E000, 0x00FFFF],
+    ],
 });
 
 const re = /\D+/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-digit class escape \D+ with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
@@ -38,11 +38,13 @@ includes: [regExpUtils.js]
 ---*/
 
 const str = buildString({
-  loneCodePoints: [],
-  ranges: [
-      [0x000000, 0x00002F],
-      [0x00003A, 0x00FFFF],
-  ],
+    loneCodePoints: [],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x00002F],
+        [0x00003A, 0x00DBFF],
+        [0x00E000, 0x00FFFF],
+    ],
 });
 
 const re = /\D/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-digit class escape \D with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-digit class escape \D with flags g
+  Compare range for non-digit class escape \D with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -60,16 +60,16 @@ const re = /\D/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-whitespace class escape \S with flags ug
+  Compare range for non-whitespace class escape \S with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -69,16 +69,16 @@ const re = /\S/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-whitespace class escape \S with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-whitespace class escape \S+ with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-whitespace class escape \S+ with flags ug
+  Compare range for non-whitespace class escape \S+ with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -69,16 +69,16 @@ const re = /\S+/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-whitespace class escape \S+ with flags g
+  Compare range for non-whitespace class escape \S+ with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -69,16 +69,16 @@ const re = /\S+/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-whitespace class escape \S+ with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-whitespace class escape \S with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-whitespace class escape \S with flags g
+  Compare range for non-whitespace class escape \S with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -69,16 +69,16 @@ const re = /\S/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-word class escape \W with flags ug
+  Compare range for non-word class escape \W with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -62,16 +62,16 @@ const re = /\W/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-word class escape \W with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-word class escape \W+ with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-word class escape \W+ with flags ug
+  Compare range for non-word class escape \W+ with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -62,16 +62,16 @@ const re = /\W+/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-word class escape \W+ with flags g
+  Compare range for non-word class escape \W+ with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -62,16 +62,16 @@ const re = /\W+/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-word class escape \W+ with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for non-word class escape \W with flags g
+  Compare range for non-word class escape \W with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -62,16 +62,16 @@ const re = /\W/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js
@@ -7,7 +7,7 @@ description: >
     Compare range for non-word class escape \W with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for whitespace class escape \s with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for whitespace class escape \s with flags ug
+  Compare range for whitespace class escape \s with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -67,16 +67,16 @@ const re = /\s/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for whitespace class escape \s+ with flags ug
+  Compare range for whitespace class escape \s+ with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -67,16 +67,16 @@ const re = /\s+/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for whitespace class escape \s+ with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
@@ -7,7 +7,7 @@ description: >
     Compare range for whitespace class escape \s+ with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for whitespace class escape \s+ with flags g
+  Compare range for whitespace class escape \s+ with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -67,16 +67,16 @@ const re = /\s+/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape.js
@@ -7,7 +7,7 @@ description: >
     Compare range for whitespace class escape \s with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for whitespace class escape \s with flags g
+  Compare range for whitespace class escape \s with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -67,16 +67,16 @@ const re = /\s/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for word class escape \w with flags ug
+  Compare range for word class escape \w with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -59,16 +59,16 @@ const re = /\w/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for word class escape \w with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
@@ -7,7 +7,7 @@ description: >
     Compare range for word class escape \w+ with flags ug
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for word class escape \w+ with flags ug
+  Compare range for word class escape \w+ with flags ug
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -59,16 +59,16 @@ const re = /\w+/ug;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
@@ -7,7 +7,7 @@ description: >
     Compare range for word class escape \w+ with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for word class escape \w+ with flags g
+  Compare range for word class escape \w+ with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -59,16 +59,16 @@ const re = /\w+/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape.js
@@ -4,42 +4,42 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for word class escape \w with flags g
+  Compare range for word class escape \w with flags g
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
@@ -59,16 +59,16 @@ const re = /\w/g;
 const errors = [];
 
 if (!re.test(str)) {
-    // Error, let's find out where
-    for (const char of str) {
-        if (!re.test(char)) {
-            errors.push('0x' + char.codePointAt(0).toString(16));
-        }
+  // Error, let's find out where
+  for (const char of str) {
+    if (!re.test(char)) {
+      errors.push('0x' + char.codePointAt(0).toString(16));
     }
+  }
 }
 
 assert.sameValue(
-    errors.length,
-    0,
-    'Expected matching code points, but received: ' + errors.join(',')
+  errors.length,
+  0,
+  'Expected matching code points, but received: ' + errors.join(',')
 );

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape.js
@@ -10,29 +10,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape.js
@@ -7,7 +7,7 @@ description: >
     Compare range for word class escape \w with flags g
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -35,6 +35,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/
 
 const str = buildString({

--- a/tools/regexp-generator/LICENSE
+++ b/tools/regexp-generator/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Bocoup
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/regexp-generator/README.md
+++ b/tools/regexp-generator/README.md
@@ -1,0 +1,2 @@
+# test262-regexp-generator
+Generete tests for RegExp based on unicode data

--- a/tools/regexp-generator/README.md
+++ b/tools/regexp-generator/README.md
@@ -1,2 +1,12 @@
-# test262-regexp-generator
-Generete tests for RegExp based on unicode data
+# RegExp Generator
+
+This tool generates the tests in the
+`test/built-ins/RegExp/CharacterClassEscapes/` folder from Unicode data.
+
+To run:
+
+```sh
+$ npm install  # before first run
+$ npm run clean  # optional
+$ npm run build
+```

--- a/tools/regexp-generator/header.js
+++ b/tools/regexp-generator/header.js
@@ -1,0 +1,42 @@
+module.exports = description => {
+    let header = `// Copyright (C) 2018 Leo Balter.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-CharacterClassEscape
+description: >
+    ${description}
+info: |
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
+    for any changes.
+
+    CharacterClassEscape[U] ::
+        d
+        D
+        s
+        S
+        w
+        W
+
+    21.2.2.12 CharacterClassEscape
+
+    The production CharacterClassEscape :: d evaluates as follows:
+        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
+    The production CharacterClassEscape :: D evaluates as follows:
+        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
+    The production CharacterClassEscape :: s evaluates as follows:
+        Return the set of characters containing the characters that are on the right-hand side of
+        the WhiteSpace or LineTerminator productions.
+    The production CharacterClassEscape :: S evaluates as follows:
+        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
+    The production CharacterClassEscape :: w evaluates as follows:
+        Return the set of all characters returned by WordCharacters().
+    The production CharacterClassEscape :: W evaluates as follows:
+        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+features: [String.fromCodePoint]
+includes: [regExpUtils.js]
+---*/\n`;
+
+    return header;
+};

--- a/tools/regexp-generator/header.mjs
+++ b/tools/regexp-generator/header.mjs
@@ -1,4 +1,4 @@
-module.exports = description => {
+export default description => {
     let header = `// Copyright (C) 2018 Leo Balter.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 

--- a/tools/regexp-generator/header.mjs
+++ b/tools/regexp-generator/header.mjs
@@ -11,29 +11,36 @@ info: |
     https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
-    CharacterClassEscape[U] ::
+    CharacterClassEscape[UnicodeMode] ::
         d
         D
         s
         S
         w
         W
+        [+UnicodeMode] p{ UnicodePropertyValueExpression }
+        [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    21.2.2.12 CharacterClassEscape
+    22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    The production CharacterClassEscape :: d evaluates as follows:
-        Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-    The production CharacterClassEscape :: D evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: d.
-    The production CharacterClassEscape :: s evaluates as follows:
-        Return the set of characters containing the characters that are on the right-hand side of
-        the WhiteSpace or LineTerminator productions.
-    The production CharacterClassEscape :: S evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: s.
-    The production CharacterClassEscape :: w evaluates as follows:
-        Return the set of all characters returned by WordCharacters().
-    The production CharacterClassEscape :: W evaluates as follows:
-        Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
+    CharacterClassEscape :: d
+        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
+            4, 5, 6, 7, 8, and 9.
+    CharacterClassEscape :: D
+        1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: s
+        1. Return the CharSet containing all characters corresponding to a code
+            point on the right-hand side of the WhiteSpace or LineTerminator
+            productions.
+    CharacterClassEscape :: S
+        1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        2. Return CharacterComplement(rer, S).
+    CharacterClassEscape :: w
+        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+    CharacterClassEscape :: W
+        1. Let S be the CharSet returned by CharacterClassEscape :: w.
+        2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]

--- a/tools/regexp-generator/header.mjs
+++ b/tools/regexp-generator/header.mjs
@@ -8,7 +8,7 @@ description: >
     ${description}
 info: |
     This is a generated test. Please check out
-    https://github.com/bocoup/test262-regexp-generator
+    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -36,6 +36,7 @@ info: |
         Return the set of all characters not included in the set returned by CharacterClassEscape :: w.
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
+flags: [generated]
 ---*/\n`;
 
     return header;

--- a/tools/regexp-generator/header.mjs
+++ b/tools/regexp-generator/header.mjs
@@ -1,50 +1,50 @@
 export default description => {
-    let header = `// Copyright (C) 2018 Leo Balter.  All rights reserved.
+  let header = `// Copyright (C) 2018 Leo Balter.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    ${description}
+  ${description}
 info: |
-    This is a generated test. Please check out
-    https://github.com/tc39/test262/tree/main/tools/regexp-generator/
-    for any changes.
+  This is a generated test. Please check out
+  https://github.com/tc39/test262/tree/main/tools/regexp-generator/
+  for any changes.
 
-    CharacterClassEscape[UnicodeMode] ::
-        d
-        D
-        s
-        S
-        w
-        W
-        [+UnicodeMode] p{ UnicodePropertyValueExpression }
-        [+UnicodeMode] P{ UnicodePropertyValueExpression }
+  CharacterClassEscape[UnicodeMode] ::
+    d
+    D
+    s
+    S
+    w
+    W
+    [+UnicodeMode] p{ UnicodePropertyValueExpression }
+    [+UnicodeMode] P{ UnicodePropertyValueExpression }
 
-    22.2.2.9 Runtime Semantics: CompileToCharSet
+  22.2.2.9 Runtime Semantics: CompileToCharSet
 
-    CharacterClassEscape :: d
-        1. Return the ten-element CharSet containing the characters 0, 1, 2, 3,
-            4, 5, 6, 7, 8, and 9.
-    CharacterClassEscape :: D
-        1. Let S be the CharSet returned by CharacterClassEscape :: d.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: s
-        1. Return the CharSet containing all characters corresponding to a code
-            point on the right-hand side of the WhiteSpace or LineTerminator
-            productions.
-    CharacterClassEscape :: S
-        1. Let S be the CharSet returned by CharacterClassEscape :: s.
-        2. Return CharacterComplement(rer, S).
-    CharacterClassEscape :: w
-        1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
-    CharacterClassEscape :: W
-        1. Let S be the CharSet returned by CharacterClassEscape :: w.
-        2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: d
+    1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4,
+      5, 6, 7, 8, and 9.
+  CharacterClassEscape :: D
+    1. Let S be the CharSet returned by CharacterClassEscape :: d.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: s
+    1. Return the CharSet containing all characters corresponding to a code
+      point on the right-hand side of the WhiteSpace or LineTerminator
+      productions.
+  CharacterClassEscape :: S
+    1. Let S be the CharSet returned by CharacterClassEscape :: s.
+    2. Return CharacterComplement(rer, S).
+  CharacterClassEscape :: w
+    1. Return MaybeSimpleCaseFolding(rer, WordCharacters(rer)).
+  CharacterClassEscape :: W
+    1. Let S be the CharSet returned by CharacterClassEscape :: w.
+    2. Return CharacterComplement(rer, S).
 features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 flags: [generated]
 ---*/\n`;
 
-    return header;
+  return header;
 };

--- a/tools/regexp-generator/index.js
+++ b/tools/regexp-generator/index.js
@@ -1,0 +1,102 @@
+const fs = require('fs');
+const rewritePattern = require('regexpu-core');
+const slugify = require('slugify');
+const filenamify = require('filenamify');
+const jsesc = require('jsesc');
+const header = require('./header');
+
+const patterns = {
+    'whitespace class escape': '\\s',
+    'non-whitespace class escape': '\\S',
+    'word class escape': '\\w',
+    'non-word class escape': '\\W',
+    'digit class escape': '\\d',
+    'non-digit class escape': '\\D',
+};
+
+function buildContent(desc, pattern, range, max, flags, skip180e) {
+    let method;
+    let features = [];
+
+    let content = header(`Compare range for ${desc} ${pattern} with flags ${flags}`);
+
+    content += `
+const str = buildString({ loneCodePoints: [], ranges: [[0, ${
+    jsesc(max, { numbers: 'hexadecimal' })
+}]] });
+
+const re = /${pattern}/${flags};
+const matchingRange = /${range}/${flags};
+
+const errors = [];
+
+function matching(str) {
+    return str.replace(re, '') === str.replace(matchingRange, '');
+}
+
+if (!matching(str)) {
+    // Error, let's find out where
+    for (const char of str) {
+        if (!matching(char)) {
+            errors.push('0x' + char.codePointAt(0).toString(16));
+        }
+    }
+}
+
+assert.sameValue(
+    errors.length,
+    0,
+    'Expected matching code points, but received: ' + errors.join(',')
+);
+`;
+
+    return content;
+}
+
+function writeFile(desc, content, suffix = '') {
+    const filename = `output/character-class-${slugify(filenamify(desc.toLowerCase()))}${suffix}.js`;
+    fs.writeFileSync(filename, content);
+}
+
+// No additions
+for (const [desc, escape] of Object.entries(patterns)) {
+    const skip180e = escape.toLowerCase().includes('s');
+    [
+        {
+            quantifier: '',
+            flags: '',
+        },
+        {
+            quantifier: '+',
+            flags: '',
+            posCb(u) { return [u, u+u]},
+            suffix: '-plus-quantifier',
+        },
+        {
+            quantifier: '',
+            flags: 'u',
+            max: 0x10FFFF,
+            suffix: '-flags-u',
+        },
+        {
+            quantifier: '+',
+            flags: 'u',
+            posCb(u) { return [u, u+u]},
+            suffix: '-plus-quantifier-flags-u',
+            max: 0x10FFFF,
+        },
+    ].forEach(({quantifier, max = 0xFFFF, flags, suffix, posCb = u => [u], negCb = u => [u]}) => {
+        flags += 'g';
+
+        const pattern = `${escape}${quantifier}`;
+        const range = rewritePattern(pattern, flags, {
+            useUnicodeFlag: flags.includes('u')
+        });
+
+        console.log(`${pattern} => ${range}, flags: ${flags}`);
+
+        const content = buildContent(desc, pattern, range, max, flags, skip180e);
+
+        writeFile(desc, content, suffix);
+    });
+}

--- a/tools/regexp-generator/index.js
+++ b/tools/regexp-generator/index.js
@@ -54,7 +54,8 @@ assert.sameValue(
 }
 
 function writeFile(desc, content, suffix = '') {
-    const filename = `output/character-class-${slugify(filenamify(desc.toLowerCase()))}${suffix}.js`;
+    const outPath = '../../test/built-ins/RegExp/CharacterClassEscapes';
+    const filename = `${outPath}/character-class-${slugify(filenamify(desc.toLowerCase()))}${suffix}.js`;
     fs.writeFileSync(filename, content);
 }
 

--- a/tools/regexp-generator/index.mjs
+++ b/tools/regexp-generator/index.mjs
@@ -1,7 +1,8 @@
 import filenamify from 'filenamify';
 import fs from 'node:fs';
-import jsesc from 'jsesc';
+import regenerate from 'regenerate';
 import rewritePattern from 'regexpu-core';
+import ESCAPE_SETS from 'regexpu-core/data/character-class-escape-sets.js';
 import slugify from 'slugify';
 
 import header from './header.mjs';
@@ -15,30 +16,85 @@ const patterns = {
     'non-digit class escape': '\\D',
 };
 
+// Pretty-printing code adapted from unicode-property-escapes-tests.
+// https://github.com/mathiasbynens/unicode-property-escapes-tests/blob/60f2dbec2b2a840ee67aa04dbd3449bb90fd2999/regenerate.js
+
+function toHex(codePoint) {
+    return '0x' + ('00000' + codePoint.toString(16).toUpperCase()).slice(-6);
+};
+
+function toTestData(reg) {
+    const data = reg.data;
+    // Iterate over the data per `(start, end)` pair.
+    let index = 0;
+    const length = data.length;
+    const loneCodePoints = [];
+    const ranges = [];
+    while (index < length) {
+        let start = data[index];
+        let end = data[index + 1] - 1; // Note: the `- 1` makes `end` inclusive.
+        if (start == end) {
+            loneCodePoints.push(start);
+        } else {
+            ranges.push([start, end]);
+        }
+        index += 2;
+    }
+    return [ loneCodePoints, ranges ];
+}
+
+function prettyPrint([ loneCodePoints, ranges ]) {
+    const indent = '    ';
+    loneCodePoints = loneCodePoints.map((codePoint) => toHex(codePoint));
+    ranges = ranges.map(
+        (range) => `[${ toHex(range[0]) }, ${ toHex(range[1]) }]`
+    );
+    const loneCodePointsOutput = loneCodePoints.length ?
+        loneCodePoints.length === 1 ? `[${loneCodePoints[0]}]` :
+            `[\n${indent}${indent}${ loneCodePoints.join(`,\n${indent}${indent}`) },\n${indent}]` :
+        `[]`;
+    const rangesOutput = ranges.length ?
+        `[\n${indent}${indent}${ ranges.join(`,\n${indent}${indent}`) },\n${indent}]` :
+        `[]`;
+    return `{\n${indent}loneCodePoints: ${ loneCodePointsOutput },\n${indent}ranges: ${ rangesOutput },\n}`;
+}
+
+const LOW_SURROGATES = regenerate().addRange(0xDC00, 0xDFFF);
+
+function buildString(escapeChar, flags) {
+    const isUnicode = flags.includes('u');
+    let escapeData = ESCAPE_SETS[isUnicode ? 'UNICODE' : 'REGULAR'].get(escapeChar);
+
+    const lowSurrogates = escapeData.clone().intersection(LOW_SURROGATES);
+    if (lowSurrogates.data.length === 0) {
+        return prettyPrint(toTestData(escapeData));
+    }
+    const rest = escapeData.clone().remove(LOW_SURROGATES);
+    const [ lowLoneCodePoints, lowRanges ] = toTestData(lowSurrogates);
+    const [ loneCodePoints, ranges ] = toTestData(rest);
+    loneCodePoints.unshift(...lowLoneCodePoints);
+    ranges.unshift(...lowRanges);
+    return prettyPrint([ loneCodePoints, ranges ]);
+}
+
 function buildContent(desc, pattern, range, max, flags, skip180e) {
+    let string = buildString(pattern[1], flags);
     let method;
     let features = [];
 
     let content = header(`Compare range for ${desc} ${pattern} with flags ${flags}`);
 
     content += `
-const str = buildString({ loneCodePoints: [], ranges: [[0, ${
-    jsesc(max, { numbers: 'hexadecimal' })
-}]] });
+const str = buildString(${string});
 
 const re = /${pattern}/${flags};
-const matchingRange = /${range}/${flags};
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/tools/regexp-generator/index.mjs
+++ b/tools/regexp-generator/index.mjs
@@ -1,9 +1,10 @@
-const fs = require('fs');
-const rewritePattern = require('regexpu-core');
-const slugify = require('slugify');
-const filenamify = require('filenamify');
-const jsesc = require('jsesc');
-const header = require('./header');
+import filenamify from 'filenamify';
+import fs from 'node:fs';
+import jsesc from 'jsesc';
+import rewritePattern from 'regexpu-core';
+import slugify from 'slugify';
+
+import header from './header.mjs';
 
 const patterns = {
     'whitespace class escape': '\\s',
@@ -91,7 +92,7 @@ for (const [desc, escape] of Object.entries(patterns)) {
 
         const pattern = `${escape}${quantifier}`;
         const range = rewritePattern(pattern, flags, {
-            useUnicodeFlag: flags.includes('u')
+            unicodeFlag: flags.includes('u') ? 'transform' : false,
         });
 
         console.log(`${pattern} => ${range}, flags: ${flags}`);

--- a/tools/regexp-generator/index.mjs
+++ b/tools/regexp-generator/index.mjs
@@ -77,10 +77,8 @@ function buildString(escapeChar, flags) {
     return prettyPrint([ loneCodePoints, ranges ]);
 }
 
-function buildContent(desc, pattern, range, max, flags, skip180e) {
+function buildContent(desc, pattern, flags) {
     let string = buildString(pattern[1], flags);
-    let method;
-    let features = [];
 
     let content = header(`Compare range for ${desc} ${pattern} with flags ${flags}`);
 
@@ -118,7 +116,6 @@ function writeFile(desc, content, suffix = '') {
 
 // No additions
 for (const [desc, escape] of Object.entries(patterns)) {
-    const skip180e = escape.toLowerCase().includes('s');
     [
         {
             quantifier: '',
@@ -127,23 +124,19 @@ for (const [desc, escape] of Object.entries(patterns)) {
         {
             quantifier: '+',
             flags: '',
-            posCb(u) { return [u, u+u]},
             suffix: '-plus-quantifier',
         },
         {
             quantifier: '',
             flags: 'u',
-            max: 0x10FFFF,
             suffix: '-flags-u',
         },
         {
             quantifier: '+',
             flags: 'u',
-            posCb(u) { return [u, u+u]},
             suffix: '-plus-quantifier-flags-u',
-            max: 0x10FFFF,
         },
-    ].forEach(({quantifier, max = 0xFFFF, flags, suffix, posCb = u => [u], negCb = u => [u]}) => {
+    ].forEach(({quantifier, flags, suffix}) => {
         flags += 'g';
 
         const pattern = `${escape}${quantifier}`;
@@ -153,7 +146,7 @@ for (const [desc, escape] of Object.entries(patterns)) {
 
         console.log(`${pattern} => ${range}, flags: ${flags}`);
 
-        const content = buildContent(desc, pattern, range, max, flags, skip180e);
+        const content = buildContent(desc, pattern, flags);
 
         writeFile(desc, content, suffix);
     });

--- a/tools/regexp-generator/package.json
+++ b/tools/regexp-generator/package.json
@@ -13,8 +13,8 @@
   "license": "MIT",
   "devDependencies": {
     "filenamify": "^6.0.0",
-    "jsesc": "^3.0.2",
     "mkdirp": "^3.0.1",
+    "regenerate": "^1.4.2",
     "regexpu-core": "^6.1.1",
     "rimraf": "^6.0.1",
     "slugify": "^1.6.6"

--- a/tools/regexp-generator/package.json
+++ b/tools/regexp-generator/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test262-regexp-class-escapes",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "node index.js"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "filenamify": "^2.1.0",
+    "jsesc": "^2.5.1",
+    "regexpu-core": "^4.2.0",
+    "slugify": "^1.3.0"
+  }
+}

--- a/tools/regexp-generator/package.json
+++ b/tools/regexp-generator/package.json
@@ -1,7 +1,5 @@
 {
-  "name": "test262-regexp-class-escapes",
-  "version": "1.0.0",
-  "description": "",
+  "private": true,
   "main": "index.mjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/tools/regexp-generator/package.json
+++ b/tools/regexp-generator/package.json
@@ -2,23 +2,21 @@
   "name": "test262-regexp-class-escapes",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "index.mjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf ../../test/built-ins/RegExp/CharacterClassEscapes",
     "prebuild": "mkdirp ../../test/built-ins/RegExp/CharacterClassEscapes",
-    "build": "node index.js"
+    "build": "node index.mjs"
   },
   "author": "",
   "license": "MIT",
-  "dependencies": {
-    "filenamify": "^2.1.0",
-    "jsesc": "^2.5.1",
-    "regexpu-core": "^4.2.0",
-    "slugify": "^1.3.0"
-  },
   "devDependencies": {
+    "filenamify": "^6.0.0",
+    "jsesc": "^3.0.2",
     "mkdirp": "^3.0.1",
-    "rimraf": "^6.0.1"
+    "regexpu-core": "^6.1.1",
+    "rimraf": "^6.0.1",
+    "slugify": "^1.6.6"
   }
 }

--- a/tools/regexp-generator/package.json
+++ b/tools/regexp-generator/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "clean": "rimraf ../../test/built-ins/RegExp/CharacterClassEscapes",
     "prebuild": "mkdirp ../../test/built-ins/RegExp/CharacterClassEscapes",
     "build": "node index.js"
   },
@@ -17,6 +18,7 @@
     "slugify": "^1.3.0"
   },
   "devDependencies": {
-    "mkdirp": "^3.0.1"
+    "mkdirp": "^3.0.1",
+    "rimraf": "^6.0.1"
   }
 }

--- a/tools/regexp-generator/package.json
+++ b/tools/regexp-generator/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "prebuild": "mkdirp ../../test/built-ins/RegExp/CharacterClassEscapes",
     "build": "node index.js"
   },
   "author": "",
@@ -14,5 +15,8 @@
     "jsesc": "^2.5.1",
     "regexpu-core": "^4.2.0",
     "slugify": "^1.3.0"
+  },
+  "devDependencies": {
+    "mkdirp": "^3.0.1"
   }
 }


### PR DESCRIPTION
https://github.com/bocoup/test262-regexp-generator was used to generate the tests in `test/built-ins/RegExp/CharacterClassEscapes/`. It makes sense for this script to live in the same repo as the tests it generates. Especially since in the meantime, the tests themselves have gotten out of sync with the upstream.

This imports the script, modernizes and cleans up the code, implements the changes necessary to match the changes made in the meantime to the tests, and integrates the script into the build process.