### PR TITLE
Remove unused fixtures file from SM staging

### DIFF
--- a/test/staging/sm/module/bug1693261-async.mjs
+++ b/test/staging/sm/module/bug1693261-async.mjs
@@ -1,7 +1,0 @@
-// |reftest| skip -- support file
-if (globalThis.testArray === undefined) {
-  globalThis.testArray = [];
-}
-globalThis.testArray.push("async 1");
-await 0;
-globalThis.testArray.push("async 2");

--- a/test/staging/sm/module/bug1693261-c1.mjs
+++ b/test/staging/sm/module/bug1693261-c1.mjs
@@ -1,6 +1,0 @@
-// |reftest| skip -- support file
-import "./bug1693261-async.mjs";
-if (globalThis.testArray === undefined) {
-  globalThis.testArray = [];
-}
-globalThis.testArray.push("c1");

--- a/test/staging/sm/module/bug1693261-c2.mjs
+++ b/test/staging/sm/module/bug1693261-c2.mjs
@@ -1,6 +1,0 @@
-// |reftest| skip -- support file
-import "./bug1693261-async.mjs";
-if (globalThis.testArray === undefined) {
-  globalThis.testArray = [];
-}
-globalThis.testArray.push("c2");

--- a/test/staging/sm/module/bug1693261-x.mjs
+++ b/test/staging/sm/module/bug1693261-x.mjs
@@ -1,6 +1,0 @@
-// |reftest| skip -- support file
-import "./bug1693261-c1.mjs";
-if (globalThis.testArray === undefined) {
-  globalThis.testArray = [];
-}
-globalThis.testArray.push("x");


### PR DESCRIPTION
These files are missing the frontmatter. I was going to add it, but then noticed that:
- they have no assertions
- they are marked as `// |reftest| skip -- support file`

They are meant to be `_FIXTURE.js` files, but they are not imported anywhere. They can be simply removed.