### PR TITLE
Temporal: Improve coverage of relativeto-string-limits tests

### DIFF
--- a/test/built-ins/Temporal/Duration/compare/relativeto-string-limits.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-string-limits.js
@@ -7,7 +7,8 @@ description: ISO strings at the edges of the representable range
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.Duration();
+const instance = new Temporal.Duration(0, 0, 0, 0, 0, /* minutes = */ 5);
+const blankInstance = new Temporal.Duration();
 
 const validStrings = [
   "-271821-04-20T00:00Z[UTC]",
@@ -21,7 +22,7 @@ const validStrings = [
 ];
 
 for (const relativeTo of validStrings) {
-  Temporal.Duration.compare(instance, instance, { relativeTo });
+  Temporal.Duration.compare(instance, blankInstance, { relativeTo });
 }
 
 const invalidStrings = [
@@ -42,7 +43,7 @@ const invalidStrings = [
 for (const relativeTo of invalidStrings) {
   assert.throws(
     RangeError,
-    () => Temporal.Duration.compare(instance, instance, { relativeTo }),
+    () => Temporal.Duration.compare(instance, blankInstance, { relativeTo }),
     `"${relativeTo}" is outside the representable range for a relativeTo parameter`
   );
 }

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-string-limits.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-string-limits.js
@@ -7,21 +7,34 @@ description: ISO strings at the edges of the representable range
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.Duration();
+const instance = new Temporal.Duration(0, 0, 0, 0, 0, /* minutes = */ 5);
+const blankInstance = new Temporal.Duration();
 
 const validStrings = [
   "-271821-04-20T00:00Z[UTC]",
-  "+275760-09-13T00:00Z[UTC]",
-  "+275760-09-13T01:00+01:00[+01:00]",
-  "+275760-09-13T23:59+23:59[+23:59]",
-  "-271821-04-19",
-  "-271821-04-19T01:00",
   "+275760-09-13",
   "+275760-09-13T23:00",
 ];
 
 for (const relativeTo of validStrings) {
   instance.round({ smallestUnit: "minutes", relativeTo });
+  blankInstance.round({ smallestUnit: "minutes", relativeTo });
+}
+
+const validStringsThatFailAfterEarlyReturn = [
+  "+275760-09-13T00:00Z[UTC]",
+  "+275760-09-13T01:00+01:00[+01:00]",
+  "+275760-09-13T23:59+23:59[+23:59]",
+  "-271821-04-19",
+  "-271821-04-19T01:00",
+];
+for (const relativeTo of validStringsThatFailAfterEarlyReturn) {
+  blankInstance.round({ smallestUnit: "minutes", relativeTo });
+  assert.throws(
+    RangeError,
+    () => instance.round({ smallestUnit: "minutes", relativeTo }),
+    `"${relativeTo}" is outside the representable range for a relativeTo parameter after conversion to DateTime`
+  );
 }
 
 const invalidStrings = [
@@ -43,6 +56,11 @@ for (const relativeTo of invalidStrings) {
   assert.throws(
     RangeError,
     () => instance.round({ smallestUnit: "minutes", relativeTo }),
+    `"${relativeTo}" is outside the representable range for a relativeTo parameter`
+  );
+  assert.throws(
+    RangeError,
+    () => blankInstance.round({ smallestUnit: "minutes", relativeTo }),
     `"${relativeTo}" is outside the representable range for a relativeTo parameter`
   );
 }

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-string-limits.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-string-limits.js
@@ -7,21 +7,34 @@ description: ISO strings at the edges of the representable range
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.Duration();
+const instance = new Temporal.Duration(0, 0, 0, 0, 0, /* minutes = */ 5);
+const blankInstance = new Temporal.Duration();
 
 const validStrings = [
   "-271821-04-20T00:00Z[UTC]",
-  "+275760-09-13T00:00Z[UTC]",
-  "+275760-09-13T01:00+01:00[+01:00]",
-  "+275760-09-13T23:59+23:59[+23:59]",
-  "-271821-04-19",
-  "-271821-04-19T01:00",
   "+275760-09-13",
   "+275760-09-13T23:00",
 ];
 
 for (const relativeTo of validStrings) {
   instance.total({ unit: "minutes", relativeTo });
+  blankInstance.total({ unit: "minutes", relativeTo });
+}
+
+const validStringsThatFailAfterEarlyReturn = [
+  "+275760-09-13T00:00Z[UTC]",
+  "+275760-09-13T01:00+01:00[+01:00]",
+  "+275760-09-13T23:59+23:59[+23:59]",
+  "-271821-04-19",
+  "-271821-04-19T01:00",
+];
+for (const relativeTo of validStringsThatFailAfterEarlyReturn) {
+  blankInstance.total({ unit: "minutes", relativeTo });
+  assert.throws(
+    RangeError,
+    () => instance.total({ unit: "minutes", relativeTo }),
+    `"${relativeTo}" is outside the representable range for a relativeTo parameter after conversion to DateTime`
+  );
 }
 
 const invalidStrings = [
@@ -43,6 +56,11 @@ for (const relativeTo of invalidStrings) {
   assert.throws(
     RangeError,
     () => instance.total({ unit: "minutes", relativeTo }),
+    `"${relativeTo}" is outside the representable range for a relativeTo parameter`
+  );
+  assert.throws(
+    RangeError,
+    () => blankInstance.total({ unit: "minutes", relativeTo }),
     `"${relativeTo}" is outside the representable range for a relativeTo parameter`
   );
 }


### PR DESCRIPTION
These tests did not fully cover Temporal.Duration.prototype.round and Temporal.Duration.prototype.total because they called those methods on a blank duration (all components zero), for which there is an early return in round() and total().

This meant that we missed an assertion that would be hit after the early return.

This makes sure to test both blank and non-blank Durations with these relativeTo strings, and expect some strings to fail at different steps with the two cases.

See: tc39/proposal-temporal#3015