### PR TITLE
Disable grouping for numeric units in Intl.DurationFormat

### DIFF
--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -2673,6 +2673,8 @@ function partitionDurationFormatPattern(durationFormat, duration) {
         nfOpts.style = "unit";
         nfOpts.unit = numberFormatUnit;
         nfOpts.unitDisplay = style;
+      } else {
+        nfOpts.useGrouping = false;
       }
 
       let nf = new Intl.NumberFormat(locale, nfOpts);


### PR DESCRIPTION
Cf. `FormatNumeric{Hours,Minutes,Seconds}` in <https://tc39.es/proposal-intl-duration-format/>.