### PR TITLE
Escape syntax character in regex

### DIFF
--- a/test/staging/sm/Function/function-bind.js
+++ b/test/staging/sm/Function/function-bind.js
@@ -261,7 +261,7 @@ function testBound(fun)
 testBound(strict);
 testBound(nonstrict);
 
-var nativeFunctionRegex = /^function\s*\(\)\s*{\s*\[native code\]\s*}$/
+var nativeFunctionRegex = /^function\s*\(\)\s*\{\s*\[native code\]\s*\}$/
 assert.sameValue(nativeFunctionRegex.test((function unbound(){"body"}).bind().toString()), true);
 
 


### PR DESCRIPTION
Syntax characters need to be escaped when they are part of a regex.

https://tc39.es/ecma262/#prod-Atom
https://tc39.es/ecma262/#prod-PatternCharacter