### PR TITLE
Add feature tag for async-iterator-helpers

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -92,6 +92,10 @@ import-defer
 # https://github.com/tc39/proposal-iterator-sequencing
 iterator-sequencing
 
+# Async Iterator Helpers
+# https://github.com/tc39/proposal-async-iterator-helpers
+async-iterator-helpers
+
 ## Standard language features
 #
 # Language features that have been included in a published version of the


### PR DESCRIPTION
The tests in "staging/sm/AsyncIterator" incorrectly use "async-iteration" (which is the feature tag for `async function*`). A new feature tag is needed for <https://github.com/tc39/proposal-async-iterator-helpers>.