### PR TITLE
Remove `let` keyword and use `using` declaration

### DIFF
--- a/test/staging/explicit-resource-management/using-with-null-or-undefined.js
+++ b/test/staging/explicit-resource-management/using-with-null-or-undefined.js
@@ -7,20 +7,20 @@ includes: [compareArray.js]
 features: [explicit-resource-management]
 ---*/
 
-// Use using with null --------------
+// Use using with null does not throw --------------
 let withNullvalues = [];
 
 (function TestUsingWithNull() {
-  let using = null;
+  using x = null;
   withNullvalues.push(42);
 })();
 assert.compareArray(withNullvalues, [42]);
 
-// Use using with undefined --------------
+// Use using with undefined does not throw --------------
 let withUndefinedvalues = [];
 
 (function TestUsingWithUndefined() {
-  let using = undefined;
+  using x = undefined;
   withUndefinedvalues.push(42);
 })();
 assert.compareArray(withUndefinedvalues, [42]);


### PR DESCRIPTION
The goal of this test is to show that `using` declarations can be used with null and undefined and should not throw. The `let` keyword should not be used here.