### PR TITLE
Refactor dayPeriod formatting tests to be robust to CLDR changes

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/format/dayPeriod-long-en.js
+++ b/test/intl402/DateTimeFormat/prototype/format/dayPeriod-long-en.js
@@ -6,88 +6,76 @@ esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, long format.
 features: [Intl.DateTimeFormat-dayPeriod]
 locale: [en]
+includes: [compareArray.js]
 ---*/
 
-const d0000 = new Date(2017, 11, 12,  0, 0, 0, 0);
-const d0100 = new Date(2017, 11, 12,  1, 0, 0, 0);
-const d0200 = new Date(2017, 11, 12,  2, 0, 0, 0);
-const d0300 = new Date(2017, 11, 12,  3, 0, 0, 0);
-const d0400 = new Date(2017, 11, 12,  4, 0, 0, 0);
-const d0500 = new Date(2017, 11, 12,  5, 0, 0, 0);
-const d0600 = new Date(2017, 11, 12,  6, 0, 0, 0);
-const d0700 = new Date(2017, 11, 12,  7, 0, 0, 0);
-const d0800 = new Date(2017, 11, 12,  8, 0, 0, 0);
-const d0900 = new Date(2017, 11, 12,  9, 0, 0, 0);
-const d1000 = new Date(2017, 11, 12, 10, 0, 0, 0);
-const d1100 = new Date(2017, 11, 12, 11, 0, 0, 0);
-const d1200 = new Date(2017, 11, 12, 12, 0, 0, 0);
-const d1300 = new Date(2017, 11, 12, 13, 0, 0, 0);
-const d1400 = new Date(2017, 11, 12, 14, 0, 0, 0);
-const d1500 = new Date(2017, 11, 12, 15, 0, 0, 0);
-const d1600 = new Date(2017, 11, 12, 16, 0, 0, 0);
-const d1700 = new Date(2017, 11, 12, 17, 0, 0, 0);
-const d1800 = new Date(2017, 11, 12, 18, 0, 0, 0);
-const d1900 = new Date(2017, 11, 12, 19, 0, 0, 0);
-const d2000 = new Date(2017, 11, 12, 20, 0, 0, 0);
-const d2100 = new Date(2017, 11, 12, 21, 0, 0, 0);
-const d2200 = new Date(2017, 11, 12, 22, 0, 0, 0);
-const d2300 = new Date(2017, 11, 12, 23, 0, 0, 0);
+// Each expected dayPeriod value must be a) contiguous, and
+// b) represented in sequence.
+var expectedDayPeriods = [
+  'in the morning',
+  'noon',
+  'in the afternoon',
+  'in the evening',
+  'at night'
+];
 
-const long = new Intl.DateTimeFormat('en', {
+// Cover all 24 hours of a single day.
+var inputs = [];
+for (var h = 0; h < 24; h++) {
+  inputs.push(new Date(2017, 11, 12,  h, 0, 0, 0));
+}
+
+// Verify complete and exclusive representation.
+var formatter = new Intl.DateTimeFormat('en', {
   dayPeriod: 'long'
 });
+var observedDayPeriods = [];
+var unexpectedDayPeriods = [];
+for (var h = 0; h < 24; h++) {
+  var dayPeriod = formatter.format(inputs[h]);
+  observedDayPeriods.push(dayPeriod);
+  if (expectedDayPeriods.indexOf(dayPeriod) === -1) {
+    unexpectedDayPeriods.push(dayPeriod);
+  }
+}
+var unusedDayPeriods = expectedDayPeriods.filter(function (dayPeriod) {
+  return observedDayPeriods.indexOf(dayPeriod) === -1;
+});
+assert.compareArray(unexpectedDayPeriods, [],
+  'unexpected dayPeriods: ' + unexpectedDayPeriods.join());
+assert.compareArray(unusedDayPeriods, [],
+  'unused dayPeriods: ' + unusedDayPeriods.join());
 
-assert.sameValue(long.format(d0000), 'at night', '00:00, long format');
-assert.sameValue(long.format(d0100), 'at night', '01:00, long format');
-assert.sameValue(long.format(d0200), 'at night', '02:00, long format');
-assert.sameValue(long.format(d0300), 'at night', '03:00, long format');
-assert.sameValue(long.format(d0400), 'at night', '04:00, long format');
-assert.sameValue(long.format(d0500), 'at night', '05:00, long format');
-assert.sameValue(long.format(d0600), 'in the morning', '06:00, long format');
-assert.sameValue(long.format(d0700), 'in the morning', '07:00, long format');
-assert.sameValue(long.format(d0800), 'in the morning', '08:00, long format');
-assert.sameValue(long.format(d0900), 'in the morning', '09:00, long format');
-assert.sameValue(long.format(d1000), 'in the morning', '10:00, long format');
-assert.sameValue(long.format(d1100), 'in the morning', '11:00, long format');
-assert.sameValue(long.format(d1200), 'noon', '12:00, long format');
-assert.sameValue(long.format(d1300), 'in the afternoon', '13:00, long format');
-assert.sameValue(long.format(d1400), 'in the afternoon', '14:00, long format');
-assert.sameValue(long.format(d1500), 'in the afternoon', '15:00, long format');
-assert.sameValue(long.format(d1600), 'in the afternoon', '16:00, long format');
-assert.sameValue(long.format(d1700), 'in the afternoon', '17:00, long format');
-assert.sameValue(long.format(d1800), 'in the evening', '18:00, long format');
-assert.sameValue(long.format(d1900), 'in the evening', '19:00, long format');
-assert.sameValue(long.format(d2000), 'in the evening', '20:00, long format');
-assert.sameValue(long.format(d2100), 'at night', '21:00, long format');
-assert.sameValue(long.format(d2200), 'at night', '22:00, long format');
-assert.sameValue(long.format(d2300), 'at night', '23:00, long format');
+function arrayAt(arr, relIndex) {
+  var realIndex = relIndex < 0 ? arr.length + relIndex : relIndex;
+  if (realIndex < 0 || realIndex >= arr.length) return undefined;
+  return arr[realIndex];
+}
 
-const longNumeric = new Intl.DateTimeFormat('en', {
+// Verify ordering, accounting for the possibility of one value spanning day
+// transitions.
+var transitionCount = 0;
+for (var h = 0; h < 24; h++) {
+  var dayPeriod = observedDayPeriods[h];
+  var prevDayPeriod = arrayAt(observedDayPeriods, h - 1);
+  if (dayPeriod === prevDayPeriod) continue;
+  transitionCount++;
+  var i = expectedDayPeriods.indexOf(dayPeriod);
+  assert.sameValue(prevDayPeriod, arrayAt(expectedDayPeriods, i - 1),
+    dayPeriod + ' must be preceded by ' + prevDayPeriod);
+}
+assert.sameValue(transitionCount, expectedDayPeriods.length,
+  'dayPeriods must be contiguous');
+
+var numericFormatter = new Intl.DateTimeFormat('en', {
   dayPeriod: 'long',
   hour: 'numeric'
 });
-
-assert.sameValue(longNumeric.format(d0000), '12 at night', '00:00, long-numeric');
-assert.sameValue(longNumeric.format(d0100), '1 at night', '01:00, long-numeric');
-assert.sameValue(longNumeric.format(d0200), '2 at night', '02:00, long-numeric');
-assert.sameValue(longNumeric.format(d0300), '3 at night', '03:00, long-numeric');
-assert.sameValue(longNumeric.format(d0400), '4 at night', '04:00, long-numeric');
-assert.sameValue(longNumeric.format(d0500), '5 at night', '05:00, long-numeric');
-assert.sameValue(longNumeric.format(d0600), '6 in the morning', '06:00, long-numeric');
-assert.sameValue(longNumeric.format(d0700), '7 in the morning', '07:00, long-numeric');
-assert.sameValue(longNumeric.format(d0800), '8 in the morning', '08:00, long-numeric');
-assert.sameValue(longNumeric.format(d0900), '9 in the morning', '09:00, long-numeric');
-assert.sameValue(longNumeric.format(d1000), '10 in the morning', '10:00, long-numeric');
-assert.sameValue(longNumeric.format(d1100), '11 in the morning', '11:00, long-numeric');
-assert.sameValue(longNumeric.format(d1200), '12 noon', '12:00, long-numeric');
-assert.sameValue(longNumeric.format(d1300), '1 in the afternoon', '13:00, long-numeric');
-assert.sameValue(longNumeric.format(d1400), '2 in the afternoon', '14:00, long-numeric');
-assert.sameValue(longNumeric.format(d1500), '3 in the afternoon', '15:00, long-numeric');
-assert.sameValue(longNumeric.format(d1600), '4 in the afternoon', '16:00, long-numeric');
-assert.sameValue(longNumeric.format(d1700), '5 in the afternoon', '17:00, long-numeric');
-assert.sameValue(longNumeric.format(d1800), '6 in the evening', '18:00, long-numeric');
-assert.sameValue(longNumeric.format(d1900), '7 in the evening', '19:00, long-numeric');
-assert.sameValue(longNumeric.format(d2000), '8 in the evening', '20:00, long-numeric');
-assert.sameValue(longNumeric.format(d2100), '9 at night', '21:00, long-numeric');
-assert.sameValue(longNumeric.format(d2200), '10 at night', '22:00, long-numeric');
-assert.sameValue(longNumeric.format(d2300), '11 at night', '23:00, long-numeric');
+for (var h = 0; h < 24; h++) {
+  assert.sameValue(
+    numericFormatter.format(inputs[h]),
+    // Hour "00" is represented as "12".
+    ((h % 12) || 12) + ' ' + observedDayPeriods[h],
+    'numeric hour must precede dayPeriod'
+  );
+}

--- a/test/intl402/DateTimeFormat/prototype/format/dayPeriod-narrow-en.js
+++ b/test/intl402/DateTimeFormat/prototype/format/dayPeriod-narrow-en.js
@@ -6,88 +6,76 @@ esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, narrow format.
 features: [Intl.DateTimeFormat-dayPeriod]
 locale: [en]
+includes: [compareArray.js]
 ---*/
 
-const d0000 = new Date(2017, 11, 12,  0, 0, 0, 0);
-const d0100 = new Date(2017, 11, 12,  1, 0, 0, 0);
-const d0200 = new Date(2017, 11, 12,  2, 0, 0, 0);
-const d0300 = new Date(2017, 11, 12,  3, 0, 0, 0);
-const d0400 = new Date(2017, 11, 12,  4, 0, 0, 0);
-const d0500 = new Date(2017, 11, 12,  5, 0, 0, 0);
-const d0600 = new Date(2017, 11, 12,  6, 0, 0, 0);
-const d0700 = new Date(2017, 11, 12,  7, 0, 0, 0);
-const d0800 = new Date(2017, 11, 12,  8, 0, 0, 0);
-const d0900 = new Date(2017, 11, 12,  9, 0, 0, 0);
-const d1000 = new Date(2017, 11, 12, 10, 0, 0, 0);
-const d1100 = new Date(2017, 11, 12, 11, 0, 0, 0);
-const d1200 = new Date(2017, 11, 12, 12, 0, 0, 0);
-const d1300 = new Date(2017, 11, 12, 13, 0, 0, 0);
-const d1400 = new Date(2017, 11, 12, 14, 0, 0, 0);
-const d1500 = new Date(2017, 11, 12, 15, 0, 0, 0);
-const d1600 = new Date(2017, 11, 12, 16, 0, 0, 0);
-const d1700 = new Date(2017, 11, 12, 17, 0, 0, 0);
-const d1800 = new Date(2017, 11, 12, 18, 0, 0, 0);
-const d1900 = new Date(2017, 11, 12, 19, 0, 0, 0);
-const d2000 = new Date(2017, 11, 12, 20, 0, 0, 0);
-const d2100 = new Date(2017, 11, 12, 21, 0, 0, 0);
-const d2200 = new Date(2017, 11, 12, 22, 0, 0, 0);
-const d2300 = new Date(2017, 11, 12, 23, 0, 0, 0);
+// Each expected dayPeriod value must be a) contiguous, and
+// b) represented in sequence.
+var expectedDayPeriods = [
+  'in the morning',
+  'n',
+  'in the afternoon',
+  'in the evening',
+  'at night'
+];
 
-const narrow = new Intl.DateTimeFormat('en', {
+// Cover all 24 hours of a single day.
+var inputs = [];
+for (var h = 0; h < 24; h++) {
+  inputs.push(new Date(2017, 11, 12,  h, 0, 0, 0));
+}
+
+// Verify complete and exclusive representation.
+var formatter = new Intl.DateTimeFormat('en', {
   dayPeriod: 'narrow'
 });
+var observedDayPeriods = [];
+var unexpectedDayPeriods = [];
+for (var h = 0; h < 24; h++) {
+  var dayPeriod = formatter.format(inputs[h]);
+  observedDayPeriods.push(dayPeriod);
+  if (expectedDayPeriods.indexOf(dayPeriod) === -1) {
+    unexpectedDayPeriods.push(dayPeriod);
+  }
+}
+var unusedDayPeriods = expectedDayPeriods.filter(function (dayPeriod) {
+  return observedDayPeriods.indexOf(dayPeriod) === -1;
+});
+assert.compareArray(unexpectedDayPeriods, [],
+  'unexpected dayPeriods: ' + unexpectedDayPeriods.join());
+assert.compareArray(unusedDayPeriods, [],
+  'unused dayPeriods: ' + unusedDayPeriods.join());
 
-assert.sameValue(narrow.format(d0000), 'at night', '00:00, narrow format');
-assert.sameValue(narrow.format(d0100), 'at night', '01:00, narrow format');
-assert.sameValue(narrow.format(d0200), 'at night', '02:00, narrow format');
-assert.sameValue(narrow.format(d0300), 'at night', '03:00, narrow format');
-assert.sameValue(narrow.format(d0400), 'at night', '04:00, narrow format');
-assert.sameValue(narrow.format(d0500), 'at night', '05:00, narrow format');
-assert.sameValue(narrow.format(d0600), 'in the morning', '06:00, narrow format');
-assert.sameValue(narrow.format(d0700), 'in the morning', '07:00, narrow format');
-assert.sameValue(narrow.format(d0800), 'in the morning', '08:00, narrow format');
-assert.sameValue(narrow.format(d0900), 'in the morning', '09:00, narrow format');
-assert.sameValue(narrow.format(d1000), 'in the morning', '10:00, narrow format');
-assert.sameValue(narrow.format(d1100), 'in the morning', '11:00, narrow format');
-assert.sameValue(narrow.format(d1200), 'n', '12:00, narrow format');
-assert.sameValue(narrow.format(d1300), 'in the afternoon', '13:00, narrow format');
-assert.sameValue(narrow.format(d1400), 'in the afternoon', '14:00, narrow format');
-assert.sameValue(narrow.format(d1500), 'in the afternoon', '15:00, narrow format');
-assert.sameValue(narrow.format(d1600), 'in the afternoon', '16:00, narrow format');
-assert.sameValue(narrow.format(d1700), 'in the afternoon', '17:00, narrow format');
-assert.sameValue(narrow.format(d1800), 'in the evening', '18:00, narrow format');
-assert.sameValue(narrow.format(d1900), 'in the evening', '19:00, narrow format');
-assert.sameValue(narrow.format(d2000), 'in the evening', '20:00, narrow format');
-assert.sameValue(narrow.format(d2100), 'at night', '21:00, narrow format');
-assert.sameValue(narrow.format(d2200), 'at night', '22:00, narrow format');
-assert.sameValue(narrow.format(d2300), 'at night', '23:00, narrow format');
+function arrayAt(arr, relIndex) {
+  var realIndex = relIndex < 0 ? arr.length + relIndex : relIndex;
+  if (realIndex < 0 || realIndex >= arr.length) return undefined;
+  return arr[realIndex];
+}
 
-const narrowNumeric = new Intl.DateTimeFormat('en', {
+// Verify ordering, accounting for the possibility of one value spanning day
+// transitions.
+var transitionCount = 0;
+for (var h = 0; h < 24; h++) {
+  var dayPeriod = observedDayPeriods[h];
+  var prevDayPeriod = arrayAt(observedDayPeriods, h - 1);
+  if (dayPeriod === prevDayPeriod) continue;
+  transitionCount++;
+  var i = expectedDayPeriods.indexOf(dayPeriod);
+  assert.sameValue(prevDayPeriod, arrayAt(expectedDayPeriods, i - 1),
+    dayPeriod + ' must be preceded by ' + prevDayPeriod);
+}
+assert.sameValue(transitionCount, expectedDayPeriods.length,
+  'dayPeriods must be contiguous');
+
+var numericFormatter = new Intl.DateTimeFormat('en', {
   dayPeriod: 'narrow',
   hour: 'numeric'
 });
-
-assert.sameValue(narrowNumeric.format(d0000), '12 at night', '00:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d0100), '1 at night', '01:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d0200), '2 at night', '02:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d0300), '3 at night', '03:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d0400), '4 at night', '04:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d0500), '5 at night', '05:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d0600), '6 in the morning', '06:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d0700), '7 in the morning', '07:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d0800), '8 in the morning', '08:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d0900), '9 in the morning', '09:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d1000), '10 in the morning', '10:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d1100), '11 in the morning', '11:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d1200), '12 n', '12:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d1300), '1 in the afternoon', '13:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d1400), '2 in the afternoon', '14:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d1500), '3 in the afternoon', '15:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d1600), '4 in the afternoon', '16:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d1700), '5 in the afternoon', '17:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d1800), '6 in the evening', '18:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d1900), '7 in the evening', '19:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d2000), '8 in the evening', '20:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d2100), '9 at night', '21:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d2200), '10 at night', '22:00, narrow-numeric');
-assert.sameValue(narrowNumeric.format(d2300), '11 at night', '23:00, narrow-numeric');
+for (var h = 0; h < 24; h++) {
+  assert.sameValue(
+    numericFormatter.format(inputs[h]),
+    // Hour "00" is represented as "12".
+    ((h % 12) || 12) + ' ' + observedDayPeriods[h],
+    'numeric hour must precede dayPeriod'
+  );
+}

--- a/test/intl402/DateTimeFormat/prototype/format/dayPeriod-short-en.js
+++ b/test/intl402/DateTimeFormat/prototype/format/dayPeriod-short-en.js
@@ -6,88 +6,76 @@ esid: sec-initializedatetimeformat
 description: Checks basic handling of dayPeriod, short format.
 features: [Intl.DateTimeFormat-dayPeriod]
 locale: [en]
+includes: [compareArray.js]
 ---*/
 
-const d0000 = new Date(2017, 11, 12,  0, 0, 0, 0);
-const d0100 = new Date(2017, 11, 12,  1, 0, 0, 0);
-const d0200 = new Date(2017, 11, 12,  2, 0, 0, 0);
-const d0300 = new Date(2017, 11, 12,  3, 0, 0, 0);
-const d0400 = new Date(2017, 11, 12,  4, 0, 0, 0);
-const d0500 = new Date(2017, 11, 12,  5, 0, 0, 0);
-const d0600 = new Date(2017, 11, 12,  6, 0, 0, 0);
-const d0700 = new Date(2017, 11, 12,  7, 0, 0, 0);
-const d0800 = new Date(2017, 11, 12,  8, 0, 0, 0);
-const d0900 = new Date(2017, 11, 12,  9, 0, 0, 0);
-const d1000 = new Date(2017, 11, 12, 10, 0, 0, 0);
-const d1100 = new Date(2017, 11, 12, 11, 0, 0, 0);
-const d1200 = new Date(2017, 11, 12, 12, 0, 0, 0);
-const d1300 = new Date(2017, 11, 12, 13, 0, 0, 0);
-const d1400 = new Date(2017, 11, 12, 14, 0, 0, 0);
-const d1500 = new Date(2017, 11, 12, 15, 0, 0, 0);
-const d1600 = new Date(2017, 11, 12, 16, 0, 0, 0);
-const d1700 = new Date(2017, 11, 12, 17, 0, 0, 0);
-const d1800 = new Date(2017, 11, 12, 18, 0, 0, 0);
-const d1900 = new Date(2017, 11, 12, 19, 0, 0, 0);
-const d2000 = new Date(2017, 11, 12, 20, 0, 0, 0);
-const d2100 = new Date(2017, 11, 12, 21, 0, 0, 0);
-const d2200 = new Date(2017, 11, 12, 22, 0, 0, 0);
-const d2300 = new Date(2017, 11, 12, 23, 0, 0, 0);
+// Each expected dayPeriod value must be a) contiguous, and
+// b) represented in sequence.
+var expectedDayPeriods = [
+  'in the morning',
+  'noon',
+  'in the afternoon',
+  'in the evening',
+  'at night'
+];
 
-const short = new Intl.DateTimeFormat('en', {
+// Cover all 24 hours of a single day.
+var inputs = [];
+for (var h = 0; h < 24; h++) {
+  inputs.push(new Date(2017, 11, 12,  h, 0, 0, 0));
+}
+
+// Verify complete and exclusive representation.
+var formatter = new Intl.DateTimeFormat('en', {
   dayPeriod: 'short'
 });
+var observedDayPeriods = [];
+var unexpectedDayPeriods = [];
+for (var h = 0; h < 24; h++) {
+  var dayPeriod = formatter.format(inputs[h]);
+  observedDayPeriods.push(dayPeriod);
+  if (expectedDayPeriods.indexOf(dayPeriod) === -1) {
+    unexpectedDayPeriods.push(dayPeriod);
+  }
+}
+var unusedDayPeriods = expectedDayPeriods.filter(function (dayPeriod) {
+  return observedDayPeriods.indexOf(dayPeriod) === -1;
+});
+assert.compareArray(unexpectedDayPeriods, [],
+  'unexpected dayPeriods: ' + unexpectedDayPeriods.join());
+assert.compareArray(unusedDayPeriods, [],
+  'unused dayPeriods: ' + unusedDayPeriods.join());
 
-assert.sameValue(short.format(d0000), 'at night', '00:00, short format');
-assert.sameValue(short.format(d0100), 'at night', '01:00, short format');
-assert.sameValue(short.format(d0200), 'at night', '02:00, short format');
-assert.sameValue(short.format(d0300), 'at night', '03:00, short format');
-assert.sameValue(short.format(d0400), 'at night', '04:00, short format');
-assert.sameValue(short.format(d0500), 'at night', '05:00, short format');
-assert.sameValue(short.format(d0600), 'in the morning', '06:00, short format');
-assert.sameValue(short.format(d0700), 'in the morning', '07:00, short format');
-assert.sameValue(short.format(d0800), 'in the morning', '08:00, short format');
-assert.sameValue(short.format(d0900), 'in the morning', '09:00, short format');
-assert.sameValue(short.format(d1000), 'in the morning', '10:00, short format');
-assert.sameValue(short.format(d1100), 'in the morning', '11:00, short format');
-assert.sameValue(short.format(d1200), 'noon', '12:00, short format');
-assert.sameValue(short.format(d1300), 'in the afternoon', '13:00, short format');
-assert.sameValue(short.format(d1400), 'in the afternoon', '14:00, short format');
-assert.sameValue(short.format(d1500), 'in the afternoon', '15:00, short format');
-assert.sameValue(short.format(d1600), 'in the afternoon', '16:00, short format');
-assert.sameValue(short.format(d1700), 'in the afternoon', '17:00, short format');
-assert.sameValue(short.format(d1800), 'in the evening', '18:00, short format');
-assert.sameValue(short.format(d1900), 'in the evening', '19:00, short format');
-assert.sameValue(short.format(d2000), 'in the evening', '20:00, short format');
-assert.sameValue(short.format(d2100), 'at night', '21:00, short format');
-assert.sameValue(short.format(d2200), 'at night', '22:00, short format');
-assert.sameValue(short.format(d2300), 'at night', '23:00, short format');
+function arrayAt(arr, relIndex) {
+  var realIndex = relIndex < 0 ? arr.length + relIndex : relIndex;
+  if (realIndex < 0 || realIndex >= arr.length) return undefined;
+  return arr[realIndex];
+}
 
-const shortNumeric = new Intl.DateTimeFormat('en', {
+// Verify ordering, accounting for the possibility of one value spanning day
+// transitions.
+var transitionCount = 0;
+for (var h = 0; h < 24; h++) {
+  var dayPeriod = observedDayPeriods[h];
+  var prevDayPeriod = arrayAt(observedDayPeriods, h - 1);
+  if (dayPeriod === prevDayPeriod) continue;
+  transitionCount++;
+  var i = expectedDayPeriods.indexOf(dayPeriod);
+  assert.sameValue(prevDayPeriod, arrayAt(expectedDayPeriods, i - 1),
+    dayPeriod + ' must be preceded by ' + prevDayPeriod);
+}
+assert.sameValue(transitionCount, expectedDayPeriods.length,
+  'dayPeriods must be contiguous');
+
+var numericFormatter = new Intl.DateTimeFormat('en', {
   dayPeriod: 'short',
   hour: 'numeric'
 });
-
-assert.sameValue(shortNumeric.format(d0000), '12 at night', '00:00, short-numeric');
-assert.sameValue(shortNumeric.format(d0100), '1 at night', '01:00, short-numeric');
-assert.sameValue(shortNumeric.format(d0200), '2 at night', '02:00, short-numeric');
-assert.sameValue(shortNumeric.format(d0300), '3 at night', '03:00, short-numeric');
-assert.sameValue(shortNumeric.format(d0400), '4 at night', '04:00, short-numeric');
-assert.sameValue(shortNumeric.format(d0500), '5 at night', '05:00, short-numeric');
-assert.sameValue(shortNumeric.format(d0600), '6 in the morning', '06:00, short-numeric');
-assert.sameValue(shortNumeric.format(d0700), '7 in the morning', '07:00, short-numeric');
-assert.sameValue(shortNumeric.format(d0800), '8 in the morning', '08:00, short-numeric');
-assert.sameValue(shortNumeric.format(d0900), '9 in the morning', '09:00, short-numeric');
-assert.sameValue(shortNumeric.format(d1000), '10 in the morning', '10:00, short-numeric');
-assert.sameValue(shortNumeric.format(d1100), '11 in the morning', '11:00, short-numeric');
-assert.sameValue(shortNumeric.format(d1200), '12 noon', '12:00, short-numeric');
-assert.sameValue(shortNumeric.format(d1300), '1 in the afternoon', '13:00, short-numeric');
-assert.sameValue(shortNumeric.format(d1400), '2 in the afternoon', '14:00, short-numeric');
-assert.sameValue(shortNumeric.format(d1500), '3 in the afternoon', '15:00, short-numeric');
-assert.sameValue(shortNumeric.format(d1600), '4 in the afternoon', '16:00, short-numeric');
-assert.sameValue(shortNumeric.format(d1700), '5 in the afternoon', '17:00, short-numeric');
-assert.sameValue(shortNumeric.format(d1800), '6 in the evening', '18:00, short-numeric');
-assert.sameValue(shortNumeric.format(d1900), '7 in the evening', '19:00, short-numeric');
-assert.sameValue(shortNumeric.format(d2000), '8 in the evening', '20:00, short-numeric');
-assert.sameValue(shortNumeric.format(d2100), '9 at night', '21:00, short-numeric');
-assert.sameValue(shortNumeric.format(d2200), '10 at night', '22:00, short-numeric');
-assert.sameValue(shortNumeric.format(d2300), '11 at night', '23:00, short-numeric');
+for (var h = 0; h < 24; h++) {
+  assert.sameValue(
+    numericFormatter.format(inputs[h]),
+    // Hour "00" is represented as "12".
+    ((h % 12) || 12) + ' ' + observedDayPeriods[h],
+    'numeric hour must precede dayPeriod'
+  );
+}

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-long-en.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-long-en.js
@@ -5,67 +5,76 @@
 esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, long format.
 features: [Intl.DateTimeFormat-dayPeriod]
+includes: [compareArray.js]
 ---*/
 
-const d0000 = new Date(2017, 11, 12,  0, 0, 0, 0);
-const d0100 = new Date(2017, 11, 12,  1, 0, 0, 0);
-const d0200 = new Date(2017, 11, 12,  2, 0, 0, 0);
-const d0300 = new Date(2017, 11, 12,  3, 0, 0, 0);
-const d0400 = new Date(2017, 11, 12,  4, 0, 0, 0);
-const d0500 = new Date(2017, 11, 12,  5, 0, 0, 0);
-const d0600 = new Date(2017, 11, 12,  6, 0, 0, 0);
-const d0700 = new Date(2017, 11, 12,  7, 0, 0, 0);
-const d0800 = new Date(2017, 11, 12,  8, 0, 0, 0);
-const d0900 = new Date(2017, 11, 12,  9, 0, 0, 0);
-const d1000 = new Date(2017, 11, 12, 10, 0, 0, 0);
-const d1100 = new Date(2017, 11, 12, 11, 0, 0, 0);
-const d1200 = new Date(2017, 11, 12, 12, 0, 0, 0);
-const d1300 = new Date(2017, 11, 12, 13, 0, 0, 0);
-const d1400 = new Date(2017, 11, 12, 14, 0, 0, 0);
-const d1500 = new Date(2017, 11, 12, 15, 0, 0, 0);
-const d1600 = new Date(2017, 11, 12, 16, 0, 0, 0);
-const d1700 = new Date(2017, 11, 12, 17, 0, 0, 0);
-const d1800 = new Date(2017, 11, 12, 18, 0, 0, 0);
-const d1900 = new Date(2017, 11, 12, 19, 0, 0, 0);
-const d2000 = new Date(2017, 11, 12, 20, 0, 0, 0);
-const d2100 = new Date(2017, 11, 12, 21, 0, 0, 0);
-const d2200 = new Date(2017, 11, 12, 22, 0, 0, 0);
-const d2300 = new Date(2017, 11, 12, 23, 0, 0, 0);
+// Each expected dayPeriod value must be a) contiguous, and
+// b) represented in sequence.
+var expectedDayPeriods = [
+  'in the morning',
+  'noon',
+  'in the afternoon',
+  'in the evening',
+  'at night'
+];
 
-const long = new Intl.DateTimeFormat('en', { dayPeriod: 'long' });
+// Cover all 24 hours of a single day.
+var inputs = [];
+for (var h = 0; h < 24; h++) {
+  inputs.push(new Date(2017, 11, 12,  h, 0, 0, 0));
+}
 
-function assertParts(parts, expected, message) {
+var formatter = new Intl.DateTimeFormat('en', {
+  dayPeriod: 'long'
+});
+
+function assertParts(parts, message) {
   assert.sameValue(parts.length, 1, `length should be 1, ${message}`);
-  assert.sameValue(parts[0].value, expected, `expected part value. ${message}`);
   assert.sameValue(parts[0].type, 'dayPeriod', `part type is dayPeriod. ${message}`);
 }
 
-assertParts(long.formatToParts(d0000), 'at night', '00:00, long format');
-assertParts(long.formatToParts(d0100), 'at night', '01:00, long format');
-assertParts(long.formatToParts(d0200), 'at night', '02:00, long format');
-assertParts(long.formatToParts(d0300), 'at night', '03:00, long format');
-assertParts(long.formatToParts(d0400), 'at night', '04:00, long format');
-assertParts(long.formatToParts(d0500), 'at night', '05:00, long format');
-assertParts(long.formatToParts(d0600), 'in the morning', '06:00, long format');
-assertParts(long.formatToParts(d0700), 'in the morning', '07:00, long format');
-assertParts(long.formatToParts(d0800), 'in the morning', '08:00, long format');
-assertParts(long.formatToParts(d0900), 'in the morning', '09:00, long format');
-assertParts(long.formatToParts(d1000), 'in the morning', '10:00, long format');
-assertParts(long.formatToParts(d1100), 'in the morning', '11:00, long format');
-assertParts(long.formatToParts(d1200), 'noon', '12:00, long format');
-assertParts(long.formatToParts(d1300), 'in the afternoon', '13:00, long format');
-assertParts(long.formatToParts(d1400), 'in the afternoon', '14:00, long format');
-assertParts(long.formatToParts(d1500), 'in the afternoon', '15:00, long format');
-assertParts(long.formatToParts(d1600), 'in the afternoon', '16:00, long format');
-assertParts(long.formatToParts(d1700), 'in the afternoon', '17:00, long format');
-assertParts(long.formatToParts(d1800), 'in the evening', '18:00, long format');
-assertParts(long.formatToParts(d1900), 'in the evening', '19:00, long format');
-assertParts(long.formatToParts(d2000), 'in the evening', '20:00, long format');
-assertParts(long.formatToParts(d2100), 'at night', '21:00, long format');
-assertParts(long.formatToParts(d2200), 'at night', '22:00, long format');
-assertParts(long.formatToParts(d2300), 'at night', '23:00, long format');
+// Verify complete and exclusive representation.
+var observedDayPeriods = [];
+var unexpectedDayPeriods = [];
+for (var h = 0; h < 24; h++) {
+  var parts = formatter.formatToParts(inputs[h]);
+  assertParts(parts, 'dayPeriod-only formatting for ' + inputs[h]);
+  var dayPeriod = parts[0].value;
+  observedDayPeriods.push(dayPeriod);
+  if (expectedDayPeriods.indexOf(dayPeriod) === -1) {
+    unexpectedDayPeriods.push(dayPeriod);
+  }
+}
+var unusedDayPeriods = expectedDayPeriods.filter(function (dayPeriod) {
+  return observedDayPeriods.indexOf(dayPeriod) === -1;
+});
+assert.compareArray(unexpectedDayPeriods, [],
+  'unexpected dayPeriods: ' + unexpectedDayPeriods.join());
+assert.compareArray(unusedDayPeriods, [],
+  'unused dayPeriods: ' + unusedDayPeriods.join());
 
-const longNumeric = new Intl.DateTimeFormat('en', {
+function arrayAt(arr, relIndex) {
+  var realIndex = relIndex < 0 ? arr.length + relIndex : relIndex;
+  if (realIndex < 0 || realIndex >= arr.length) return undefined;
+  return arr[realIndex];
+}
+
+// Verify ordering, accounting for the possibility of one value spanning day
+// transitions.
+var transitionCount = 0;
+for (var h = 0; h < 24; h++) {
+  var dayPeriod = observedDayPeriods[h];
+  var prevDayPeriod = arrayAt(observedDayPeriods, h - 1);
+  if (dayPeriod === prevDayPeriod) continue;
+  transitionCount++;
+  var i = expectedDayPeriods.indexOf(dayPeriod);
+  assert.sameValue(prevDayPeriod, arrayAt(expectedDayPeriods, i - 1),
+    dayPeriod + ' must be preceded by ' + prevDayPeriod);
+}
+assert.sameValue(transitionCount, expectedDayPeriods.length,
+  'dayPeriods must be contiguous');
+
+var numericFormatter = new Intl.DateTimeFormat('en', {
   dayPeriod: 'long',
   hour: 'numeric'
 });
@@ -80,27 +89,12 @@ function assertPartsNumeric(parts, hour, expected, message) {
   assert.sameValue(parts[2].type, 'dayPeriod', `expected part type. ${message}`);
 }
 
-assertPartsNumeric(longNumeric.formatToParts(d0000), '12', 'at night', '00:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d0100),  '1', 'at night', '01:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d0200),  '2', 'at night', '02:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d0300),  '3', 'at night', '03:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d0400),  '4', 'at night', '04:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d0500),  '5', 'at night', '05:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d0600),  '6', 'in the morning', '06:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d0700),  '7', 'in the morning', '07:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d0800),  '8', 'in the morning', '08:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d0900),  '9', 'in the morning', '09:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d1000), '10', 'in the morning', '10:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d1100), '11', 'in the morning', '11:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d1200), '12', 'noon', '12:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d1300),  '1', 'in the afternoon', '13:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d1400),  '2', 'in the afternoon', '14:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d1500),  '3', 'in the afternoon', '15:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d1600),  '4', 'in the afternoon', '16:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d1700),  '5', 'in the afternoon', '17:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d1800),  '6', 'in the evening', '18:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d1900),  '7', 'in the evening', '19:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d2000),  '8', 'in the evening', '20:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d2100),  '9', 'at night', '21:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d2200), '10', 'at night', '22:00, long-numeric');
-assertPartsNumeric(longNumeric.formatToParts(d2300), '11', 'at night', '23:00, long-numeric');
+for (var h = 0; h < 24; h++) {
+  assertPartsNumeric(
+    numericFormatter.formatToParts(inputs[h]),
+    // Hour "00" is represented as "12".
+    String((h % 12) || 12),
+    observedDayPeriods[h],
+    'numeric hour must precede dayPeriod'
+  );
+}

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-narrow-en.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-narrow-en.js
@@ -5,67 +5,76 @@
 esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, narrow format.
 features: [Intl.DateTimeFormat-dayPeriod]
+includes: [compareArray.js]
 ---*/
 
-const d0000 = new Date(2017, 11, 12,  0, 0, 0, 0);
-const d0100 = new Date(2017, 11, 12,  1, 0, 0, 0);
-const d0200 = new Date(2017, 11, 12,  2, 0, 0, 0);
-const d0300 = new Date(2017, 11, 12,  3, 0, 0, 0);
-const d0400 = new Date(2017, 11, 12,  4, 0, 0, 0);
-const d0500 = new Date(2017, 11, 12,  5, 0, 0, 0);
-const d0600 = new Date(2017, 11, 12,  6, 0, 0, 0);
-const d0700 = new Date(2017, 11, 12,  7, 0, 0, 0);
-const d0800 = new Date(2017, 11, 12,  8, 0, 0, 0);
-const d0900 = new Date(2017, 11, 12,  9, 0, 0, 0);
-const d1000 = new Date(2017, 11, 12, 10, 0, 0, 0);
-const d1100 = new Date(2017, 11, 12, 11, 0, 0, 0);
-const d1200 = new Date(2017, 11, 12, 12, 0, 0, 0);
-const d1300 = new Date(2017, 11, 12, 13, 0, 0, 0);
-const d1400 = new Date(2017, 11, 12, 14, 0, 0, 0);
-const d1500 = new Date(2017, 11, 12, 15, 0, 0, 0);
-const d1600 = new Date(2017, 11, 12, 16, 0, 0, 0);
-const d1700 = new Date(2017, 11, 12, 17, 0, 0, 0);
-const d1800 = new Date(2017, 11, 12, 18, 0, 0, 0);
-const d1900 = new Date(2017, 11, 12, 19, 0, 0, 0);
-const d2000 = new Date(2017, 11, 12, 20, 0, 0, 0);
-const d2100 = new Date(2017, 11, 12, 21, 0, 0, 0);
-const d2200 = new Date(2017, 11, 12, 22, 0, 0, 0);
-const d2300 = new Date(2017, 11, 12, 23, 0, 0, 0);
+// Each expected dayPeriod value must be a) contiguous, and
+// b) represented in sequence.
+var expectedDayPeriods = [
+  'in the morning',
+  'n',
+  'in the afternoon',
+  'in the evening',
+  'at night'
+];
 
-const narrow = new Intl.DateTimeFormat('en', { dayPeriod: 'narrow' });
+// Cover all 24 hours of a single day.
+var inputs = [];
+for (var h = 0; h < 24; h++) {
+  inputs.push(new Date(2017, 11, 12,  h, 0, 0, 0));
+}
 
-function assertParts(parts, expected, message) {
+var formatter = new Intl.DateTimeFormat('en', {
+  dayPeriod: 'narrow'
+});
+
+function assertParts(parts, message) {
   assert.sameValue(parts.length, 1, `length should be 1, ${message}`);
-  assert.sameValue(parts[0].value, expected, `expected part value. ${message}`);
   assert.sameValue(parts[0].type, 'dayPeriod', `part type is dayPeriod. ${message}`);
 }
 
-assertParts(narrow.formatToParts(d0000), 'at night', '00:00, narrow format');
-assertParts(narrow.formatToParts(d0100), 'at night', '01:00, narrow format');
-assertParts(narrow.formatToParts(d0200), 'at night', '02:00, narrow format');
-assertParts(narrow.formatToParts(d0300), 'at night', '03:00, narrow format');
-assertParts(narrow.formatToParts(d0400), 'at night', '04:00, narrow format');
-assertParts(narrow.formatToParts(d0500), 'at night', '05:00, narrow format');
-assertParts(narrow.formatToParts(d0600), 'in the morning', '06:00, narrow format');
-assertParts(narrow.formatToParts(d0700), 'in the morning', '07:00, narrow format');
-assertParts(narrow.formatToParts(d0800), 'in the morning', '08:00, narrow format');
-assertParts(narrow.formatToParts(d0900), 'in the morning', '09:00, narrow format');
-assertParts(narrow.formatToParts(d1000), 'in the morning', '10:00, narrow format');
-assertParts(narrow.formatToParts(d1100), 'in the morning', '11:00, narrow format');
-assertParts(narrow.formatToParts(d1200), 'n', '12:00, narrow format');
-assertParts(narrow.formatToParts(d1300), 'in the afternoon', '13:00, narrow format');
-assertParts(narrow.formatToParts(d1400), 'in the afternoon', '14:00, narrow format');
-assertParts(narrow.formatToParts(d1500), 'in the afternoon', '15:00, narrow format');
-assertParts(narrow.formatToParts(d1600), 'in the afternoon', '16:00, narrow format');
-assertParts(narrow.formatToParts(d1700), 'in the afternoon', '17:00, narrow format');
-assertParts(narrow.formatToParts(d1800), 'in the evening', '18:00, narrow format');
-assertParts(narrow.formatToParts(d1900), 'in the evening', '19:00, narrow format');
-assertParts(narrow.formatToParts(d2000), 'in the evening', '20:00, narrow format');
-assertParts(narrow.formatToParts(d2100), 'at night', '21:00, narrow format');
-assertParts(narrow.formatToParts(d2200), 'at night', '22:00, narrow format');
-assertParts(narrow.formatToParts(d2300), 'at night', '23:00, narrow format');
+// Verify complete and exclusive representation.
+var observedDayPeriods = [];
+var unexpectedDayPeriods = [];
+for (var h = 0; h < 24; h++) {
+  var parts = formatter.formatToParts(inputs[h]);
+  assertParts(parts, 'dayPeriod-only formatting for ' + inputs[h]);
+  var dayPeriod = parts[0].value;
+  observedDayPeriods.push(dayPeriod);
+  if (expectedDayPeriods.indexOf(dayPeriod) === -1) {
+    unexpectedDayPeriods.push(dayPeriod);
+  }
+}
+var unusedDayPeriods = expectedDayPeriods.filter(function (dayPeriod) {
+  return observedDayPeriods.indexOf(dayPeriod) === -1;
+});
+assert.compareArray(unexpectedDayPeriods, [],
+  'unexpected dayPeriods: ' + unexpectedDayPeriods.join());
+assert.compareArray(unusedDayPeriods, [],
+  'unused dayPeriods: ' + unusedDayPeriods.join());
 
-const narrowNumeric = new Intl.DateTimeFormat('en', {
+function arrayAt(arr, relIndex) {
+  var realIndex = relIndex < 0 ? arr.length + relIndex : relIndex;
+  if (realIndex < 0 || realIndex >= arr.length) return undefined;
+  return arr[realIndex];
+}
+
+// Verify ordering, accounting for the possibility of one value spanning day
+// transitions.
+var transitionCount = 0;
+for (var h = 0; h < 24; h++) {
+  var dayPeriod = observedDayPeriods[h];
+  var prevDayPeriod = arrayAt(observedDayPeriods, h - 1);
+  if (dayPeriod === prevDayPeriod) continue;
+  transitionCount++;
+  var i = expectedDayPeriods.indexOf(dayPeriod);
+  assert.sameValue(prevDayPeriod, arrayAt(expectedDayPeriods, i - 1),
+    dayPeriod + ' must be preceded by ' + prevDayPeriod);
+}
+assert.sameValue(transitionCount, expectedDayPeriods.length,
+  'dayPeriods must be contiguous');
+
+var numericFormatter = new Intl.DateTimeFormat('en', {
   dayPeriod: 'narrow',
   hour: 'numeric'
 });
@@ -80,27 +89,12 @@ function assertPartsNumeric(parts, hour, expected, message) {
   assert.sameValue(parts[2].type, 'dayPeriod', `expected part type. ${message}`);
 }
 
-assertPartsNumeric(narrowNumeric.formatToParts(d0000), '12', 'at night', '00:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d0100),  '1', 'at night', '01:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d0200),  '2', 'at night', '02:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d0300),  '3', 'at night', '03:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d0400),  '4', 'at night', '04:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d0500),  '5', 'at night', '05:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d0600),  '6', 'in the morning', '06:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d0700),  '7', 'in the morning', '07:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d0800),  '8', 'in the morning', '08:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d0900),  '9', 'in the morning', '09:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d1000), '10', 'in the morning', '10:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d1100), '11', 'in the morning', '11:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d1200), '12', 'n', '12:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d1300),  '1', 'in the afternoon', '13:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d1400),  '2', 'in the afternoon', '14:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d1500),  '3', 'in the afternoon', '15:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d1600),  '4', 'in the afternoon', '16:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d1700),  '5', 'in the afternoon', '17:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d1800),  '6', 'in the evening', '18:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d1900),  '7', 'in the evening', '19:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d2000),  '8', 'in the evening', '20:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d2100),  '9', 'at night', '21:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d2200), '10', 'at night', '22:00, narrow-numeric');
-assertPartsNumeric(narrowNumeric.formatToParts(d2300), '11', 'at night', '23:00, narrow-numeric');
+for (var h = 0; h < 24; h++) {
+  assertPartsNumeric(
+    numericFormatter.formatToParts(inputs[h]),
+    // Hour "00" is represented as "12".
+    String((h % 12) || 12),
+    observedDayPeriods[h],
+    'numeric hour must precede dayPeriod'
+  );
+}

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-short-en.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-short-en.js
@@ -5,67 +5,76 @@
 esid: sec-createdatetimeformat
 description: Checks basic handling of dayPeriod, short format.
 features: [Intl.DateTimeFormat-dayPeriod]
+includes: [compareArray.js]
 ---*/
 
-const d0000 = new Date(2017, 11, 12,  0, 0, 0, 0);
-const d0100 = new Date(2017, 11, 12,  1, 0, 0, 0);
-const d0200 = new Date(2017, 11, 12,  2, 0, 0, 0);
-const d0300 = new Date(2017, 11, 12,  3, 0, 0, 0);
-const d0400 = new Date(2017, 11, 12,  4, 0, 0, 0);
-const d0500 = new Date(2017, 11, 12,  5, 0, 0, 0);
-const d0600 = new Date(2017, 11, 12,  6, 0, 0, 0);
-const d0700 = new Date(2017, 11, 12,  7, 0, 0, 0);
-const d0800 = new Date(2017, 11, 12,  8, 0, 0, 0);
-const d0900 = new Date(2017, 11, 12,  9, 0, 0, 0);
-const d1000 = new Date(2017, 11, 12, 10, 0, 0, 0);
-const d1100 = new Date(2017, 11, 12, 11, 0, 0, 0);
-const d1200 = new Date(2017, 11, 12, 12, 0, 0, 0);
-const d1300 = new Date(2017, 11, 12, 13, 0, 0, 0);
-const d1400 = new Date(2017, 11, 12, 14, 0, 0, 0);
-const d1500 = new Date(2017, 11, 12, 15, 0, 0, 0);
-const d1600 = new Date(2017, 11, 12, 16, 0, 0, 0);
-const d1700 = new Date(2017, 11, 12, 17, 0, 0, 0);
-const d1800 = new Date(2017, 11, 12, 18, 0, 0, 0);
-const d1900 = new Date(2017, 11, 12, 19, 0, 0, 0);
-const d2000 = new Date(2017, 11, 12, 20, 0, 0, 0);
-const d2100 = new Date(2017, 11, 12, 21, 0, 0, 0);
-const d2200 = new Date(2017, 11, 12, 22, 0, 0, 0);
-const d2300 = new Date(2017, 11, 12, 23, 0, 0, 0);
+// Each expected dayPeriod value must be a) contiguous, and
+// b) represented in sequence.
+var expectedDayPeriods = [
+  'in the morning',
+  'noon',
+  'in the afternoon',
+  'in the evening',
+  'at night'
+];
 
-const short = new Intl.DateTimeFormat('en', { dayPeriod: 'short' });
+// Cover all 24 hours of a single day.
+var inputs = [];
+for (var h = 0; h < 24; h++) {
+  inputs.push(new Date(2017, 11, 12,  h, 0, 0, 0));
+}
 
-function assertParts(parts, expected, message) {
+var formatter = new Intl.DateTimeFormat('en', {
+  dayPeriod: 'short'
+});
+
+function assertParts(parts, message) {
   assert.sameValue(parts.length, 1, `length should be 1, ${message}`);
-  assert.sameValue(parts[0].value, expected, `expected part value. ${message}`);
   assert.sameValue(parts[0].type, 'dayPeriod', `part type is dayPeriod. ${message}`);
 }
 
-assertParts(short.formatToParts(d0000), 'at night', '00:00, short format');
-assertParts(short.formatToParts(d0100), 'at night', '01:00, short format');
-assertParts(short.formatToParts(d0200), 'at night', '02:00, short format');
-assertParts(short.formatToParts(d0300), 'at night', '03:00, short format');
-assertParts(short.formatToParts(d0400), 'at night', '04:00, short format');
-assertParts(short.formatToParts(d0500), 'at night', '05:00, short format');
-assertParts(short.formatToParts(d0600), 'in the morning', '06:00, short format');
-assertParts(short.formatToParts(d0700), 'in the morning', '07:00, short format');
-assertParts(short.formatToParts(d0800), 'in the morning', '08:00, short format');
-assertParts(short.formatToParts(d0900), 'in the morning', '09:00, short format');
-assertParts(short.formatToParts(d1000), 'in the morning', '10:00, short format');
-assertParts(short.formatToParts(d1100), 'in the morning', '11:00, short format');
-assertParts(short.formatToParts(d1200), 'noon', '12:00, short format');
-assertParts(short.formatToParts(d1300), 'in the afternoon', '13:00, short format');
-assertParts(short.formatToParts(d1400), 'in the afternoon', '14:00, short format');
-assertParts(short.formatToParts(d1500), 'in the afternoon', '15:00, short format');
-assertParts(short.formatToParts(d1600), 'in the afternoon', '16:00, short format');
-assertParts(short.formatToParts(d1700), 'in the afternoon', '17:00, short format');
-assertParts(short.formatToParts(d1800), 'in the evening', '18:00, short format');
-assertParts(short.formatToParts(d1900), 'in the evening', '19:00, short format');
-assertParts(short.formatToParts(d2000), 'in the evening', '20:00, short format');
-assertParts(short.formatToParts(d2100), 'at night', '21:00, short format');
-assertParts(short.formatToParts(d2200), 'at night', '22:00, short format');
-assertParts(short.formatToParts(d2300), 'at night', '23:00, short format');
+// Verify complete and exclusive representation.
+var observedDayPeriods = [];
+var unexpectedDayPeriods = [];
+for (var h = 0; h < 24; h++) {
+  var parts = formatter.formatToParts(inputs[h]);
+  assertParts(parts, 'dayPeriod-only formatting for ' + inputs[h]);
+  var dayPeriod = parts[0].value;
+  observedDayPeriods.push(dayPeriod);
+  if (expectedDayPeriods.indexOf(dayPeriod) === -1) {
+    unexpectedDayPeriods.push(dayPeriod);
+  }
+}
+var unusedDayPeriods = expectedDayPeriods.filter(function (dayPeriod) {
+  return observedDayPeriods.indexOf(dayPeriod) === -1;
+});
+assert.compareArray(unexpectedDayPeriods, [],
+  'unexpected dayPeriods: ' + unexpectedDayPeriods.join());
+assert.compareArray(unusedDayPeriods, [],
+  'unused dayPeriods: ' + unusedDayPeriods.join());
 
-const shortNumeric = new Intl.DateTimeFormat('en', {
+function arrayAt(arr, relIndex) {
+  var realIndex = relIndex < 0 ? arr.length + relIndex : relIndex;
+  if (realIndex < 0 || realIndex >= arr.length) return undefined;
+  return arr[realIndex];
+}
+
+// Verify ordering, accounting for the possibility of one value spanning day
+// transitions.
+var transitionCount = 0;
+for (var h = 0; h < 24; h++) {
+  var dayPeriod = observedDayPeriods[h];
+  var prevDayPeriod = arrayAt(observedDayPeriods, h - 1);
+  if (dayPeriod === prevDayPeriod) continue;
+  transitionCount++;
+  var i = expectedDayPeriods.indexOf(dayPeriod);
+  assert.sameValue(prevDayPeriod, arrayAt(expectedDayPeriods, i - 1),
+    dayPeriod + ' must be preceded by ' + prevDayPeriod);
+}
+assert.sameValue(transitionCount, expectedDayPeriods.length,
+  'dayPeriods must be contiguous');
+
+var numericFormatter = new Intl.DateTimeFormat('en', {
   dayPeriod: 'short',
   hour: 'numeric'
 });
@@ -80,27 +89,12 @@ function assertPartsNumeric(parts, hour, expected, message) {
   assert.sameValue(parts[2].type, 'dayPeriod', `expected part type. ${message}`);
 }
 
-assertPartsNumeric(shortNumeric.formatToParts(d0000), '12', 'at night', '00:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d0100),  '1', 'at night', '01:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d0200),  '2', 'at night', '02:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d0300),  '3', 'at night', '03:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d0400),  '4', 'at night', '04:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d0500),  '5', 'at night', '05:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d0600),  '6', 'in the morning', '06:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d0700),  '7', 'in the morning', '07:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d0800),  '8', 'in the morning', '08:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d0900),  '9', 'in the morning', '09:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d1000), '10', 'in the morning', '10:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d1100), '11', 'in the morning', '11:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d1200), '12', 'noon', '12:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d1300),  '1', 'in the afternoon', '13:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d1400),  '2', 'in the afternoon', '14:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d1500),  '3', 'in the afternoon', '15:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d1600),  '4', 'in the afternoon', '16:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d1700),  '5', 'in the afternoon', '17:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d1800),  '6', 'in the evening', '18:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d1900),  '7', 'in the evening', '19:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d2000),  '8', 'in the evening', '20:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d2100),  '9', 'at night', '21:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d2200), '10', 'at night', '22:00, short-numeric');
-assertPartsNumeric(shortNumeric.formatToParts(d2300), '11', 'at night', '23:00, short-numeric');
+for (var h = 0; h < 24; h++) {
+  assertPartsNumeric(
+    numericFormatter.formatToParts(inputs[h]),
+    // Hour "00" is represented as "12".
+    String((h % 12) || 12),
+    observedDayPeriods[h],
+    'numeric hour must precede dayPeriod'
+  );
+}


### PR DESCRIPTION
Taken from Richard's suggestion in https://github.com/tc39/test262/pull/4428#pullrequestreview-2691878561