### PR TITLE
Remove chakra

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,15 +68,6 @@ jobs:
       hostPath: spidermonkey
       hostName: spidermonkey
     <<: [*execution_steps]
-  # "ChakraCore: New or modified tests execution":
-  #   docker:
-  #     - image: *node_image
-  #   working_directory: ~/test262
-  #   environment:
-  #     hostType: ch
-  #     hostPath: chakra
-  #     hostName: chakra
-  #   <<: [*execution_steps]
   "JSC: New or modified tests execution":
     docker:
       - image: *node_image
@@ -110,7 +101,6 @@ workflows:
   version: 2
   Tests execution:
     jobs:
-      # - "ChakraCore: New or modified tests execution"
       - "JSC: New or modified tests execution"
       - "SpiderMonkey: New or modified tests execution"
       - "V8: New or modified tests execution"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,8 +299,8 @@ function Test262Error(message) {
 
 The [Module section of INTERPRETING.md](https://github.com/tc39/test262/blob/HEAD/INTERPRETING.md#modules) states that `_FIXTURE` files will not have Realm modifications applied. In practice, this means that code in `_FIXTURE` files must abide by the following rules:
 
-- **MUST NOT** refer to, or make use of any [Test262-Defined Bindings](https://github.com/tc39/test262/blob/HEAD/INTERPRETING.md#test262-defined-bindings) in any way. 
-- **MUST NOT** refer to, or make use of any [Host-Defined Functions](https://github.com/tc39/test262/blob/HEAD/INTERPRETING.md#host-defined-functions) in any way. 
+- **MUST NOT** refer to, or make use of any [Test262-Defined Bindings](https://github.com/tc39/test262/blob/HEAD/INTERPRETING.md#test262-defined-bindings) in any way.
+- **MUST NOT** refer to, or make use of any [Host-Defined Functions](https://github.com/tc39/test262/blob/HEAD/INTERPRETING.md#host-defined-functions) in any way.
 
 ## Handling Errors and Negative Test Cases
 
@@ -459,7 +459,7 @@ Tests expressed with this convention are built automatically following the sourc
 ## Reporting Bugs to Implementers
 
 - [Boa](https://github.com/boa-dev/boa/issues/new)
-- [ChakraCore](https://github.com/microsoft/ChakraCore/issues/new)
+- [ChakraCore](https://github.com/chakra-core/ChakraCore/issues/new)
 - [engine262](https://github.com/engine262/engine262/issues/new)
 - [GraalJS](https://github.com/oracle/graal/issues/new?labels=bug&template=5_issues_other.md&title=)
 - [Hermes](https://github.com/facebook/hermes/issues/new?labels%5B%5D=need+triage&labels%5B%5D=bug&template=01_bug_report.md&title=)
@@ -469,5 +469,3 @@ Tests expressed with this convention are built automatically following the sourc
 - [QuickJS](https://github.com/bellard/quickjs/issues/new)
 - [SpiderMonkey](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=JavaScript%20Engine)
 - [V8](https://bugs.chromium.org/p/v8/issues/entry)
-
-

--- a/package.json
+++ b/package.json
@@ -20,10 +20,9 @@
     "ci": "./tools/scripts/ci_test.sh",
     "test": "test262-harness",
     "diff": "git diff --diff-filter ACMR --name-only main.. -- test/ && git ls-files --exclude-standard --others -- test/",
-    "test:diff": "npm run test:diff:v8 && npm run test:diff:spidermonkey && npm run test:diff:chakra && npm run test:diff:javascriptcore",
+    "test:diff": "npm run test:diff:v8 && npm run test:diff:spidermonkey && npm run test:diff:javascriptcore",
     "test:diff:v8": "test262-harness -t 8 --hostType=d8 --hostPath=v8 $(npm run --silent diff)",
     "test:diff:spidermonkey": "test262-harness -t 8 --hostType=jsshell --hostPath=spidermonkey $(npm run --silent diff)",
-    "test:diff:chakra": "test262-harness -t 8 --hostType=ch --hostPath=chakra $(npm run --silent diff)",
     "test:diff:javascriptcore": "test262-harness -t 8 --hostType=jsc --hostPath=javascriptcore $(npm run --silent diff)",
     "test:diff:xs": "test262-harness -t 8 --hostType=xs --hostPath=xs $(npm run --silent diff)"
   }


### PR DESCRIPTION
While still a relatively active project, ChakraCore is no longer maintained by Microsoft. It's not supported by esvu anymore and it was already disabled on CI.

Also realized while making this PR that my editor automatically trimmed some unnecessary whitespace from CONTRIBUTING.md, wasn't sure if I should go back and get rid of those changes or if it's actually okay. Let me know either way.