### PR TITLE
Update String.fromCodePoint info to align with latest ECMAScript spec

### DIFF
--- a/test/built-ins/String/fromCodePoint/argument-is-Symbol.js
+++ b/test/built-ins/String/fromCodePoint/argument-is-Symbol.js
@@ -7,14 +7,12 @@ description: >
 info: |
   String.fromCodePoint ( ...codePoints )
 
-  1. Let codePoints be a List containing the arguments passed to this function.
-  2. Let length be the number of elements in codePoints.
-  3. Let elements be a new List.
-  4. Let nextIndex be 0.
-  5. Repeat while nextIndex < length
-    a. Let next be codePoints[nextIndex].
-    b. Let nextCP be ToNumber(next).
-    c. ReturnIfAbrupt(nextCP).
+  1. Let result be the empty String.
+  2. For each element next of codePoints, do
+    a. Let nextCP be ? ToNumber(next).
+    b. If nextCP is not an integral Number, throw a RangeError exception.
+    c. If ℝ(nextCP) < 0 or ℝ(nextCP) > 0x10FFFF, throw a RangeError exception.
+  ...
 features: [Symbol, String.fromCodePoint]
 ---*/
 

--- a/test/built-ins/String/fromCodePoint/argument-is-not-integer.js
+++ b/test/built-ins/String/fromCodePoint/argument-is-not-integer.js
@@ -7,16 +7,10 @@ description: >
 info: |
   String.fromCodePoint ( ...codePoints )
 
-  1. Let codePoints be a List containing the arguments passed to this function.
-  2. Let length be the number of elements in codePoints.
-  3. Let elements be a new List.
-  4. Let nextIndex be 0.
-  5. Repeat while nextIndex < length
-    a. Let next be codePoints[nextIndex].
-    b. Let nextCP be ToNumber(next).
-    c. ReturnIfAbrupt(nextCP).
-    d. If SameValue(nextCP, ToInteger(nextCP)) is false, throw a RangeError
-    exception.
+  1. Let result be the empty String.
+  2. For each element next of codePoints, do
+    a. Let nextCP be ? ToNumber(next).
+    b. If nextCP is not an integral Number, throw a RangeError exception.
   ...
 features: [String.fromCodePoint]
 ---*/

--- a/test/built-ins/String/fromCodePoint/argument-not-coercible.js
+++ b/test/built-ins/String/fromCodePoint/argument-not-coercible.js
@@ -7,14 +7,14 @@ description: >
 info: |
   String.fromCodePoint ( ...codePoints )
 
-  1. Let codePoints be a List containing the arguments passed to this function.
-  2. Let length be the number of elements in codePoints.
-  3. Let elements be a new List.
-  4. Let nextIndex be 0.
-  5. Repeat while nextIndex < length
-    a. Let next be codePoints[nextIndex].
-    b. Let nextCP be ToNumber(next).
-    c. ReturnIfAbrupt(nextCP).
+  1. Let result be the empty String.
+  2. For each element next of codePoints, do
+    a. Let nextCP be ? ToNumber(next).
+    b. If nextCP is not an integral Number, throw a RangeError exception.
+    c. If ℝ(nextCP) < 0 or ℝ(nextCP) > 0x10FFFF, throw a RangeError exception.
+    d. Set result to the string-concatenation of result and UTF16EncodeCodePoint(ℝ(nextCP)).
+  3. Assert: If codePoints is empty, then result is the empty String.
+  4. Return result.
 features: [String.fromCodePoint]
 ---*/
 

--- a/test/built-ins/String/fromCodePoint/arguments-is-empty.js
+++ b/test/built-ins/String/fromCodePoint/arguments-is-empty.js
@@ -7,16 +7,11 @@ description: >
 info: |
   String.fromCodePoint ( ...codePoints )
 
-  1. Let codePoints be a List containing the arguments passed to this function.
-  ...
-  5. Repeat while nextIndex < length
+  1. Let result be the empty String.
+  2. For each element next of codePoints, do
     ...
-    f. Append the elements of the UTF16Encoding (10.1.1) of nextCP to the end of
-    elements.
-    g. Let nextIndex be nextIndex + 1.
-  6. Return the String value whose elements are, in order, the elements in the
-  List elements. If length is 0, the empty string is returned.
-
+  3. Assert: If codePoints is empty, then result is the empty String.
+  4. Return result.
 features: [String.fromCodePoint]
 ---*/
 

--- a/test/built-ins/String/fromCodePoint/number-is-out-of-range.js
+++ b/test/built-ins/String/fromCodePoint/number-is-out-of-range.js
@@ -7,17 +7,11 @@ description: >
 info: |
   String.fromCodePoint ( ...codePoints )
 
-  1. Let codePoints be a List containing the arguments passed to this function.
-  2. Let length be the number of elements in codePoints.
-  3. Let elements be a new List.
-  4. Let nextIndex be 0.
-  5. Repeat while nextIndex < length
-    a. Let next be codePoints[nextIndex].
-    b. Let nextCP be ToNumber(next).
-    c. ReturnIfAbrupt(nextCP).
-    d. If SameValue(nextCP, ToInteger(nextCP)) is false, throw a RangeError
-    exception.
-    e. If nextCP < 0 or nextCP > 0x10FFFF, throw a RangeError exception.
+  1. Let result be the empty String.
+  2. For each element next of codePoints, do
+    a. Let nextCP be ? ToNumber(next).
+    b. If nextCP is not an integral Number, throw a RangeError exception.
+    c. If ℝ(nextCP) < 0 or ℝ(nextCP) > 0x10FFFF, throw a RangeError exception.
   ...
 features: [String.fromCodePoint]
 ---*/

--- a/test/built-ins/String/fromCodePoint/return-string-value.js
+++ b/test/built-ins/String/fromCodePoint/return-string-value.js
@@ -8,15 +8,11 @@ description: >
 info: |
   String.fromCodePoint ( ...codePoints )
 
-  1. Let codePoints be a List containing the arguments passed to this function.
-  ...
-  5. Repeat while nextIndex < length
+  1. Let result be the empty String.
+  2. For each element next of codePoints, do
     ...
-    f. Append the elements of the UTF16Encoding (10.1.1) of nextCP to the end of
-    elements.
-    g. Let nextIndex be nextIndex + 1.
-  6. Return the String value whose elements are, in order, the elements in the
-  List elements. If length is 0, the empty string is returned.
+  3. Assert: If codePoints is empty, then result is the empty String.
+  4. Return result.
 features: [String.fromCodePoint]
 ---*/
 

--- a/test/built-ins/String/fromCodePoint/to-number-conversions.js
+++ b/test/built-ins/String/fromCodePoint/to-number-conversions.js
@@ -7,15 +7,15 @@ description: >
 info: |
   String.fromCodePoint ( ...codePoints )
 
-  1. Let codePoints be a List containing the arguments passed to this function.
-  ...
-  5. Repeat while nextIndex < length
-    a. Let next be codePoints[nextIndex].
-    b. Let nextCP be ToNumber(next).
-    ...
-  6. Return the String value whose elements are, in order, the elements in the
-  List elements. If length is 0, the empty string is returned.
-
+  1. Let result be the empty String.
+  2. For each element next of codePoints, do
+    a. Let nextCP be ? ToNumber(next).
+    b. If nextCP is not an integral Number, throw a RangeError exception.
+    c. If ℝ(nextCP) < 0 or ℝ(nextCP) > 0x10FFFF, throw a RangeError exception.
+    d. Set result to the string-concatenation of result and UTF16EncodeCodePoint(ℝ(nextCP)).
+  3. Assert: If codePoints is empty, then result is the empty String.
+  4. Return result.
+  
   Ref: 7.1.3 ToNumber ( argument )
 features: [String.fromCodePoint]
 ---*/


### PR DESCRIPTION
It might be a minor detail, but it seems that the specification for fromCodePoint was changed in [tc39/ecma262#2018](https://github.com/tc39/ecma262/pull/2018) and [tc39/ecma262#2152](https://github.com/tc39/ecma262/pull/2152), while the info section had not been updated. So, I updated it accordingly.