### PR TITLE
Update Object.freeze tests for resizable TypedArrays

### DIFF
--- a/test/built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js
+++ b/test/built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js
@@ -5,12 +5,11 @@
 esid: sec-object.freeze
 description: >
   Object.freeze throws on non-0-length TypedArrays backed by resizable
-  buffers but do not throw on 0-length ones
+  buffers
 features: [resizable-arraybuffer]
 includes: [resizableArrayBufferUtils.js]
 ---*/
 
-// Freezing non-OOB non-zero-length TAs throws.
 for (let ctor of ctors) {
   const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
   const fixedLength = new ctor(rab, 0, 4);
@@ -36,9 +35,15 @@ for (let ctor of ctors) {
   const fixedLength = new ctor(rab, 0, 0);
   const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 0);
   const lengthTrackingWithOffset = new ctor(rab, 4 * ctor.BYTES_PER_ELEMENT);
-  Object.freeze(fixedLength);
-  Object.freeze(fixedLengthWithOffset);
-  Object.freeze(lengthTrackingWithOffset);
+  assert.throws(TypeError, () => {
+    Object.freeze(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    Object.freeze(fixedLengthWithOffset);
+  });
+  assert.throws(TypeError, () => {
+    Object.freeze(lengthTrackingWithOffset);
+  });
 }
 // If the buffer has been resized to make length-tracking TAs zero-length,
 // freezing them also doesn't throw.
@@ -47,7 +52,11 @@ for (let ctor of ctors) {
   const lengthTracking = new ctor(rab);
   const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
   rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-  Object.freeze(lengthTrackingWithOffset);
+  assert.throws(TypeError, () => {
+    Object.freeze(lengthTrackingWithOffset);
+  });
   rab.resize(0 * ctor.BYTES_PER_ELEMENT);
-  Object.freeze(lengthTracking);
+  assert.throws(TypeError, () => {
+    Object.freeze(lengthTracking);
+  });
 }


### PR DESCRIPTION
Object.freeze will always throw on variable-length TAs with this has-consensus PR: https://github.com/tc39/ecma262/pull/3453