### PR TITLE
Fix expected value for UTC-like time zone

### DIFF
--- a/test/intl402/Temporal/ZonedDateTime/prototype/equals/canonicalize-utc-timezone.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/equals/canonicalize-utc-timezone.js
@@ -34,7 +34,7 @@ for (var ix = 0; ix < utcIdentifiers.length; ix++) {
   var dateTime = new Temporal.ZonedDateTime(0n, timeZone);
   assert.sameValue(
     dateTime.timeZoneId,
-    utcDateTime.timeZoneId,
+    timeZone,
     timeZone + " should be preserved and not canonicalized to UTC");
   assert(dateTime.equals(utcDateTime), "Time zone " + timeZone + " should be equal to primary identifier UTC");
 }


### PR DESCRIPTION
If `timeZone` should be preserved, then it can't be the same string as `utcDateTime.timeZoneId`.