### PR TITLE
Fix AbstractModuleSource.prototype descriptor

### DIFF
--- a/test/built-ins/AbstractModuleSource/prototype.js
+++ b/test/built-ins/AbstractModuleSource/prototype.js
@@ -19,5 +19,5 @@ verifyProperty($262.AbstractModuleSource, 'prototype', {
   value: $262.AbstractModuleSource.prototype,
   writable: false,
   enumerable: false,
-  configurable: true
+  configurable: false
 });


### PR DESCRIPTION
The descriptor should be `{ [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }`.