### PR TITLE
Rewrite import defer resolution test to not expect specific error

### DIFF
--- a/test/language/import/import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js
+++ b/test/language/import/import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js
@@ -9,14 +9,18 @@ info: |
   LoadRequestedModules ([ _hostDefined_ ])
     - just notice that it does not check if the module is deferred
 
-flags: [module]
+flags: [async, module]
+includes: [asyncHelpers.js]
 features: [import-defer]
-
-negative:
-  phase: resolution
-  type: SyntaxError
 ---*/
 
-$DONOTEVALUATE();
-
-import defer * as ns from "./resolution-error_FIXTURE.js";
+asyncTest(async () => {
+  globalThis.evaluated = false;
+  try {
+    await import("./main_FIXTURE.js");
+  } catch {
+    assert.sameValue(globalThis.evaluated, false, "The module should not be evaluated");
+    return;
+  }
+  throw new Error("The module should throw");
+})

--- a/test/language/import/import-defer/errors/resolution-error/main_FIXTURE.js
+++ b/test/language/import/import-defer/errors/resolution-error/main_FIXTURE.js
@@ -1,0 +1,6 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import defer * as ns from "./resolution-error_FIXTURE.js";
+
+globalThis.evaluated = true;


### PR DESCRIPTION
The error type is host-defined, so we cannot use a negative-style test.