### PR TITLE
Add syntax tests for `import.defer`

### DIFF
--- a/src/assignment-target-type/importcall-defer.case
+++ b/src/assignment-target-type/importcall-defer.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-static-semantics-static-semantics-assignmenttargettype
+desc: >
+  Static Semantics AssignmentTargetType, Return invalid.
+info: |
+  ImportCall
+  Static Semantics AssignmentTargetType, Return invalid.
+template: invalid
+flags: [module]
+features: [import-defer]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+//- assignmenttarget
+import.defer()
+//- operator
+=
+//- value
+1

--- a/src/dynamic-import/import-defer-assignment-expr-not-optional.case
+++ b/src/dynamic-import/import-defer-assignment-expr-not-optional.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// Copyright (C) 2018 Rick Waldron. All rights reserved.
+// Copyright (C) 2018 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: It's a SyntaxError if AssignmentExpression is omitted
+template: syntax/invalid
+info: |
+  ImportCall[Yield, Await] :
+      import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+features: [import-defer]
+---*/
+//- import
+import.defer()
+//- teardown
+/* The params region intentionally empty */

--- a/src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+++ b/src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
@@ -1,0 +1,12 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// Copyright (C) 2018 Rick Waldron. All rights reserved.
+// Copyright (C) 2018 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Calling import.defer('')
+template: syntax/valid
+features: [import-defer]
+---*/
+
+//- import
+import.defer('./empty_FIXTURE.js')

--- a/src/dynamic-import/import-defer-no-new-call-expression.case
+++ b/src/dynamic-import/import-defer-no-new-call-expression.case
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: ImportCall is a CallExpression, it can't be preceded by the new keyword
+template: syntax/invalid
+info: |
+  CallExpression:
+    ImportCall
+
+  ImportCall :
+      import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+features: [import-defer]
+---*/
+
+//- import
+new import.defer('./empty_FIXTURE.js')

--- a/src/dynamic-import/import-defer-no-rest-param.case
+++ b/src/dynamic-import/import-defer-no-rest-param.case
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: ImportCall is not extensible - no rest parameter
+template: syntax/invalid
+info: |
+  ImportCall :
+      import . source ( AssignmentExpression[+In, ?Yield] )
+
+  This production doesn't allow the following production from ArgumentsList:
+
+  ... AssignmentExpression
+features: [import-defer]
+---*/
+
+//- import
+import.defer(...['./empty_FIXTURE.js'])

--- a/src/dynamic-import/import-defer-no-rest-param.case
+++ b/src/dynamic-import/import-defer-no-rest-param.case
@@ -6,7 +6,7 @@ desc: ImportCall is not extensible - no rest parameter
 template: syntax/invalid
 info: |
   ImportCall :
-      import . source ( AssignmentExpression[+In, ?Yield] )
+      import . defer ( AssignmentExpression[+In, ?Yield] )
 
   This production doesn't allow the following production from ArgumentsList:
 

--- a/src/dynamic-import/import-defer-script-code-valid.case
+++ b/src/dynamic-import/import-defer-script-code-valid.case
@@ -7,10 +7,5 @@ template: syntax/valid
 features: [import-defer]
 ---*/
 
-//- setup
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 //- import
 import.defer('./empty_FIXTURE.js')

--- a/src/dynamic-import/import-defer-script-code-valid.case
+++ b/src/dynamic-import/import-defer-script-code-valid.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: import.defer() can be used in script code
+template: syntax/valid
+features: [import-defer]
+---*/
+
+//- setup
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+//- import
+import.defer('./empty_FIXTURE.js')

--- a/src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+++ b/src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// Copyright (C) 2018 Rick Waldron. All rights reserved.
+// Copyright (C) 2018 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+    Abrupt from ToString(specifier) rejects the promise
+esid: sec-moduleevaluation
+info: |
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+template: catch
+features: [import-defer]
+---*/
+
+//- setup
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+//- import
+import.defer(obj)
+//- body
+assert.sameValue(error, 'custom error');

--- a/test/language/expressions/assignmenttargettype/direct-importcall-defer.js
+++ b/test/language/expressions/assignmenttargettype/direct-importcall-defer.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/assignment-target-type/importcall-defer.case
+// - src/assignment-target-type/invalid/direct.template
+/*---
+description: Static Semantics AssignmentTargetType, Return invalid. (Direct assignment)
+features: [import-defer]
+flags: [generated, module]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Direct assignment
+
+    ImportCall
+    Static Semantics AssignmentTargetType, Return invalid.
+
+---*/
+
+$DONOTEVALUATE();
+
+import.defer() = 1;

--- a/test/language/expressions/assignmenttargettype/parenthesized-importcall-defer.js
+++ b/test/language/expressions/assignmenttargettype/parenthesized-importcall-defer.js
@@ -1,0 +1,24 @@
+// This file was procedurally generated from the following sources:
+// - src/assignment-target-type/importcall-defer.case
+// - src/assignment-target-type/invalid/parenthesized.template
+/*---
+description: Static Semantics AssignmentTargetType, Return invalid. (ParenthesizedExpression)
+esid: sec-grouping-operator-static-semantics-assignmenttargettype
+features: [import-defer]
+flags: [generated, module]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ParenthesizedExpression: (Expression)
+
+    Return AssignmentTargetType of Expression.
+
+    ImportCall
+    Static Semantics AssignmentTargetType, Return invalid.
+
+---*/
+
+$DONOTEVALUATE();
+
+(import.defer()) = 1;

--- a/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-arrow.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested arrow)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+let f = () => {
+  import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+};
+
+f();

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-async-arrow-fn-await.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested in async arrow function, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+const f = async () => {
+  await import.defer(obj);
+}
+
+f().catch(error => {
+
+  assert.sameValue(error, 'custom error');
+
+}).then($DONE, $DONE);

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-async-arrow-fn-return-await.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested in async arrow function, returned)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+const f = async () => await import.defer(obj);
+
+f().catch(error => {
+
+  assert.sameValue(error, 'custom error');
+
+}).then($DONE, $DONE);

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-await-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-await-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-async-function-await.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested in async function, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+async function f() {
+  await import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+}
+
+f();

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-async-function.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested in async function)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+async function f() {
+  import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+}
+
+f();
+

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-async-function-return-await.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested in async function, returns awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+async function f() {
+  return await import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+}
+
+f();

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-await-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-await-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-async-generator-await.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested in async generator, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import, async-iteration]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+async function * f() {
+  await import.defer(obj);
+}
+
+f().next().catch(error => {
+
+  assert.sameValue(error, 'custom error');
+
+}).then($DONE, $DONE);

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-async-generator-return-await.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested in async generator, returns awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import, async-iteration]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+async function * f() {
+  return await import.defer(obj);
+}
+
+f().next().catch(error => {
+
+  assert.sameValue(error, 'custom error');
+
+}).then($DONE, $DONE);

--- a/test/language/expressions/dynamic-import/catch/nested-block-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-block-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-block.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested block)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+{
+  import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+};

--- a/test/language/expressions/dynamic-import/catch/nested-block-labeled-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-block-labeled-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-block-labeled.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+label: {
+  import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+};

--- a/test/language/expressions/dynamic-import/catch/nested-do-while-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-do-while-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-do-while.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested do while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+do {
+  import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+} while (false);

--- a/test/language/expressions/dynamic-import/catch/nested-else-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-else-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-else.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested else)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+if (false) {
+
+} else {
+  import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+}

--- a/test/language/expressions/dynamic-import/catch/nested-function-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-function-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-function.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested function)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+function f() {
+  import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+}
+f();

--- a/test/language/expressions/dynamic-import/catch/nested-if-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-if-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-if.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested if)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+if (true) {
+  import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+}

--- a/test/language/expressions/dynamic-import/catch/nested-while-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/nested-while-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/nested-while.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (nested while)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+let x = 0;
+while (!x) {
+  x++;
+  import.defer(obj).catch(error => {
+
+    assert.sameValue(error, 'custom error');
+
+  }).then($DONE, $DONE);
+};

--- a/test/language/expressions/dynamic-import/catch/top-level-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+++ b/test/language/expressions/dynamic-import/catch/top-level-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-specifier-tostring-abrupt-rejects.case
+// - src/dynamic-import/catch/top-level.template
+/*---
+description: Abrupt from ToString(specifier) rejects the promise (top level)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, async]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    Import Calls
+
+    Runtime Semantics: Evaluation
+
+    ImportCall : import . defer ( |AssignmentExpression| )
+        1. Return ? EvaluateImportCall(|AssignmentExpression|, ~defer~)
+
+    EvaluateImportCall ( specifierExpression, phase )
+        1. Let _referrer_ be GetActiveScriptOrModule().
+        1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
+        1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+        1. Let _specifier_ be ? GetValue(_specifierRef_).
+        1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _specifierString_ be Completion(ToString(_specifier_)).
+        1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+        ...
+
+---*/
+const obj = {
+    toString() {
+        throw 'custom error';
+    }
+};
+
+
+import.defer(obj).catch(error => {
+
+  assert.sameValue(error, 'custom error');
+
+}).then($DONE, $DONE);

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-arrow-assignment-expression.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+let f = () => import.defer();
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-new-call-expression.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-arrow-assignment-expression.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+let f = () => new import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-rest-param.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-arrow-assignment-expression.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+let f = () => import.defer(...['./empty_FIXTURE.js']);

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-arrow.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+let f = () => {
+  import.defer();
+};
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-arrow.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+let f = () => {
+  new import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-arrow.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+let f = () => {
+  import.defer(...['./empty_FIXTURE.js']);
+};

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-async-arrow-fn-await.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested in async arrow function, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+(async () => {
+  await import.defer()
+});
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-async-arrow-fn-await.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested in async arrow function, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+(async () => {
+  await new import.defer('./empty_FIXTURE.js')
+});

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-async-arrow-fn-await.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested in async arrow function, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+(async () => {
+  await import.defer(...['./empty_FIXTURE.js'])
+});

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-async-arrow-fn-return-await.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested in async arrow function, returned)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+(async () => await import.defer())
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-no-new-call-expression.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-async-arrow-fn-return-await.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested in async arrow function, returned)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+(async () => await new import.defer('./empty_FIXTURE.js'))

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-no-rest-param.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-async-arrow-fn-return-await.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested in async arrow function, returned)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+(async () => await import.defer(...['./empty_FIXTURE.js']))

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-async-function-await.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+async function f() {
+  await import.defer();
+}
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-async-function-await.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+async function f() {
+  await new import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-async-function-await.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+async function f() {
+  await import.defer(...['./empty_FIXTURE.js']);
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-async-function.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+async function f() {
+  import.defer();
+}
+
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-no-new-call-expression.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-async-function.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+async function f() {
+  new import.defer('./empty_FIXTURE.js');
+}
+

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-no-rest-param.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-async-function.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+async function f() {
+  import.defer(...['./empty_FIXTURE.js']);
+}
+

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-async-function-return-await.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+async function f() {
+  return await import.defer();
+}
+
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-no-new-call-expression.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-async-function-return-await.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+async function f() {
+  return await new import.defer('./empty_FIXTURE.js');
+}
+

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-no-rest-param.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-async-function-return-await.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+async function f() {
+  return await import.defer(...['./empty_FIXTURE.js']);
+}
+

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-async-generator-await.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested in async generator, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import, async-iteration]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+async function * f() {
+  await import.defer()
+}
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-async-generator-await.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested in async generator, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import, async-iteration]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+async function * f() {
+  await new import.defer('./empty_FIXTURE.js')
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-async-generator-await.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested in async generator, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import, async-iteration]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+async function * f() {
+  await import.defer(...['./empty_FIXTURE.js'])
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-block.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+{
+  import.defer();
+};
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-block.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+{
+  new import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-block.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+{
+  import.defer(...['./empty_FIXTURE.js']);
+};

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-block-labeled.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+label: {
+  import.defer();
+};
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-block-labeled.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+label: {
+  new import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-block-labeled.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+label: {
+  import.defer(...['./empty_FIXTURE.js']);
+};

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-do-while.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested do while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+do {
+  import.defer();
+} while (false);
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-do-while.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested do while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+do {
+  new import.defer('./empty_FIXTURE.js');
+} while (false);

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-do-while.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested do while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+do {
+  import.defer(...['./empty_FIXTURE.js']);
+} while (false);

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-else-braceless.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested else syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+if (false) {
+
+} else import.defer();
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-else-braceless.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested else syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+if (false) {
+
+} else new import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-else-braceless.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested else syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+if (false) {
+
+} else import.defer(...['./empty_FIXTURE.js']);

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-else.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested else syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+if (false) {
+
+} else {
+  import.defer();
+}
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-no-new-call-expression.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-else.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested else syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+if (false) {
+
+} else {
+  new import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-no-rest-param.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-else.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested else syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+if (false) {
+
+} else {
+  import.defer(...['./empty_FIXTURE.js']);
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-function.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested function syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+function fn() {
+  import.defer();
+}
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-function.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested function syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+function fn() {
+  new import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-function.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested function syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+function fn() {
+  import.defer(...['./empty_FIXTURE.js']);
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-function-return.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested function syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+function fn() {
+  return import.defer();
+}
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-function-return.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested function syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+function fn() {
+  return new import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-function-return.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested function syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+function fn() {
+  return import.defer(...['./empty_FIXTURE.js']);
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-if-braceless.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested if syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+if (true) import.defer();
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-no-new-call-expression.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-if-braceless.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested if syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+if (true) new import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-no-rest-param.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-if-braceless.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested if syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+if (true) import.defer(...['./empty_FIXTURE.js']);

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-if.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested if syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+if (true) {
+  import.defer();
+}
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-if.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested if syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+if (true) {
+  new import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-if.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested if syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+if (true) {
+  import.defer(...['./empty_FIXTURE.js']);
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-while.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+let x = 0;
+while (!x) {
+  x++;
+  import.defer();
+};
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-no-new-call-expression.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-while.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+let x = 0;
+while (!x) {
+  x++;
+  new import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-no-rest-param.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-while.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+let x = 0;
+while (!x) {
+  x++;
+  import.defer(...['./empty_FIXTURE.js']);
+};

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-with-expression.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested with syntax in the expression position)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, noStrict]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+with (import.defer()) {}
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-no-new-call-expression.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-with-expression.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested with syntax in the expression position)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, noStrict]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+with (new import.defer('./empty_FIXTURE.js')) {}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-no-rest-param.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-with-expression.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested with syntax in the expression position)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, noStrict]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+with (import.defer(...['./empty_FIXTURE.js'])) {}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/nested-with.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (nested with syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, noStrict]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+with ({}) {
+  import.defer();
+}
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-no-new-call-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/nested-with.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested with syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, noStrict]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+with ({}) {
+  new import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-no-rest-param.js
@@ -25,7 +25,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-no-rest-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/nested-with.template
+/*---
+description: ImportCall is not extensible - no rest parameter (nested with syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, noStrict]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+with ({}) {
+  import.defer(...['./empty_FIXTURE.js']);
+}

--- a/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-assignment-expr-not-optional.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-assignment-expr-not-optional.case
+// - src/dynamic-import/syntax/invalid/top-level.template
+/*---
+description: It's a SyntaxError if AssignmentExpression is omitted (top level syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+
+    ImportCall[Yield, Await] :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+import.defer();
+
+/* The params region intentionally empty */

--- a/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-no-new-call-expression.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-new-call-expression.case
+// - src/dynamic-import/syntax/invalid/top-level.template
+/*---
+description: ImportCall is a CallExpression, it can't be preceded by the new keyword (top level syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+
+    CallExpression:
+      ImportCall
+
+    ImportCall :
+        import . defer ( AssignmentExpression[+In, ?Yield, ?Await] )
+
+---*/
+
+$DONOTEVALUATE();
+
+new import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-no-rest-param.js
@@ -15,7 +15,7 @@ info: |
 
 
     ImportCall :
-        import . source ( AssignmentExpression[+In, ?Yield] )
+        import . defer ( AssignmentExpression[+In, ?Yield] )
 
     This production doesn't allow the following production from ArgumentsList:
 

--- a/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-no-rest-param.js
@@ -1,0 +1,28 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-no-rest-param.case
+// - src/dynamic-import/syntax/invalid/top-level.template
+/*---
+description: ImportCall is not extensible - no rest parameter (top level syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+
+    ImportCall :
+        import . source ( AssignmentExpression[+In, ?Yield] )
+
+    This production doesn't allow the following production from ArgumentsList:
+
+    ... AssignmentExpression
+
+---*/
+
+$DONOTEVALUATE();
+
+import.defer(...['./empty_FIXTURE.js']);

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-arrow-assignment-expression.template
+/*---
+description: Calling import.defer('') (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+let f = () => import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-defer-script-code-valid.js
@@ -21,9 +21,5 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 let f = () => import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-defer-script-code-valid.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-arrow-assignment-expression.template
+/*---
+description: import.defer() can be used in script code (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+let f = () => import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-arrow.template
+/*---
+description: Calling import.defer('') (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+let f = () => {
+  import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-arrow.template
+/*---
+description: import.defer() can be used in script code (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+let f = () => {
+  import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 let f = () => {
   import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-async-arrow-fn-await.template
+/*---
+description: Calling import.defer('') (nested in async arrow function)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+(async () => {
+  await import.defer('./empty_FIXTURE.js')
+});

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-async-arrow-fn-await.template
+/*---
+description: import.defer() can be used in script code (nested in async arrow function)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+(async () => {
+  await import.defer('./empty_FIXTURE.js')
+});

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 (async () => {
   await import.defer('./empty_FIXTURE.js')

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-async-arrow-fn-return-await.template
+/*---
+description: Calling import.defer('') (nested in async arrow function, returned)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+(async () => await import.defer('./empty_FIXTURE.js'));

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-defer-script-code-valid.js
@@ -21,9 +21,5 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 (async () => await import.defer('./empty_FIXTURE.js'));

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-defer-script-code-valid.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-async-arrow-fn-return-await.template
+/*---
+description: import.defer() can be used in script code (nested in async arrow function, returned)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+(async () => await import.defer('./empty_FIXTURE.js'));

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-async-function-await.template
+/*---
+description: Calling import.defer('') (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+async function f() {
+  await import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-async-function-await.template
+/*---
+description: import.defer() can be used in script code (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+async function f() {
+  await import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 async function f() {
   await import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,28 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-async-function.template
+/*---
+description: Calling import.defer('') (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+async function f() {
+  import.defer('./empty_FIXTURE.js');
+}
+

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 async function f() {
   import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-defer-script-code-valid.js
@@ -1,0 +1,32 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-async-function.template
+/*---
+description: import.defer() can be used in script code (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+async function f() {
+  import.defer('./empty_FIXTURE.js');
+}
+

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,28 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-async-function-return-await.template
+/*---
+description: Calling import.defer('') (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+async function f() {
+  return await import.defer('./empty_FIXTURE.js');
+}
+

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-defer-script-code-valid.js
@@ -1,0 +1,32 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-async-function-return-await.template
+/*---
+description: import.defer() can be used in script code (nested arrow syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+async function f() {
+  return await import.defer('./empty_FIXTURE.js');
+}
+

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 async function f() {
   return await import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-async-generator-await.template
+/*---
+description: Calling import.defer('') (nested in async generator, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import, async-iteration]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+async function * f() {
+  await import.defer('./empty_FIXTURE.js')
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 async function * f() {
   await import.defer('./empty_FIXTURE.js')

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-async-generator-await.template
+/*---
+description: import.defer() can be used in script code (nested in async generator, awaited)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import, async-iteration]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+async function * f() {
+  await import.defer('./empty_FIXTURE.js')
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-block.template
+/*---
+description: Calling import.defer('') (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+{
+  import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 {
   import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-block.template
+/*---
+description: import.defer() can be used in script code (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+{
+  import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-block-labeled.template
+/*---
+description: Calling import.defer('') (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+label: {
+  import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-block-labeled.template
+/*---
+description: import.defer() can be used in script code (nested block syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+label: {
+  import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 label: {
   import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-do-while.template
+/*---
+description: Calling import.defer('') (nested do while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+do {
+  import.defer('./empty_FIXTURE.js');
+} while (false);

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 do {
   import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-do-while.template
+/*---
+description: import.defer() can be used in script code (nested do while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+do {
+  import.defer('./empty_FIXTURE.js');
+} while (false);

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-else-braceless.template
+/*---
+description: Calling import.defer('') (nested else syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+if (false) {
+
+} else import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-else-braceless.template
+/*---
+description: import.defer() can be used in script code (nested else syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+if (false) {
+
+} else import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 if (false) {
 

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-else.template
+/*---
+description: Calling import.defer('') (nested else syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+if (false) {
+
+} else {
+  import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-import-defer-script-code-valid.js
@@ -1,0 +1,33 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-else.template
+/*---
+description: import.defer() can be used in script code (nested else syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+if (false) {
+
+} else {
+  import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 if (false) {
 

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-function.template
+/*---
+description: Calling import.defer('') (nested function syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+function fn() {
+  import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-function.template
+/*---
+description: import.defer() can be used in script code (nested function syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+function fn() {
+  import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 function fn() {
   import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-function-return.template
+/*---
+description: Calling import.defer('') (nested function syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+function fn() {
+  return import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 function fn() {
   return import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-function-return.template
+/*---
+description: import.defer() can be used in script code (nested function syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+function fn() {
+  return import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-if-braceless.template
+/*---
+description: Calling import.defer('') (nested if syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+if (true) import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-defer-script-code-valid.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-if-braceless.template
+/*---
+description: import.defer() can be used in script code (nested if syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+if (true) import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-defer-script-code-valid.js
@@ -21,9 +21,5 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 if (true) import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-if.template
+/*---
+description: Calling import.defer('') (nested if syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+if (true) {
+  import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 if (true) {
   import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-if.template
+/*---
+description: import.defer() can be used in script code (nested if syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+if (true) {
+  import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-while-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-while-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-while.template
+/*---
+description: Calling import.defer('') (nested while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+let x = 0;
+while (!x) {
+  x++;
+  import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-while-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-while-import-defer-script-code-valid.js
@@ -1,0 +1,33 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-while.template
+/*---
+description: import.defer() can be used in script code (nested while syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+let x = 0;
+while (!x) {
+  x++;
+  import.defer('./empty_FIXTURE.js');
+};

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-while-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-while-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 let x = 0;
 while (!x) {

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,28 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-with-expression.template
+/*---
+description: Calling import.defer('') (nested with syntax in the expression position)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, noStrict]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+with (import.defer('./empty_FIXTURE.js')) {
+    assert.sameValue(then, Promise.prototype.then);
+    assert.sameValue(constructor, Promise);
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-defer-script-code-valid.js
@@ -1,0 +1,32 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-with-expression.template
+/*---
+description: import.defer() can be used in script code (nested with syntax in the expression position)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, noStrict]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+with (import.defer('./empty_FIXTURE.js')) {
+    assert.sameValue(then, Promise.prototype.then);
+    assert.sameValue(constructor, Promise);
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 with (import.defer('./empty_FIXTURE.js')) {
     assert.sameValue(then, Promise.prototype.then);

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,27 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/nested-with.template
+/*---
+description: Calling import.defer('') (nested with syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, noStrict]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+
+with ({}) {
+  import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-import-defer-script-code-valid.js
@@ -21,10 +21,6 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 with ({}) {
   import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-import-defer-script-code-valid.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/nested-with.template
+/*---
+description: import.defer() can be used in script code (nested with syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated, noStrict]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+    1. Let referencingScriptOrModule be ! GetActiveScriptOrModule().
+    2. Assert: referencingScriptOrModule is a Script Record or Module Record (i.e. is not null).
+    3. Let argRef be the result of evaluating AssignmentExpression.
+    4. Let specifier be ? GetValue(argRef).
+    5. Let promiseCapability be ! NewPromiseCapability(%Promise%).
+    6. Let specifierString be ToString(specifier).
+    7. IfAbruptRejectPromise(specifierString, promiseCapability).
+    8. Perform ! HostImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability).
+    9. Return promiseCapability.[[Promise]].
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+with ({}) {
+  import.defer('./empty_FIXTURE.js');
+}

--- a/test/language/expressions/dynamic-import/syntax/valid/top-level-import-defer-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/top-level-import-defer-empty-str-is-valid-assign-expr.js
@@ -1,0 +1,15 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-empty-str-is-valid-assign-expr.case
+// - src/dynamic-import/syntax/valid/top-level.template
+/*---
+description: Calling import.defer('') (top level syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+---*/
+
+import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/top-level-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/top-level-import-defer-script-code-valid.js
@@ -11,9 +11,5 @@ info: |
         import( AssignmentExpression )
 
 ---*/
-// This is still valid in script code, and should not be valid for module code
-// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
-var smoosh; function smoosh() {}
-
 
 import.defer('./empty_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/syntax/valid/top-level-import-defer-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/top-level-import-defer-script-code-valid.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/dynamic-import/import-defer-script-code-valid.case
+// - src/dynamic-import/syntax/valid/top-level.template
+/*---
+description: import.defer() can be used in script code (top level syntax)
+esid: sec-import-call-runtime-semantics-evaluation
+features: [import-defer, dynamic-import]
+flags: [generated]
+info: |
+    ImportCall :
+        import( AssignmentExpression )
+
+---*/
+// This is still valid in script code, and should not be valid for module code
+// https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
+var smoosh; function smoosh() {}
+
+
+import.defer('./empty_FIXTURE.js');


### PR DESCRIPTION
These tests are all based on the existing dynamic import syntax tests, just updated to use the new syntax.

This PR does not contain any manually written tests -- they are all generated.

Ref https://github.com/tc39/test262/issues/4215