### PR TITLE
Wrap `toSpliced` call with try-finally in sm test

### DIFF
--- a/test/staging/sm/Array/change-array-by-copy-errors-from-correct-realm.js
+++ b/test/staging/sm/Array/change-array-by-copy-errors-from-correct-realm.js
@@ -41,8 +41,11 @@ function test(otherGlobal) {
         ["toSpliced - array too long", () => {
             var oldLen = arrayLike.length;
             arrayLike.length = 2**53 - 1;
-            gToSpliced.call(arrayLike, 0, 0, 1);
-            arrayLike.length = oldLen;
+            try {
+                gToSpliced.call(arrayLike, 0, 0, 1);
+            } finally {
+                arrayLike.length = oldLen;
+            }
         }]
     ]
 


### PR DESCRIPTION
`gToSpliced.call(arrayLike, 0, 0, 1)` throw `TypeError` so `arrayLike.length = oldLen` never executed.
So this PR changes to wrap it with try-finally.
