### PR TITLE
Prefer "islamic-tbla" over "islamic" for Hijri calendars

### DIFF
--- a/test/intl402/Temporal/Instant/prototype/toLocaleString/dateStyle.js
+++ b/test/intl402/Temporal/Instant/prototype/toLocaleString/dateStyle.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal.instant.prototype.tolocalestring
 description: Basic tests that dateStyle option affects output
-locale: [en-u-ca-gregory, en-u-ca-islamic]
+locale: [en-u-ca-gregory, en-u-ca-islamic-tbla]
 features: [Temporal, Intl.DateTimeFormat-datetimestyle]
 ---*/
 
@@ -19,10 +19,10 @@ assert(
   "dateStyle: short does not write month of March out in full"
 );
 assert(
-  instant.toLocaleString("en-u-ca-islamic", { dateStyle: "long" }).includes("Ramadan"),
+  instant.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "long" }).includes("Ramadan"),
   "dateStyle: long writes month of Ramadan out in full"
 );
 assert(
-  !instant.toLocaleString("en-u-ca-islamic", { dateStyle: "short" }).includes("Ramadan"),
+  !instant.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "short" }).includes("Ramadan"),
   "dateStyle: short does not write month of Ramadan out in full"
 );

--- a/test/intl402/Temporal/PlainDate/prototype/toLocaleString/dateStyle.js
+++ b/test/intl402/Temporal/PlainDate/prototype/toLocaleString/dateStyle.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal.plaindate.prototype.tolocalestring
 description: Basic tests that dateStyle option affects output
-locale: [en-u-ca-gregory, en-u-ca-islamic]
+locale: [en-u-ca-gregory, en-u-ca-islamic-tbla]
 features: [Temporal, Intl.DateTimeFormat-datetimestyle]
 ---*/
 
@@ -19,13 +19,13 @@ assert(
   "dateStyle: short does not write month of March out in full"
 );
 
-const dateIslamic = new Temporal.PlainDate(2024, 3, 26, "islamic");
+const dateIslamic = new Temporal.PlainDate(2024, 3, 26, "islamic-tbla");
 
 assert(
-  dateIslamic.toLocaleString("en-u-ca-islamic", { dateStyle: "long" }).includes("Ramadan"),
+  dateIslamic.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "long" }).includes("Ramadan"),
   "dateStyle: long writes month of Ramadan out in full"
 );
 assert(
-  !dateIslamic.toLocaleString("en-u-ca-islamic", { dateStyle: "short" }).includes("Ramadan"),
+  !dateIslamic.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "short" }).includes("Ramadan"),
   "dateStyle: short does not write month of Ramadan out in full"
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/dateStyle.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/dateStyle.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal.plaindatetime.prototype.tolocalestring
 description: Basic tests that dateStyle option affects output
-locale: [en-u-ca-gregory, en-u-ca-islamic]
+locale: [en-u-ca-gregory, en-u-ca-islamic-tbla]
 features: [Temporal, Intl.DateTimeFormat-datetimestyle]
 ---*/
 
@@ -19,13 +19,13 @@ assert(
   "dateStyle: short does not write month of March out in full"
 );
 
-const dateIslamic = new Temporal.PlainDateTime(2024, 3, 26, 10, 30, 0, 0, 0, 0, "islamic");
+const dateIslamic = new Temporal.PlainDateTime(2024, 3, 26, 10, 30, 0, 0, 0, 0, "islamic-tbla");
 
 assert(
-  dateIslamic.toLocaleString("en-u-ca-islamic", { dateStyle: "long" }).includes("Ramadan"),
+  dateIslamic.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "long" }).includes("Ramadan"),
   "dateStyle: long writes month of Ramadan out in full"
 );
 assert(
-  !dateIslamic.toLocaleString("en-u-ca-islamic", { dateStyle: "short" }).includes("Ramadan"),
+  !dateIslamic.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "short" }).includes("Ramadan"),
   "dateStyle: short does not write month of Ramadan out in full"
 );

--- a/test/intl402/Temporal/PlainMonthDay/prototype/toLocaleString/dateStyle.js
+++ b/test/intl402/Temporal/PlainMonthDay/prototype/toLocaleString/dateStyle.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal.plainmonthday.prototype.tolocalestring
 description: Basic tests that dateStyle option affects output
-locale: [en-u-ca-gregory, en-u-ca-islamic]
+locale: [en-u-ca-gregory, en-u-ca-islamic-tbla]
 features: [Temporal, Intl.DateTimeFormat-datetimestyle]
 ---*/
 
@@ -19,13 +19,13 @@ assert(
   "dateStyle: short does not write month of March out in full"
 );
 
-const dateIslamic = Temporal.PlainMonthDay.from({ monthCode: "M09", day: 16, calendar: "islamic" });
+const dateIslamic = Temporal.PlainMonthDay.from({ monthCode: "M09", day: 16, calendar: "islamic-tbla" });
 
 assert(
-  dateIslamic.toLocaleString("en-u-ca-islamic", { dateStyle: "long" }).includes("Ramadan"),
+  dateIslamic.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "long" }).includes("Ramadan"),
   "dateStyle: long writes month of Ramadan out in full"
 );
 assert(
-  !dateIslamic.toLocaleString("en-u-ca-islamic", { dateStyle: "short" }).includes("Ramadan"),
+  !dateIslamic.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "short" }).includes("Ramadan"),
   "dateStyle: short does not write month of Ramadan out in full"
 );

--- a/test/intl402/Temporal/PlainYearMonth/prototype/toLocaleString/dateStyle.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/toLocaleString/dateStyle.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal.plainyearmonth.prototype.tolocalestring
 description: Basic tests that dateStyle option affects output
-locale: [en-u-ca-gregory, en-u-ca-islamic]
+locale: [en-u-ca-gregory, en-u-ca-islamic-tbla]
 features: [Temporal, Intl.DateTimeFormat-datetimestyle]
 ---*/
 
@@ -19,13 +19,13 @@ assert(
   "dateStyle: short does not write month of March out in full"
 );
 
-const dateIslamic = Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M09", calendar: "islamic" });
+const dateIslamic = Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M09", calendar: "islamic-tbla" });
 
 assert(
-  dateIslamic.toLocaleString("en-u-ca-islamic", { dateStyle: "long" }).includes("Ramadan"),
+  dateIslamic.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "long" }).includes("Ramadan"),
   "dateStyle: long writes month of Ramadan out in full"
 );
 assert(
-  !dateIslamic.toLocaleString("en-u-ca-islamic", { dateStyle: "short" }).includes("Ramadan"),
+  !dateIslamic.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "short" }).includes("Ramadan"),
   "dateStyle: short does not write month of Ramadan out in full"
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/toLocaleString/dateStyle.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/toLocaleString/dateStyle.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal.plaindate.prototype.tolocalestring
 description: Basic tests that dateStyle option affects output
-locale: [en-u-ca-gregory, en-u-ca-islamic]
+locale: [en-u-ca-gregory, en-u-ca-islamic-tbla]
 features: [Temporal, Intl.DateTimeFormat-datetimestyle]
 ---*/
 
@@ -19,13 +19,13 @@ assert(
   "dateStyle: short does not write month of March out in full"
 );
 
-const dateIslamic = new Temporal.ZonedDateTime(1711475200_000_000_000n, "UTC", "islamic");
+const dateIslamic = new Temporal.ZonedDateTime(1711475200_000_000_000n, "UTC", "islamic-tbla");
 
 assert(
-  dateIslamic.toLocaleString("en-u-ca-islamic", { dateStyle: "long" }).includes("Ramadan"),
+  dateIslamic.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "long" }).includes("Ramadan"),
   "dateStyle: long writes month of Ramadan out in full"
 );
 assert(
-  !dateIslamic.toLocaleString("en-u-ca-islamic", { dateStyle: "short" }).includes("Ramadan"),
+  !dateIslamic.toLocaleString("en-u-ca-islamic-tbla", { dateStyle: "short" }).includes("Ramadan"),
   "dateStyle: short does not write month of Ramadan out in full"
 );


### PR DESCRIPTION
"islamic" is underspecified because it doesn't include any information which location and algorithms should be used to approximate new moon observations. Instead switch to "islamic-tbla".