### PR TITLE
Fix the not-a-constructor test for Math.f16round()

### DIFF
--- a/test/built-ins/Math/f16round/not-a-constructor.js
+++ b/test/built-ins/Math/f16round/not-a-constructor.js
@@ -12,5 +12,5 @@ features: [Float16Array, Reflect.construct]
 assert(!isConstructor(Math.f16round), "Math.f16round is not a constructor");
 
 assert.throws(TypeError, function () {
-  new Math.fround();
+  new Math.f16round();
 });


### PR DESCRIPTION
Previously, this was using Math.fround() instead of the f16 version.