### PR TITLE
DurationFormat: Add tests for durations with `style: "digital"`, `hoursDisplay: "auto"` and zero hours

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/digital-style-with-hours-display-auto-with-zero-hour.js
+++ b/test/intl402/DurationFormat/prototype/format/digital-style-with-hours-display-auto-with-zero-hour.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2024 Sosuke Suzuki. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.format
+description: >
+  The separator isn't printed when style is digital, hoursDisplay is auto and hours value is zero
+locale: [en-US]
+features: [Intl.DurationFormat]
+---*/
+
+const df = new Intl.DurationFormat("en", {
+  style: "digital",
+  hoursDisplay: "auto",
+});
+
+const durations = [
+  // basic zero hours
+  [{ hours: 0, minutes: 0, seconds: 2 }, "00:02"],
+  [{ hours: 0, minutes: 1, seconds: 2 }, "01:02"],
+  [{ days: 1, hours: 0, minutes: 1, seconds: 2 }, "1 day, 01:02"],
+
+  // without hours
+  [{ minutes: 0, seconds: 2 }, "00:02"],
+  [{ minutes: 1, seconds: 2 }, "01:02"],
+  [{ days: 1,  minutes: 1, seconds: 2 }, "1 day, 01:02"],
+
+  // negative sign
+  [{ hours: 0, minutes: -1, seconds: -2 }, "-01:02"],
+  [{ hours: 0, minutes: -1, seconds: -2 }, "-01:02"],
+  [{ days: -1, hours: 0, minutes: -1, seconds: -2 }, "-1 day, 01:02"],
+];
+
+for (const [duration, expected] of durations) {
+  assert.sameValue(df.format(duration), expected, `Duration is ${duration}`);
+}

--- a/test/intl402/DurationFormat/prototype/format/digital-style-with-hours-display-auto-with-zero-hour.js
+++ b/test/intl402/DurationFormat/prototype/format/digital-style-with-hours-display-auto-with-zero-hour.js
@@ -32,5 +32,5 @@ const durations = [
 ];
 
 for (const [duration, expected] of durations) {
-  assert.sameValue(df.format(duration), expected, `Duration is ${duration}`);
+  assert.sameValue(df.format(duration), expected, `Duration is ${JSON.stringify(duration)}`);
 }


### PR DESCRIPTION
The implementation of `Intl.DurationFormat` in WebKit (JavaScriptCore) has passed all test262 test cases, but we discovered two incompatibilities with the specification. This Pull Request adds tests addressing those issues.

The first one is described in [bug 285078](https://bugs.webkit.org/show_bug.cgi?id=285078). A separator is printed erroneously for an unprinted hours value:

```js
const df = new Intl.DurationFormat('en-US', {
  style: "digital",
  hoursDisplay: "auto",
});
df.format({hours: 0, minutes: 1, seconds: 2});
// expected: "01:02"
// actual  : ":, 01:02"
```

The second one is described in [bug 285212](https://bugs.webkit.org/show_bug.cgi?id=285212). A negative sign is not printed:

```js
const df = new Intl.DurationFormat('en-US', {
  style: "digital",
  hoursDisplay: "auto",
});
df.format({ hours: 0, minutes: -2, seconds: -3 });
// expected: "-02:03"
// actual  : "02:03"
```

Both issues occur when `style: "digital"`, `hoursDisplay: "auto"`, and the hours value is 0 or absent. For that reason, they are combined into a single test file.
