### PR TITLE
Add tests for symbols added in Explicit Resource Management

### DIFF
--- a/test/built-ins/Symbol/asyncDispose/cross-realm.js
+++ b/test/built-ins/Symbol/asyncDispose/cross-realm.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: Value shared by all realms
+info: |
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [cross-realm, explicit-resource-management]
+---*/
+
+var OSymbol = $262.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.asyncDispose, OSymbol.asyncDispose);

--- a/test/built-ins/Symbol/dispose/cross-realm.js
+++ b/test/built-ins/Symbol/dispose/cross-realm.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: Value shared by all realms
+info: |
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [cross-realm, explicit-resource-management]
+---*/
+
+var OSymbol = $262.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.dispose, OSymbol.dispose);


### PR DESCRIPTION
Hello!

This pr just adds the simple symbol tests from https://github.com/tc39/test262/pull/3866

Thank you!