### PR TITLE
Add coverage for value coercions in TypedArray.p.with

### DIFF
--- a/test/built-ins/TypedArray/prototype/with/order-of-evaluation.js
+++ b/test/built-ins/TypedArray/prototype/with/order-of-evaluation.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.with
+description: >
+  Index parameter is coerced before value parameter.
+info: |
+  %TypedArray%.prototype.with ( index, value )
+
+  ...
+  4. Let relativeIndex be ? ToIntegerOrInfinity(index).
+  ...
+  8. Else, let numericValue be ? ToNumber(value).
+  ...
+features: [TypedArray, change-array-by-copy]
+includes: [testTypedArray.js, compareArray.js]
+---*/
+
+testWithTypedArrayConstructors(TA => {
+  var ta = new TA(1);
+
+  var logs = [];
+
+  var index = {
+    valueOf() {
+      logs.push("index");
+      return 0;
+    }
+  };
+
+  var value = {
+    valueOf() {
+      logs.push("value");
+      return 0;
+    }
+  };
+
+  ta.with(index, value);
+
+  assert.compareArray(logs, ["index", "value"]);
+});

--- a/test/built-ins/TypedArray/prototype/with/valid-typedarray-index-checked-after-coercions.js
+++ b/test/built-ins/TypedArray/prototype/with/valid-typedarray-index-checked-after-coercions.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.with
+description: >
+  IsValidIntegerIndex is checked after all coercions happened.
+info: |
+  %TypedArray%.prototype.with ( index, value )
+
+  ...
+  8. Else, let numericValue be ? ToNumber(value).
+  9. If IsValidIntegerIndex(O, 𝔽(actualIndex)) is false, throw a RangeError exception.
+  ...
+features: [TypedArray, change-array-by-copy, resizable-arraybuffer]
+includes: [testTypedArray.js]
+---*/
+
+testWithTypedArrayConstructors(TA => {
+  var rab = new ArrayBuffer(0, {maxByteLength: TA.BYTES_PER_ELEMENT});
+  var ta = new TA(rab);
+  assert.sameValue(ta.length, 0);
+
+  var value = {
+    valueOf() {
+      rab.resize(TA.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+
+  var result = ta.with(0, value);
+
+  assert.sameValue(result.length, 0);
+  assert.sameValue(rab.byteLength, TA.BYTES_PER_ELEMENT);
+});


### PR DESCRIPTION
Both tests fail in V8, but succeed in JSC and SM.