### PR TITLE
[explicit-resource-management] Add remaining tests specific to `await using` statement syntax

### DIFF
--- a/test/language/statements/await-using/syntax/await-using-allowed-at-top-level-of-module.js
+++ b/test/language/statements/await-using/syntax/await-using-allowed-at-top-level-of-module.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations allowed at the top level of a module
+info: |
+  AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+flags: [module]
+features: [explicit-resource-management]
+---*/
+
+await using x = null;

--- a/test/language/statements/await-using/syntax/await-using-allows-bindingidentifier.js
+++ b/test/language/statements/await-using/syntax/await-using-allows-bindingidentifier.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' allows BindingIdentifier in lexical bindings
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+asyncTest(async function () {
+  await using x = null;
+});

--- a/test/language/statements/await-using/syntax/await-using-allows-multiple-bindings.js
+++ b/test/language/statements/await-using/syntax/await-using-allows-multiple-bindings.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' allows multiple lexical bindings
+features: [explicit-resource-management]
+---*/
+
+async function f() {
+  await using x = null, y = null;
+}

--- a/test/language/statements/await-using/syntax/await-using-declaring-let-split-across-two-lines.js
+++ b/test/language/statements/await-using/syntax/await-using-declaring-let-split-across-two-lines.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using: |await using let| split across two lines is treated as two statements.
+info: |
+  Lexical declarations may not declare a binding named "let".
+flags: [noStrict, async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await using
+  let = "irrelevant initializer";
+
+  assert(typeof let === "string");
+  var using, let;
+});

--- a/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern-after-bindingidentifier.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern-after-bindingidentifier.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' does not allow ArrayBindingPattern in lexical bindings, even after a valid lexical binding
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+async function f() {
+  await using x = null, [] = null;
+}

--- a/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern-does-not-break-element-access.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern-does-not-break-element-access.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' does not break existing element access
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+var using = [], x = 0;
+
+asyncTest(async function () {
+  await using[x];
+});

--- a/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' does not allow ArrayBindingPattern in lexical bindings
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function() {
+  await using [] = null;
+}

--- a/test/language/statements/await-using/syntax/await-using-invalid-assignment-next-expression-for.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-assignment-next-expression-for.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using: invalid assignment in next expression
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function() {
+    for (await using i = 0; i < 1; i++) {}
+  });
+});

--- a/test/language/statements/await-using/syntax/await-using-invalid-assignment-statement-body-for-of.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-assignment-statement-body-for-of.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using: invalid assignment in Statement body
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(TypeError, async function () {
+    for (await using x of [1, 2, 3]) { x++ }
+  });
+});

--- a/test/language/statements/await-using/syntax/await-using-invalid-for-in.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-for-in.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    await using: not allowed in for..in
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  for (await using x in [1, 2, 3]) { }
+}

--- a/test/language/statements/await-using/syntax/await-using-invalid-objectbindingpattern-after-bindingidentifier.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-objectbindingpattern-after-bindingidentifier.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' does not allow ObjectBindingPattern in lexical bindings, even after a valid lexical binding
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  await using x = null, {} = null;
+}

--- a/test/language/statements/await-using/syntax/await-using-invalid-objectbindingpattern.js
+++ b/test/language/statements/await-using/syntax/await-using-invalid-objectbindingpattern.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'await using' does not allow ObjectBindingPattern in lexical bindings
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  await using {} = null;
+}

--- a/test/language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-eval.js
+++ b/test/language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-eval.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations not allowed at the top level of eval
+info: |
+  AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(SyntaxError, async function () {
+    eval('await using x = null;')
+  });
+});

--- a/test/language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-script.js
+++ b/test/language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-script.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations not allowed at the top level of a Script
+info: |
+  AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+await using x = null;

--- a/test/language/statements/await-using/syntax/await-using-outer-inner-using-bindings.js
+++ b/test/language/statements/await-using/syntax/await-using-outer-inner-using-bindings.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    outer await using binding unchanged by for-loop await using binding
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  const outer_x = { [Symbol.dispose]() {} };
+  const outer_y = { [Symbol.dispose]() {} };
+  const inner_x = { [Symbol.dispose]() {} };
+  const inner_y = { [Symbol.dispose]() {} };
+
+  {
+    await using x = outer_x;
+    await using y = outer_y;
+    var i = 0;
+
+    for (await using x = inner_x; i < 1; i++) {
+      await using y = inner_y;
+
+      assert.sameValue(x, inner_x);
+      assert.sameValue(y, inner_y);
+    }
+    assert.sameValue(x, outer_x);
+    assert.sameValue(y, outer_y);
+  }
+});

--- a/test/language/statements/await-using/syntax/await-using-valid-for-await-using-of-of.js
+++ b/test/language/statements/await-using/syntax/await-using-valid-for-await-using-of-of.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    await using: 'for (await using of of' interpreted as 'await using'
+features: [explicit-resource-management]
+---*/
+
+async function f() {
+  for (await using of of []) { }
+}

--- a/test/language/statements/await-using/syntax/await-using.js
+++ b/test/language/statements/await-using/syntax/await-using.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    module and block scope await using
+flags: [module]
+features: [explicit-resource-management]
+---*/
+
+await using z = null;
+
+// Block local
+{
+  await using z = undefined;
+}
+
+assert.sameValue(z, null);
+
+if (true) {
+  const obj = { [Symbol.dispose]() { } };
+  await using z = obj;
+  assert.sameValue(z, obj);
+}
+

--- a/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-mixed-with-without-initializer.js
+++ b/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-mixed-with-without-initializer.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations mixed: with, without initializer
+negative:
+  phase: parse
+  type: SyntaxError
+flags: [async]
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  await using x = null, y;
+}

--- a/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-mixed-without-with-initializer.js
+++ b/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-mixed-without-with-initializer.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations mixed: without, with initializer
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  await using x, y = null;
+}

--- a/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-without-initializer.js
+++ b/test/language/statements/await-using/syntax/block-scope-syntax-await-using-declarations-without-initializer.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initializer
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  await using x;
+}

--- a/test/language/statements/await-using/syntax/with-initializer-case-expression-statement-list.js
+++ b/test/language/statements/await-using/syntax/with-initializer-case-expression-statement-list.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    case Expression : StatementList
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+asyncTest(async function () {
+    switch (true) { case true: await using x = null; }
+});

--- a/test/language/statements/await-using/syntax/with-initializer-default-statement-list.js
+++ b/test/language/statements/await-using/syntax/with-initializer-default-statement-list.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    default : StatementList
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+asyncTest(async function () {
+    switch (true) { default: await using x = null; }
+});

--- a/test/language/statements/await-using/syntax/with-initializer-do-statement-while-expression.js
+++ b/test/language/statements/await-using/syntax/with-initializer-do-statement-while-expression.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    do Statement while ( Expression )
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  do await using x = 1; while (false)
+}

--- a/test/language/statements/await-using/syntax/with-initializer-for-statement.js
+++ b/test/language/statements/await-using/syntax/with-initializer-for-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    for (;;) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  for (;false;) await using x = null;
+}

--- a/test/language/statements/await-using/syntax/with-initializer-if-expression-statement-else-statement.js
+++ b/test/language/statements/await-using/syntax/with-initializer-if-expression-statement-else-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    if ( Expression ) Statement else Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  if (true) {} else await using x = null;
+}

--- a/test/language/statements/await-using/syntax/with-initializer-if-expression-statement.js
+++ b/test/language/statements/await-using/syntax/with-initializer-if-expression-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    if ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  if (true) await using x = null;
+}

--- a/test/language/statements/await-using/syntax/with-initializer-label-statement.js
+++ b/test/language/statements/await-using/syntax/with-initializer-label-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    label: Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  label: await using x = null;
+}

--- a/test/language/statements/await-using/syntax/with-initializer-while-expression-statement.js
+++ b/test/language/statements/await-using/syntax/with-initializer-while-expression-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations with initialisers in statement positions:
+    while ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  while (false) await using x = null;
+}

--- a/test/language/statements/await-using/syntax/without-initializer-case-expression-statement-list.js
+++ b/test/language/statements/await-using/syntax/without-initializer-case-expression-statement-list.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    case Expression : StatementList
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  switch (true) { case true: await using x; }
+}

--- a/test/language/statements/await-using/syntax/without-initializer-default-statement-list.js
+++ b/test/language/statements/await-using/syntax/without-initializer-default-statement-list.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    default : StatementList
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  switch (true) { default: await using x; }
+}

--- a/test/language/statements/await-using/syntax/without-initializer-do-statement-while-expression.js
+++ b/test/language/statements/await-using/syntax/without-initializer-do-statement-while-expression.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    do Statement while ( Expression )
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  do await using x; while (false)
+}

--- a/test/language/statements/await-using/syntax/without-initializer-for-statement.js
+++ b/test/language/statements/await-using/syntax/without-initializer-for-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    for ( ;;) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  for (;false;) await using x;
+}

--- a/test/language/statements/await-using/syntax/without-initializer-if-expression-statement-else-statement.js
+++ b/test/language/statements/await-using/syntax/without-initializer-if-expression-statement-else-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    if ( Expression ) Statement else Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  if (true) {} else await using x;
+}

--- a/test/language/statements/await-using/syntax/without-initializer-if-expression-statement.js
+++ b/test/language/statements/await-using/syntax/without-initializer-if-expression-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    if ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  if (true) await using x;
+}

--- a/test/language/statements/await-using/syntax/without-initializer-label-statement.js
+++ b/test/language/statements/await-using/syntax/without-initializer-label-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    label: Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  label: await using x;
+}

--- a/test/language/statements/await-using/syntax/without-initializer-while-expression-statement.js
+++ b/test/language/statements/await-using/syntax/without-initializer-while-expression-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    await using declarations without initialisers in statement positions:
+    while ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  while (false) await using x;
+}


### PR DESCRIPTION
In an effort to make review more manageable, this extracts the remaining tests specific to `await using` statement syntax from #3866