### PR TITLE
Error.isError: Add test for DOMException

### DIFF
--- a/test/built-ins/Error/isError/dom-exception.js
+++ b/test/built-ins/Error/isError/dom-exception.js
@@ -1,0 +1,13 @@
+// Copyright 2024 Lionel Rowe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-error.iserror
+description: >
+  Returns true on DOMException instances
+features: [Error.isError]
+---*/
+
+if (typeof DOMException === 'function') {
+  assert.sameValue(Error.isError(new DOMException()), true);
+}


### PR DESCRIPTION
Given that `DOMException`s diverge in certain ways from other types of error (notably not having an `[[ErrorData]]` internal slot as of current Web IDL spec, pending https://github.com/whatwg/webidl/pull/1421), it seems prudent to include a test for this case.