### PR TITLE
Add WMAS Test Suite to Test262 Runners section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Volunteer-maintained projects that may be used to execute Test262 in various ECM
 - https://bakkot.github.io/test262-web-runner/ (platform: web)
 - https://github.com/Izhido/test262_harness_cpp (platform: C++)
 - https://github.com/lahma/test262-harness-dotnet (platform: .NET)
-
+- https://github.com/cta-wave/WMAS/ (platform: Python with Docker support)
 
 ### How To Read CI Results
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Volunteer-maintained projects that may be used to execute Test262 in various ECM
 - https://bakkot.github.io/test262-web-runner/ (platform: web)
 - https://github.com/Izhido/test262_harness_cpp (platform: C++)
 - https://github.com/lahma/test262-harness-dotnet (platform: .NET)
-- https://github.com/cta-wave/WMAS/ (platform: Python with Docker support)
+- https://github.com/cta-wave/WMAS/tree/latest (platform: Python; [Docker Deploy Instructions](https://github.com/cta-wave/WMAS-deploy/tree/wmas-latest))
 
 ### How To Read CI Results
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Volunteer-maintained projects that may be used to execute Test262 in various ECM
 - https://bakkot.github.io/test262-web-runner/ (platform: web)
 - https://github.com/Izhido/test262_harness_cpp (platform: C++)
 - https://github.com/lahma/test262-harness-dotnet (platform: .NET)
-- https://github.com/cta-wave/WMAS/tree/latest (platform: Python; [Docker Deploy Instructions](https://github.com/cta-wave/WMAS-deploy/tree/wmas-latest))
+- https://github.com/cta-wave/WMAS/tree/latest/tools/wave/ecmascript (platform: Python; [Docker Deploy Instructions](https://github.com/cta-wave/WMAS-deploy/tree/wmas-latest))
 
 ### How To Read CI Results
 


### PR DESCRIPTION
Integrates Test262 ECMAScript tests into the [WMAS Test Suite](https://github.com/cta-wave/WMAS/), built on Web Platform Tests ([WPT](https://github.com/web-platform-tests/wpt/)). Ensures Test262 results are compatible with the WPT format.