### PR TITLE
Add indent to sm tests metadata

### DIFF
--- a/test/staging/sm/Array/array-length-set-during-for-in.js
+++ b/test/staging/sm/Array/array-length-set-during-for-in.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/array-length-set-on-nonarray.js
+++ b/test/staging/sm/Array/array-length-set-on-nonarray.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/at.js
+++ b/test/staging/sm/Array/at.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/change-array-by-copy-cross-compartment-create.js
+++ b/test/staging/sm/Array/change-array-by-copy-cross-compartment-create.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/change-array-by-copy-errors-from-correct-realm.js
+++ b/test/staging/sm/Array/change-array-by-copy-errors-from-correct-realm.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/concat-proxy.js
+++ b/test/staging/sm/Array/concat-proxy.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/concat-spreadable-basic.js
+++ b/test/staging/sm/Array/concat-spreadable-basic.js
@@ -5,7 +5,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 description: |
   pending

--- a/test/staging/sm/Array/concat-spreadable-primitive.js
+++ b/test/staging/sm/Array/concat-spreadable-primitive.js
@@ -5,7 +5,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 description: |
   pending

--- a/test/staging/sm/Array/fill.js
+++ b/test/staging/sm/Array/fill.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/for_of_1.js
+++ b/test/staging/sm/Array/for_of_1.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/for_of_2.js
+++ b/test/staging/sm/Array/for_of_2.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/for_of_3.js
+++ b/test/staging/sm/Array/for_of_3.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/for_of_4.js
+++ b/test/staging/sm/Array/for_of_4.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from-iterator-close.js
+++ b/test/staging/sm/Array/from-iterator-close.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_basics.js
+++ b/test/staging/sm/Array/from_basics.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_constructor.js
+++ b/test/staging/sm/Array/from_constructor.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_errors.js
+++ b/test/staging/sm/Array/from_errors.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_iterable.js
+++ b/test/staging/sm/Array/from_iterable.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_length_setter.js
+++ b/test/staging/sm/Array/from_length_setter.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_mapping.js
+++ b/test/staging/sm/Array/from_mapping.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_primitive.js
+++ b/test/staging/sm/Array/from_primitive.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_proxy.js
+++ b/test/staging/sm/Array/from_proxy.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_realms.js
+++ b/test/staging/sm/Array/from_realms.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_string.js
+++ b/test/staging/sm/Array/from_string.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_surfaces.js
+++ b/test/staging/sm/Array/from_surfaces.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/from_this.js
+++ b/test/staging/sm/Array/from_this.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/frozen-dense-array.js
+++ b/test/staging/sm/Array/frozen-dense-array.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/frozen-dict-mode-length.js
+++ b/test/staging/sm/Array/frozen-dict-mode-length.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/getter-name.js
+++ b/test/staging/sm/Array/getter-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/group-callback-evaluation.js
+++ b/test/staging/sm/Array/group-callback-evaluation.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/group-propertkey-is-length.js
+++ b/test/staging/sm/Array/group-propertkey-is-length.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/group.js
+++ b/test/staging/sm/Array/group.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/includes-trailing-holes.js
+++ b/test/staging/sm/Array/includes-trailing-holes.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/includes.js
+++ b/test/staging/sm/Array/includes.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/index-with-null-character.js
+++ b/test/staging/sm/Array/index-with-null-character.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/indexOf-never-returns-negative-zero.js
+++ b/test/staging/sm/Array/indexOf-never-returns-negative-zero.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/indexOf-packed-array.js
+++ b/test/staging/sm/Array/indexOf-packed-array.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/isArray.js
+++ b/test/staging/sm/Array/isArray.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/join-01.js
+++ b/test/staging/sm/Array/join-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/join-no-has-trap.js
+++ b/test/staging/sm/Array/join-no-has-trap.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/lastIndexOf-never-returns-negative-zero.js
+++ b/test/staging/sm/Array/lastIndexOf-never-returns-negative-zero.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/length-01.js
+++ b/test/staging/sm/Array/length-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/length-nonwritable-redefine-nop.js
+++ b/test/staging/sm/Array/length-nonwritable-redefine-nop.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/length-set-object.js
+++ b/test/staging/sm/Array/length-set-object.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/length-truncate-nonconfigurable-sparse.js
+++ b/test/staging/sm/Array/length-truncate-nonconfigurable-sparse.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/length-truncate-nonconfigurable.js
+++ b/test/staging/sm/Array/length-truncate-nonconfigurable.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/length-truncate-with-indexed.js
+++ b/test/staging/sm/Array/length-truncate-with-indexed.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/pop-empty-nonwritable.js
+++ b/test/staging/sm/Array/pop-empty-nonwritable.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/pop-no-has-trap.js
+++ b/test/staging/sm/Array/pop-no-has-trap.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/pop-nonarray-higher-elements.js
+++ b/test/staging/sm/Array/pop-nonarray-higher-elements.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/redefine-length-frozen-array.js
+++ b/test/staging/sm/Array/redefine-length-frozen-array.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/redefine-length-frozen-dictionarymode-array.js
+++ b/test/staging/sm/Array/redefine-length-frozen-dictionarymode-array.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/redefine-nonwritable-length-custom-conversion-call-counts.js
+++ b/test/staging/sm/Array/redefine-nonwritable-length-custom-conversion-call-counts.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/redefine-nonwritable-length-custom-conversion-throw.js
+++ b/test/staging/sm/Array/redefine-nonwritable-length-custom-conversion-throw.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/redefine-nonwritable-length-nonnumeric.js
+++ b/test/staging/sm/Array/redefine-nonwritable-length-nonnumeric.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/regress-386030.js
+++ b/test/staging/sm/Array/regress-386030.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/regress-424954.js
+++ b/test/staging/sm/Array/regress-424954.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/regress-566651.js
+++ b/test/staging/sm/Array/regress-566651.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/regress-599159.js
+++ b/test/staging/sm/Array/regress-599159.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/regress-619970.js
+++ b/test/staging/sm/Array/regress-619970.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/reverse-order-of-low-high-accesses.js
+++ b/test/staging/sm/Array/reverse-order-of-low-high-accesses.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/set-with-indexed-property-on-prototype-chain.js
+++ b/test/staging/sm/Array/set-with-indexed-property-on-prototype-chain.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/shift-no-has-trap.js
+++ b/test/staging/sm/Array/shift-no-has-trap.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/shift_for_in.js
+++ b/test/staging/sm/Array/shift_for_in.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/sort-01.js
+++ b/test/staging/sm/Array/sort-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/sort-array-with-holes-and-undefined.js
+++ b/test/staging/sm/Array/sort-array-with-holes-and-undefined.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/sort-delete-ascending-order.js
+++ b/test/staging/sm/Array/sort-delete-ascending-order.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/sort-non-function.js
+++ b/test/staging/sm/Array/sort-non-function.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/sort-typedarray-with-own-length.js
+++ b/test/staging/sm/Array/sort-typedarray-with-own-length.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/sort_holes.js
+++ b/test/staging/sm/Array/sort_holes.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/sort_native_string_nan.js
+++ b/test/staging/sm/Array/sort_native_string_nan.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/sort_proxy.js
+++ b/test/staging/sm/Array/sort_proxy.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/sort_small.js
+++ b/test/staging/sm/Array/sort_small.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/species.js
+++ b/test/staging/sm/Array/species.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/splice-return-array-elements-defined-not-set.js
+++ b/test/staging/sm/Array/splice-return-array-elements-defined-not-set.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/splice-species-changes-length.js
+++ b/test/staging/sm/Array/splice-species-changes-length.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/splice-suppresses-unvisited-indexes.js
+++ b/test/staging/sm/Array/splice-suppresses-unvisited-indexes.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/to-length.js
+++ b/test/staging/sm/Array/to-length.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/toLocaleString-01.js
+++ b/test/staging/sm/Array/toLocaleString-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/toLocaleString-nointl.js
+++ b/test/staging/sm/Array/toLocaleString-nointl.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/toLocaleString.js
+++ b/test/staging/sm/Array/toLocaleString.js
@@ -3,7 +3,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/Array/toSpliced-dense.js
+++ b/test/staging/sm/Array/toSpliced-dense.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/toSpliced.js
+++ b/test/staging/sm/Array/toSpliced.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/toString-01.js
+++ b/test/staging/sm/Array/toString-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/unscopables.js
+++ b/test/staging/sm/Array/unscopables.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/unshift-01.js
+++ b/test/staging/sm/Array/unshift-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/unshift-with-enumeration.js
+++ b/test/staging/sm/Array/unshift-with-enumeration.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/values.js
+++ b/test/staging/sm/Array/values.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/with-dense.js
+++ b/test/staging/sm/Array/with-dense.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Array/with.js
+++ b/test/staging/sm/Array/with.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/ArrayBuffer/CloneArrayBuffer.js
+++ b/test/staging/sm/ArrayBuffer/CloneArrayBuffer.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/ArrayBuffer/bug1777413.js
+++ b/test/staging/sm/ArrayBuffer/bug1777413.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   needs shell functions
 description: |

--- a/test/staging/sm/ArrayBuffer/constructorNotCallable.js
+++ b/test/staging/sm/ArrayBuffer/constructorNotCallable.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/ArrayBuffer/getter-name.js
+++ b/test/staging/sm/ArrayBuffer/getter-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/ArrayBuffer/slice-species.js
+++ b/test/staging/sm/ArrayBuffer/slice-species.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/AsyncGenerators/async-generator-declaration-in-modules.js
+++ b/test/staging/sm/AsyncGenerators/async-generator-declaration-in-modules.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/AsyncGenerators/create-function-parse-before-getprototype.js
+++ b/test/staging/sm/AsyncGenerators/create-function-parse-before-getprototype.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/AsyncGenerators/for-await-bad-syntax.js
+++ b/test/staging/sm/AsyncGenerators/for-await-bad-syntax.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/AsyncGenerators/for-await-of-error.js
+++ b/test/staging/sm/AsyncGenerators/for-await-of-error.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Atomics/cross-compartment.js
+++ b/test/staging/sm/Atomics/cross-compartment.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Atomics/detached-buffers.js
+++ b/test/staging/sm/Atomics/detached-buffers.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/BigInt/Number-conversion-rounding.js
+++ b/test/staging/sm/BigInt/Number-conversion-rounding.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/BigInt/decimal.js
+++ b/test/staging/sm/BigInt/decimal.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/BigInt/large-bit-length.js
+++ b/test/staging/sm/BigInt/large-bit-length.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/BigInt/mod.js
+++ b/test/staging/sm/BigInt/mod.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/BigInt/property-name.js
+++ b/test/staging/sm/BigInt/property-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Boolean/15.6.4.2.js
+++ b/test/staging/sm/Boolean/15.6.4.2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Boolean/no-boolean-toJSON.js
+++ b/test/staging/sm/Boolean/no-boolean-toJSON.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/DataView/detach-after-construction.js
+++ b/test/staging/sm/DataView/detach-after-construction.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/DataView/get-set-index-range.js
+++ b/test/staging/sm/DataView/get-set-index-range.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/DataView/getter-name.js
+++ b/test/staging/sm/DataView/getter-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/UTC-convert-all-arguments.js
+++ b/test/staging/sm/Date/UTC-convert-all-arguments.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/constructor-convert-all-arguments.js
+++ b/test/staging/sm/Date/constructor-convert-all-arguments.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/constructor-one-Date-argument.js
+++ b/test/staging/sm/Date/constructor-one-Date-argument.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/constructor-one-argument.js
+++ b/test/staging/sm/Date/constructor-one-argument.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/defaultvalue.js
+++ b/test/staging/sm/Date/defaultvalue.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/dst-offset-caching-1-of-8.js
+++ b/test/staging/sm/Date/dst-offset-caching-1-of-8.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/dst-offset-caching-2-of-8.js
+++ b/test/staging/sm/Date/dst-offset-caching-2-of-8.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/dst-offset-caching-3-of-8.js
+++ b/test/staging/sm/Date/dst-offset-caching-3-of-8.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/dst-offset-caching-4-of-8.js
+++ b/test/staging/sm/Date/dst-offset-caching-4-of-8.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/dst-offset-caching-5-of-8.js
+++ b/test/staging/sm/Date/dst-offset-caching-5-of-8.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/dst-offset-caching-6-of-8.js
+++ b/test/staging/sm/Date/dst-offset-caching-6-of-8.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/dst-offset-caching-7-of-8.js
+++ b/test/staging/sm/Date/dst-offset-caching-7-of-8.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/dst-offset-caching-8-of-8.js
+++ b/test/staging/sm/Date/dst-offset-caching-8-of-8.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/equality-to-boolean.js
+++ b/test/staging/sm/Date/equality-to-boolean.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/fractions.js
+++ b/test/staging/sm/Date/fractions.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/makeday-year-month-is-infinity.js
+++ b/test/staging/sm/Date/makeday-year-month-is-infinity.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/non-iso.js
+++ b/test/staging/sm/Date/non-iso.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/prototype-is-not-a-date.js
+++ b/test/staging/sm/Date/prototype-is-not-a-date.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/setTime-argument-shortcircuiting.js
+++ b/test/staging/sm/Date/setTime-argument-shortcircuiting.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/time-components-negative-zero.js
+++ b/test/staging/sm/Date/time-components-negative-zero.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/timeclip.js
+++ b/test/staging/sm/Date/timeclip.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/to-temporal-instant.js
+++ b/test/staging/sm/Date/to-temporal-instant.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/toISOString-01.js
+++ b/test/staging/sm/Date/toISOString-01.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/toISOString.js
+++ b/test/staging/sm/Date/toISOString.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/toJSON-01.js
+++ b/test/staging/sm/Date/toJSON-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/toPrimitive.js
+++ b/test/staging/sm/Date/toPrimitive.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/toString-generic.js
+++ b/test/staging/sm/Date/toString-generic.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Date/two-digit-years.js
+++ b/test/staging/sm/Date/two-digit-years.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Date-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Error/AggregateError.js
+++ b/test/staging/sm/Error/AggregateError.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Error/constructor-ordering.js
+++ b/test/staging/sm/Error/constructor-ordering.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Error/constructor-proto.js
+++ b/test/staging/sm/Error/constructor-proto.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Error/isError.js
+++ b/test/staging/sm/Error/isError.js
@@ -3,10 +3,10 @@
 
 /*---
 features:
-- Error.isError
+  - Error.isError
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Error/prototype-properties.js
+++ b/test/staging/sm/Error/prototype-properties.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Error/prototype.js
+++ b/test/staging/sm/Error/prototype.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Exceptions/error-expando-reconfigure.js
+++ b/test/staging/sm/Exceptions/error-expando-reconfigure.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Exceptions/error-property-enumerability.js
+++ b/test/staging/sm/Exceptions/error-property-enumerability.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/10.2.1.1.6.js
+++ b/test/staging/sm/Function/10.2.1.1.6.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/15.3.4.3-01.js
+++ b/test/staging/sm/Function/15.3.4.3-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/Function-prototype.js
+++ b/test/staging/sm/Function/Function-prototype.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/Function-with-eval.js
+++ b/test/staging/sm/Function/Function-with-eval.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/arguments-caller-callee.js
+++ b/test/staging/sm/Function/arguments-caller-callee.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/arguments-extra-property.js
+++ b/test/staging/sm/Function/arguments-extra-property.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/arguments-iterator.js
+++ b/test/staging/sm/Function/arguments-iterator.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/arguments-parameter-shadowing.js
+++ b/test/staging/sm/Function/arguments-parameter-shadowing.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/arguments-property-attributes.js
+++ b/test/staging/sm/Function/arguments-property-attributes.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/arrow-has-duplicated.js
+++ b/test/staging/sm/Function/arrow-has-duplicated.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/bound-length-and-name.js
+++ b/test/staging/sm/Function/bound-length-and-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/bound-non-constructable.js
+++ b/test/staging/sm/Function/bound-non-constructable.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/builtin-no-construct.js
+++ b/test/staging/sm/Function/builtin-no-construct.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/builtin-no-prototype.js
+++ b/test/staging/sm/Function/builtin-no-prototype.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/configurable-length-builtins.js
+++ b/test/staging/sm/Function/configurable-length-builtins.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/configurable-length.js
+++ b/test/staging/sm/Function/configurable-length.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/constructor-binding.js
+++ b/test/staging/sm/Function/constructor-binding.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/create-function-parse-before-getprototype.js
+++ b/test/staging/sm/Function/create-function-parse-before-getprototype.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-bind.js
+++ b/test/staging/sm/Function/function-bind.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-call.js
+++ b/test/staging/sm/Function/function-call.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-caller-restrictions.js
+++ b/test/staging/sm/Function/function-caller-restrictions.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-caller.js
+++ b/test/staging/sm/Function/function-caller.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-constructor-toString-arguments-before-parsing-params.js
+++ b/test/staging/sm/Function/function-constructor-toString-arguments-before-parsing-params.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-name-assignment.js
+++ b/test/staging/sm/Function/function-name-assignment.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-name-binding.js
+++ b/test/staging/sm/Function/function-name-binding.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-name-class.js
+++ b/test/staging/sm/Function/function-name-class.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-name-computed-01.js
+++ b/test/staging/sm/Function/function-name-computed-01.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-name-computed-02.js
+++ b/test/staging/sm/Function/function-name-computed-02.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-name-for.js
+++ b/test/staging/sm/Function/function-name-for.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-name-method.js
+++ b/test/staging/sm/Function/function-name-method.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-name-property.js
+++ b/test/staging/sm/Function/function-name-property.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-name.js
+++ b/test/staging/sm/Function/function-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-toString-builtin-name.js
+++ b/test/staging/sm/Function/function-toString-builtin-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/function-toString-builtin.js
+++ b/test/staging/sm/Function/function-toString-builtin.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/has-instance-jitted.js
+++ b/test/staging/sm/Function/has-instance-jitted.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/has-instance.js
+++ b/test/staging/sm/Function/has-instance.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/implicit-this-in-parameter-expression.js
+++ b/test/staging/sm/Function/implicit-this-in-parameter-expression.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/invalid-parameter-list.js
+++ b/test/staging/sm/Function/invalid-parameter-list.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/line-terminator-before-arrow.js
+++ b/test/staging/sm/Function/line-terminator-before-arrow.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/method-has-duplicated.js
+++ b/test/staging/sm/Function/method-has-duplicated.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/parameter-redeclaration.js
+++ b/test/staging/sm/Function/parameter-redeclaration.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/redefine-arguments-length.js
+++ b/test/staging/sm/Function/redefine-arguments-length.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/regress-518103.js
+++ b/test/staging/sm/Function/regress-518103.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/regress-524826.js
+++ b/test/staging/sm/Function/regress-524826.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/regress-528082.js
+++ b/test/staging/sm/Function/regress-528082.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/regress-533254.js
+++ b/test/staging/sm/Function/regress-533254.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/regress-545980.js
+++ b/test/staging/sm/Function/regress-545980.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/rest-has-duplicated.js
+++ b/test/staging/sm/Function/rest-has-duplicated.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/rest-parameter-names.js
+++ b/test/staging/sm/Function/rest-parameter-names.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/return-finally.js
+++ b/test/staging/sm/Function/return-finally.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/spread-iterator-primitive.js
+++ b/test/staging/sm/Function/spread-iterator-primitive.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/strict-arguments.js
+++ b/test/staging/sm/Function/strict-arguments.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Function/throw-type-error.js
+++ b/test/staging/sm/Function/throw-type-error.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/constructor-subclassable.js
+++ b/test/staging/sm/Iterator/constructor-subclassable.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/constructor-throw-when-called-directly.js
+++ b/test/staging/sm/Iterator/constructor-throw-when-called-directly.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/constructor-throw-without-new.js
+++ b/test/staging/sm/Iterator/constructor-throw-without-new.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/constructor.js
+++ b/test/staging/sm/Iterator/constructor.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/from/Iterator.from-descriptor.js
+++ b/test/staging/sm/Iterator/from/Iterator.from-descriptor.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/from/Iterator.from-length.js
+++ b/test/staging/sm/Iterator/from/Iterator.from-length.js
@@ -12,9 +12,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 esid: pending
 ---*/
 const propDesc = Reflect.getOwnPropertyDescriptor(Iterator.from, 'length');

--- a/test/staging/sm/Iterator/from/Iterator.from-name.js
+++ b/test/staging/sm/Iterator/from/Iterator.from-name.js
@@ -6,9 +6,9 @@ description: |
   `name` property of Iterator.from.
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 esid: pending

--- a/test/staging/sm/Iterator/from/call-from-with-different-this.js
+++ b/test/staging/sm/Iterator/from/call-from-with-different-this.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/from/iterator-not-callable-throws.js
+++ b/test/staging/sm/Iterator/from/iterator-not-callable-throws.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/from/modify-next.js
+++ b/test/staging/sm/Iterator/from/modify-next.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/from/modify-return.js
+++ b/test/staging/sm/Iterator/from/modify-return.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/from/o-not-object-throws.js
+++ b/test/staging/sm/Iterator/from/o-not-object-throws.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/from/proxy-not-wrapped.js
+++ b/test/staging/sm/Iterator/from/proxy-not-wrapped.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/from/proxy-wrap-next.js
+++ b/test/staging/sm/Iterator/from/proxy-wrap-next.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/from/proxy-wrap-return.js
+++ b/test/staging/sm/Iterator/from/proxy-wrap-return.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/from/return-iterator-if-iterable.js
+++ b/test/staging/sm/Iterator/from/return-iterator-if-iterable.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/from/return-wrapper-if-not-iterable.js
+++ b/test/staging/sm/Iterator/from/return-wrapper-if-not-iterable.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/from/return-wrapper-if-not-iterator-instance.js
+++ b/test/staging/sm/Iterator/from/return-wrapper-if-not-iterator-instance.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/from/wrap-functions-on-other-global.js
+++ b/test/staging/sm/Iterator/from/wrap-functions-on-other-global.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/from/wrap-method-with-non-wrap-this-throws.js
+++ b/test/staging/sm/Iterator/from/wrap-method-with-non-wrap-this-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/from/wrap-new-global.js
+++ b/test/staging/sm/Iterator/from/wrap-new-global.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/from/wrap-next-forwards-value.js
+++ b/test/staging/sm/Iterator/from/wrap-next-forwards-value.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/from/wrap-next-not-object-throws.js
+++ b/test/staging/sm/Iterator/from/wrap-next-not-object-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/from/wrap-return-closes-iterator.js
+++ b/test/staging/sm/Iterator/from/wrap-return-closes-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/iterator.js
+++ b/test/staging/sm/Iterator/iterator.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/length.js
+++ b/test/staging/sm/Iterator/length.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/name.js
+++ b/test/staging/sm/Iterator/name.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/proto.js
+++ b/test/staging/sm/Iterator/proto.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/drop/drop-more-than-available.js
+++ b/test/staging/sm/Iterator/prototype/drop/drop-more-than-available.js
@@ -11,10 +11,10 @@ info: |
     b. Let next be ? IteratorStep(iterated).
     c. If next is false, return undefined.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/drop/length.js
+++ b/test/staging/sm/Iterator/prototype/drop/length.js
@@ -8,11 +8,11 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- Symbol.iterator
-- iterator-helpers
+  - Symbol.iterator
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/drop/name.js
+++ b/test/staging/sm/Iterator/prototype/drop/name.js
@@ -8,10 +8,10 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 assert.sameValue(Iterator.prototype.drop.name, 'drop');
 

--- a/test/staging/sm/Iterator/prototype/every/check-fn-after-getting-iterator.js
+++ b/test/staging/sm/Iterator/prototype/every/check-fn-after-getting-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/every/coerce-result-to-boolean.js
+++ b/test/staging/sm/Iterator/prototype/every/coerce-result-to-boolean.js
@@ -3,11 +3,11 @@
 
 /*---
 features:
-- IsHTMLDDA
-- iterator-helpers
+  - IsHTMLDDA
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/every/descriptor.js
+++ b/test/staging/sm/Iterator/prototype/every/descriptor.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/every/error-from-correct-realm.js
+++ b/test/staging/sm/Iterator/prototype/every/error-from-correct-realm.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/every/fn-not-callable-throws.js
+++ b/test/staging/sm/Iterator/prototype/every/fn-not-callable-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/every/fn-throws-close-iterator.js
+++ b/test/staging/sm/Iterator/prototype/every/fn-throws-close-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/every/length.js
+++ b/test/staging/sm/Iterator/prototype/every/length.js
@@ -12,9 +12,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 esid: pending
 ---*/
 const propDesc = Reflect.getOwnPropertyDescriptor(Iterator.prototype.every, 'length');

--- a/test/staging/sm/Iterator/prototype/every/name.js
+++ b/test/staging/sm/Iterator/prototype/every/name.js
@@ -6,9 +6,9 @@ description: |
   `name` property of Iterator.prototype.every.
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 esid: pending

--- a/test/staging/sm/Iterator/prototype/every/next-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/every/next-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/every/proxy.js
+++ b/test/staging/sm/Iterator/prototype/every/proxy.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/every/return-true-if-all-match.js
+++ b/test/staging/sm/Iterator/prototype/every/return-true-if-all-match.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/every/short-circuit-on-false.js
+++ b/test/staging/sm/Iterator/prototype/every/short-circuit-on-false.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/every/this-not-iterator-throws.js
+++ b/test/staging/sm/Iterator/prototype/every/this-not-iterator-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/every/value-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/every/value-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/filter/coerce-result-to-boolean.js
+++ b/test/staging/sm/Iterator/prototype/filter/coerce-result-to-boolean.js
@@ -3,11 +3,11 @@
 
 /*---
 features:
-- IsHTMLDDA
-- iterator-helpers
+  - IsHTMLDDA
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/filter/length.js
+++ b/test/staging/sm/Iterator/prototype/filter/length.js
@@ -8,11 +8,11 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- Symbol.iterator
-- iterator-helpers
+  - Symbol.iterator
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/filter/name.js
+++ b/test/staging/sm/Iterator/prototype/filter/name.js
@@ -8,10 +8,10 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 assert.sameValue(Iterator.prototype.filter.name, 'filter');
 

--- a/test/staging/sm/Iterator/prototype/find/check-fn-after-getting-iterator.js
+++ b/test/staging/sm/Iterator/prototype/find/check-fn-after-getting-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/find/coerce-result-to-boolean.js
+++ b/test/staging/sm/Iterator/prototype/find/coerce-result-to-boolean.js
@@ -3,11 +3,11 @@
 
 /*---
 features:
-- IsHTMLDDA
-- iterator-helpers
+  - IsHTMLDDA
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/find/descriptor.js
+++ b/test/staging/sm/Iterator/prototype/find/descriptor.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/find/error-from-correct-realm.js
+++ b/test/staging/sm/Iterator/prototype/find/error-from-correct-realm.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/find/fn-not-callable-throws.js
+++ b/test/staging/sm/Iterator/prototype/find/fn-not-callable-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/find/fn-throws-close-iterator.js
+++ b/test/staging/sm/Iterator/prototype/find/fn-throws-close-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/find/length.js
+++ b/test/staging/sm/Iterator/prototype/find/length.js
@@ -12,9 +12,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 esid: pending
 ---*/
 const propDesc = Reflect.getOwnPropertyDescriptor(Iterator.prototype.find, 'length');

--- a/test/staging/sm/Iterator/prototype/find/name.js
+++ b/test/staging/sm/Iterator/prototype/find/name.js
@@ -6,9 +6,9 @@ description: |
   `name` property of Iterator.prototype.find.
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 esid: pending

--- a/test/staging/sm/Iterator/prototype/find/next-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/find/next-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/find/proxy.js
+++ b/test/staging/sm/Iterator/prototype/find/proxy.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/find/return-undefined-if-none-match.js
+++ b/test/staging/sm/Iterator/prototype/find/return-undefined-if-none-match.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/find/short-circuit-on-match.js
+++ b/test/staging/sm/Iterator/prototype/find/short-circuit-on-match.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/find/this-not-iterator-throws.js
+++ b/test/staging/sm/Iterator/prototype/find/this-not-iterator-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/find/value-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/find/value-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/flatMap/close-iterator-when-inner-complete-throws.js
+++ b/test/staging/sm/Iterator/prototype/flatMap/close-iterator-when-inner-complete-throws.js
@@ -12,10 +12,10 @@ info: |
       iii. Let innerComplete be IteratorComplete(innerNext).
       iv. IfAbruptCloseIterator(innerComplete, iterated).
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 class TestIterator extends Iterator {
   next() {

--- a/test/staging/sm/Iterator/prototype/flatMap/close-iterator-when-inner-next-throws.js
+++ b/test/staging/sm/Iterator/prototype/flatMap/close-iterator-when-inner-next-throws.js
@@ -12,10 +12,10 @@ info: |
       i. Let innerNext be IteratorNext(innerIterator).
       ii. IfAbruptCloseIterator(innerNext, iterated).
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 class TestIterator extends Iterator {
   next() {

--- a/test/staging/sm/Iterator/prototype/flatMap/close-iterator-when-inner-value-throws.js
+++ b/test/staging/sm/Iterator/prototype/flatMap/close-iterator-when-inner-value-throws.js
@@ -14,10 +14,10 @@ info: |
         1. Let innerValue be IteratorValue(innerNext).
         2. IfAbruptCloseIterator(innerValue, iterated).
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 class TestIterator extends Iterator {
   next() {

--- a/test/staging/sm/Iterator/prototype/flatMap/inner-empty-iterable.js
+++ b/test/staging/sm/Iterator/prototype/flatMap/inner-empty-iterable.js
@@ -14,10 +14,10 @@ info: |
       ...
       v. If innerComplete is true, set innerAlive to false.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 let iter = [0, 1, 2, 3].values().flatMap(x => x % 2 ? [] : [x]);
 

--- a/test/staging/sm/Iterator/prototype/flatMap/inner-generator.js
+++ b/test/staging/sm/Iterator/prototype/flatMap/inner-generator.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5.7
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 const iter = [1, 2].values().flatMap(function*(x) {
   yield x;

--- a/test/staging/sm/Iterator/prototype/flatMap/length.js
+++ b/test/staging/sm/Iterator/prototype/flatMap/length.js
@@ -8,11 +8,11 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- Symbol.iterator
-- iterator-helpers
+  - Symbol.iterator
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 assert.sameValue(Iterator.prototype.flatMap.length, 1);
 

--- a/test/staging/sm/Iterator/prototype/flatMap/name.js
+++ b/test/staging/sm/Iterator/prototype/flatMap/name.js
@@ -8,10 +8,10 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 assert.sameValue(Iterator.prototype.flatMap.name, 'flatMap');
 

--- a/test/staging/sm/Iterator/prototype/flatMap/throw-when-inner-not-iterable.js
+++ b/test/staging/sm/Iterator/prototype/flatMap/throw-when-inner-not-iterable.js
@@ -11,10 +11,10 @@ info: |
     f. Let innerIterator be GetIteratorFlattenable(mapped).
     g. IfAbruptCloseIterator(innerIterator, iterated).
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 class InvalidIterable {
   [Symbol.iterator]() {

--- a/test/staging/sm/Iterator/prototype/forEach/check-fn-after-getting-iterator.js
+++ b/test/staging/sm/Iterator/prototype/forEach/check-fn-after-getting-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/forEach/descriptor.js
+++ b/test/staging/sm/Iterator/prototype/forEach/descriptor.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/forEach/error-from-correct-realm.js
+++ b/test/staging/sm/Iterator/prototype/forEach/error-from-correct-realm.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/forEach/fn-not-callable-throws.js
+++ b/test/staging/sm/Iterator/prototype/forEach/fn-not-callable-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/forEach/fn-throws-close-iterator.js
+++ b/test/staging/sm/Iterator/prototype/forEach/fn-throws-close-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/forEach/forEach.js
+++ b/test/staging/sm/Iterator/prototype/forEach/forEach.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/forEach/length.js
+++ b/test/staging/sm/Iterator/prototype/forEach/length.js
@@ -12,9 +12,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 esid: pending
 ---*/
 const propDesc = Reflect.getOwnPropertyDescriptor(Iterator.prototype.forEach, 'length');

--- a/test/staging/sm/Iterator/prototype/forEach/name.js
+++ b/test/staging/sm/Iterator/prototype/forEach/name.js
@@ -6,9 +6,9 @@ description: |
   `name` property of Iterator.prototype.forEach.
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 esid: pending

--- a/test/staging/sm/Iterator/prototype/forEach/next-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/forEach/next-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/forEach/proxy.js
+++ b/test/staging/sm/Iterator/prototype/forEach/proxy.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/forEach/this-not-iterator-throws.js
+++ b/test/staging/sm/Iterator/prototype/forEach/this-not-iterator-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/forEach/value-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/forEach/value-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/generator-methods-throw-on-iterator-helpers.js
+++ b/test/staging/sm/Iterator/prototype/generator-methods-throw-on-iterator-helpers.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/iterator-helper-methods-throw-on-generators.js
+++ b/test/staging/sm/Iterator/prototype/iterator-helper-methods-throw-on-generators.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/iterator-helpers-from-other-global.js
+++ b/test/staging/sm/Iterator/prototype/iterator-helpers-from-other-global.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/lazy-methods-from-other-global.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-from-other-global.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/lazy-methods-handle-empty-iterators.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-handle-empty-iterators.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-interleaved.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-interleaved.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-iterator-closed-on-call-throws.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-iterator-closed-on-call-throws.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-iterator-closed-on-yield-throws.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-iterator-closed-on-yield-throws.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-iterator-not-closed-on-next-throws.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-iterator-not-closed-on-next-throws.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-iterator-not-closed-on-value-throws.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-iterator-not-closed-on-value-throws.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-iterator-returns-done-generator-finishes.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-iterator-returns-done-generator-finishes.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/lazy-methods-multiple-return-close-iterator-once.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-multiple-return-close-iterator-once.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-pass-through-lastValue.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-pass-through-lastValue.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/lazy-methods-pass-value-through-chain.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-pass-value-through-chain.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/lazy-methods-proxy-accesses.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-proxy-accesses.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   Lazy %Iterator.prototype% methods access specified properties only.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/lazy-methods-reentry-not-close-iterator.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-reentry-not-close-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/lazy-methods-return-closes-iterator.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-return-closes-iterator.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-return-new-iterator-result.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-return-new-iterator-result.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-throw-eagerly-on-next-non-callable.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-throw-eagerly-on-next-non-callable.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 1.1.1
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-throw-eagerly-on-non-callable.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-throw-eagerly-on-non-callable.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-throw-eagerly-on-non-iterator.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-throw-eagerly-on-non-iterator.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 1.1.1
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-throw-next-done-throws.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-throw-next-done-throws.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-throw-next-not-object.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-throw-next-not-object.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/lazy-methods-throw-on-reentry.js
+++ b/test/staging/sm/Iterator/prototype/lazy-methods-throw-on-reentry.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/map/call-next-on-iterator-while-iterating.js
+++ b/test/staging/sm/Iterator/prototype/map/call-next-on-iterator-while-iterating.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   Call next on an iterator that is being iterated over.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 const iterator = [1, 2, 3].values()

--- a/test/staging/sm/Iterator/prototype/map/clobber-symbol.js
+++ b/test/staging/sm/Iterator/prototype/map/clobber-symbol.js
@@ -6,12 +6,12 @@ esid: pending
 description: |
   %Iterator.prototype%.map works even if the global Symbol has been clobbered..
 features:
-- Symbol
-- Symbol.iterator
-- iterator-helpers
+  - Symbol
+  - Symbol.iterator
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   Iterator is not enabled unconditionally
 ---*/

--- a/test/staging/sm/Iterator/prototype/map/interleaved-map-calls.js
+++ b/test/staging/sm/Iterator/prototype/map/interleaved-map-calls.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   Interleaved %Iterator.prototype%.map calls on the same iterator.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/map/length.js
+++ b/test/staging/sm/Iterator/prototype/map/length.js
@@ -8,11 +8,11 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- Symbol.iterator
-- iterator-helpers
+  - Symbol.iterator
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 assert.sameValue(Iterator.prototype.map.length, 1);
 

--- a/test/staging/sm/Iterator/prototype/map/map.js
+++ b/test/staging/sm/Iterator/prototype/map/map.js
@@ -8,10 +8,10 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 const map = Reflect.getOwnPropertyDescriptor(Iterator.prototype, 'map');

--- a/test/staging/sm/Iterator/prototype/map/mapper-not-callable-throw.js
+++ b/test/staging/sm/Iterator/prototype/map/mapper-not-callable-throw.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   Eagerly throw TypeError when `mapper` is not callable.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/map/mutate-iterator-after-done.js
+++ b/test/staging/sm/Iterator/prototype/map/mutate-iterator-after-done.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   Mutate an iterator after it has been mapped and returned done.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/map/mutate-iterator.js
+++ b/test/staging/sm/Iterator/prototype/map/mutate-iterator.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   Mutate an iterator after it has been mapped.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/map/name.js
+++ b/test/staging/sm/Iterator/prototype/map/name.js
@@ -8,10 +8,10 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 assert.sameValue(Iterator.prototype.map.name, 'map');
 

--- a/test/staging/sm/Iterator/prototype/map/output-at-generator-end.js
+++ b/test/staging/sm/Iterator/prototype/map/output-at-generator-end.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   %Iterator.prototype%.map outputs correct value at end of iterator.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 const iterator = [0].values().map(x => x);
 

--- a/test/staging/sm/Iterator/prototype/map/pass-lastValue-to-next.js
+++ b/test/staging/sm/Iterator/prototype/map/pass-lastValue-to-next.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers Proposal 2.1.5.2
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 const iteratorWhereNextTakesValue = Object.setPrototypeOf({
   next: function(value) {

--- a/test/staging/sm/Iterator/prototype/map/proxy-abrupt-completion-in-iteratorValue.js
+++ b/test/staging/sm/Iterator/prototype/map/proxy-abrupt-completion-in-iteratorValue.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   %Iterator.prototype%.map does not call return when IteratorValue returns an abrupt completion.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 const handlerProxy = log => new Proxy({}, {
   get: (target, key, receiver) => (...args) => {

--- a/test/staging/sm/Iterator/prototype/map/proxy-abrupt-completion-in-yield.js
+++ b/test/staging/sm/Iterator/prototype/map/proxy-abrupt-completion-in-yield.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   %Iterator.prototype%.map calls return when yield throws.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 class TestError extends Error {}
 

--- a/test/staging/sm/Iterator/prototype/map/proxy-abrupt-completion.js
+++ b/test/staging/sm/Iterator/prototype/map/proxy-abrupt-completion.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   %Iterator.prototype%.map accesses specified properties only.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 const handlerProxy = log => new Proxy({}, {
   get: (target, key, receiver) => (...args) => {

--- a/test/staging/sm/Iterator/prototype/map/proxy-accesses.js
+++ b/test/staging/sm/Iterator/prototype/map/proxy-accesses.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   %Iterator.prototype%.map accesses specified properties only.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 const handlerProxy = log => new Proxy({}, {
   get: (target, key, receiver) => (...args) => {

--- a/test/staging/sm/Iterator/prototype/map/reenter-map-generator-from-mapper.js
+++ b/test/staging/sm/Iterator/prototype/map/reenter-map-generator-from-mapper.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/map/this-not-iterator-throw.js
+++ b/test/staging/sm/Iterator/prototype/map/this-not-iterator-throw.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   Eagerly throw TypeError when `this` is not an iterator.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/map/this-value-array-throws.js
+++ b/test/staging/sm/Iterator/prototype/map/this-value-array-throws.js
@@ -6,11 +6,11 @@ esid: pending
 description: |
   TypeError not thrown when `this` is an Array.
 features:
-- Symbol.iterator
-- iterator-helpers
+  - Symbol.iterator
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/map/throw-when-iterator-returns-non-object.js
+++ b/test/staging/sm/Iterator/prototype/map/throw-when-iterator-returns-non-object.js
@@ -6,10 +6,10 @@ esid: pending
 description: |
   Throw TypeError if `next` call returns non-object.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/map/values-pass-through-chained-maps-to-next.js
+++ b/test/staging/sm/Iterator/prototype/map/values-pass-through-chained-maps-to-next.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers Proposal 2.1.5.2
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 //
 

--- a/test/staging/sm/Iterator/prototype/reduce/accumulator-set-to-initial-value.js
+++ b/test/staging/sm/Iterator/prototype/reduce/accumulator-set-to-initial-value.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/check-fn-after-getting-iterator.js
+++ b/test/staging/sm/Iterator/prototype/reduce/check-fn-after-getting-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/descriptor.js
+++ b/test/staging/sm/Iterator/prototype/reduce/descriptor.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/reduce/empty-iterator-without-initial-value-throws.js
+++ b/test/staging/sm/Iterator/prototype/reduce/empty-iterator-without-initial-value-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/error-from-correct-realm.js
+++ b/test/staging/sm/Iterator/prototype/reduce/error-from-correct-realm.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/iterator-empty-return-initial-value.js
+++ b/test/staging/sm/Iterator/prototype/reduce/iterator-empty-return-initial-value.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/iterator-next-return-non-object-throws.js
+++ b/test/staging/sm/Iterator/prototype/reduce/iterator-next-return-non-object-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/left-associative.js
+++ b/test/staging/sm/Iterator/prototype/reduce/left-associative.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/length.js
+++ b/test/staging/sm/Iterator/prototype/reduce/length.js
@@ -12,9 +12,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 esid: pending
 ---*/
 const propDesc = Reflect.getOwnPropertyDescriptor(Iterator.prototype.reduce, 'length');

--- a/test/staging/sm/Iterator/prototype/reduce/name.js
+++ b/test/staging/sm/Iterator/prototype/reduce/name.js
@@ -6,9 +6,9 @@ description: |
   `name` property of Iterator.prototype.reduce.
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 esid: pending

--- a/test/staging/sm/Iterator/prototype/reduce/next-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/reduce/next-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/no-initial-value-set-accumulator-to-first-value.js
+++ b/test/staging/sm/Iterator/prototype/reduce/no-initial-value-set-accumulator-to-first-value.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/proxy.js
+++ b/test/staging/sm/Iterator/prototype/reduce/proxy.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/reduce.js
+++ b/test/staging/sm/Iterator/prototype/reduce/reduce.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/reducer-not-callable-throws.js
+++ b/test/staging/sm/Iterator/prototype/reduce/reducer-not-callable-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/reducer-throws-iterator-closed.js
+++ b/test/staging/sm/Iterator/prototype/reduce/reducer-throws-iterator-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/this-not-iterator-throws.js
+++ b/test/staging/sm/Iterator/prototype/reduce/this-not-iterator-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/reduce/value-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/reduce/value-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/check-fn-after-getting-iterator.js
+++ b/test/staging/sm/Iterator/prototype/some/check-fn-after-getting-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/coerce-result-to-boolean.js
+++ b/test/staging/sm/Iterator/prototype/some/coerce-result-to-boolean.js
@@ -3,11 +3,11 @@
 
 /*---
 features:
-- IsHTMLDDA
-- iterator-helpers
+  - IsHTMLDDA
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/descriptor.js
+++ b/test/staging/sm/Iterator/prototype/some/descriptor.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/some/error-from-correct-realm.js
+++ b/test/staging/sm/Iterator/prototype/some/error-from-correct-realm.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/fn-not-callable-throws.js
+++ b/test/staging/sm/Iterator/prototype/some/fn-not-callable-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/fn-throws-close-iterator.js
+++ b/test/staging/sm/Iterator/prototype/some/fn-throws-close-iterator.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/length.js
+++ b/test/staging/sm/Iterator/prototype/some/length.js
@@ -12,9 +12,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 esid: pending
 ---*/
 const propDesc = Reflect.getOwnPropertyDescriptor(Iterator.prototype.some, 'length');

--- a/test/staging/sm/Iterator/prototype/some/name.js
+++ b/test/staging/sm/Iterator/prototype/some/name.js
@@ -6,9 +6,9 @@ description: |
   `name` property of Iterator.prototype.some.
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 esid: pending

--- a/test/staging/sm/Iterator/prototype/some/next-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/some/next-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/proxy.js
+++ b/test/staging/sm/Iterator/prototype/some/proxy.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/return-false-if-none-match.js
+++ b/test/staging/sm/Iterator/prototype/some/return-false-if-none-match.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/short-circuit-on-true.js
+++ b/test/staging/sm/Iterator/prototype/some/short-circuit-on-true.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/this-not-iterator-throws.js
+++ b/test/staging/sm/Iterator/prototype/some/this-not-iterator-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/some/value-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/some/value-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/take-drop-throw-eagerly-on-negative.js
+++ b/test/staging/sm/Iterator/prototype/take-drop-throw-eagerly-on-negative.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5.4 and 2.1.5.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/take-drop-throw-eagerly-on-non-integer.js
+++ b/test/staging/sm/Iterator/prototype/take-drop-throw-eagerly-on-non-integer.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5.4 and 2.1.5.5
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/take/close-iterator-when-none-remaining.js
+++ b/test/staging/sm/Iterator/prototype/take/close-iterator-when-none-remaining.js
@@ -8,10 +8,10 @@ description: |
 info: |
   Iterator Helpers proposal 2.1.5.4
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/take/length.js
+++ b/test/staging/sm/Iterator/prototype/take/length.js
@@ -8,11 +8,11 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- Symbol.iterator
-- iterator-helpers
+  - Symbol.iterator
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 assert.sameValue(Iterator.prototype.take.length, 1);
 

--- a/test/staging/sm/Iterator/prototype/take/name.js
+++ b/test/staging/sm/Iterator/prototype/take/name.js
@@ -8,10 +8,10 @@ description: |
 info: |
   17 ECMAScript Standard Built-in Objects
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 assert.sameValue(Iterator.prototype.take.name, 'take');
 

--- a/test/staging/sm/Iterator/prototype/take/take-more-than-available.js
+++ b/test/staging/sm/Iterator/prototype/take/take-more-than-available.js
@@ -11,10 +11,10 @@ info: |
     c. Let next be ? IteratorStep(iterated, lastValue).
     d. If next is false, return undefined.
 features:
-- iterator-helpers
+  - iterator-helpers
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 ---*/
 
 //

--- a/test/staging/sm/Iterator/prototype/toArray/create-in-current-realm.js
+++ b/test/staging/sm/Iterator/prototype/toArray/create-in-current-realm.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/toArray/descriptor.js
+++ b/test/staging/sm/Iterator/prototype/toArray/descriptor.js
@@ -8,9 +8,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Iterator/prototype/toArray/iterator-empty.js
+++ b/test/staging/sm/Iterator/prototype/toArray/iterator-empty.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/toArray/length.js
+++ b/test/staging/sm/Iterator/prototype/toArray/length.js
@@ -12,9 +12,9 @@ info: |
   Iterator is not enabled unconditionally
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 esid: pending
 ---*/
 const propDesc = Reflect.getOwnPropertyDescriptor(Iterator.prototype.toArray, 'length');

--- a/test/staging/sm/Iterator/prototype/toArray/name.js
+++ b/test/staging/sm/Iterator/prototype/toArray/name.js
@@ -6,9 +6,9 @@ description: |
   `name` property of Iterator.prototype.toArray.
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 esid: pending

--- a/test/staging/sm/Iterator/prototype/toArray/next-throws.js
+++ b/test/staging/sm/Iterator/prototype/toArray/next-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/toArray/proxy.js
+++ b/test/staging/sm/Iterator/prototype/toArray/proxy.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/toArray/this-not-iterator-throws.js
+++ b/test/staging/sm/Iterator/prototype/toArray/this-not-iterator-throws.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/toArray/toArray.js
+++ b/test/staging/sm/Iterator/prototype/toArray/toArray.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/Iterator/prototype/toArray/value-throws-iterator-not-closed.js
+++ b/test/staging/sm/Iterator/prototype/toArray/value-throws-iterator-not-closed.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- iterator-helpers
+  - iterator-helpers
 info: |
   Iterator is not enabled unconditionally
 description: |

--- a/test/staging/sm/JSON/cyclic-stringify-unrelated.js
+++ b/test/staging/sm/JSON/cyclic-stringify-unrelated.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/cyclic-stringify.js
+++ b/test/staging/sm/JSON/cyclic-stringify.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-arguments.js
+++ b/test/staging/sm/JSON/parse-arguments.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-crockford-01.js
+++ b/test/staging/sm/JSON/parse-crockford-01.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-mega-huge-array.js
+++ b/test/staging/sm/JSON/parse-mega-huge-array.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-number-syntax.js
+++ b/test/staging/sm/JSON/parse-number-syntax.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-octal-syntax-error.js
+++ b/test/staging/sm/JSON/parse-octal-syntax-error.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-primitives.js
+++ b/test/staging/sm/JSON/parse-primitives.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-reviver-array-delete.js
+++ b/test/staging/sm/JSON/parse-reviver-array-delete.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-reviver.js
+++ b/test/staging/sm/JSON/parse-reviver.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-syntax-errors-01.js
+++ b/test/staging/sm/JSON/parse-syntax-errors-01.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-syntax-errors-02.js
+++ b/test/staging/sm/JSON/parse-syntax-errors-02.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-syntax-errors-03.js
+++ b/test/staging/sm/JSON/parse-syntax-errors-03.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse-with-source.js
+++ b/test/staging/sm/JSON/parse-with-source.js
@@ -4,7 +4,7 @@
 /*---
 includes: [compareArray.js, deepEqual.js, sm/non262-JSON-shell.js, sm/non262-shell.js, sm/non262.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/parse.js
+++ b/test/staging/sm/JSON/parse.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/regress-459293.js
+++ b/test/staging/sm/JSON/regress-459293.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/small-codepoints.js
+++ b/test/staging/sm/JSON/small-codepoints.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-boxed-primitives.js
+++ b/test/staging/sm/JSON/stringify-boxed-primitives.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-call-replacer-once.js
+++ b/test/staging/sm/JSON/stringify-call-replacer-once.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-call-toJSON-once.js
+++ b/test/staging/sm/JSON/stringify-call-toJSON-once.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-dropping-elements.js
+++ b/test/staging/sm/JSON/stringify-dropping-elements.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-gap.js
+++ b/test/staging/sm/JSON/stringify-gap.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-ignore-noncallable-toJSON.js
+++ b/test/staging/sm/JSON/stringify-ignore-noncallable-toJSON.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-large-replacer-array.js
+++ b/test/staging/sm/JSON/stringify-large-replacer-array.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-missing-arguments.js
+++ b/test/staging/sm/JSON/stringify-missing-arguments.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-nonarray-noncallable-replacer.js
+++ b/test/staging/sm/JSON/stringify-nonarray-noncallable-replacer.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-primitives.js
+++ b/test/staging/sm/JSON/stringify-primitives.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-replacer-array-boxed-elements.js
+++ b/test/staging/sm/JSON/stringify-replacer-array-boxed-elements.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-replacer-array-duplicated-element.js
+++ b/test/staging/sm/JSON/stringify-replacer-array-duplicated-element.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-replacer-array-edgecase-jsid-elements.js
+++ b/test/staging/sm/JSON/stringify-replacer-array-edgecase-jsid-elements.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-replacer-array-hijinks.js
+++ b/test/staging/sm/JSON/stringify-replacer-array-hijinks.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-replacer-array-skipped-element.js
+++ b/test/staging/sm/JSON/stringify-replacer-array-skipped-element.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-replacer-array-trailing-holes.js
+++ b/test/staging/sm/JSON/stringify-replacer-array-trailing-holes.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-replacer-with-array-indexes.js
+++ b/test/staging/sm/JSON/stringify-replacer-with-array-indexes.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-replacer.js
+++ b/test/staging/sm/JSON/stringify-replacer.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-special-escapes.js
+++ b/test/staging/sm/JSON/stringify-special-escapes.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify-toJSON-arguments.js
+++ b/test/staging/sm/JSON/stringify-toJSON-arguments.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/stringify.js
+++ b/test/staging/sm/JSON/stringify.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/JSON/trailing-comma.js
+++ b/test/staging/sm/JSON/trailing-comma.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-JSON-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Map/NaN-as-key.js
+++ b/test/staging/sm/Map/NaN-as-key.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Map/constructor-iterator-close.js
+++ b/test/staging/sm/Map/constructor-iterator-close.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Map/constructor-iterator-primitive.js
+++ b/test/staging/sm/Map/constructor-iterator-primitive.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Map/forEach-selfhosted-behavior.js
+++ b/test/staging/sm/Map/forEach-selfhosted-behavior.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Map/getter-name.js
+++ b/test/staging/sm/Map/getter-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Map/iterable.js
+++ b/test/staging/sm/Map/iterable.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Map/iterator-thisv-error.js
+++ b/test/staging/sm/Map/iterator-thisv-error.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Map/symbols.js
+++ b/test/staging/sm/Map/symbols.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/20.2.2.ToNumber.js
+++ b/test/staging/sm/Math/20.2.2.ToNumber.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/acosh-approx.js
+++ b/test/staging/sm/Math/acosh-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/acosh-exact.js
+++ b/test/staging/sm/Math/acosh-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/asinh-approx.js
+++ b/test/staging/sm/Math/asinh-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/asinh-exact.js
+++ b/test/staging/sm/Math/asinh-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/atanh-approx.js
+++ b/test/staging/sm/Math/atanh-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/atanh-exact.js
+++ b/test/staging/sm/Math/atanh-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/cbrt-approx.js
+++ b/test/staging/sm/Math/cbrt-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/cbrt-exact.js
+++ b/test/staging/sm/Math/cbrt-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/clz32.js
+++ b/test/staging/sm/Math/clz32.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/cosh-approx.js
+++ b/test/staging/sm/Math/cosh-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/cosh-exact.js
+++ b/test/staging/sm/Math/cosh-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/exp-exact.js
+++ b/test/staging/sm/Math/exp-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/expm1-approx.js
+++ b/test/staging/sm/Math/expm1-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/expm1-exact.js
+++ b/test/staging/sm/Math/expm1-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/expm1-monotonicity.js
+++ b/test/staging/sm/Math/expm1-monotonicity.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/f16round.js
+++ b/test/staging/sm/Math/f16round.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/fround.js
+++ b/test/staging/sm/Math/fround.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/log10-approx.js
+++ b/test/staging/sm/Math/log10-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/log10-exact.js
+++ b/test/staging/sm/Math/log10-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/log1p-approx.js
+++ b/test/staging/sm/Math/log1p-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/log1p-exact.js
+++ b/test/staging/sm/Math/log1p-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/log2-approx.js
+++ b/test/staging/sm/Math/log2-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/log2-exact.js
+++ b/test/staging/sm/Math/log2-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/sign.js
+++ b/test/staging/sm/Math/sign.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/sinh-approx.js
+++ b/test/staging/sm/Math/sinh-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/sinh-exact.js
+++ b/test/staging/sm/Math/sinh-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/tanh-approx.js
+++ b/test/staging/sm/Math/tanh-approx.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/tanh-exact.js
+++ b/test/staging/sm/Math/tanh-exact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Math/trunc.js
+++ b/test/staging/sm/Math/trunc.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Math-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/0x-without-following-hexdigits.js
+++ b/test/staging/sm/Number/0x-without-following-hexdigits.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/15.7.3.7-EPSILON.js
+++ b/test/staging/sm/Number/15.7.3.7-EPSILON.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/15.7.4.2.js
+++ b/test/staging/sm/Number/15.7.4.2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/20.1.2.10-MIN_SAFE_INTEGER.js
+++ b/test/staging/sm/Number/20.1.2.10-MIN_SAFE_INTEGER.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/20.1.2.6-MAX_SAFE_INTEGER.js
+++ b/test/staging/sm/Number/20.1.2.6-MAX_SAFE_INTEGER.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/20.1.3.2-toExponential.js
+++ b/test/staging/sm/Number/20.1.3.2-toExponential.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/20.1.3.2-toPrecision.js
+++ b/test/staging/sm/Number/20.1.3.2-toPrecision.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/20.1.3.3-toFixed.js
+++ b/test/staging/sm/Number/20.1.3.3-toFixed.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/conversion-invalid-precision.js
+++ b/test/staging/sm/Number/conversion-invalid-precision.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/defaultvalue.js
+++ b/test/staging/sm/Number/defaultvalue.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/isSafeInteger-01.js
+++ b/test/staging/sm/Number/isSafeInteger-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/numericSeparator.js
+++ b/test/staging/sm/Number/numericSeparator.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/parseFloat-01.js
+++ b/test/staging/sm/Number/parseFloat-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/parseInt-01.js
+++ b/test/staging/sm/Number/parseInt-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/parseInt-default-to-decimal.js
+++ b/test/staging/sm/Number/parseInt-default-to-decimal.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/toExponential-values.js
+++ b/test/staging/sm/Number/toExponential-values.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/toFixed-values.js
+++ b/test/staging/sm/Number/toFixed-values.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/toPrecision-values.js
+++ b/test/staging/sm/Number/toPrecision-values.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/toString-radix-handling.js
+++ b/test/staging/sm/Number/toString-radix-handling.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Number/tonumber-string-hex.js
+++ b/test/staging/sm/Number/tonumber-string-hex.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/constructor-args.js
+++ b/test/staging/sm/PrivateName/constructor-args.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/error-outside-class.js
+++ b/test/staging/sm/PrivateName/error-outside-class.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/home-object-when-preceded-by-computed-key.js
+++ b/test/staging/sm/PrivateName/home-object-when-preceded-by-computed-key.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/illegal-in-class-context.js
+++ b/test/staging/sm/PrivateName/illegal-in-class-context.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/illegal-in-identifier-context.js
+++ b/test/staging/sm/PrivateName/illegal-in-identifier-context.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/illegal-in-object-context.js
+++ b/test/staging/sm/PrivateName/illegal-in-object-context.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/lexical-presence.js
+++ b/test/staging/sm/PrivateName/lexical-presence.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/modify-non-extensible.js
+++ b/test/staging/sm/PrivateName/modify-non-extensible.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/names.js
+++ b/test/staging/sm/PrivateName/names.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/nested-class-in-computed-property-key.js
+++ b/test/staging/sm/PrivateName/nested-class-in-computed-property-key.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/nested-class-name-used.js
+++ b/test/staging/sm/PrivateName/nested-class-name-used.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/not-iterable.js
+++ b/test/staging/sm/PrivateName/not-iterable.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/parse-utf8-non-ascii-identifier.js
+++ b/test/staging/sm/PrivateName/parse-utf8-non-ascii-identifier.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/proxy-1.js
+++ b/test/staging/sm/PrivateName/proxy-1.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/proxy-init-set.js
+++ b/test/staging/sm/PrivateName/proxy-init-set.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/read-private-eval.js
+++ b/test/staging/sm/PrivateName/read-private-eval.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/PrivateName/unicode-names.js
+++ b/test/staging/sm/PrivateName/unicode-names.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Promise/bug-1287334.js
+++ b/test/staging/sm/Promise/bug-1287334.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Promise/bug-1288382.js
+++ b/test/staging/sm/Promise/bug-1288382.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Promise/bug-1289040.js
+++ b/test/staging/sm/Promise/bug-1289040.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Promise/for-of-iterator-uses-getv.js
+++ b/test/staging/sm/Promise/for-of-iterator-uses-getv.js
@@ -3,7 +3,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/Promise/methods-non-enumerable.js
+++ b/test/staging/sm/Promise/methods-non-enumerable.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Promise/promise-species.js
+++ b/test/staging/sm/Promise/promise-species.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/define-writable-as-non-writable.js
+++ b/test/staging/sm/Proxy/define-writable-as-non-writable.js
@@ -3,7 +3,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/Proxy/delete-non-extensible.js
+++ b/test/staging/sm/Proxy/delete-non-extensible.js
@@ -3,7 +3,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/Proxy/getPrototypeOf.js
+++ b/test/staging/sm/Proxy/getPrototypeOf.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/global-receiver.js
+++ b/test/staging/sm/Proxy/global-receiver.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/hasInstance.js
+++ b/test/staging/sm/Proxy/hasInstance.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/json-stringify-replacer-array-revocable-proxy.js
+++ b/test/staging/sm/Proxy/json-stringify-replacer-array-revocable-proxy.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/ownkeys-allowed-types.js
+++ b/test/staging/sm/Proxy/ownkeys-allowed-types.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/ownkeys-linear.js
+++ b/test/staging/sm/Proxy/ownkeys-linear.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/ownkeys-trap-duplicates.js
+++ b/test/staging/sm/Proxy/ownkeys-trap-duplicates.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/proxy-__proto__.js
+++ b/test/staging/sm/Proxy/proxy-__proto__.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/proxy-constructNonObject.js
+++ b/test/staging/sm/Proxy/proxy-constructNonObject.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/proxy-no-receiver-overwrite.js
+++ b/test/staging/sm/Proxy/proxy-no-receiver-overwrite.js
@@ -3,7 +3,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/Proxy/proxy-proto-lazy-props.js
+++ b/test/staging/sm/Proxy/proxy-proto-lazy-props.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/proxy-with-revoked-arguments.js
+++ b/test/staging/sm/Proxy/proxy-with-revoked-arguments.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/regress-bug1037770.js
+++ b/test/staging/sm/Proxy/regress-bug1037770.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/regress-bug1062349.js
+++ b/test/staging/sm/Proxy/regress-bug1062349.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/regress-bug950407.js
+++ b/test/staging/sm/Proxy/regress-bug950407.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/report-writable-as-non-writable.js
+++ b/test/staging/sm/Proxy/report-writable-as-non-writable.js
@@ -3,7 +3,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/Proxy/revocable-proxy-prototype.js
+++ b/test/staging/sm/Proxy/revocable-proxy-prototype.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/revoke-as-side-effect.js
+++ b/test/staging/sm/Proxy/revoke-as-side-effect.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/revoke-no-name.js
+++ b/test/staging/sm/Proxy/revoke-no-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/revoked-get-function-realm-typeerror.js
+++ b/test/staging/sm/Proxy/revoked-get-function-realm-typeerror.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/setPrototypeOf.js
+++ b/test/staging/sm/Proxy/setPrototypeOf.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Proxy/trap-null.js
+++ b/test/staging/sm/Proxy/trap-null.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/apply.js
+++ b/test/staging/sm/Reflect/apply.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/argumentsList.js
+++ b/test/staging/sm/Reflect/argumentsList.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/construct.js
+++ b/test/staging/sm/Reflect/construct.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/defineProperty.js
+++ b/test/staging/sm/Reflect/defineProperty.js
@@ -5,10 +5,10 @@
 
 /*---
 features:
-- IsHTMLDDA
+  - IsHTMLDDA
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/deleteProperty.js
+++ b/test/staging/sm/Reflect/deleteProperty.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/get.js
+++ b/test/staging/sm/Reflect/get.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/getOwnPropertyDescriptor.js
+++ b/test/staging/sm/Reflect/getOwnPropertyDescriptor.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/getPrototypeOf.js
+++ b/test/staging/sm/Reflect/getPrototypeOf.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/has.js
+++ b/test/staging/sm/Reflect/has.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/isExtensible.js
+++ b/test/staging/sm/Reflect/isExtensible.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/ownKeys.js
+++ b/test/staging/sm/Reflect/ownKeys.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/preventExtensions.js
+++ b/test/staging/sm/Reflect/preventExtensions.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/propertyKeys.js
+++ b/test/staging/sm/Reflect/propertyKeys.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/set.js
+++ b/test/staging/sm/Reflect/set.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/setPrototypeOf.js
+++ b/test/staging/sm/Reflect/setPrototypeOf.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/surfaces.js
+++ b/test/staging/sm/Reflect/surfaces.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Reflect/target.js
+++ b/test/staging/sm/Reflect/target.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Reflect-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/15.10.5-01.js
+++ b/test/staging/sm/RegExp/15.10.5-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/15.10.7.5-01.js
+++ b/test/staging/sm/RegExp/15.10.7.5-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/7.8.5-01.js
+++ b/test/staging/sm/RegExp/7.8.5-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/RegExpExec-exec-type-check.js
+++ b/test/staging/sm/RegExp/RegExpExec-exec-type-check.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/RegExpExec-exec.js
+++ b/test/staging/sm/RegExp/RegExpExec-exec.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/RegExpExec-return.js
+++ b/test/staging/sm/RegExp/RegExpExec-return.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/character-class-escape-s.js
+++ b/test/staging/sm/RegExp/character-class-escape-s.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/class-null.js
+++ b/test/staging/sm/RegExp/class-null.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/compile-lastIndex.js
+++ b/test/staging/sm/RegExp/compile-lastIndex.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/constructor-IsRegExp.js
+++ b/test/staging/sm/RegExp/constructor-IsRegExp.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/constructor-constructor.js
+++ b/test/staging/sm/RegExp/constructor-constructor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/constructor-ordering-2.js
+++ b/test/staging/sm/RegExp/constructor-ordering-2.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/constructor-ordering.js
+++ b/test/staging/sm/RegExp/constructor-ordering.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/constructor-regexp-unicode.js
+++ b/test/staging/sm/RegExp/constructor-regexp-unicode.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/constructor-regexp.js
+++ b/test/staging/sm/RegExp/constructor-regexp.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/cross-compartment-getter.js
+++ b/test/staging/sm/RegExp/cross-compartment-getter.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/descriptor.js
+++ b/test/staging/sm/RegExp/descriptor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/empty-lookahead.js
+++ b/test/staging/sm/RegExp/empty-lookahead.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/escape.js
+++ b/test/staging/sm/RegExp/escape.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/exec-lastIndex-ToInteger.js
+++ b/test/staging/sm/RegExp/exec-lastIndex-ToInteger.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/exec-lastIndex-negative.js
+++ b/test/staging/sm/RegExp/exec-lastIndex-negative.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/exec.js
+++ b/test/staging/sm/RegExp/exec.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/flag-accessors.js
+++ b/test/staging/sm/RegExp/flag-accessors.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/flags-param-handling.js
+++ b/test/staging/sm/RegExp/flags-param-handling.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/flags.js
+++ b/test/staging/sm/RegExp/flags.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/getter-name.js
+++ b/test/staging/sm/RegExp/getter-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/ignoreCase-multiple.js
+++ b/test/staging/sm/RegExp/ignoreCase-multiple.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/ignoreCase-non-latin1-to-latin1.js
+++ b/test/staging/sm/RegExp/ignoreCase-non-latin1-to-latin1.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/instance-property-storage-introspection.js
+++ b/test/staging/sm/RegExp/instance-property-storage-introspection.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/lastIndex-exec.js
+++ b/test/staging/sm/RegExp/lastIndex-exec.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/lastIndex-match-or-replace.js
+++ b/test/staging/sm/RegExp/lastIndex-match-or-replace.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/lastIndex-nonwritable.js
+++ b/test/staging/sm/RegExp/lastIndex-nonwritable.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/lastIndex-search.js
+++ b/test/staging/sm/RegExp/lastIndex-search.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/match-local-tolength-recompilation.js
+++ b/test/staging/sm/RegExp/match-local-tolength-recompilation.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/match-this.js
+++ b/test/staging/sm/RegExp/match-this.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/match-trace.js
+++ b/test/staging/sm/RegExp/match-trace.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/match.js
+++ b/test/staging/sm/RegExp/match.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/prototype-different-global.js
+++ b/test/staging/sm/RegExp/prototype-different-global.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/prototype.js
+++ b/test/staging/sm/RegExp/prototype.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/regress-576828.js
+++ b/test/staging/sm/RegExp/regress-576828.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/regress-613820-1.js
+++ b/test/staging/sm/RegExp/regress-613820-1.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/regress-613820-2.js
+++ b/test/staging/sm/RegExp/regress-613820-2.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/regress-613820-3.js
+++ b/test/staging/sm/RegExp/regress-613820-3.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/regress-yarr-regexp.js
+++ b/test/staging/sm/RegExp/regress-yarr-regexp.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace-compile-elembase.js
+++ b/test/staging/sm/RegExp/replace-compile-elembase.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace-compile.js
+++ b/test/staging/sm/RegExp/replace-compile.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace-global-unicode.js
+++ b/test/staging/sm/RegExp/replace-global-unicode.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace-local-tolength-lastindex.js
+++ b/test/staging/sm/RegExp/replace-local-tolength-lastindex.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace-local-tolength-recompilation.js
+++ b/test/staging/sm/RegExp/replace-local-tolength-recompilation.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace-sticky-lastIndex.js
+++ b/test/staging/sm/RegExp/replace-sticky-lastIndex.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace-sticky.js
+++ b/test/staging/sm/RegExp/replace-sticky.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace-this.js
+++ b/test/staging/sm/RegExp/replace-this.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace-trace.js
+++ b/test/staging/sm/RegExp/replace-trace.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace-twoBytes.js
+++ b/test/staging/sm/RegExp/replace-twoBytes.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/replace.js
+++ b/test/staging/sm/RegExp/replace.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/search-this.js
+++ b/test/staging/sm/RegExp/search-this.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/search-trace.js
+++ b/test/staging/sm/RegExp/search-trace.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/search.js
+++ b/test/staging/sm/RegExp/search.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/source.js
+++ b/test/staging/sm/RegExp/source.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/split-deleted-flags.js
+++ b/test/staging/sm/RegExp/split-deleted-flags.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/split-flags-on-obj.js
+++ b/test/staging/sm/RegExp/split-flags-on-obj.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/split-invalid-lastIndex.js
+++ b/test/staging/sm/RegExp/split-invalid-lastIndex.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/split-limit.js
+++ b/test/staging/sm/RegExp/split-limit.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/split-obj.js
+++ b/test/staging/sm/RegExp/split-obj.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/split-prop-access.js
+++ b/test/staging/sm/RegExp/split-prop-access.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/split-this.js
+++ b/test/staging/sm/RegExp/split-this.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/split-trace.js
+++ b/test/staging/sm/RegExp/split-trace.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/split.js
+++ b/test/staging/sm/RegExp/split.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/sticky.js
+++ b/test/staging/sm/RegExp/sticky.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/test-emptyMatch.js
+++ b/test/staging/sm/RegExp/test-emptyMatch.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/test-trailing.js
+++ b/test/staging/sm/RegExp/test-trailing.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/toString.js
+++ b/test/staging/sm/RegExp/toString.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-back-reference.js
+++ b/test/staging/sm/RegExp/unicode-back-reference.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-braced.js
+++ b/test/staging/sm/RegExp/unicode-braced.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-character-class-escape.js
+++ b/test/staging/sm/RegExp/unicode-character-class-escape.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-class-braced.js
+++ b/test/staging/sm/RegExp/unicode-class-braced.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-class-empty.js
+++ b/test/staging/sm/RegExp/unicode-class-empty.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-class-ignoreCase.js
+++ b/test/staging/sm/RegExp/unicode-class-ignoreCase.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-class-lead-trail.js
+++ b/test/staging/sm/RegExp/unicode-class-lead-trail.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-class-negated.js
+++ b/test/staging/sm/RegExp/unicode-class-negated.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-class-range.js
+++ b/test/staging/sm/RegExp/unicode-class-range.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-class-raw.js
+++ b/test/staging/sm/RegExp/unicode-class-raw.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-disallow-extended.js
+++ b/test/staging/sm/RegExp/unicode-disallow-extended.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-everything.js
+++ b/test/staging/sm/RegExp/unicode-everything.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-ignoreCase-ascii.js
+++ b/test/staging/sm/RegExp/unicode-ignoreCase-ascii.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-ignoreCase-escape.js
+++ b/test/staging/sm/RegExp/unicode-ignoreCase-escape.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-ignoreCase-negated.js
+++ b/test/staging/sm/RegExp/unicode-ignoreCase-negated.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-ignoreCase-word-boundary.js
+++ b/test/staging/sm/RegExp/unicode-ignoreCase-word-boundary.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-ignoreCase.js
+++ b/test/staging/sm/RegExp/unicode-ignoreCase.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-lead-trail.js
+++ b/test/staging/sm/RegExp/unicode-lead-trail.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/RegExp/unicode-raw.js
+++ b/test/staging/sm/RegExp/unicode-raw.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-RegExp-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Set/difference.js
+++ b/test/staging/sm/Set/difference.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Set-shell.js, deepEqual.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Set/intersection.js
+++ b/test/staging/sm/Set/intersection.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Set-shell.js, deepEqual.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Set/is-disjoint-from.js
+++ b/test/staging/sm/Set/is-disjoint-from.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Set-shell.js, deepEqual.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Set/is-subset-of.js
+++ b/test/staging/sm/Set/is-subset-of.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Set-shell.js, deepEqual.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Set/is-superset-of.js
+++ b/test/staging/sm/Set/is-superset-of.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Set-shell.js, deepEqual.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Set/symmetric-difference.js
+++ b/test/staging/sm/Set/symmetric-difference.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Set-shell.js, deepEqual.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Set/union.js
+++ b/test/staging/sm/Set/union.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Set-shell.js, deepEqual.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/15.5.4.11-01.js
+++ b/test/staging/sm/String/15.5.4.11-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/15.5.4.2.js
+++ b/test/staging/sm/String/15.5.4.2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/15.5.4.7.js
+++ b/test/staging/sm/String/15.5.4.7.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/AdvanceStringIndex.js
+++ b/test/staging/sm/String/AdvanceStringIndex.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/IsRegExp.js
+++ b/test/staging/sm/String/IsRegExp.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/at.js
+++ b/test/staging/sm/String/at.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/codePointAt.js
+++ b/test/staging/sm/String/codePointAt.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/defaultvalue.js
+++ b/test/staging/sm/String/defaultvalue.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/fromCodePoint.js
+++ b/test/staging/sm/String/fromCodePoint.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/internalUsage.js
+++ b/test/staging/sm/String/internalUsage.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/iterator_edge_cases.js
+++ b/test/staging/sm/String/iterator_edge_cases.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/match-GetMethod.js
+++ b/test/staging/sm/String/match-GetMethod.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/match-defines-match-elements.js
+++ b/test/staging/sm/String/match-defines-match-elements.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/match-forward-lookahead.js
+++ b/test/staging/sm/String/match-forward-lookahead.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/match-throws-nonwritable-lastIndex-global.js
+++ b/test/staging/sm/String/match-throws-nonwritable-lastIndex-global.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/match-updates-global-lastIndex.js
+++ b/test/staging/sm/String/match-updates-global-lastIndex.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/match.js
+++ b/test/staging/sm/String/match.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/matchAll.js
+++ b/test/staging/sm/String/matchAll.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/normalize-form-non-atom.js
+++ b/test/staging/sm/String/normalize-form-non-atom.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/normalize-generateddata-input.js
+++ b/test/staging/sm/String/normalize-generateddata-input.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/normalize-generic.js
+++ b/test/staging/sm/String/normalize-generic.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/normalize-parameter.js
+++ b/test/staging/sm/String/normalize-parameter.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/normalize-rope.js
+++ b/test/staging/sm/String/normalize-rope.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/raw.js
+++ b/test/staging/sm/String/raw.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/regress-369778.js
+++ b/test/staging/sm/String/regress-369778.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/replace-GetMethod.js
+++ b/test/staging/sm/String/replace-GetMethod.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/replace-bad-dollar-single-quote.js
+++ b/test/staging/sm/String/replace-bad-dollar-single-quote.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/replace-flags.js
+++ b/test/staging/sm/String/replace-flags.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/replace-math.js
+++ b/test/staging/sm/String/replace-math.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/replace-throws-nonwritable-lastIndex-global.js
+++ b/test/staging/sm/String/replace-throws-nonwritable-lastIndex-global.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/replace-updates-global-lastIndex.js
+++ b/test/staging/sm/String/replace-updates-global-lastIndex.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/replace.js
+++ b/test/staging/sm/String/replace.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/replaceAll.js
+++ b/test/staging/sm/String/replaceAll.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/search-GetMethod.js
+++ b/test/staging/sm/String/search-GetMethod.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/search.js
+++ b/test/staging/sm/String/search.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/split-01.js
+++ b/test/staging/sm/String/split-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/split-GetMethod.js
+++ b/test/staging/sm/String/split-GetMethod.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/split-order.js
+++ b/test/staging/sm/String/split-order.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/split-undefined-separator.js
+++ b/test/staging/sm/String/split-undefined-separator.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/split-xregexp.js
+++ b/test/staging/sm/String/split-xregexp.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/split.js
+++ b/test/staging/sm/String/split.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/string-code-point-upper-lower-mapping.js
+++ b/test/staging/sm/String/string-code-point-upper-lower-mapping.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/string-pad-start-end.js
+++ b/test/staging/sm/String/string-pad-start-end.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/string-space-trim.js
+++ b/test/staging/sm/String/string-space-trim.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/string-upper-lower-mapping.js
+++ b/test/staging/sm/String/string-upper-lower-mapping.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/thisv-error.js
+++ b/test/staging/sm/String/thisv-error.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/two-length-nonlatin-indexOf.js
+++ b/test/staging/sm/String/two-length-nonlatin-indexOf.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/String/unicode-braced.js
+++ b/test/staging/sm/String/unicode-braced.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-String-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/as-base-value.js
+++ b/test/staging/sm/Symbol/as-base-value.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/comparisons.js
+++ b/test/staging/sm/Symbol/comparisons.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/constructor.js
+++ b/test/staging/sm/Symbol/constructor.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/conversions.js
+++ b/test/staging/sm/Symbol/conversions.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/enumeration-order.js
+++ b/test/staging/sm/Symbol/enumeration-order.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/enumeration.js
+++ b/test/staging/sm/Symbol/enumeration.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/equality.js
+++ b/test/staging/sm/Symbol/equality.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/errors.js
+++ b/test/staging/sm/Symbol/errors.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/for-in-order.js
+++ b/test/staging/sm/Symbol/for-in-order.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/for.js
+++ b/test/staging/sm/Symbol/for.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/json-stringify-keys.js
+++ b/test/staging/sm/Symbol/json-stringify-keys.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/json-stringify-values.js
+++ b/test/staging/sm/Symbol/json-stringify-values.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/keyFor.js
+++ b/test/staging/sm/Symbol/keyFor.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/property-accessor.js
+++ b/test/staging/sm/Symbol/property-accessor.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/property-basics.js
+++ b/test/staging/sm/Symbol/property-basics.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/property-inheritance.js
+++ b/test/staging/sm/Symbol/property-inheritance.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/property-nonwritable.js
+++ b/test/staging/sm/Symbol/property-nonwritable.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/property-reflection.js
+++ b/test/staging/sm/Symbol/property-reflection.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/realms.js
+++ b/test/staging/sm/Symbol/realms.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/species.js
+++ b/test/staging/sm/Symbol/species.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/surfaces.js
+++ b/test/staging/sm/Symbol/surfaces.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/symbol-object-not-unboxed-for-value-to-id.js
+++ b/test/staging/sm/Symbol/symbol-object-not-unboxed-for-value-to-id.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/toPrimitive-undefined-or-null.js
+++ b/test/staging/sm/Symbol/toPrimitive-undefined-or-null.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/toPrimitive.js
+++ b/test/staging/sm/Symbol/toPrimitive.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/toString.js
+++ b/test/staging/sm/Symbol/toString.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/toStringTag.js
+++ b/test/staging/sm/Symbol/toStringTag.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/typed-arrays.js
+++ b/test/staging/sm/Symbol/typed-arrays.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/typeof.js
+++ b/test/staging/sm/Symbol/typeof.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/valueOf.js
+++ b/test/staging/sm/Symbol/valueOf.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Symbol/well-known.js
+++ b/test/staging/sm/Symbol/well-known.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/Calendar/compare-to-datetimeformat.js
+++ b/test/staging/sm/Temporal/Calendar/compare-to-datetimeformat.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainDate/from-constrain-hebrew.js
+++ b/test/staging/sm/Temporal/PlainDate/from-constrain-hebrew.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainDate/from-constrain-japanese.js
+++ b/test/staging/sm/Temporal/PlainDate/from-constrain-japanese.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainDate/from-hebrew-keviah.js
+++ b/test/staging/sm/Temporal/PlainDate/from-hebrew-keviah.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainDate/from-indian.js
+++ b/test/staging/sm/Temporal/PlainDate/from-indian.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainDate/from-islamic-umalqura.js
+++ b/test/staging/sm/Temporal/PlainDate/from-islamic-umalqura.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainDate/non-positive-era-year.js
+++ b/test/staging/sm/Temporal/PlainDate/non-positive-era-year.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainDate/too-large-dates.js
+++ b/test/staging/sm/Temporal/PlainDate/too-large-dates.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainDate/withCalendar.js
+++ b/test/staging/sm/Temporal/PlainDate/withCalendar.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainMonthDay/from-chinese-leap-month-common.js
+++ b/test/staging/sm/Temporal/PlainMonthDay/from-chinese-leap-month-common.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Temporal-PlainMonthDay-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainMonthDay/from-chinese-leap-month-uncommon.js
+++ b/test/staging/sm/Temporal/PlainMonthDay/from-chinese-leap-month-uncommon.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Temporal-PlainMonthDay-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainMonthDay/from-chinese.js
+++ b/test/staging/sm/Temporal/PlainMonthDay/from-chinese.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Temporal-PlainMonthDay-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainMonthDay/from-coptic.js
+++ b/test/staging/sm/Temporal/PlainMonthDay/from-coptic.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Temporal-PlainMonthDay-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainMonthDay/from-gregory.js
+++ b/test/staging/sm/Temporal/PlainMonthDay/from-gregory.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Temporal-PlainMonthDay-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/PlainMonthDay/result-not-after-1972-dec-31.js
+++ b/test/staging/sm/Temporal/PlainMonthDay/result-not-after-1972-dec-31.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-Temporal-PlainMonthDay-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/Temporal/ZonedDateTime/zones-and-links.js
+++ b/test/staging/sm/Temporal/ZonedDateTime/zones-and-links.js
@@ -4,9 +4,9 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 features:
-- Temporal
+  - Temporal
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/Tconstructor-fromTypedArray-byteLength.js
+++ b/test/staging/sm/TypedArray/Tconstructor-fromTypedArray-byteLength.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/at.js
+++ b/test/staging/sm/TypedArray/at.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/bug1526838.js
+++ b/test/staging/sm/TypedArray/bug1526838.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/constructor-ArrayBuffer-species-wrap.js
+++ b/test/staging/sm/TypedArray/constructor-ArrayBuffer-species-wrap.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/constructor-ArrayBuffer-species.js
+++ b/test/staging/sm/TypedArray/constructor-ArrayBuffer-species.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+++ b/test/staging/sm/TypedArray/constructor-buffer-sequence.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/constructor-byteoffsets-bounds.js
+++ b/test/staging/sm/TypedArray/constructor-byteoffsets-bounds.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/constructor-iterator-primitive.js
+++ b/test/staging/sm/TypedArray/constructor-iterator-primitive.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/constructor-non-detached.js
+++ b/test/staging/sm/TypedArray/constructor-non-detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/constructor-not-callable.js
+++ b/test/staging/sm/TypedArray/constructor-not-callable.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/constructor-typedarray-species-other-global.js
+++ b/test/staging/sm/TypedArray/constructor-typedarray-species-other-global.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/constructor-undefined-args.js
+++ b/test/staging/sm/TypedArray/constructor-undefined-args.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/constructor_bad-args.js
+++ b/test/staging/sm/TypedArray/constructor_bad-args.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/detached-array-buffer-checks.js
+++ b/test/staging/sm/TypedArray/detached-array-buffer-checks.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/element-setting-converts-using-ToNumber.js
+++ b/test/staging/sm/TypedArray/element-setting-converts-using-ToNumber.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/entries.js
+++ b/test/staging/sm/TypedArray/entries.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/every-and-some.js
+++ b/test/staging/sm/TypedArray/every-and-some.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/fill-detached.js
+++ b/test/staging/sm/TypedArray/fill-detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/fill.js
+++ b/test/staging/sm/TypedArray/fill.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/filter-species.js
+++ b/test/staging/sm/TypedArray/filter-species.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/find-and-findIndex.js
+++ b/test/staging/sm/TypedArray/find-and-findIndex.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/findLast-and-findLastIndex.js
+++ b/test/staging/sm/TypedArray/findLast-and-findLastIndex.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/forEach.js
+++ b/test/staging/sm/TypedArray/forEach.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/from_basics.js
+++ b/test/staging/sm/TypedArray/from_basics.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/from_constructor.js
+++ b/test/staging/sm/TypedArray/from_constructor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/from_errors.js
+++ b/test/staging/sm/TypedArray/from_errors.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/from_iterable.js
+++ b/test/staging/sm/TypedArray/from_iterable.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/from_mapping.js
+++ b/test/staging/sm/TypedArray/from_mapping.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/from_realms.js
+++ b/test/staging/sm/TypedArray/from_realms.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/from_string.js
+++ b/test/staging/sm/TypedArray/from_string.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/from_surfaces.js
+++ b/test/staging/sm/TypedArray/from_surfaces.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/from_this.js
+++ b/test/staging/sm/TypedArray/from_this.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/from_typedarray_fastpath_detached.js
+++ b/test/staging/sm/TypedArray/from_typedarray_fastpath_detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/getter-name.js
+++ b/test/staging/sm/TypedArray/getter-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/has-property-op.js
+++ b/test/staging/sm/TypedArray/has-property-op.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/includes.js
+++ b/test/staging/sm/TypedArray/includes.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/indexOf-and-lastIndexOf.js
+++ b/test/staging/sm/TypedArray/indexOf-and-lastIndexOf.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/indexOf-never-returns-negative-zero.js
+++ b/test/staging/sm/TypedArray/indexOf-never-returns-negative-zero.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/iterator-next-with-detached.js
+++ b/test/staging/sm/TypedArray/iterator-next-with-detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/iterator.js
+++ b/test/staging/sm/TypedArray/iterator.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/join.js
+++ b/test/staging/sm/TypedArray/join.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/keys.js
+++ b/test/staging/sm/TypedArray/keys.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/lastIndexOf-never-returns-negative-zero.js
+++ b/test/staging/sm/TypedArray/lastIndexOf-never-returns-negative-zero.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/map-and-filter.js
+++ b/test/staging/sm/TypedArray/map-and-filter.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/map-species.js
+++ b/test/staging/sm/TypedArray/map-species.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/object-defineproperty.js
+++ b/test/staging/sm/TypedArray/object-defineproperty.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/of.js
+++ b/test/staging/sm/TypedArray/of.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/prototype-constructor-identity.js
+++ b/test/staging/sm/TypedArray/prototype-constructor-identity.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/reduce-and-reduceRight.js
+++ b/test/staging/sm/TypedArray/reduce-and-reduceRight.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/reverse.js
+++ b/test/staging/sm/TypedArray/reverse.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/seal-and-freeze.js
+++ b/test/staging/sm/TypedArray/seal-and-freeze.js
@@ -3,7 +3,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 description: |
   pending

--- a/test/staging/sm/TypedArray/set-detached-bigint.js
+++ b/test/staging/sm/TypedArray/set-detached-bigint.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/set-detached.js
+++ b/test/staging/sm/TypedArray/set-detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/set-negative-offset.js
+++ b/test/staging/sm/TypedArray/set-negative-offset.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/set-same-buffer-different-source-target-types.js
+++ b/test/staging/sm/TypedArray/set-same-buffer-different-source-target-types.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/set-tointeger.js
+++ b/test/staging/sm/TypedArray/set-tointeger.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/set-toobject.js
+++ b/test/staging/sm/TypedArray/set-toobject.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/set-with-receiver.js
+++ b/test/staging/sm/TypedArray/set-with-receiver.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/set-wrapped.js
+++ b/test/staging/sm/TypedArray/set-wrapped.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/set.js
+++ b/test/staging/sm/TypedArray/set.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/slice-bitwise-same.js
+++ b/test/staging/sm/TypedArray/slice-bitwise-same.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/slice-conversion.js
+++ b/test/staging/sm/TypedArray/slice-conversion.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/slice-detached.js
+++ b/test/staging/sm/TypedArray/slice-detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/slice-memcpy.js
+++ b/test/staging/sm/TypedArray/slice-memcpy.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/slice-species.js
+++ b/test/staging/sm/TypedArray/slice-species.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/slice.js
+++ b/test/staging/sm/TypedArray/slice.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort-negative-nan.js
+++ b/test/staging/sm/TypedArray/sort-negative-nan.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort-non-function.js
+++ b/test/staging/sm/TypedArray/sort-non-function.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_byteoffset.js
+++ b/test/staging/sm/TypedArray/sort_byteoffset.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_comparators.js
+++ b/test/staging/sm/TypedArray/sort_comparators.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_compare_nan.js
+++ b/test/staging/sm/TypedArray/sort_compare_nan.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_errors.js
+++ b/test/staging/sm/TypedArray/sort_errors.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_globals.js
+++ b/test/staging/sm/TypedArray/sort_globals.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_large_countingsort.js
+++ b/test/staging/sm/TypedArray/sort_large_countingsort.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_modifications.js
+++ b/test/staging/sm/TypedArray/sort_modifications.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_small.js
+++ b/test/staging/sm/TypedArray/sort_small.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_snans.js
+++ b/test/staging/sm/TypedArray/sort_snans.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_sorted.js
+++ b/test/staging/sm/TypedArray/sort_sorted.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sort_stable.js
+++ b/test/staging/sm/TypedArray/sort_stable.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/sorting_buffer_access.js
+++ b/test/staging/sm/TypedArray/sorting_buffer_access.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/subarray-species.js
+++ b/test/staging/sm/TypedArray/subarray-species.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/subarray.js
+++ b/test/staging/sm/TypedArray/subarray.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/test-integrity-level-detached.js
+++ b/test/staging/sm/TypedArray/test-integrity-level-detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/test-integrity-level.js
+++ b/test/staging/sm/TypedArray/test-integrity-level.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/toLocaleString-detached.js
+++ b/test/staging/sm/TypedArray/toLocaleString-detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/toLocaleString-nointl.js
+++ b/test/staging/sm/TypedArray/toLocaleString-nointl.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/toLocaleString.js
+++ b/test/staging/sm/TypedArray/toLocaleString.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/toReversed-detached.js
+++ b/test/staging/sm/TypedArray/toReversed-detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/toSorted-detached.js
+++ b/test/staging/sm/TypedArray/toSorted-detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/toString.js
+++ b/test/staging/sm/TypedArray/toString.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/toStringTag-cross-compartment.js
+++ b/test/staging/sm/TypedArray/toStringTag-cross-compartment.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/uint8clamped-constructor.js
+++ b/test/staging/sm/TypedArray/uint8clamped-constructor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/values.js
+++ b/test/staging/sm/TypedArray/values.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/with-detached.js
+++ b/test/staging/sm/TypedArray/with-detached.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/with.js
+++ b/test/staging/sm/TypedArray/with.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/TypedArray/write-out-of-bounds-tonumber.js
+++ b/test/staging/sm/TypedArray/write-out-of-bounds-tonumber.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-TypedArray-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/WeakMap/symbols.js
+++ b/test/staging/sm/WeakMap/symbols.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   requires shell-options
 description: |

--- a/test/staging/sm/argumentsLengthOpt.js
+++ b/test/staging/sm/argumentsLengthOpt.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/async-contains-unicode-escape.js
+++ b/test/staging/sm/async-functions/async-contains-unicode-escape.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/async-function-declaration-in-modules.js
+++ b/test/staging/sm/async-functions/async-function-declaration-in-modules.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- module
+  - module
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/async-property-name-error.js
+++ b/test/staging/sm/async-functions/async-property-name-error.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/await-error.js
+++ b/test/staging/sm/async-functions/await-error.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/await-in-arrow-parameters.js
+++ b/test/staging/sm/async-functions/await-in-arrow-parameters.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/await-in-parameters-of-async-func.js
+++ b/test/staging/sm/async-functions/await-in-parameters-of-async-func.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/constructor.js
+++ b/test/staging/sm/async-functions/constructor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/create-function-parse-before-getprototype.js
+++ b/test/staging/sm/async-functions/create-function-parse-before-getprototype.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/inner-caller.js
+++ b/test/staging/sm/async-functions/inner-caller.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/length.js
+++ b/test/staging/sm/async-functions/length.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/no-expression-closure.js
+++ b/test/staging/sm/async-functions/no-expression-closure.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/property.js
+++ b/test/staging/sm/async-functions/property.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/async-functions/toString.js
+++ b/test/staging/sm/async-functions/toString.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/boundFunctionSubclassing.js
+++ b/test/staging/sm/class/boundFunctionSubclassing.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/bytecodePatternMatching.js
+++ b/test/staging/sm/class/bytecodePatternMatching.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/classConstructorNoCall.js
+++ b/test/staging/sm/class/classConstructorNoCall.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/classHeritage.js
+++ b/test/staging/sm/class/classHeritage.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/className.js
+++ b/test/staging/sm/class/className.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/classPrototype.js
+++ b/test/staging/sm/class/classPrototype.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/compPropDestr.js
+++ b/test/staging/sm/class/compPropDestr.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/compPropNames.js
+++ b/test/staging/sm/class/compPropNames.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/constructorCalled.js
+++ b/test/staging/sm/class/constructorCalled.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/defaultConstructorBase.js
+++ b/test/staging/sm/class/defaultConstructorBase.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/defaultConstructorDerivedSpread.js
+++ b/test/staging/sm/class/defaultConstructorDerivedSpread.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/defaultConstructorNotCallable.js
+++ b/test/staging/sm/class/defaultConstructorNotCallable.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorArrowEvalBinding.js
+++ b/test/staging/sm/class/derivedConstructorArrowEvalBinding.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorArrowEvalClosed.js
+++ b/test/staging/sm/class/derivedConstructorArrowEvalClosed.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorArrowEvalEscape.js
+++ b/test/staging/sm/class/derivedConstructorArrowEvalEscape.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorArrowEvalEscapeUninitialized.js
+++ b/test/staging/sm/class/derivedConstructorArrowEvalEscapeUninitialized.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorArrowEvalGetThis.js
+++ b/test/staging/sm/class/derivedConstructorArrowEvalGetThis.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorArrowEvalNestedSuperCall.js
+++ b/test/staging/sm/class/derivedConstructorArrowEvalNestedSuperCall.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorArrowEvalSuperCall.js
+++ b/test/staging/sm/class/derivedConstructorArrowEvalSuperCall.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorInlining.js
+++ b/test/staging/sm/class/derivedConstructorInlining.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorName.js
+++ b/test/staging/sm/class/derivedConstructorName.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorReturnPrimitive.js
+++ b/test/staging/sm/class/derivedConstructorReturnPrimitive.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorTDZExplicitThis.js
+++ b/test/staging/sm/class/derivedConstructorTDZExplicitThis.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorTDZOffEdge.js
+++ b/test/staging/sm/class/derivedConstructorTDZOffEdge.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorTDZReturnAliasedTry.js
+++ b/test/staging/sm/class/derivedConstructorTDZReturnAliasedTry.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorTDZReturnObject.js
+++ b/test/staging/sm/class/derivedConstructorTDZReturnObject.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorTDZReturnTry.js
+++ b/test/staging/sm/class/derivedConstructorTDZReturnTry.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/derivedConstructorTDZReturnUndefined.js
+++ b/test/staging/sm/class/derivedConstructorTDZReturnUndefined.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/extendBuiltinConstructors.js
+++ b/test/staging/sm/class/extendBuiltinConstructors.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/fields-instance-class-name-binding-eval.js
+++ b/test/staging/sm/class/fields-instance-class-name-binding-eval.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/fields-instance-class-name-binding.js
+++ b/test/staging/sm/class/fields-instance-class-name-binding.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/fields-static-class-name-binding-eval.js
+++ b/test/staging/sm/class/fields-static-class-name-binding-eval.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/fields-static-class-name-binding.js
+++ b/test/staging/sm/class/fields-static-class-name-binding.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/geterNoExprClosure.js
+++ b/test/staging/sm/class/geterNoExprClosure.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/innerBinding.js
+++ b/test/staging/sm/class/innerBinding.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/methDefn.js
+++ b/test/staging/sm/class/methDefn.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/methDefnGen.js
+++ b/test/staging/sm/class/methDefnGen.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/methodInstallation.js
+++ b/test/staging/sm/class/methodInstallation.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/methodName.js
+++ b/test/staging/sm/class/methodName.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/methodOverwrites.js
+++ b/test/staging/sm/class/methodOverwrites.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/methodsPrototype.js
+++ b/test/staging/sm/class/methodsPrototype.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetArgumentsIntact.js
+++ b/test/staging/sm/class/newTargetArgumentsIntact.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetArrow.js
+++ b/test/staging/sm/class/newTargetArrow.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetBound.js
+++ b/test/staging/sm/class/newTargetBound.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetCCW.js
+++ b/test/staging/sm/class/newTargetCCW.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetDVG.js
+++ b/test/staging/sm/class/newTargetDVG.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetDefaults.js
+++ b/test/staging/sm/class/newTargetDefaults.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetDirectInvoke.js
+++ b/test/staging/sm/class/newTargetDirectInvoke.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetEval.js
+++ b/test/staging/sm/class/newTargetEval.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetGenerators.js
+++ b/test/staging/sm/class/newTargetGenerators.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetMethods.js
+++ b/test/staging/sm/class/newTargetMethods.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetNonFunction.js
+++ b/test/staging/sm/class/newTargetNonFunction.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/newTargetProxyNative.js
+++ b/test/staging/sm/class/newTargetProxyNative.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/parenExprToString.js
+++ b/test/staging/sm/class/parenExprToString.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/staticConstructor.js
+++ b/test/staging/sm/class/staticConstructor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/staticMethods.js
+++ b/test/staging/sm/class/staticMethods.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/strictExecution.js
+++ b/test/staging/sm/class/strictExecution.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/stringConstructor.js
+++ b/test/staging/sm/class/stringConstructor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/subclassedArrayUnboxed.js
+++ b/test/staging/sm/class/subclassedArrayUnboxed.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superCallBadDynamicSuperClass.js
+++ b/test/staging/sm/class/superCallBadDynamicSuperClass.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superCallBadNewTargetPrototype.js
+++ b/test/staging/sm/class/superCallBadNewTargetPrototype.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superCallBaseInvoked.js
+++ b/test/staging/sm/class/superCallBaseInvoked.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superCallIllegal.js
+++ b/test/staging/sm/class/superCallIllegal.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superCallInvalidBase.js
+++ b/test/staging/sm/class/superCallInvalidBase.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superCallOrder.js
+++ b/test/staging/sm/class/superCallOrder.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superCallProperBase.js
+++ b/test/staging/sm/class/superCallProperBase.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superCallSpreadCall.js
+++ b/test/staging/sm/class/superCallSpreadCall.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superCallThisInit.js
+++ b/test/staging/sm/class/superCallThisInit.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superElemDelete.js
+++ b/test/staging/sm/class/superElemDelete.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropBasicCalls.js
+++ b/test/staging/sm/class/superPropBasicCalls.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropBasicChain.js
+++ b/test/staging/sm/class/superPropBasicChain.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropBasicGetter.js
+++ b/test/staging/sm/class/superPropBasicGetter.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropBasicNew.js
+++ b/test/staging/sm/class/superPropBasicNew.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropChains.js
+++ b/test/staging/sm/class/superPropChains.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropDVG.js
+++ b/test/staging/sm/class/superPropDVG.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropDelete.js
+++ b/test/staging/sm/class/superPropDelete.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropDerivedCalls.js
+++ b/test/staging/sm/class/superPropDerivedCalls.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropDestructuring.js
+++ b/test/staging/sm/class/superPropDestructuring.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropEvalInsideArrow.js
+++ b/test/staging/sm/class/superPropEvalInsideArrow.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropEvalInsideNested.js
+++ b/test/staging/sm/class/superPropEvalInsideNested.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropFor.js
+++ b/test/staging/sm/class/superPropFor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropHeavyweightArrow.js
+++ b/test/staging/sm/class/superPropHeavyweightArrow.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropHomeObject.js
+++ b/test/staging/sm/class/superPropHomeObject.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropIncDecElem.js
+++ b/test/staging/sm/class/superPropIncDecElem.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropLazyInnerFunction.js
+++ b/test/staging/sm/class/superPropLazyInnerFunction.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropNoOverwriting.js
+++ b/test/staging/sm/class/superPropNoOverwriting.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropOrdering.js
+++ b/test/staging/sm/class/superPropOrdering.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropProtoChanges.js
+++ b/test/staging/sm/class/superPropProtoChanges.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropProxies.js
+++ b/test/staging/sm/class/superPropProxies.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropSkips.js
+++ b/test/staging/sm/class/superPropSkips.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropStatics.js
+++ b/test/staging/sm/class/superPropStatics.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superPropStrictAssign.js
+++ b/test/staging/sm/class/superPropStrictAssign.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/superThisStrictNoBoxing.js
+++ b/test/staging/sm/class/superThisStrictNoBoxing.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/class/uninitializedThisError.js
+++ b/test/staging/sm/class/uninitializedThisError.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/destructuring/array-default-class.js
+++ b/test/staging/sm/destructuring/array-default-class.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/destructuring/array-iterator-close.js
+++ b/test/staging/sm/destructuring/array-iterator-close.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/destructuring/bug1396261.js
+++ b/test/staging/sm/destructuring/bug1396261.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/destructuring/constant-folding.js
+++ b/test/staging/sm/destructuring/constant-folding.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/destructuring/iterator-primitive.js
+++ b/test/staging/sm/destructuring/iterator-primitive.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/destructuring/order-super.js
+++ b/test/staging/sm/destructuring/order-super.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/destructuring/order.js
+++ b/test/staging/sm/destructuring/order.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-fun-normalcaller-direct-normalcode.js
+++ b/test/staging/sm/eval/exhaustive-fun-normalcaller-direct-normalcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-fun-normalcaller-direct-strictcode.js
+++ b/test/staging/sm/eval/exhaustive-fun-normalcaller-direct-strictcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-fun-normalcaller-indirect-normalcode.js
+++ b/test/staging/sm/eval/exhaustive-fun-normalcaller-indirect-normalcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-fun-normalcaller-indirect-strictcode.js
+++ b/test/staging/sm/eval/exhaustive-fun-normalcaller-indirect-strictcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-fun-strictcaller-direct-normalcode.js
+++ b/test/staging/sm/eval/exhaustive-fun-strictcaller-direct-normalcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-fun-strictcaller-direct-strictcode.js
+++ b/test/staging/sm/eval/exhaustive-fun-strictcaller-direct-strictcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-fun-strictcaller-indirect-normalcode.js
+++ b/test/staging/sm/eval/exhaustive-fun-strictcaller-indirect-normalcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-fun-strictcaller-indirect-strictcode.js
+++ b/test/staging/sm/eval/exhaustive-fun-strictcaller-indirect-strictcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-global-normalcaller-direct-normalcode.js
+++ b/test/staging/sm/eval/exhaustive-global-normalcaller-direct-normalcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-global-normalcaller-direct-strictcode.js
+++ b/test/staging/sm/eval/exhaustive-global-normalcaller-direct-strictcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-global-normalcaller-indirect-normalcode.js
+++ b/test/staging/sm/eval/exhaustive-global-normalcaller-indirect-normalcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-global-normalcaller-indirect-strictcode.js
+++ b/test/staging/sm/eval/exhaustive-global-normalcaller-indirect-strictcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/exhaustive-global-strictcaller-direct-normalcode.js
+++ b/test/staging/sm/eval/exhaustive-global-strictcaller-direct-normalcode.js
@@ -5,7 +5,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/eval/exhaustive-global-strictcaller-direct-strictcode.js
+++ b/test/staging/sm/eval/exhaustive-global-strictcaller-direct-strictcode.js
@@ -5,7 +5,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/eval/exhaustive-global-strictcaller-indirect-normalcode.js
+++ b/test/staging/sm/eval/exhaustive-global-strictcaller-indirect-normalcode.js
@@ -5,7 +5,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/eval/exhaustive-global-strictcaller-indirect-strictcode.js
+++ b/test/staging/sm/eval/exhaustive-global-strictcaller-indirect-strictcode.js
@@ -5,7 +5,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/eval/line-terminator-paragraph-terminator.js
+++ b/test/staging/sm/eval/line-terminator-paragraph-terminator.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/redeclared-arguments-in-param-expression-eval.js
+++ b/test/staging/sm/eval/redeclared-arguments-in-param-expression-eval.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/regress-531682.js
+++ b/test/staging/sm/eval/regress-531682.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/eval/undeclared-name-in-nested-strict-eval.js
+++ b/test/staging/sm/eval/undeclared-name-in-nested-strict-eval.js
@@ -5,7 +5,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/expressions/11.1.5-01.js
+++ b/test/staging/sm/expressions/11.1.5-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/ToPropertyKey-symbols.js
+++ b/test/staging/sm/expressions/ToPropertyKey-symbols.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/binary-literals.js
+++ b/test/staging/sm/expressions/binary-literals.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/computed-property-side-effects.js
+++ b/test/staging/sm/expressions/computed-property-side-effects.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/constant-folded-labeled-statement.js
+++ b/test/staging/sm/expressions/constant-folded-labeled-statement.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/delete-constant-folded-and-or.js
+++ b/test/staging/sm/expressions/delete-constant-folded-and-or.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/delete-name-parenthesized-early-error-strict-mode.js
+++ b/test/staging/sm/expressions/delete-name-parenthesized-early-error-strict-mode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-array-default-call.js
+++ b/test/staging/sm/expressions/destructuring-array-default-call.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-array-default-class.js
+++ b/test/staging/sm/expressions/destructuring-array-default-class.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-array-default-function-nested.js
+++ b/test/staging/sm/expressions/destructuring-array-default-function-nested.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-array-default-function.js
+++ b/test/staging/sm/expressions/destructuring-array-default-function.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-array-default-simple.js
+++ b/test/staging/sm/expressions/destructuring-array-default-simple.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-array-default-yield.js
+++ b/test/staging/sm/expressions/destructuring-array-default-yield.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-array-done.js
+++ b/test/staging/sm/expressions/destructuring-array-done.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-array-lexical.js
+++ b/test/staging/sm/expressions/destructuring-array-lexical.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-object-__proto__-1.js
+++ b/test/staging/sm/expressions/destructuring-object-__proto__-1.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-object-__proto__-2.js
+++ b/test/staging/sm/expressions/destructuring-object-__proto__-2.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/destructuring-pattern-parenthesized.js
+++ b/test/staging/sm/expressions/destructuring-pattern-parenthesized.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/exponentiation-unparenthesised-unary.js
+++ b/test/staging/sm/expressions/exponentiation-unparenthesised-unary.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/inNotObjectError.js
+++ b/test/staging/sm/expressions/inNotObjectError.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/named-accessor-function.js
+++ b/test/staging/sm/expressions/named-accessor-function.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/nested-delete-name-in-evalcode.js
+++ b/test/staging/sm/expressions/nested-delete-name-in-evalcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/nullish-coalescing.js
+++ b/test/staging/sm/expressions/nullish-coalescing.js
@@ -3,10 +3,10 @@
 
 /*---
 features:
-- IsHTMLDDA
+  - IsHTMLDDA
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/object-literal-__proto__.js
+++ b/test/staging/sm/expressions/object-literal-__proto__.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/object-literal-accessor-arguments.js
+++ b/test/staging/sm/expressions/object-literal-accessor-arguments.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/object-literal-accessor-property-name.js
+++ b/test/staging/sm/expressions/object-literal-accessor-property-name.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/object-literal-computed-property-evaluation.js
+++ b/test/staging/sm/expressions/object-literal-computed-property-evaluation.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/octal-literals.js
+++ b/test/staging/sm/expressions/octal-literals.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/optional-chain-class-heritage.js
+++ b/test/staging/sm/expressions/optional-chain-class-heritage.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/optional-chain-first-expression.js
+++ b/test/staging/sm/expressions/optional-chain-first-expression.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/optional-chain-super-elem.js
+++ b/test/staging/sm/expressions/optional-chain-super-elem.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/optional-chain-tdz.js
+++ b/test/staging/sm/expressions/optional-chain-tdz.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/optional-chain.js
+++ b/test/staging/sm/expressions/optional-chain.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/primitive-this-boxing-behavior.js
+++ b/test/staging/sm/expressions/primitive-this-boxing-behavior.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/short-circuit-compound-assignment-anon-fns.js
+++ b/test/staging/sm/expressions/short-circuit-compound-assignment-anon-fns.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/short-circuit-compound-assignment-const.js
+++ b/test/staging/sm/expressions/short-circuit-compound-assignment-const.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/short-circuit-compound-assignment-property-key-evaluation.js
+++ b/test/staging/sm/expressions/short-circuit-compound-assignment-property-key-evaluation.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/short-circuit-compound-assignment-tdz.js
+++ b/test/staging/sm/expressions/short-circuit-compound-assignment-tdz.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/short-circuit-compound-assignment.js
+++ b/test/staging/sm/expressions/short-circuit-compound-assignment.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/string-literal-escape-sequences.js
+++ b/test/staging/sm/expressions/string-literal-escape-sequences.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/expressions/tagged-template-constant-folding.js
+++ b/test/staging/sm/expressions/tagged-template-constant-folding.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-expressions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/8.12.5-01.js
+++ b/test/staging/sm/extensions/8.12.5-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/ArrayBuffer-slice-arguments-detaching.js
+++ b/test/staging/sm/extensions/ArrayBuffer-slice-arguments-detaching.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/DataView-construct-arguments-detaching.js
+++ b/test/staging/sm/extensions/DataView-construct-arguments-detaching.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/DataView-set-arguments-detaching.js
+++ b/test/staging/sm/extensions/DataView-set-arguments-detaching.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/RegExp-error-message-skip-selfhosted-frames.js
+++ b/test/staging/sm/extensions/RegExp-error-message-skip-selfhosted-frames.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/String-match-flags.js
+++ b/test/staging/sm/extensions/String-match-flags.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/TypedArray-set-object-funky-length-detaches.js
+++ b/test/staging/sm/extensions/TypedArray-set-object-funky-length-detaches.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/TypedArray-subarray-arguments-detaching.js
+++ b/test/staging/sm/extensions/TypedArray-subarray-arguments-detaching.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/__proto__.js
+++ b/test/staging/sm/extensions/__proto__.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/arguments-property-access-in-function.js
+++ b/test/staging/sm/extensions/arguments-property-access-in-function.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/array-inherited-__proto__.js
+++ b/test/staging/sm/extensions/array-inherited-__proto__.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/array-length-protochange.js
+++ b/test/staging/sm/extensions/array-length-protochange.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/array-pop-proxy.js
+++ b/test/staging/sm/extensions/array-pop-proxy.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/arraybuffer-prototype.js
+++ b/test/staging/sm/extensions/arraybuffer-prototype.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/bug472534.js
+++ b/test/staging/sm/extensions/bug472534.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/builtin-function-arguments-caller.js
+++ b/test/staging/sm/extensions/builtin-function-arguments-caller.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/censor-strict-caller.js
+++ b/test/staging/sm/extensions/censor-strict-caller.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/cross-global-eval-is-indirect.js
+++ b/test/staging/sm/extensions/cross-global-eval-is-indirect.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   needs newGlobal()
 description: |

--- a/test/staging/sm/extensions/dataview.js
+++ b/test/staging/sm/extensions/dataview.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/decompile-for-of.js
+++ b/test/staging/sm/extensions/decompile-for-of.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/destructure-accessor.js
+++ b/test/staging/sm/extensions/destructure-accessor.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/destructuring-__proto__-shorthand-assignment-before-var.js
+++ b/test/staging/sm/extensions/destructuring-__proto__-shorthand-assignment-before-var.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/destructuring-__proto__-shorthand-assignment.js
+++ b/test/staging/sm/extensions/destructuring-__proto__-shorthand-assignment.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/destructuring-__proto__-target-assignment.js
+++ b/test/staging/sm/extensions/destructuring-__proto__-target-assignment.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/destructuring-for-inof-__proto__.js
+++ b/test/staging/sm/extensions/destructuring-for-inof-__proto__.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/element-setting-ToNumber-detaches.js
+++ b/test/staging/sm/extensions/element-setting-ToNumber-detaches.js
@@ -5,7 +5,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 description: |
   pending

--- a/test/staging/sm/extensions/error-tostring-function.js
+++ b/test/staging/sm/extensions/error-tostring-function.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/es5ish-defineGetter-defineSetter.js
+++ b/test/staging/sm/extensions/es5ish-defineGetter-defineSetter.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/eval-native-callback-is-indirect.js
+++ b/test/staging/sm/extensions/eval-native-callback-is-indirect.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/expression-closure-syntax.js
+++ b/test/staging/sm/extensions/expression-closure-syntax.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/extension-methods-reject-null-undefined-this.js
+++ b/test/staging/sm/extensions/extension-methods-reject-null-undefined-this.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/for-loop-with-lexical-declaration-and-nested-function-statement.js
+++ b/test/staging/sm/extensions/for-loop-with-lexical-declaration-and-nested-function-statement.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/function-caller-skips-eval-frames.js
+++ b/test/staging/sm/extensions/function-caller-skips-eval-frames.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/function-properties.js
+++ b/test/staging/sm/extensions/function-properties.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/getOwnPropertyNames-__proto__.js
+++ b/test/staging/sm/extensions/getOwnPropertyNames-__proto__.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/inc-dec-functioncall.js
+++ b/test/staging/sm/extensions/inc-dec-functioncall.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/keyword-unescaped-requirement.js
+++ b/test/staging/sm/extensions/keyword-unescaped-requirement.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/mutable-proto-special-form.js
+++ b/test/staging/sm/extensions/mutable-proto-special-form.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/nested-delete-name-in-evalcode.js
+++ b/test/staging/sm/extensions/nested-delete-name-in-evalcode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/new-cross-compartment.js
+++ b/test/staging/sm/extensions/new-cross-compartment.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/new-parenthesization.js
+++ b/test/staging/sm/extensions/new-parenthesization.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/newer-type-functions-caller-arguments.js
+++ b/test/staging/sm/extensions/newer-type-functions-caller-arguments.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/proxy-array-target-length-definition.js
+++ b/test/staging/sm/extensions/proxy-array-target-length-definition.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/proxy-enumeration.js
+++ b/test/staging/sm/extensions/proxy-enumeration.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/proxy-strict.js
+++ b/test/staging/sm/extensions/proxy-strict.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/quote-string-for-nul-character.js
+++ b/test/staging/sm/extensions/quote-string-for-nul-character.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/recursion.js
+++ b/test/staging/sm/extensions/recursion.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/regress-455380.js
+++ b/test/staging/sm/extensions/regress-455380.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/regress-469625-01.js
+++ b/test/staging/sm/extensions/regress-469625-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/regress-480579.js
+++ b/test/staging/sm/extensions/regress-480579.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/regress-481516.js
+++ b/test/staging/sm/extensions/regress-481516.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/regress-591450.js
+++ b/test/staging/sm/extensions/regress-591450.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/regress-645160.js
+++ b/test/staging/sm/extensions/regress-645160.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/regress-650753.js
+++ b/test/staging/sm/extensions/regress-650753.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/regress-bug629723.js
+++ b/test/staging/sm/extensions/regress-bug629723.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/reviver-mutates-holder-array-nonnative.js
+++ b/test/staging/sm/extensions/reviver-mutates-holder-array-nonnative.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/reviver-mutates-holder-array.js
+++ b/test/staging/sm/extensions/reviver-mutates-holder-array.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/reviver-mutates-holder-object-nonnative.js
+++ b/test/staging/sm/extensions/reviver-mutates-holder-object-nonnative.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/reviver-mutates-holder-object.js
+++ b/test/staging/sm/extensions/reviver-mutates-holder-object.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/set-property-non-extensible.js
+++ b/test/staging/sm/extensions/set-property-non-extensible.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   preventExtensions on global
 description: |

--- a/test/staging/sm/extensions/shareddataview.js
+++ b/test/staging/sm/extensions/shareddataview.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/sps-generators.js
+++ b/test/staging/sm/extensions/sps-generators.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/string-literal-getter-setter-decompilation.js
+++ b/test/staging/sm/extensions/string-literal-getter-setter-decompilation.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/typedarray-copyWithin-arguments-detaching.js
+++ b/test/staging/sm/extensions/typedarray-copyWithin-arguments-detaching.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/typedarray-set-detach.js
+++ b/test/staging/sm/extensions/typedarray-set-detach.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/typedarray-subarray-of-subarray.js
+++ b/test/staging/sm/extensions/typedarray-subarray-of-subarray.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/extensions/weakmap.js
+++ b/test/staging/sm/extensions/weakmap.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-extensions-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/fields/await-identifier-module-1.js
+++ b/test/staging/sm/fields/await-identifier-module-1.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- module
+  - module
 negative:
   phase: parse
   type: SyntaxError

--- a/test/staging/sm/fields/await-identifier-module-2.js
+++ b/test/staging/sm/fields/await-identifier-module-2.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- module
+  - module
 negative:
   phase: parse
   type: SyntaxError

--- a/test/staging/sm/fields/await-identifier-module-3.js
+++ b/test/staging/sm/fields/await-identifier-module-3.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- module
+  - module
 negative:
   phase: parse
   type: SyntaxError

--- a/test/staging/sm/fields/await-identifier-script.js
+++ b/test/staging/sm/fields/await-identifier-script.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/fields/bug1587574.js
+++ b/test/staging/sm/fields/bug1587574.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/fields/init-order.js
+++ b/test/staging/sm/fields/init-order.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/fields/numeric-fields.js
+++ b/test/staging/sm/fields/numeric-fields.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/fields/scopes.js
+++ b/test/staging/sm/fields/scopes.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/fields/unimplemented.js
+++ b/test/staging/sm/fields/unimplemented.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/create-function-parse-before-getprototype.js
+++ b/test/staging/sm/generators/create-function-parse-before-getprototype.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-1.js
+++ b/test/staging/sm/generators/delegating-yield-1.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-10.js
+++ b/test/staging/sm/generators/delegating-yield-10.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-11.js
+++ b/test/staging/sm/generators/delegating-yield-11.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-12.js
+++ b/test/staging/sm/generators/delegating-yield-12.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-2.js
+++ b/test/staging/sm/generators/delegating-yield-2.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-3.js
+++ b/test/staging/sm/generators/delegating-yield-3.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-4.js
+++ b/test/staging/sm/generators/delegating-yield-4.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-5.js
+++ b/test/staging/sm/generators/delegating-yield-5.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-6.js
+++ b/test/staging/sm/generators/delegating-yield-6.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-7.js
+++ b/test/staging/sm/generators/delegating-yield-7.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-8.js
+++ b/test/staging/sm/generators/delegating-yield-8.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/delegating-yield-9.js
+++ b/test/staging/sm/generators/delegating-yield-9.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/gen-with-call-obj.js
+++ b/test/staging/sm/generators/gen-with-call-obj.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/iteration.js
+++ b/test/staging/sm/generators/iteration.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/iterator-next-non-object.js
+++ b/test/staging/sm/generators/iterator-next-non-object.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/objects.js
+++ b/test/staging/sm/generators/objects.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/regress-366941.js
+++ b/test/staging/sm/generators/regress-366941.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/return-finally.js
+++ b/test/staging/sm/generators/return-finally.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/runtime.js
+++ b/test/staging/sm/generators/runtime.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/syntax.js
+++ b/test/staging/sm/generators/syntax.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/yield-error.js
+++ b/test/staging/sm/generators/yield-error.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/yield-iterator-close.js
+++ b/test/staging/sm/generators/yield-iterator-close.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/yield-non-regexp.js
+++ b/test/staging/sm/generators/yield-non-regexp.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/yield-star-iterator-close.js
+++ b/test/staging/sm/generators/yield-star-iterator-close.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/yield-star-iterator-primitive.js
+++ b/test/staging/sm/generators/yield-star-iterator-primitive.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/generators/yield-star-throw-htmldda.js
+++ b/test/staging/sm/generators/yield-star-throw-htmldda.js
@@ -3,10 +3,10 @@
 
 /*---
 features:
-- IsHTMLDDA
+  - IsHTMLDDA
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-generators-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/adding-global-var-nonextensible-error.js
+++ b/test/staging/sm/global/adding-global-var-nonextensible-error.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   preventExtensions on global
 description: |

--- a/test/staging/sm/global/bug-320887.js
+++ b/test/staging/sm/global/bug-320887.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/bug660612.js
+++ b/test/staging/sm/global/bug660612.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/decodeURI-decodes-FFFE-FFFF.js
+++ b/test/staging/sm/global/decodeURI-decodes-FFFE-FFFF.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/delete-global-NaN-property.js
+++ b/test/staging/sm/global/delete-global-NaN-property.js
@@ -5,7 +5,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/global/direct-eval-but-not.js
+++ b/test/staging/sm/global/direct-eval-but-not.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/eval-01.js
+++ b/test/staging/sm/global/eval-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/eval-02.js
+++ b/test/staging/sm/global/eval-02.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/eval-in-strict-eval-in-normal-function.js
+++ b/test/staging/sm/global/eval-in-strict-eval-in-normal-function.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/eval-inside-with-is-direct.js
+++ b/test/staging/sm/global/eval-inside-with-is-direct.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/eval-native-callback-is-indirect.js
+++ b/test/staging/sm/global/eval-native-callback-is-indirect.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/globalThis-enumeration.js
+++ b/test/staging/sm/global/globalThis-enumeration.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/parenthesized-eval-is-direct.js
+++ b/test/staging/sm/global/parenthesized-eval-is-direct.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/parseFloat-01.js
+++ b/test/staging/sm/global/parseFloat-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/parseInt-01.js
+++ b/test/staging/sm/global/parseInt-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/global/parseInt-default-to-decimal.js
+++ b/test/staging/sm/global/parseInt-default-to-decimal.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-arguments.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-arguments.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-eval.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-eval.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-generators.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-generators.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-if.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-if.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-label.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-label.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-notapplicable.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-notapplicable.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-parameter.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-parameter.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-same-name.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-same-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-with.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-annex-b-with.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-annex-b.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-annex-b.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-deprecated-redecl.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-deprecated-redecl.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-hoisted-tdz.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-hoisted-tdz.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/block-scoped-functions-strict.js
+++ b/test/staging/sm/lexical-environment/block-scoped-functions-strict.js
@@ -3,7 +3,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/lexical-environment/bug-1216623.js
+++ b/test/staging/sm/lexical-environment/bug-1216623.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/catch-body.js
+++ b/test/staging/sm/lexical-environment/catch-body.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/const-declaration-in-for-loop.js
+++ b/test/staging/sm/lexical-environment/const-declaration-in-for-loop.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/eval-has-lexical-environment.js
+++ b/test/staging/sm/lexical-environment/eval-has-lexical-environment.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/for-loop-with-bindings-added-at-runtime.js
+++ b/test/staging/sm/lexical-environment/for-loop-with-bindings-added-at-runtime.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/for-loop.js
+++ b/test/staging/sm/lexical-environment/for-loop.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/implicit-this-in-with.js
+++ b/test/staging/sm/lexical-environment/implicit-this-in-with.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-basics.js
+++ b/test/staging/sm/lexical-environment/unscopables-basics.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-closures.js
+++ b/test/staging/sm/lexical-environment/unscopables-closures.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-const.js
+++ b/test/staging/sm/lexical-environment/unscopables-const.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-delete.js
+++ b/test/staging/sm/lexical-environment/unscopables-delete.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-getters.js
+++ b/test/staging/sm/lexical-environment/unscopables-getters.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-global.js
+++ b/test/staging/sm/lexical-environment/unscopables-global.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-ignored.js
+++ b/test/staging/sm/lexical-environment/unscopables-ignored.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-miss.js
+++ b/test/staging/sm/lexical-environment/unscopables-miss.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-mutation-frozen.js
+++ b/test/staging/sm/lexical-environment/unscopables-mutation-frozen.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-proto.js
+++ b/test/staging/sm/lexical-environment/unscopables-proto.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-proxy.js
+++ b/test/staging/sm/lexical-environment/unscopables-proxy.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/unscopables-tdz.js
+++ b/test/staging/sm/lexical-environment/unscopables-tdz.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/var-in-catch-body-annex-b-eval.js
+++ b/test/staging/sm/lexical-environment/var-in-catch-body-annex-b-eval.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/lexical-environment/with-global-ignores-global-let-variables.js
+++ b/test/staging/sm/lexical-environment/with-global-ignores-global-let-variables.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/literals/numeric/idstart-after-numeric.js
+++ b/test/staging/sm/literals/numeric/idstart-after-numeric.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/bug1126318.js
+++ b/test/staging/sm/misc/bug1126318.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/builtin-methods-reject-null-undefined-this.js
+++ b/test/staging/sm/misc/builtin-methods-reject-null-undefined-this.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/enumerate-undefined.js
+++ b/test/staging/sm/misc/enumerate-undefined.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/error-undefined-message.js
+++ b/test/staging/sm/misc/error-undefined-message.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/explicit-undefined-optional-argument.js
+++ b/test/staging/sm/misc/explicit-undefined-optional-argument.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/function-definition-eval.js
+++ b/test/staging/sm/misc/function-definition-eval.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/future-reserved-words.js
+++ b/test/staging/sm/misc/future-reserved-words.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/getter-setter-outerize-this.js
+++ b/test/staging/sm/misc/getter-setter-outerize-this.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/global-numeric-properties.js
+++ b/test/staging/sm/misc/global-numeric-properties.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/line-paragraph-separator-parse-as-lineterminator.js
+++ b/test/staging/sm/misc/line-paragraph-separator-parse-as-lineterminator.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/new-with-non-constructor.js
+++ b/test/staging/sm/misc/new-with-non-constructor.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/redeclare-var-non-writable-property.js
+++ b/test/staging/sm/misc/redeclare-var-non-writable-property.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/regexp-functions-with-undefined.js
+++ b/test/staging/sm/misc/regexp-functions-with-undefined.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/syntax-error-end-of-for-head-part.js
+++ b/test/staging/sm/misc/syntax-error-end-of-for-head-part.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/unicode-escaped-keyword.js
+++ b/test/staging/sm/misc/unicode-escaped-keyword.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/unicode-identifier-1d17.js
+++ b/test/staging/sm/misc/unicode-identifier-1d17.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/unicode-identifier-82f1.js
+++ b/test/staging/sm/misc/unicode-identifier-82f1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/misc/unwrapped-no-such-method.js
+++ b/test/staging/sm/misc/unwrapped-no-such-method.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/module/await-restricted-nested.js
+++ b/test/staging/sm/module/await-restricted-nested.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- module
+  - module
 negative:
   phase: parse
   type: SyntaxError

--- a/test/staging/sm/module/bug1488117.js
+++ b/test/staging/sm/module/bug1488117.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- module
+  - module
 description: |
   pending
 esid: pending

--- a/test/staging/sm/module/duplicate-exported-names-in-single-export-declaration.js
+++ b/test/staging/sm/module/duplicate-exported-names-in-single-export-declaration.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- module
+  - module
 negative:
   phase: parse
   type: SyntaxError

--- a/test/staging/sm/module/duplicate-exported-names-in-single-export-var-declaration.js
+++ b/test/staging/sm/module/duplicate-exported-names-in-single-export-var-declaration.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- module
+  - module
 negative:
   phase: parse
   type: SyntaxError

--- a/test/staging/sm/module/module-export-name-star.js
+++ b/test/staging/sm/module/module-export-name-star.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- module
+  - module
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/15.2.3.12.js
+++ b/test/staging/sm/object/15.2.3.12.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/15.2.3.14-01.js
+++ b/test/staging/sm/object/15.2.3.14-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/15.2.3.4-01.js
+++ b/test/staging/sm/object/15.2.3.4-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/15.2.3.4-02.js
+++ b/test/staging/sm/object/15.2.3.4-02.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/15.2.3.4-03.js
+++ b/test/staging/sm/object/15.2.3.4-03.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/15.2.3.4-04.js
+++ b/test/staging/sm/object/15.2.3.4-04.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/15.2.3.5-01.js
+++ b/test/staging/sm/object/15.2.3.5-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/15.2.3.6-define-over-method.js
+++ b/test/staging/sm/object/15.2.3.6-define-over-method.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/15.2.3.7-01.js
+++ b/test/staging/sm/object/15.2.3.7-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/15.2.3.9.js
+++ b/test/staging/sm/object/15.2.3.9.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/accessor-arguments-rest.js
+++ b/test/staging/sm/object/accessor-arguments-rest.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/accessor-name.js
+++ b/test/staging/sm/object/accessor-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/accessor-non-constructor.js
+++ b/test/staging/sm/object/accessor-non-constructor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/add-property-non-extensible.js
+++ b/test/staging/sm/object/add-property-non-extensible.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/bug-1150906.js
+++ b/test/staging/sm/object/bug-1150906.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/bug-1206700.js
+++ b/test/staging/sm/object/bug-1206700.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/clear-dictionary-accessor-getset.js
+++ b/test/staging/sm/object/clear-dictionary-accessor-getset.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/defineGetter-defineSetter.js
+++ b/test/staging/sm/object/defineGetter-defineSetter.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/defineProperties-callable-accessor.js
+++ b/test/staging/sm/object/defineProperties-callable-accessor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/defineProperties-order.js
+++ b/test/staging/sm/object/defineProperties-order.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/defineProperty-proxy.js
+++ b/test/staging/sm/object/defineProperty-proxy.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/duplProps.js
+++ b/test/staging/sm/object/duplProps.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/entries.js
+++ b/test/staging/sm/object/entries.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/extensibility-01.js
+++ b/test/staging/sm/object/extensibility-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/extensibility-02.js
+++ b/test/staging/sm/object/extensibility-02.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/freeze-proxy.js
+++ b/test/staging/sm/object/freeze-proxy.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/freeze.js
+++ b/test/staging/sm/object/freeze.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/gOPD-vs-prototype-accessor.js
+++ b/test/staging/sm/object/gOPD-vs-prototype-accessor.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/getOwnPropertyDescriptor.js
+++ b/test/staging/sm/object/getOwnPropertyDescriptor.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/getOwnPropertySymbols-proxy.js
+++ b/test/staging/sm/object/getOwnPropertySymbols-proxy.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/getOwnPropertySymbols.js
+++ b/test/staging/sm/object/getOwnPropertySymbols.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/getPrototypeOf-array.js
+++ b/test/staging/sm/object/getPrototypeOf-array.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/getPrototypeOf.js
+++ b/test/staging/sm/object/getPrototypeOf.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/getter-name.js
+++ b/test/staging/sm/object/getter-name.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/hasOwn.js
+++ b/test/staging/sm/object/hasOwn.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/isExtensible.js
+++ b/test/staging/sm/object/isExtensible.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/isFrozen.js
+++ b/test/staging/sm/object/isFrozen.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/isPrototypeOf.js
+++ b/test/staging/sm/object/isPrototypeOf.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/isSealed.js
+++ b/test/staging/sm/object/isSealed.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/keys.js
+++ b/test/staging/sm/object/keys.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/method-non-constructor.js
+++ b/test/staging/sm/object/method-non-constructor.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/mutation-prevention-methods.js
+++ b/test/staging/sm/object/mutation-prevention-methods.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/object-create-with-primitive-second-arg.js
+++ b/test/staging/sm/object/object-create-with-primitive-second-arg.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/object-toString-01.js
+++ b/test/staging/sm/object/object-toString-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/preventExtensions-idempotent.js
+++ b/test/staging/sm/object/preventExtensions-idempotent.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/preventExtensions-proxy.js
+++ b/test/staging/sm/object/preventExtensions-proxy.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/preventExtensions.js
+++ b/test/staging/sm/object/preventExtensions.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/property-descriptor-order.js
+++ b/test/staging/sm/object/property-descriptor-order.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/propertyIsEnumerable-proxy.js
+++ b/test/staging/sm/object/propertyIsEnumerable-proxy.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/propertyIsEnumerable.js
+++ b/test/staging/sm/object/propertyIsEnumerable.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/proto-property-change-writability-set.js
+++ b/test/staging/sm/object/proto-property-change-writability-set.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/regress-459405.js
+++ b/test/staging/sm/object/regress-459405.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/seal-proxy.js
+++ b/test/staging/sm/object/seal-proxy.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/seal.js
+++ b/test/staging/sm/object/seal.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/setPrototypeOf-cross-realm-cycle.js
+++ b/test/staging/sm/object/setPrototypeOf-cross-realm-cycle.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/setPrototypeOf-same-value.js
+++ b/test/staging/sm/object/setPrototypeOf-same-value.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/toLocaleString-01.js
+++ b/test/staging/sm/object/toLocaleString-01.js
@@ -3,7 +3,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 description: |
   pending

--- a/test/staging/sm/object/toLocaleString.js
+++ b/test/staging/sm/object/toLocaleString.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/toPrimitive-callers.js
+++ b/test/staging/sm/object/toPrimitive-callers.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/toPrimitive.js
+++ b/test/staging/sm/object/toPrimitive.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, deepEqual.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/vacuous-accessor-unqualified-name.js
+++ b/test/staging/sm/object/vacuous-accessor-unqualified-name.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/values-entries-indexed.js
+++ b/test/staging/sm/object/values-entries-indexed.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/values-entries-lazy-props.js
+++ b/test/staging/sm/object/values-entries-lazy-props.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/values-entries-typedarray.js
+++ b/test/staging/sm/object/values-entries-typedarray.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/object/values.js
+++ b/test/staging/sm/object/values.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js, sm/non262-object-shell.js, compareArray.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-10278.js
+++ b/test/staging/sm/regress/regress-10278.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-1383630.js
+++ b/test/staging/sm/regress/regress-1383630.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-1507322-deep-weakmap.js
+++ b/test/staging/sm/regress/regress-1507322-deep-weakmap.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-162392.js
+++ b/test/staging/sm/regress/regress-162392.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-306794.js
+++ b/test/staging/sm/regress/regress-306794.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-325925.js
+++ b/test/staging/sm/regress/regress-325925.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-373843.js
+++ b/test/staging/sm/regress/regress-373843.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-383682.js
+++ b/test/staging/sm/regress/regress-383682.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-383902.js
+++ b/test/staging/sm/regress/regress-383902.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-410852.js
+++ b/test/staging/sm/regress/regress-410852.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-428366.js
+++ b/test/staging/sm/regress/regress-428366.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-441477-01.js
+++ b/test/staging/sm/regress/regress-441477-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-449627.js
+++ b/test/staging/sm/regress/regress-449627.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-449666.js
+++ b/test/staging/sm/regress/regress-449666.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-452189.js
+++ b/test/staging/sm/regress/regress-452189.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-452498-051.js
+++ b/test/staging/sm/regress/regress-452498-051.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-452498-053.js
+++ b/test/staging/sm/regress/regress-452498-053.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-452498-079.js
+++ b/test/staging/sm/regress/regress-452498-079.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-459085.js
+++ b/test/staging/sm/regress/regress-459085.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-469625-02.js
+++ b/test/staging/sm/regress/regress-469625-02.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-469625-03.js
+++ b/test/staging/sm/regress/regress-469625-03.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-469758.js
+++ b/test/staging/sm/regress/regress-469758.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-470758-01.js
+++ b/test/staging/sm/regress/regress-470758-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-470758-02.js
+++ b/test/staging/sm/regress/regress-470758-02.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-499524.js
+++ b/test/staging/sm/regress/regress-499524.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-500528.js
+++ b/test/staging/sm/regress/regress-500528.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-503860.js
+++ b/test/staging/sm/regress/regress-503860.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-530879.js
+++ b/test/staging/sm/regress/regress-530879.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-541255-3.js
+++ b/test/staging/sm/regress/regress-541255-3.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-541455.js
+++ b/test/staging/sm/regress/regress-541455.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-551763-0.js
+++ b/test/staging/sm/regress/regress-551763-0.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-551763-1.js
+++ b/test/staging/sm/regress/regress-551763-1.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-551763-2.js
+++ b/test/staging/sm/regress/regress-551763-2.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-552432.js
+++ b/test/staging/sm/regress/regress-552432.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-553778.js
+++ b/test/staging/sm/regress/regress-553778.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-554955-1.js
+++ b/test/staging/sm/regress/regress-554955-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-554955-2.js
+++ b/test/staging/sm/regress/regress-554955-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-554955-3.js
+++ b/test/staging/sm/regress/regress-554955-3.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-554955-4.js
+++ b/test/staging/sm/regress/regress-554955-4.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-554955-5.js
+++ b/test/staging/sm/regress/regress-554955-5.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-554955-6.js
+++ b/test/staging/sm/regress/regress-554955-6.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-559402-1.js
+++ b/test/staging/sm/regress/regress-559402-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-559402-2.js
+++ b/test/staging/sm/regress/regress-559402-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-559438.js
+++ b/test/staging/sm/regress/regress-559438.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-560998-1.js
+++ b/test/staging/sm/regress/regress-560998-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-560998-2.js
+++ b/test/staging/sm/regress/regress-560998-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-561031.js
+++ b/test/staging/sm/regress/regress-561031.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-563221.js
+++ b/test/staging/sm/regress/regress-563221.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-567152.js
+++ b/test/staging/sm/regress/regress-567152.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-569306.js
+++ b/test/staging/sm/regress/regress-569306.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-571014.js
+++ b/test/staging/sm/regress/regress-571014.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-573875.js
+++ b/test/staging/sm/regress/regress-573875.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-577648-1.js
+++ b/test/staging/sm/regress/regress-577648-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-577648-2.js
+++ b/test/staging/sm/regress/regress-577648-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-580544.js
+++ b/test/staging/sm/regress/regress-580544.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-583429.js
+++ b/test/staging/sm/regress/regress-583429.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-584355.js
+++ b/test/staging/sm/regress/regress-584355.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-586482-1.js
+++ b/test/staging/sm/regress/regress-586482-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-586482-2.js
+++ b/test/staging/sm/regress/regress-586482-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-586482-3.js
+++ b/test/staging/sm/regress/regress-586482-3.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-586482-4.js
+++ b/test/staging/sm/regress/regress-586482-4.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-586482-5.js
+++ b/test/staging/sm/regress/regress-586482-5.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-588339.js
+++ b/test/staging/sm/regress/regress-588339.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-591897.js
+++ b/test/staging/sm/regress/regress-591897.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-592202-3.js
+++ b/test/staging/sm/regress/regress-592202-3.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-592202-4.js
+++ b/test/staging/sm/regress/regress-592202-4.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-592556-c35.js
+++ b/test/staging/sm/regress/regress-592556-c35.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-593256.js
+++ b/test/staging/sm/regress/regress-593256.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-595365-1.js
+++ b/test/staging/sm/regress/regress-595365-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-596103.js
+++ b/test/staging/sm/regress/regress-596103.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-596805-1.js
+++ b/test/staging/sm/regress/regress-596805-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-596805-2.js
+++ b/test/staging/sm/regress/regress-596805-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-597945-1.js
+++ b/test/staging/sm/regress/regress-597945-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-597945-2.js
+++ b/test/staging/sm/regress/regress-597945-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-598176.js
+++ b/test/staging/sm/regress/regress-598176.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-600067.js
+++ b/test/staging/sm/regress/regress-600067.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-601399.js
+++ b/test/staging/sm/regress/regress-601399.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-602621.js
+++ b/test/staging/sm/regress/regress-602621.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-609617.js
+++ b/test/staging/sm/regress/regress-609617.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-610026.js
+++ b/test/staging/sm/regress/regress-610026.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-617405-1.js
+++ b/test/staging/sm/regress/regress-617405-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-617405-2.js
+++ b/test/staging/sm/regress/regress-617405-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-618572.js
+++ b/test/staging/sm/regress/regress-618572.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-619003-1.js
+++ b/test/staging/sm/regress/regress-619003-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-619003-2.js
+++ b/test/staging/sm/regress/regress-619003-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-624547.js
+++ b/test/staging/sm/regress/regress-624547.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-624968.js
+++ b/test/staging/sm/regress/regress-624968.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-626436.js
+++ b/test/staging/sm/regress/regress-626436.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-633741.js
+++ b/test/staging/sm/regress/regress-633741.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 info: |
   preventExtensions on global
 description: |

--- a/test/staging/sm/regress/regress-634210-1.js
+++ b/test/staging/sm/regress/regress-634210-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-634210-2.js
+++ b/test/staging/sm/regress/regress-634210-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-634210-3.js
+++ b/test/staging/sm/regress/regress-634210-3.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-634210-4.js
+++ b/test/staging/sm/regress/regress-634210-4.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-636364.js
+++ b/test/staging/sm/regress/regress-636364.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-640075.js
+++ b/test/staging/sm/regress/regress-640075.js
@@ -5,7 +5,7 @@
 
 /*---
 flags:
-- onlyStrict
+  - onlyStrict
 includes: [sm/non262.js, sm/non262-shell.js]
 description: |
   pending

--- a/test/staging/sm/regress/regress-642247.js
+++ b/test/staging/sm/regress/regress-642247.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-643222.js
+++ b/test/staging/sm/regress/regress-643222.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-646820-1.js
+++ b/test/staging/sm/regress/regress-646820-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-646820-2.js
+++ b/test/staging/sm/regress/regress-646820-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-646820-3.js
+++ b/test/staging/sm/regress/regress-646820-3.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-665355.js
+++ b/test/staging/sm/regress/regress-665355.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-672892.js
+++ b/test/staging/sm/regress/regress-672892.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-672893.js
+++ b/test/staging/sm/regress/regress-672893.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-694306.js
+++ b/test/staging/sm/regress/regress-694306.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-698028-1.js
+++ b/test/staging/sm/regress/regress-698028-1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-699682.js
+++ b/test/staging/sm/regress/regress-699682.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/regress/regress-810525.js
+++ b/test/staging/sm/regress/regress-810525.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/arrow-function-at-end-of-for-statement-head.js
+++ b/test/staging/sm/statements/arrow-function-at-end-of-for-statement-head.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/arrow-function-in-for-statement-head.js
+++ b/test/staging/sm/statements/arrow-function-in-for-statement-head.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-in-with-declaration.js
+++ b/test/staging/sm/statements/for-in-with-declaration.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-in-with-gc-and-unvisited-deletion.js
+++ b/test/staging/sm/statements/for-in-with-gc-and-unvisited-deletion.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-inof-finally.js
+++ b/test/staging/sm/statements/for-inof-finally.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-inof-loop-const-declaration.js
+++ b/test/staging/sm/statements/for-inof-loop-const-declaration.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-inof-name-iteration-expression-contains-index-string.js
+++ b/test/staging/sm/statements/for-inof-name-iteration-expression-contains-index-string.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-loop-declaration-contains-computed-name.js
+++ b/test/staging/sm/statements/for-loop-declaration-contains-computed-name.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-loop-declaration-contains-initializer.js
+++ b/test/staging/sm/statements/for-loop-declaration-contains-initializer.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-of-iterator-close-throw.js
+++ b/test/staging/sm/statements/for-of-iterator-close-throw.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-of-iterator-close.js
+++ b/test/staging/sm/statements/for-of-iterator-close.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-of-iterator-primitive.js
+++ b/test/staging/sm/statements/for-of-iterator-primitive.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/for-of-var-with-initializer.js
+++ b/test/staging/sm/statements/for-of-var-with-initializer.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/if-constant-folding.js
+++ b/test/staging/sm/statements/if-constant-folding.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/property-reference-self-assignment.js
+++ b/test/staging/sm/statements/property-reference-self-assignment.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/regress-642975.js
+++ b/test/staging/sm/statements/regress-642975.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/statements/try-completion.js
+++ b/test/staging/sm/statements/try-completion.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/10.4.2.js
+++ b/test/staging/sm/strict/10.4.2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/10.4.3.js
+++ b/test/staging/sm/strict/10.4.3.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/10.6.js
+++ b/test/staging/sm/strict/10.6.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/11.1.5.js
+++ b/test/staging/sm/strict/11.1.5.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/11.13.1.js
+++ b/test/staging/sm/strict/11.13.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/11.13.2.js
+++ b/test/staging/sm/strict/11.13.2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/11.3.1.js
+++ b/test/staging/sm/strict/11.3.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/11.3.2.js
+++ b/test/staging/sm/strict/11.3.2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/11.4.1.js
+++ b/test/staging/sm/strict/11.4.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/11.4.4.js
+++ b/test/staging/sm/strict/11.4.4.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/11.4.5.js
+++ b/test/staging/sm/strict/11.4.5.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/12.10.1.js
+++ b/test/staging/sm/strict/12.10.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/12.14.1.js
+++ b/test/staging/sm/strict/12.14.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/12.2.1-01.js
+++ b/test/staging/sm/strict/12.2.1-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/12.2.1.js
+++ b/test/staging/sm/strict/12.2.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/13.1.js
+++ b/test/staging/sm/strict/13.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.10.7.js
+++ b/test/staging/sm/strict/15.10.7.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.3.4.5.js
+++ b/test/staging/sm/strict/15.3.4.5.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.3.5.1.js
+++ b/test/staging/sm/strict/15.3.5.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.3.5.2.js
+++ b/test/staging/sm/strict/15.3.5.2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.4.4.11.js
+++ b/test/staging/sm/strict/15.4.4.11.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.4.4.12.js
+++ b/test/staging/sm/strict/15.4.4.12.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.4.4.13.js
+++ b/test/staging/sm/strict/15.4.4.13.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.4.4.6.js
+++ b/test/staging/sm/strict/15.4.4.6.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.4.4.8.js
+++ b/test/staging/sm/strict/15.4.4.8.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.4.4.9.js
+++ b/test/staging/sm/strict/15.4.4.9.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.4.5.1.js
+++ b/test/staging/sm/strict/15.4.5.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.5.5.1.js
+++ b/test/staging/sm/strict/15.5.5.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/15.5.5.2.js
+++ b/test/staging/sm/strict/15.5.5.2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/8.12.5.js
+++ b/test/staging/sm/strict/8.12.5.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/8.12.7-2.js
+++ b/test/staging/sm/strict/8.12.7-2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/8.12.7.js
+++ b/test/staging/sm/strict/8.12.7.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/8.7.2-01.js
+++ b/test/staging/sm/strict/8.7.2-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/8.7.2.js
+++ b/test/staging/sm/strict/8.7.2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/B.1.1.js
+++ b/test/staging/sm/strict/B.1.1.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/B.1.2.js
+++ b/test/staging/sm/strict/B.1.2.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/assign-to-callee-name.js
+++ b/test/staging/sm/strict/assign-to-callee-name.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/deprecated-octal-noctal-tokens.js
+++ b/test/staging/sm/strict/deprecated-octal-noctal-tokens.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/directive-prologue-01.js
+++ b/test/staging/sm/strict/directive-prologue-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/eval-variable-environment.js
+++ b/test/staging/sm/strict/eval-variable-environment.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/primitive-assignment.js
+++ b/test/staging/sm/strict/primitive-assignment.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/primitive-this-getter.js
+++ b/test/staging/sm/strict/primitive-this-getter.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/primitive-this-no-writeback.js
+++ b/test/staging/sm/strict/primitive-this-no-writeback.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/rebind-eval-should-fail-in-strict-mode.js
+++ b/test/staging/sm/strict/rebind-eval-should-fail-in-strict-mode.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/regress-532041.js
+++ b/test/staging/sm/strict/regress-532041.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/regress-532254.js
+++ b/test/staging/sm/strict/regress-532254.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/regress-599159.js
+++ b/test/staging/sm/strict/regress-599159.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/strict-function-statements.js
+++ b/test/staging/sm/strict/strict-function-statements.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/strict-this-is-not-truthy.js
+++ b/test/staging/sm/strict/strict-this-is-not-truthy.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/this-for-function-expression-recursion.js
+++ b/test/staging/sm/strict/this-for-function-expression-recursion.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/strict/unbrand-this.js
+++ b/test/staging/sm/strict/unbrand-this.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-strict-shell.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/bug1863308.js
+++ b/test/staging/sm/syntax/bug1863308.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/class-error.js
+++ b/test/staging/sm/syntax/class-error.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/declaration-forbidden-in-label.js
+++ b/test/staging/sm/syntax/declaration-forbidden-in-label.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/escaped-let-static-identifier.js
+++ b/test/staging/sm/syntax/escaped-let-static-identifier.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/keyword-unescaped-requirement.js
+++ b/test/staging/sm/syntax/keyword-unescaped-requirement.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/let-as-label.js
+++ b/test/staging/sm/syntax/let-as-label.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/linefeed-at-eof-in-unterminated-string-or-template.js
+++ b/test/staging/sm/syntax/linefeed-at-eof-in-unterminated-string-or-template.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/omitted-catch-binding.js
+++ b/test/staging/sm/syntax/omitted-catch-binding.js
@@ -4,7 +4,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/syntax-parsed-arrow-then-bigint.js
+++ b/test/staging/sm/syntax/syntax-parsed-arrow-then-bigint.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/syntax-parsed-arrow-then-directive.js
+++ b/test/staging/sm/syntax/syntax-parsed-arrow-then-directive.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/syntax/yield-as-identifier.js
+++ b/test/staging/sm/syntax/yield-as-identifier.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/template.js
+++ b/test/staging/sm/template.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending

--- a/test/staging/sm/types/8.12.5-01.js
+++ b/test/staging/sm/types/8.12.5-01.js
@@ -6,7 +6,7 @@
 /*---
 includes: [sm/non262.js, sm/non262-shell.js]
 flags:
-- noStrict
+  - noStrict
 description: |
   pending
 esid: pending


### PR DESCRIPTION
To solve the problem that the YAML parser used by the WebKit project was unable to parse unindented lists, so add indent to SM tests metadata YAML.
