### PR TITLE
Add missing `from` in two `import defer` tests

### DIFF
--- a/test/language/import/import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js
+++ b/test/language/import/import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js
@@ -19,4 +19,4 @@ negative:
 
 $DONOTEVALUATE();
 
-import defer * as ns "./resolution-error_FIXTURE.js";
+import defer * as ns from "./resolution-error_FIXTURE.js";

--- a/test/language/import/import-defer/errors/syntax-error/import-defer-of-syntax-error-fails.js
+++ b/test/language/import/import-defer/errors/syntax-error/import-defer-of-syntax-error-fails.js
@@ -19,4 +19,4 @@ negative:
 
 $DONOTEVALUATE();
 
-import defer * as ns "./syntax-error_FIXTURE.js";
+import defer * as ns from "./syntax-error_FIXTURE.js";


### PR DESCRIPTION
We probably missed those two tests when running in the WebKit implementation because they are expected to fail, but due to the error in the dependency and not in the file itself.

Noticed in https://github.com/babel/babel/pull/17011