### PR TITLE
Remove "US/Pacific-New" from time zone tests

### DIFF
--- a/test/intl402/DateTimeFormat/timezone-case-insensitive.js
+++ b/test/intl402/DateTimeFormat/timezone-case-insensitive.js
@@ -601,7 +601,6 @@ const timeZoneIdentifiers = [
   "US/Michigan",
   "US/Mountain",
   "US/Pacific",
-  "US/Pacific-New",
   "US/Samoa",
   "UTC",
   "Universal",

--- a/test/intl402/Temporal/ZonedDateTime/from/timezone-case-insensitive.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/timezone-case-insensitive.js
@@ -602,7 +602,6 @@ const timeZoneIdentifiers = [
   'US/Michigan',
   'US/Mountain',
   'US/Pacific',
-  'US/Pacific-New',
   'US/Samoa',
   'UTC',
   'Universal',

--- a/test/intl402/Temporal/ZonedDateTime/timezone-case-insensitive.js
+++ b/test/intl402/Temporal/ZonedDateTime/timezone-case-insensitive.js
@@ -606,7 +606,6 @@ const timeZoneIdentifiers = [
   'US/Michigan',
   'US/Mountain',
   'US/Pacific',
-  'US/Pacific-New',
   'US/Samoa',
   'UTC',
   'Universal',


### PR DESCRIPTION
"US/Pacific-New" was removed in tzdata2020b.