### PR TITLE
Add testcases for setUTC* functions return value

### DIFF
--- a/test/built-ins/Date/prototype/setUTCHours/this-value-valid-date-hour.js
+++ b/test/built-ins/Date/prototype/setUTCHours/this-value-valid-date-hour.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2025 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutchours
+description: Return value for valid dates (setting UTC hour)
+info: |
+  1. Let dateObject be the this value.
+  2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+  3. Let t be dateObject.[[DateValue]].
+  4. Let h be ? ToNumber(hour).
+  5. If min is present, let m be ? ToNumber(min).
+  6. If sec is present, let s be ? ToNumber(sec).
+  7. If ms is present, let milli be ? ToNumber(ms).
+  8. If t is NaN, return NaN.
+  9. If min is not present, let m be MinFromTime(t).
+  10. If sec is not present, let s be SecFromTime(t).
+  11. If ms is not present, let milli be msFromTime(t).
+  12. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  13. Let v be TimeClip(date).
+  14. Set dateObject.[[DateValue]] to v.
+  15. Return v.
+---*/
+
+var date = new Date(Date.UTC(2016, 6, 1));
+var returnValue, expected;
+
+returnValue = date.setUTCHours(6);
+
+expected = Date.UTC(2016, 6, 1, 6);
+assert.sameValue(
+  returnValue, expected, 'hour within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'hour within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCHours(-1);
+
+expected = Date.UTC(2016, 5, 30, 23);
+assert.sameValue(
+  returnValue, expected, 'hour before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'hour before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCHours(24);
+
+expected = Date.UTC(2016, 6, 1, 0);
+assert.sameValue(
+  returnValue, expected, 'hour after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'hour after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setUTCHours/this-value-valid-date-min.js
+++ b/test/built-ins/Date/prototype/setUTCHours/this-value-valid-date-min.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2025 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutchours
+description: Return value for valid dates (setting min)
+info: |
+  1. Let dateObject be the this value.
+  2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+  3. Let t be dateObject.[[DateValue]].
+  4. Let h be ? ToNumber(hour).
+  5. If min is present, let m be ? ToNumber(min).
+  6. If sec is present, let s be ? ToNumber(sec).
+  7. If ms is present, let milli be ? ToNumber(ms).
+  8. If t is NaN, return NaN.
+  9. If min is not present, let m be MinFromTime(t).
+  10. If sec is not present, let s be SecFromTime(t).
+  11. If ms is not present, let milli be msFromTime(t).
+  12. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  13. Let v be TimeClip(date).
+  14. Set dateObject.[[DateValue]] to v.
+  15. Return v.
+---*/
+
+var date = new Date(Date.UTC(2016, 6, 1));
+var returnValue, expected;
+
+returnValue = date.setUTCHours(0, 23);
+
+expected = Date.UTC(2016, 6, 1, 0, 23);
+assert.sameValue(
+  returnValue, expected, 'minute within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'minute within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCHours(0, -1);
+
+expected = Date.UTC(2016, 5, 30, 23, 59);
+assert.sameValue(
+  returnValue, expected, 'minute before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'minute before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCHours(0, 60);
+
+expected = Date.UTC(2016, 5, 30, 1);
+assert.sameValue(
+  returnValue, expected, 'minute after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'minute after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setUTCHours/this-value-valid-date-ms.js
+++ b/test/built-ins/Date/prototype/setUTCHours/this-value-valid-date-ms.js
@@ -1,0 +1,61 @@
+// Copyright (C) 2025 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutchours
+description: Return value for valid dates (setting ms)
+info: |
+  1. Let dateObject be the this value.
+  2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+  3. Let t be dateObject.[[DateValue]].
+  4. Let h be ? ToNumber(hour).
+  5. If min is present, let m be ? ToNumber(min).
+  6. If sec is present, let s be ? ToNumber(sec).
+  7. If ms is present, let milli be ? ToNumber(ms).
+  8. If t is NaN, return NaN.
+  9. If min is not present, let m be MinFromTime(t).
+  10. If sec is not present, let s be SecFromTime(t).
+  11. If ms is not present, let milli be msFromTime(t).
+  12. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  13. Let v be TimeClip(date).
+  14. Set dateObject.[[DateValue]] to v.
+  15. Return v.
+---*/
+
+var date = new Date(Date.UTC(2016, 6, 1));
+var returnValue, expected;
+
+returnValue = date.setUTCHours(0, 0, 0, 543);
+
+expected = Date.UTC(2016, 6, 1, 0, 0, 0, 543);
+assert.sameValue(
+  returnValue, expected, 'millisecond within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCHours(0, 0, 0, -1);
+
+expected = Date.UTC(2016, 5, 30, 23, 59, 59, 999);
+assert.sameValue(
+  returnValue, expected, 'millisecond before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCHours(0, 0, 0, 1000);
+
+expected = Date.UTC(2016, 5, 30, 0, 0, 1);
+assert.sameValue(
+  returnValue, expected, 'millisecond after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setUTCHours/this-value-valid-date-sec.js
+++ b/test/built-ins/Date/prototype/setUTCHours/this-value-valid-date-sec.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2025 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutchours
+description: Return value for valid dates (setting sec)
+info: |
+  1. Let dateObject be the this value.
+  2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+  3. Let t be dateObject.[[DateValue]].
+  4. Let h be ? ToNumber(hour).
+  5. If min is present, let m be ? ToNumber(min).
+  6. If sec is present, let s be ? ToNumber(sec).
+  7. If ms is present, let milli be ? ToNumber(ms).
+  8. If t is NaN, return NaN.
+  9. If min is not present, let m be MinFromTime(t).
+  10. If sec is not present, let s be SecFromTime(t).
+  11. If ms is not present, let milli be msFromTime(t).
+  12. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  13. Let v be TimeClip(date).
+  14. Set dateObject.[[DateValue]] to v.
+  15. Return v.
+---*/
+
+var date = new Date(Date.UTC(2016, 6, 1));
+var returnValue, expected;
+
+returnValue = date.setUTCHours(0, 0, 45);
+
+expected = Date.UTC(2016, 6, 1, 0, 0, 45);
+assert.sameValue(
+  returnValue, expected, 'second within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'second within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCHours(0, 0, -1);
+
+expected = Date.UTC(2016, 5, 30, 23, 59, 59);
+assert.sameValue(
+  returnValue, expected, 'second before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCHours(0, 0, 60);
+
+expected = Date.UTC(2016, 5, 30, 0, 1);
+assert.sameValue(
+  returnValue, expected, 'second after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setUTCMilliseconds/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/setUTCMilliseconds/this-value-valid-date.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2025 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcmilliseconds
+description: Return value for valid dates
+info: |
+  1. Let dateObject be the this value.
+  2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+  3. Let t be dateObject.[[DateValue]].
+  4. Set ms to ? ToNumber(ms).
+  5. If t is NaN, return NaN.
+  6. Let time be MakeTime(HourFromTime(t), MinFromTime(t), SecFromTime(t), ms).
+  7. Let v be TimeClip(MakeDate(Day(t), time)).
+  8. Set dateObject.[[DateValue]] to v.
+  9. Return v.
+---*/
+
+var date = new Date(Date.UTC(2016, 6));
+var returnValue, expected;
+
+returnValue = date.setUTCMilliseconds(333);
+
+expected = Date.UTC(2016, 6, 1, 0, 0, 0, 333);
+assert.sameValue(
+  returnValue, expected, 'within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMilliseconds(-1);
+
+expected = Date.UTC(2016, 5, 30, 23, 59, 59, 999);
+assert.sameValue(
+  returnValue, expected, 'before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMilliseconds(1000);
+
+expected = Date.UTC(2016, 6, 1);
+assert.sameValue(
+  returnValue, expected, 'after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setUTCMinutes/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/setUTCMinutes/this-value-valid-date.js
@@ -1,0 +1,131 @@
+// Copyright (C) 2025 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcminutes
+description: Return value for valid dates
+info: |
+  1. Let dateObject be the this value.
+  2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+  3. Let t be dateObject.[[DateValue]].
+  4. Let m be ? ToNumber(min).
+  5. If sec is present, let s be ? ToNumber(sec).
+  6. If ms is present, let milli be ? ToNumber(ms).
+  7. If t is NaN, return NaN.
+  8. If sec is not present, let s be SecFromTime(t).
+  9. If ms is not present, let milli be msFromTime(t).
+  10. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
+  11. Let v be TimeClip(date).
+  12. Set dateObject.[[DateValue]] to v.
+  13. Return v.
+---*/
+
+var date = new Date(Date.UTC(2016, 6, 1));
+var returnValue, expected;
+
+returnValue = date.setUTCMinutes(23);
+
+expected = Date.UTC(2016, 6, 1, 0, 23);
+assert.sameValue(
+  returnValue, expected, 'minute within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'minute within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMinutes(-1);
+
+expected = Date.UTC(2016, 5, 30, 23, 59);
+assert.sameValue(
+  returnValue, expected, 'minute before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'minute before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMinutes(60);
+
+expected = Date.UTC(2016, 6, 1);
+assert.sameValue(
+  returnValue, expected, 'minute after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'minute after time unit boundary ([[DateValue]] slot)'
+);
+
+date = new Date(Date.UTC(2016, 6, 1));
+
+returnValue = date.setUTCMinutes(0, 45);
+
+expected = Date.UTC(2016, 6, 1, 0, 0, 45);
+assert.sameValue(
+  returnValue, expected, 'second within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'second within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMinutes(0, -1);
+
+expected = Date.UTC(2016, 5, 30, 23, 59, 59);
+assert.sameValue(
+  returnValue, expected, 'second before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMinutes(0, 60);
+
+expected = Date.UTC(2016, 5, 30, 23, 1);
+assert.sameValue(
+  returnValue, expected, 'second after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second after time unit boundary ([[DateValue]] slot)'
+);
+
+date = new Date(Date.UTC(2016, 6, 1));
+
+returnValue = date.setUTCMinutes(0, 0, 345);
+
+expected = Date.UTC(2016, 6, 1, 0, 0, 0, 345);
+assert.sameValue(
+  returnValue, expected, 'millisecond within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMinutes(0, 0, -1);
+
+expected = Date.UTC(2016, 5, 30, 23, 59, 59, 999);
+assert.sameValue(
+  returnValue, expected, 'millisecond before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMinutes(0, 0, 1000);
+
+expected = Date.UTC(2016, 5, 30, 23, 0, 1);
+assert.sameValue(
+  returnValue, expected, 'millisecond after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setUTCMonth/this-value-valid-date-date.js
+++ b/test/built-ins/Date/prototype/setUTCMonth/this-value-valid-date-date.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcmonth
+description: Return value for valid dates (setting date)
+info: |
+  1. Let dateObject be the this value.
+  2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+  3. Let t be dateObject.[[DateValue]].
+  4. Let m be ? ToNumber(month).
+  5. If date is present, let dt be ? ToNumber(date).
+  6. If t is NaN, return NaN.
+  7. If date is not present, let dt be DateFromTime(t).
+  8. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
+  9. Let v be TimeClip(newDate).
+  10. Set dateObject.[[DateValue]] to v.
+  11. Return v.
+---*/
+
+var date = new Date(Date.UTC(2016, 6));
+var returnValue, expected;
+
+returnValue = date.setUTCMonth(6, 6);
+
+expected = Date.UTC(2016, 6, 6);
+assert.sameValue(
+  returnValue, expected, 'date within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'date within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMonth(6, 0);
+
+expected = Date.UTC(2016, 5, 30);
+assert.sameValue(
+  returnValue, expected, 'date before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'date before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMonth(5, 31);
+
+expected = Date.UTC(2016, 6, 1);
+assert.sameValue(
+  returnValue, expected, 'date after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'date after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setUTCMonth/this-value-valid-date-month.js
+++ b/test/built-ins/Date/prototype/setUTCMonth/this-value-valid-date-month.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcmonth
+description: Return value for valid dates (setting month)
+info: |
+  1. Let dateObject be the this value.
+  2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+  3. Let t be dateObject.[[DateValue]].
+  4. Let m be ? ToNumber(month).
+  5. If date is present, let dt be ? ToNumber(date).
+  6. If t is NaN, return NaN.
+  7. If date is not present, let dt be DateFromTime(t).
+  8. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
+  9. Let v be TimeClip(newDate).
+  10. Set dateObject.[[DateValue]] to v.
+  11. Return v.
+---*/
+
+var date = new Date(Date.UTC(2016, 6));
+var returnValue, expected;
+
+returnValue = date.setUTCMonth(3);
+
+expected = Date.UTC(2016, 3);
+assert.sameValue(
+  returnValue, expected, 'month within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'month within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMonth(-1);
+
+expected = Date.UTC(2015, 11);
+assert.sameValue(
+  returnValue, expected, 'month before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'month before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCMonth(12);
+
+expected = Date.UTC(2016, 0);
+assert.sameValue(
+  returnValue, expected, 'month after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'month after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setUTCSeconds/this-value-valid-date-ms.js
+++ b/test/built-ins/Date/prototype/setUTCSeconds/this-value-valid-date-ms.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcseconds
+description: Return value for valid dates (setting ms)
+info: |
+  1. Let dateObject be the this value.
+  2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+  3. Let t be dateObject.[[DateValue]].
+  4. Let s be ? ToNumber(sec).
+  5. If ms is present, let milli be ? ToNumber(ms).
+  6. If t is NaN, return NaN.
+  7. If ms is not present, let milli be msFromTime(t).
+  8. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
+  9. Let v be TimeClip(date).
+  10. Set dateObject.[[DateValue]] to v.
+  11. Return v.
+---*/
+
+var date = new Date(Date.UTC(2016, 6));
+var returnValue, expected;
+
+returnValue = date.setUTCSeconds(0, 543);
+
+expected = Date.UTC(2016, 6, 1, 0, 0, 0, 543);
+assert.sameValue(
+  returnValue, expected, 'millisecond within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCSeconds(0, -1);
+
+expected = Date.UTC(2016, 5, 30, 23, 59, 59, 999);
+assert.sameValue(
+  returnValue, expected, 'millisecond before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCSeconds(0, 1000);
+
+expected = Date.UTC(2016, 5, 30, 23, 59, 1, 0);
+assert.sameValue(
+  returnValue, expected, 'millisecond after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setUTCSeconds/this-value-valid-date-sec.js
+++ b/test/built-ins/Date/prototype/setUTCSeconds/this-value-valid-date-sec.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcseconds
+description: Return value for valid dates (setting sec)
+info: |
+  1. Let dateObject be the this value.
+  2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+  3. Let t be dateObject.[[DateValue]].
+  4. Let s be ? ToNumber(sec).
+  5. If ms is present, let milli be ? ToNumber(ms).
+  6. If t is NaN, return NaN.
+  7. If ms is not present, let milli be msFromTime(t).
+  8. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
+  9. Let v be TimeClip(date).
+  10. Set dateObject.[[DateValue]] to v.
+  11. Return v.
+---*/
+
+var date = new Date(Date.UTC(2016, 6));
+var returnValue, expected;
+
+returnValue = date.setUTCSeconds(45);
+
+expected = Date.UTC(2016, 6, 1, 0, 0, 45);
+assert.sameValue(
+  returnValue, expected, 'second within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'second within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCSeconds(-1);
+
+expected = Date.UTC(2016, 5, 30, 23, 59, 59);
+assert.sameValue(
+  returnValue, expected, 'second before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setUTCSeconds(60);
+
+expected = Date.UTC(2016, 6);
+assert.sameValue(
+  returnValue, expected, 'second after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second after time unit boundary ([[DateValue]] slot)'
+);


### PR DESCRIPTION
I found some missing testcase for setUTC* functions unlike set* functions do. While I am working on [this CL](https://chromium-review.googlesource.com/c/v8/v8/+/6332619), I found that I was missing the `std::optional::value_or` of setUTC* functions by mistake but test262  succeeded. (But set* functions failed.)

So, I think this is a good point to add the cases. The TCs are from set* cases. (e.g., [setHours](https://github.com/tc39/test262/blob/main/test/built-ins/Date/prototype/setHours/this-value-valid-date-hour.js))