### PR TITLE
Fix the `phase` in tests about invalid JSON module bindings

### DIFF
--- a/test/language/import/import-attributes/json-invalid.js
+++ b/test/language/import/import-attributes/json-invalid.js
@@ -14,7 +14,7 @@ info: |
 flags: [module]
 features: [import-attributes, json-modules]
 negative:
-  phase: parse
+  phase: resolution
   type: SyntaxError
 ---*/
 

--- a/test/language/import/import-attributes/json-named-bindings.js
+++ b/test/language/import/import-attributes/json-named-bindings.js
@@ -11,7 +11,7 @@ info: |
 flags: [module]
 features: [import-attributes, json-modules]
 negative:
-  phase: parse
+  phase: resolution
   type: SyntaxError
 ---*/
 


### PR DESCRIPTION
These errors don't happen when parsing the file, but when linking it with its dependencies.

Fixes half of https://github.com/tc39/test262/issues/4124