### PR TITLE
Fix `single-line-html-close-first-line-*` failing with `Test262Error is not defined`

### DIFF
--- a/test/annexB/language/comments/single-line-html-close-first-line-1.js
+++ b/test/annexB/language/comments/single-line-html-close-first-line-1.js
@@ -21,7 +21,7 @@ info: |
       WhiteSpaceSequence[opt] SingleLineDelimitedCommentSequence[opt] --> SingleLineCommentChars[opt]
 negative:
   phase: runtime
-  type: Error
+  type: EvalError
 ---*/
 
 // Because this test concerns the interpretation of non-executable character
@@ -31,4 +31,4 @@ negative:
 // Express the intended behavior by intentionally throwing an error; this
 // guarantees that test runners will only consider the test "passing" if
 // executable sequences are correctly interpreted as such.
-throw new Error("This is not in a comment");
+throw new EvalError("This is not in a comment");

--- a/test/annexB/language/comments/single-line-html-close-first-line-1.js
+++ b/test/annexB/language/comments/single-line-html-close-first-line-1.js
@@ -21,7 +21,7 @@ info: |
       WhiteSpaceSequence[opt] SingleLineDelimitedCommentSequence[opt] --> SingleLineCommentChars[opt]
 negative:
   phase: runtime
-  type: Test262Error
+  type: Error
 ---*/
 
 // Because this test concerns the interpretation of non-executable character
@@ -31,4 +31,4 @@ negative:
 // Express the intended behavior by intentionally throwing an error; this
 // guarantees that test runners will only consider the test "passing" if
 // executable sequences are correctly interpreted as such.
-throw new Test262Error("This is not in a comment");
+throw new Error("This is not in a comment");

--- a/test/annexB/language/comments/single-line-html-close-first-line-2.js
+++ b/test/annexB/language/comments/single-line-html-close-first-line-2.js
@@ -21,7 +21,7 @@ info: |
       WhiteSpaceSequence[opt] SingleLineDelimitedCommentSequence[opt] --> SingleLineCommentChars[opt]
 negative:
   phase: runtime
-  type: Error
+  type: EvalError
 ---*/
 
 // Because this test concerns the interpretation of non-executable character
@@ -31,4 +31,4 @@ negative:
 // Express the intended behavior by intentionally throwing an error; this
 // guarantees that test runners will only consider the test "passing" if
 // executable sequences are correctly interpreted as such.
-throw new Error("This is not in a comment");
+throw new EvalError("This is not in a comment");

--- a/test/annexB/language/comments/single-line-html-close-first-line-2.js
+++ b/test/annexB/language/comments/single-line-html-close-first-line-2.js
@@ -21,7 +21,7 @@ info: |
       WhiteSpaceSequence[opt] SingleLineDelimitedCommentSequence[opt] --> SingleLineCommentChars[opt]
 negative:
   phase: runtime
-  type: Test262Error
+  type: Error
 ---*/
 
 // Because this test concerns the interpretation of non-executable character
@@ -31,4 +31,4 @@ negative:
 // Express the intended behavior by intentionally throwing an error; this
 // guarantees that test runners will only consider the test "passing" if
 // executable sequences are correctly interpreted as such.
-throw new Test262Error("This is not in a comment");
+throw new Error("This is not in a comment");

--- a/test/annexB/language/comments/single-line-html-close-first-line-3.js
+++ b/test/annexB/language/comments/single-line-html-close-first-line-3.js
@@ -21,7 +21,7 @@ info: |
       WhiteSpaceSequence[opt] SingleLineDelimitedCommentSequence[opt] --> SingleLineCommentChars[opt]
 negative:
   phase: runtime
-  type: Error
+  type: EvalError
 ---*/
 
 // Because this test concerns the interpretation of non-executable character
@@ -31,4 +31,4 @@ negative:
 // Express the intended behavior by intentionally throwing an error; this
 // guarantees that test runners will only consider the test "passing" if
 // executable sequences are correctly interpreted as such.
-throw new Error("This is not in a comment");
+throw new EvalError("This is not in a comment");

--- a/test/annexB/language/comments/single-line-html-close-first-line-3.js
+++ b/test/annexB/language/comments/single-line-html-close-first-line-3.js
@@ -21,7 +21,7 @@ info: |
       WhiteSpaceSequence[opt] SingleLineDelimitedCommentSequence[opt] --> SingleLineCommentChars[opt]
 negative:
   phase: runtime
-  type: Test262Error
+  type: Error
 ---*/
 
 // Because this test concerns the interpretation of non-executable character
@@ -31,4 +31,4 @@ negative:
 // Express the intended behavior by intentionally throwing an error; this
 // guarantees that test runners will only consider the test "passing" if
 // executable sequences are correctly interpreted as such.
-throw new Test262Error("This is not in a comment");
+throw new Error("This is not in a comment");


### PR DESCRIPTION
closes #4020

Updated the tests per https://github.com/tc39/test262/issues/4020#issuecomment-2009885892