### PR TITLE
RegExp: Add test cases for Unicode Script_Extensions=Unknown

### DIFF
--- a/test/built-ins/RegExp/property-escapes/special-property-value-Script_Extensions-Unknown.js
+++ b/test/built-ins/RegExp/property-escapes/special-property-value-Script_Extensions-Unknown.js
@@ -1,0 +1,17 @@
+// Copyright 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Richard Gibson
+description: >
+  Unicode property "Script_Extensions" and alias "scx" must support
+  special value "Unknown" and alias "Zzzz" (cf.
+  https://www.unicode.org/reports/tr24/#Script_Extensions_Def ).
+esid: sec-compiletocharset
+features: [regexp-unicode-property-escapes]
+---*/
+
+/\p{Script_Extensions=Unknown}/u;
+/\p{Script_Extensions=Zzzz}/u;
+/\p{scx=Unknown}/u;
+/\p{scx=Zzzz}/u;


### PR DESCRIPTION
Ref https://github.com/tc39/ecma262/issues/3590

regexp-generator is unfortunately unaware of the value: https://github.com/mathiasbynens/regenerate-unicode-properties/issues/7