### PR TITLE
Fix expected maximumFractionDigits for compact notation

### DIFF
--- a/test/intl402/NumberFormat/currency-digits-nonstandard-notation.js
+++ b/test/intl402/NumberFormat/currency-digits-nonstandard-notation.js
@@ -27,7 +27,7 @@ for (const notation of ["compact", "engineering", "scientific"]) {
     const maximumFractionDigits = resolvedOptions.maximumFractionDigits;
 
     assert.sameValue(minimumFractionDigits, 0, "Didn't get correct minimumFractionDigits for " + currency + " in " + notation + " notation.");
-    assert.sameValue(maximumFractionDigits, 3, "Didn't get correct maximumFractionDigits for " + currency + " in " + notation + " notation.");
+    assert.sameValue(maximumFractionDigits, notation !== "compact" ? 3 : 0, "Didn't get correct maximumFractionDigits for " + currency + " in " + notation + " notation.");
   }
 }
 


### PR DESCRIPTION
[[MaximumFractionDigits]] is set to zero in SetNumberFormatDigitOptions, step 24.b.