### PR TITLE
Temporal: Fix name of constructor

### DIFF
--- a/test/intl402/Temporal/Duration/prototype/round/rounding-with-largestunit.js
+++ b/test/intl402/Temporal/Duration/prototype/round/rounding-with-largestunit.js
@@ -9,7 +9,7 @@ features: [Temporal]
 
 // Based on a test case by Adam Shaw
 
-const dur = new Temporal.Duration.from(0, 0, 0, 0, /* hours = */ 13, 0, 0, 0, 0, 0);
+const dur = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 13, 0, 0, 0, 0, 0);
 const zdt = new Temporal.ZonedDateTime(0n, "UTC");
 
 TemporalHelpers.assertDuration(


### PR DESCRIPTION
I mistakenly committed something slightly different in my code review suggestion for #4306 than what I had modified locally.