### PR TITLE
Update sm tests for iterator helpers

### DIFF
--- a/test/staging/sm/Iterator/prototype/every/check-fn-after-getting-iterator.js
+++ b/test/staging/sm/Iterator/prototype/every/check-fn-after-getting-iterator.js
@@ -32,6 +32,6 @@ assertThrowsInstanceOf(() => iter.every(1), TypeError);
 
 assert.compareArray(
   log,
-  ["get: every"]
+  ["get: every", "get: return"]
 );
 

--- a/test/staging/sm/Iterator/prototype/find/check-fn-after-getting-iterator.js
+++ b/test/staging/sm/Iterator/prototype/find/check-fn-after-getting-iterator.js
@@ -32,6 +32,6 @@ assertThrowsInstanceOf(() => iter.find(1), TypeError);
 
 assert.compareArray(
   log,
-  ["get: find"]
+  ["get: find", "get: return"]
 );
 

--- a/test/staging/sm/Iterator/prototype/forEach/check-fn-after-getting-iterator.js
+++ b/test/staging/sm/Iterator/prototype/forEach/check-fn-after-getting-iterator.js
@@ -32,6 +32,6 @@ assertThrowsInstanceOf(() => iter.forEach(1), TypeError);
 
 assert.compareArray(
   log,
-  ["get: forEach"]
+  ["get: forEach", "get: return"]
 );
 

--- a/test/staging/sm/Iterator/prototype/reduce/check-fn-after-getting-iterator.js
+++ b/test/staging/sm/Iterator/prototype/reduce/check-fn-after-getting-iterator.js
@@ -32,6 +32,6 @@ assertThrowsInstanceOf(() => iter.reduce(1), TypeError);
 
 assert.compareArray(
   log,
-  ["get: reduce"]
+  ["get: reduce", "get: return"]
 );
 

--- a/test/staging/sm/Iterator/prototype/some/check-fn-after-getting-iterator.js
+++ b/test/staging/sm/Iterator/prototype/some/check-fn-after-getting-iterator.js
@@ -32,6 +32,6 @@ assertThrowsInstanceOf(() => iter.some(1), TypeError);
 
 assert.compareArray(
   log,
-  ["get: some"]
+  ["get: some", "get: return"]
 );
 


### PR DESCRIPTION
After a recent normative change on iterator helpers (https://github.com/tc39/ecma262/pull/3467), the expectations of these tests should be updated.