### PR TITLE
Temporal: Add test case for rounding Duration relative to a ZonedDateTime

### DIFF
--- a/test/intl402/Temporal/Duration/prototype/round/rounding-with-largestunit.js
+++ b/test/intl402/Temporal/Duration/prototype/round/rounding-with-largestunit.js
@@ -9,8 +9,8 @@ features: [Temporal]
 
 // Based on a test case by Adam Shaw
 
-const dur = Temporal.Duration.from({"hours": 13});
-const zdt = Temporal.ZonedDateTime.from('2024-03-10T00:00:00[America/New_York]');
+const dur = new Temporal.Duration.from(0, 0, 0, 0, /* hours = */ 13, 0, 0, 0, 0, 0);
+const zdt = new Temporal.ZonedDateTime(0n, "UTC");
 
 TemporalHelpers.assertDuration(
     dur.round({

--- a/test/intl402/Temporal/Duration/prototype/round/rounding-with-largestunit.js
+++ b/test/intl402/Temporal/Duration/prototype/round/rounding-with-largestunit.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-temporal.duration.prototype.round
+description: Rounding mode is taken into account when largestUnit is present.
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+// Based on a test case by Adam Shaw
+
+const dur = Temporal.Duration.from({"hours": 13});
+const zdt = Temporal.ZonedDateTime.from('2024-03-10T00:00:00[America/New_York]');
+
+TemporalHelpers.assertDuration(
+    dur.round({
+        relativeTo: zdt,
+        largestUnit: 'hours',
+        smallestUnit: 'hours',
+        roundingIncrement: 12,
+        roundingMode: 'ceil'
+    }), 0, 0, 0, 0, 24, 0, 0, 0, 0, 0);


### PR DESCRIPTION
This is the test for the change in https://github.com/tc39/proposal-temporal/pull/3036 and is a variation of the test from https://github.com/tc39/proposal-temporal/issues/2814 .