### PR TITLE
add tests for "iterator helpers close receiver on argument validation failure"

### DIFF
--- a/test/built-ins/Iterator/prototype/drop/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/drop/argument-validation-failure-closes-underlying.js
@@ -19,6 +19,7 @@ let closable = {
   },
   return() {
     closed = true;
+    return {};
   },
 };
 

--- a/test/built-ins/Iterator/prototype/drop/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/drop/argument-validation-failure-closes-underlying.js
@@ -41,7 +41,8 @@ assert.throws(RangeError, function() {
 assert.sameValue(closed, true);
 
 closed = false;
-assert.throws(Test262Error, function() {
-  closable.drop({ get valueOf() { throw new Test262Error(); }});
+class ShouldNotGetValueOf {}
+assert.throws(ShouldNotGetValueOf, function() {
+  closable.drop({ get valueOf() { throw new ShouldNotGetValueOf(); }});
 });
 assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/drop/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/drop/argument-validation-failure-closes-underlying.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.drop
+description: >
+  Underlying iterator is closed when argument validation fails
+info: |
+  %Iterator.prototype%.drop ( limit )
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let closed = false;
+let closable = {
+  __proto__: Iterator.prototype,
+  get next() {
+    throw new Test262Error('next should not be read');
+  },
+  return() {
+    closed = true;
+  },
+};
+
+assert.throws(RangeError, function() {
+  closable.drop();
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(RangeError, function() {
+  closable.drop(NaN);
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(RangeError, function() {
+  closable.drop(-1);
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(Test262Error, function() {
+  closable.drop({ get valueOf() { throw new Test262Error(); }});
+});
+assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/every/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/every/argument-validation-failure-closes-underlying.js
@@ -19,6 +19,7 @@ let closable = {
   },
   return() {
     closed = true;
+    return {};
   },
 };
 

--- a/test/built-ins/Iterator/prototype/every/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/every/argument-validation-failure-closes-underlying.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.every
+description: >
+  Underlying iterator is closed when argument validation fails
+info: |
+  %Iterator.prototype%.every ( predicate )
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let closed = false;
+let closable = {
+  __proto__: Iterator.prototype,
+  get next() {
+    throw new Test262Error('next should not be read');
+  },
+  return() {
+    closed = true;
+  },
+};
+
+assert.throws(TypeError, function() {
+  closable.every();
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(TypeError, function() {
+  closable.every({});
+});
+assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/filter/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/filter/argument-validation-failure-closes-underlying.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.filter
+description: >
+  Underlying iterator is closed when argument validation fails
+info: |
+  %Iterator.prototype%.filter ( predicate )
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let closed = false;
+let closable = {
+  __proto__: Iterator.prototype,
+  get next() {
+    throw new Test262Error('next should not be read');
+  },
+  return() {
+    closed = true;
+  },
+};
+
+assert.throws(TypeError, function() {
+  closable.filter();
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(TypeError, function() {
+  closable.filter({});
+});
+assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/filter/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/filter/argument-validation-failure-closes-underlying.js
@@ -19,6 +19,7 @@ let closable = {
   },
   return() {
     closed = true;
+    return {};
   },
 };
 

--- a/test/built-ins/Iterator/prototype/find/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/find/argument-validation-failure-closes-underlying.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.find
+description: >
+  Underlying iterator is closed when argument validation fails
+info: |
+  %Iterator.prototype%.find ( predicate )
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let closed = false;
+let closable = {
+  __proto__: Iterator.prototype,
+  get next() {
+    throw new Test262Error('next should not be read');
+  },
+  return() {
+    closed = true;
+  },
+};
+
+assert.throws(TypeError, function() {
+  closable.find();
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(TypeError, function() {
+  closable.find({});
+});
+assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/find/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/find/argument-validation-failure-closes-underlying.js
@@ -19,6 +19,7 @@ let closable = {
   },
   return() {
     closed = true;
+    return {};
   },
 };
 

--- a/test/built-ins/Iterator/prototype/flatMap/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/flatMap/argument-validation-failure-closes-underlying.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.flatMap
+description: >
+  Underlying iterator is closed when argument validation fails
+info: |
+  %Iterator.prototype%.flatMap ( mapper )
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let closed = false;
+let closable = {
+  __proto__: Iterator.prototype,
+  get next() {
+    throw new Test262Error('next should not be read');
+  },
+  return() {
+    closed = true;
+  },
+};
+
+assert.throws(TypeError, function() {
+  closable.flatMap();
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(TypeError, function() {
+  closable.flatMap({});
+});
+assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/flatMap/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/flatMap/argument-validation-failure-closes-underlying.js
@@ -19,6 +19,7 @@ let closable = {
   },
   return() {
     closed = true;
+    return {};
   },
 };
 

--- a/test/built-ins/Iterator/prototype/forEach/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/forEach/argument-validation-failure-closes-underlying.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.forEach
+description: >
+  Underlying iterator is closed when argument validation fails
+info: |
+  %Iterator.prototype%.forEach ( predicate )
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let closed = false;
+let closable = {
+  __proto__: Iterator.prototype,
+  get next() {
+    throw new Test262Error('next should not be read');
+  },
+  return() {
+    closed = true;
+  },
+};
+
+assert.throws(TypeError, function() {
+  closable.forEach();
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(TypeError, function() {
+  closable.forEach({});
+});
+assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/forEach/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/forEach/argument-validation-failure-closes-underlying.js
@@ -19,6 +19,7 @@ let closable = {
   },
   return() {
     closed = true;
+    return {};
   },
 };
 

--- a/test/built-ins/Iterator/prototype/map/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/map/argument-validation-failure-closes-underlying.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.map
+description: >
+  Underlying iterator is closed when argument validation fails
+info: |
+  %Iterator.prototype%.map ( mapper )
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let closed = false;
+let closable = {
+  __proto__: Iterator.prototype,
+  get next() {
+    throw new Test262Error('next should not be read');
+  },
+  return() {
+    closed = true;
+  },
+};
+
+assert.throws(TypeError, function() {
+  closable.map();
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(TypeError, function() {
+  closable.map({});
+});
+assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/map/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/map/argument-validation-failure-closes-underlying.js
@@ -19,6 +19,7 @@ let closable = {
   },
   return() {
     closed = true;
+    return {};
   },
 };
 

--- a/test/built-ins/Iterator/prototype/reduce/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/reduce/argument-validation-failure-closes-underlying.js
@@ -19,6 +19,7 @@ let closable = {
   },
   return() {
     closed = true;
+    return {};
   },
 };
 

--- a/test/built-ins/Iterator/prototype/reduce/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/reduce/argument-validation-failure-closes-underlying.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.reduce
+description: >
+  Underlying iterator is closed when argument validation fails
+info: |
+  %Iterator.prototype%.reduce ( reducer, [ initialValue ] )
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let closed = false;
+let closable = {
+  __proto__: Iterator.prototype,
+  get next() {
+    throw new Test262Error('next should not be read');
+  },
+  return() {
+    closed = true;
+  },
+};
+
+assert.throws(TypeError, function() {
+  closable.reduce();
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(TypeError, function() {
+  closable.reduce({});
+});
+assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/reduce/non-callable-reducer.js
+++ b/test/built-ins/Iterator/prototype/reduce/non-callable-reducer.js
@@ -11,12 +11,12 @@ features: [iterator-helpers]
 flags: []
 ---*/
 let nonCallable = {};
-let iterator = (function* () {
+function* gen() {
   yield 1;
-})();
+}
 
 assert.throws(TypeError, function () {
-  iterator.reduce(nonCallable);
+  gen().reduce(nonCallable);
 });
 
-iterator.reduce(() => {});
+gen().reduce(() => {});

--- a/test/built-ins/Iterator/prototype/some/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/some/argument-validation-failure-closes-underlying.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.some
+description: >
+  Underlying iterator is closed when argument validation fails
+info: |
+  %Iterator.prototype%.some ( predicate )
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let closed = false;
+let closable = {
+  __proto__: Iterator.prototype,
+  get next() {
+    throw new Test262Error('next should not be read');
+  },
+  return() {
+    closed = true;
+  },
+};
+
+assert.throws(TypeError, function() {
+  closable.some();
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(TypeError, function() {
+  closable.some({});
+});
+assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/some/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/some/argument-validation-failure-closes-underlying.js
@@ -19,6 +19,7 @@ let closable = {
   },
   return() {
     closed = true;
+    return {};
   },
 };
 

--- a/test/built-ins/Iterator/prototype/take/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/take/argument-validation-failure-closes-underlying.js
@@ -19,6 +19,7 @@ let closable = {
   },
   return() {
     closed = true;
+    return {};
   },
 };
 

--- a/test/built-ins/Iterator/prototype/take/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/take/argument-validation-failure-closes-underlying.js
@@ -41,7 +41,8 @@ assert.throws(RangeError, function() {
 assert.sameValue(closed, true);
 
 closed = false;
-assert.throws(Test262Error, function() {
-  closable.take({ get valueOf() { throw new Test262Error(); }});
+class ShouldNotGetValueOf {}
+assert.throws(ShouldNotGetValueOf, function() {
+  closable.take({ get valueOf() { throw new ShouldNotGetValueOf(); }});
 });
 assert.sameValue(closed, true);

--- a/test/built-ins/Iterator/prototype/take/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/take/argument-validation-failure-closes-underlying.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.take
+description: >
+  Underlying iterator is closed when argument validation fails
+info: |
+  %Iterator.prototype%.take ( limit )
+
+features: [iterator-helpers]
+flags: []
+---*/
+
+let closed = false;
+let closable = {
+  __proto__: Iterator.prototype,
+  get next() {
+    throw new Test262Error('next should not be read');
+  },
+  return() {
+    closed = true;
+  },
+};
+
+assert.throws(RangeError, function() {
+  closable.take();
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(RangeError, function() {
+  closable.take(NaN);
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(RangeError, function() {
+  closable.take(-1);
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(Test262Error, function() {
+  closable.take({ get valueOf() { throw new Test262Error(); }});
+});
+assert.sameValue(closed, true);


### PR DESCRIPTION
Tests for https://github.com/tc39/ecma262/pull/3467, which has consensus and is just waiting for tests.

No existing tests were invalidated as far as I can tell (presumably because if we'd thought to test this behavior then we'd have updated the proposal instead of needing the PR).