### PR TITLE
Update ESIDs of Temporal.*.prototype properties

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/Duration/prototype/prop-desc.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-duration-prototype
+esid: sec-temporal.duration.prototype
 description: The "prototype" property of Temporal.Duration
 includes: [propertyHelper.js]
 features: [Temporal]

--- a/test/built-ins/Temporal/Instant/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/Instant/prototype/prop-desc.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-instant-prototype
+esid: sec-temporal.instant.prototype
 description: The "prototype" property of Temporal.Instant
 includes: [propertyHelper.js]
 features: [Temporal]

--- a/test/built-ins/Temporal/PlainDate/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/prop-desc.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-plaindate-prototype
+esid: sec-temporal.plaindate.prototype
 description: The "prototype" property of Temporal.PlainDate
 includes: [propertyHelper.js]
 features: [Temporal]

--- a/test/built-ins/Temporal/PlainDateTime/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/prop-desc.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-plaindatetime-prototype
+esid: sec-temporal.plaindatetime.prototype
 description: The "prototype" property of Temporal.PlainDateTime
 includes: [propertyHelper.js]
 features: [Temporal]

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/prop-desc.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-plainmonthday-prototype
+esid: sec-temporal.plainmonthday.prototype
 description: The "prototype" property of Temporal.PlainMonthDay
 includes: [propertyHelper.js]
 features: [Temporal]

--- a/test/built-ins/Temporal/PlainTime/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/prop-desc.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-plaintime-prototype
+esid: sec-temporal.plaintime.prototype
 description: The "prototype" property of Temporal.PlainTime
 includes: [propertyHelper.js]
 features: [Temporal]

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/prop-desc.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-plainyearmonth-prototype
+esid: sec-temporal.plainyearmonth.prototype
 description: The "prototype" property of Temporal.PlainYearMonth
 includes: [propertyHelper.js]
 features: [Temporal]

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/prop-desc.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-zoneddatetime-prototype
+esid: sec-temporal.zoneddatetime.prototype
 description: The "prototype" property of Temporal.ZonedDateTime
 includes: [propertyHelper.js]
 features: [Temporal]


### PR DESCRIPTION
These ESIDs were updated to use dots instead of dashes, to be more consistent with the ESIDs of other properties.