### PR TITLE
Update UTC time zone canonicalization to match proposal-canonical-tz

### DIFF
--- a/test/intl402/DateTimeFormat/canonicalize-utc-timezone.js
+++ b/test/intl402/DateTimeFormat/canonicalize-utc-timezone.js
@@ -2,25 +2,33 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-createdatetimeformat
-description: Tests that the time zone names "Etc/UTC", "Etc/GMT", and "GMT" all resolve to "UTC".
+description: >
+  Tests that the time zone names "Etc/UTC", "Etc/GMT", and "GMT" are not
+  canonicalized to "UTC" in "resolvedOptions".
 info: |
   CreateDateTimeFormat ( dateTimeFormat, locales, options, required, default )
 
-  29. If IsTimeZoneOffsetString(timeZone) is true, then
+  30. If IsTimeZoneOffsetString(timeZone) is true, then
   ...
-  30. Else,
+  31. Else,
     a. Let timeZoneIdentifierRecord be GetAvailableNamedTimeZoneIdentifier(timeZone).
+    ...
+    c. Set timeZone to timeZoneIdentifierRecord.[[Identifier]].
 
   GetAvailableNamedTimeZoneIdentifier ( timeZoneIdentifier )
 
-  ...
-  5. For each element identifier of identifiers, do
-  ...
-    c. If primary is one of "Etc/UTC", "Etc/GMT", or "GMT", set primary to "UTC".
+  1. For each element record of AvailableNamedTimeZoneIdentifiers(), do
+    a. If record.[[Identifier]] is an ASCII-case-insensitive match for
+       timeZoneIdentifier, return record.
+
+features: [canonical-tz]
 ---*/
 
 const utcIdentifiers = ["Etc/GMT", "Etc/UTC", "GMT"];
 
 for (const timeZone of utcIdentifiers) {
-  assert.sameValue(new Intl.DateTimeFormat([], {timeZone}).resolvedOptions().timeZone, "UTC", "Time zone name " + timeZone + " not canonicalized to 'UTC'.");
+  assert.sameValue(
+    new Intl.DateTimeFormat([], {timeZone}).resolvedOptions().timeZone,
+    timeZone,
+    "Time zone name " + timeZone + " should be preserved and not canonicalized to 'UTC'");
 }

--- a/test/intl402/Temporal/ZonedDateTime/prototype/equals/canonicalize-utc-timezone.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/equals/canonicalize-utc-timezone.js
@@ -1,0 +1,40 @@
+// Copyright 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: >
+  Tests that the time zone names "Etc/UTC", "Etc/GMT", and "GMT" are equal to,
+  but not canonicalized to, "UTC".
+info: |
+  Temporal.ZonedDateTime.prototype.equals ( other )
+
+  ...
+  5. If TimeZoneEquals(zonedDateTime.[[TimeZone]], other.[[TimeZone]]) is false,
+     return false.
+
+  TimeZoneEquals ( one, two )
+
+  ...
+  4.a. Let recordOne be GetAvailableNamedTimeZoneIdentifier(one).
+    b. Let recordTwo be GetAvailableNamedTimeZoneIdentifier(two).
+    c. If recordOne is not empty and recordTwo is not empty and
+       recordOne.[[PrimaryIdentifier]] is recordTwo.[[PrimaryIdentifier]],
+       return true.
+
+features: [canonical-tz, Temporal]
+---*/
+
+var utcDateTime = new Temporal.ZonedDateTime(0n, "UTC");
+assert.sameValue(utcDateTime.timeZoneId, "UTC", "Time zone name 'UTC' is preserved");
+
+var utcIdentifiers = ["Etc/GMT", "Etc/UTC", "GMT"];
+
+for (var ix = 0; ix < utcIdentifiers.length; ix++) {
+  var timeZone = utcIdentifiers[ix];
+  var dateTime = new Temporal.ZonedDateTime(0n, timeZone);
+  assert.sameValue(
+    dateTime.timeZoneId,
+    utcDateTime.timeZoneId,
+    timeZone + " should be preserved and not canonicalized to UTC");
+  assert(dateTime.equals(utcDateTime), "Time zone " + timeZone + " should be equal to primary identifier UTC");
+}


### PR DESCRIPTION
The test for https://github.com/tc39/ecma402/pull/724 (added in https://github.com/tc39/test262/pull/4328) didn't take the Time Zone Canonicalization proposal into account; but it should, because that proposal is stage 3.

As of that proposal, the [[TimeZone]] slot of DateTimeFormat gets the case-regularized original identifier, no longer the primary identifier. So the resolvedOptions().timeZone property also no longer returns the primary identifier.