### PR TITLE
[explicit-resource-management] Add remaining tests specific to using statement syntax

### DIFF
--- a/test/language/statements/using/syntax/block-scope-syntax-using-declarations-mixed-with-without-initializer.js
+++ b/test/language/statements/using/syntax/block-scope-syntax-using-declarations-mixed-with-without-initializer.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations mixed: with, without initializer
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+{
+  using x = null, y;
+}

--- a/test/language/statements/using/syntax/block-scope-syntax-using-declarations-mixed-without-with-initializer.js
+++ b/test/language/statements/using/syntax/block-scope-syntax-using-declarations-mixed-without-with-initializer.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations mixed: without, with initializer
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+{
+  using x, y = null;
+}

--- a/test/language/statements/using/syntax/block-scope-syntax-using-declarations-without-initializer.js
+++ b/test/language/statements/using/syntax/block-scope-syntax-using-declarations-without-initializer.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initializer
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+{
+  using x;
+}

--- a/test/language/statements/using/syntax/using-allowed-at-top-level-of-module.js
+++ b/test/language/statements/using/syntax/using-allowed-at-top-level-of-module.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations allowed at the top level of a module
+info: |
+  UsingDeclaration : using BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+flags: [module]
+features: [explicit-resource-management]
+---*/
+
+using x = null;

--- a/test/language/statements/using/syntax/using-allows-bindingidentifier.js
+++ b/test/language/statements/using/syntax/using-allows-bindingidentifier.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' allows BindingIdentifier in lexical bindings
+features: [explicit-resource-management]
+---*/
+{
+  using x = null;
+}

--- a/test/language/statements/using/syntax/using-allows-multiple-bindings.js
+++ b/test/language/statements/using/syntax/using-allows-multiple-bindings.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' allows multiple lexical bindings
+features: [explicit-resource-management]
+---*/
+
+{
+  using x = null, y = null;
+}

--- a/test/language/statements/using/syntax/using-declaring-let-split-across-two-lines.js
+++ b/test/language/statements/using/syntax/using-declaring-let-split-across-two-lines.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using: |using let| split across two lines is treated as two statements.
+info: |
+  Lexical declarations may not declare a binding named "let".
+flags: [noStrict]
+features: [explicit-resource-management]
+---*/
+
+{
+  using
+  let = "irrelevant initializer";
+
+  assert(typeof let === "string");
+  var using, let;
+}

--- a/test/language/statements/using/syntax/using-invalid-arraybindingpattern-after-bindingidentifier.js
+++ b/test/language/statements/using/syntax/using-invalid-arraybindingpattern-after-bindingidentifier.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' does not allow ArrayBindingPattern in lexical bindings, even after a valid lexical binding
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+{
+  using x = null, [] = null;
+}

--- a/test/language/statements/using/syntax/using-invalid-arraybindingpattern-does-not-break-element-access.js
+++ b/test/language/statements/using/syntax/using-invalid-arraybindingpattern-does-not-break-element-access.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' does not break existing element access
+features: [explicit-resource-management]
+---*/
+
+var using = [], x = 0;
+
+{
+  using[x] = null;
+}

--- a/test/language/statements/using/syntax/using-invalid-arraybindingpattern.js
+++ b/test/language/statements/using/syntax/using-invalid-arraybindingpattern.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' does not allow ArrayBindingPattern in lexical bindings
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+{
+  using [] = null;
+}

--- a/test/language/statements/using/syntax/using-invalid-assignment-next-expression-for.js
+++ b/test/language/statements/using/syntax/using-invalid-assignment-next-expression-for.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using: invalid assignment in next expression
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function() {
+  for (using i = 0; i < 1; i++) {}
+});

--- a/test/language/statements/using/syntax/using-invalid-assignment-statement-body-for-of.js
+++ b/test/language/statements/using/syntax/using-invalid-assignment-statement-body-for-of.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using: invalid assignment in Statement body
+features: [explicit-resource-management]
+---*/
+
+assert.throws(TypeError, function() {
+  for (using x of [1, 2, 3]) { x++ }
+});

--- a/test/language/statements/using/syntax/using-invalid-for-in.js
+++ b/test/language/statements/using/syntax/using-invalid-for-in.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    using: not allowed in for..in
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+for (using x in [1, 2, 3]) { }

--- a/test/language/statements/using/syntax/using-invalid-for-using-of-of.js
+++ b/test/language/statements/using/syntax/using-invalid-for-using-of-of.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    using: 'for (using of' is always interpreted as identifier 
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+for (using of of [1, 2, 3]) { }

--- a/test/language/statements/using/syntax/using-invalid-objectbindingpattern-after-bindingidentifier.js
+++ b/test/language/statements/using/syntax/using-invalid-objectbindingpattern-after-bindingidentifier.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' does not allow ObjectBindingPattern in lexical bindings, even after a valid lexical binding
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+{
+  using x = null, {} = null;
+}

--- a/test/language/statements/using/syntax/using-invalid-objectbindingpattern.js
+++ b/test/language/statements/using/syntax/using-invalid-objectbindingpattern.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    'using' does not allow ObjectBindingPattern in lexical bindings
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+{
+  using {} = null;
+}

--- a/test/language/statements/using/syntax/using-not-allowed-at-top-level-of-eval.js
+++ b/test/language/statements/using/syntax/using-not-allowed-at-top-level-of-eval.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations not allowed at the top level of eval
+info: |
+  UsingDeclaration : using BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+features: [explicit-resource-management]
+---*/
+
+assert.throws(SyntaxError, function() {
+  eval('using x = null;')
+});

--- a/test/language/statements/using/syntax/using-not-allowed-at-top-level-of-script.js
+++ b/test/language/statements/using/syntax/using-not-allowed-at-top-level-of-script.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations not allowed at the top level of a Script
+info: |
+  UsingDeclaration : using BindingList ;
+
+  - It is a Syntax Error if the goal symbol is Script and UsingDeclaration is not contained, either directly or 
+    indirectly, within a Block, CaseBlock, ForStatement, ForInOfStatement, FunctionBody, GeneratorBody, 
+    AsyncGeneratorBody, AsyncFunctionBody, ClassStaticBlockBody, or ClassBody.
+
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+using x = null;

--- a/test/language/statements/using/syntax/using-outer-inner-using-bindings.js
+++ b/test/language/statements/using/syntax/using-outer-inner-using-bindings.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    outer using binding unchanged by for-loop using binding
+features: [explicit-resource-management]
+---*/
+
+const outer_x = { [Symbol.dispose]() {} };
+const outer_y = { [Symbol.dispose]() {} };
+const inner_x = { [Symbol.dispose]() {} };
+const inner_y = { [Symbol.dispose]() {} };
+
+{
+  using x = outer_x;
+  using y = outer_y;
+  var i = 0;
+
+  for (using x = inner_x; i < 1; i++) {
+    using y = inner_y;
+
+    assert.sameValue(x, inner_x);
+    assert.sameValue(y, inner_y);
+  }
+  assert.sameValue(x, outer_x);
+  assert.sameValue(y, outer_y);
+}

--- a/test/language/statements/using/syntax/using.js
+++ b/test/language/statements/using/syntax/using.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    module and block scope using
+flags: [module]
+features: [explicit-resource-management]
+---*/
+
+using z = null;
+
+// Block local
+{
+  using z = undefined;
+}
+
+assert.sameValue(z, null);
+
+if (true) {
+  const obj = { [Symbol.dispose]() { } };
+  using z = obj;
+  assert.sameValue(z, obj);
+}

--- a/test/language/statements/using/syntax/with-initializer-case-expression-statement-list.js
+++ b/test/language/statements/using/syntax/with-initializer-case-expression-statement-list.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    case Expression : StatementList
+features: [explicit-resource-management]
+---*/
+switch (true) { case true: using x = null; }

--- a/test/language/statements/using/syntax/with-initializer-default-statement-list.js
+++ b/test/language/statements/using/syntax/with-initializer-default-statement-list.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    default : StatementList
+features: [explicit-resource-management]
+---*/
+switch (true) { default: using x = null; }

--- a/test/language/statements/using/syntax/with-initializer-do-statement-while-expression.js
+++ b/test/language/statements/using/syntax/with-initializer-do-statement-while-expression.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    do Statement while ( Expression )
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+do using x = 1; while (false)

--- a/test/language/statements/using/syntax/with-initializer-for-statement.js
+++ b/test/language/statements/using/syntax/with-initializer-for-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    for (;;) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+for (;false;) using x = null;

--- a/test/language/statements/using/syntax/with-initializer-if-expression-statement-else-statement.js
+++ b/test/language/statements/using/syntax/with-initializer-if-expression-statement-else-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    if ( Expression ) Statement else Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+if (true) {} else using x = null;

--- a/test/language/statements/using/syntax/with-initializer-if-expression-statement.js
+++ b/test/language/statements/using/syntax/with-initializer-if-expression-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    if ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+if (true) using x = null;

--- a/test/language/statements/using/syntax/with-initializer-label-statement.js
+++ b/test/language/statements/using/syntax/with-initializer-label-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    label: Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+label: using x = null;

--- a/test/language/statements/using/syntax/with-initializer-while-expression-statement.js
+++ b/test/language/statements/using/syntax/with-initializer-while-expression-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations with initialisers in statement positions:
+    while ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+while (false) using x = null;

--- a/test/language/statements/using/syntax/without-initializer-case-expression-statement-list.js
+++ b/test/language/statements/using/syntax/without-initializer-case-expression-statement-list.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    case Expression : StatementList
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+switch (true) { case true: using x; }

--- a/test/language/statements/using/syntax/without-initializer-default-statement-list.js
+++ b/test/language/statements/using/syntax/without-initializer-default-statement-list.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    default : StatementList
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+switch (true) { default: using x; }

--- a/test/language/statements/using/syntax/without-initializer-do-statement-while-expression.js
+++ b/test/language/statements/using/syntax/without-initializer-do-statement-while-expression.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    do Statement while ( Expression )
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+do using x; while (false)

--- a/test/language/statements/using/syntax/without-initializer-for-statement.js
+++ b/test/language/statements/using/syntax/without-initializer-for-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    for ( ;;) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+for (;false;) using x;

--- a/test/language/statements/using/syntax/without-initializer-if-expression-statement-else-statement.js
+++ b/test/language/statements/using/syntax/without-initializer-if-expression-statement-else-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    if ( Expression ) Statement else Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+if (true) {} else using x;

--- a/test/language/statements/using/syntax/without-initializer-if-expression-statement.js
+++ b/test/language/statements/using/syntax/without-initializer-if-expression-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    if ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+if (true) using x;

--- a/test/language/statements/using/syntax/without-initializer-label-statement.js
+++ b/test/language/statements/using/syntax/without-initializer-label-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    label: Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+label: using x;

--- a/test/language/statements/using/syntax/without-initializer-while-expression-statement.js
+++ b/test/language/statements/using/syntax/without-initializer-while-expression-statement.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: pending
+description: >
+    using declarations without initialisers in statement positions:
+    while ( Expression ) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+while (false) using x;


### PR DESCRIPTION
In an effort to make review more manageable, this extracts the remaining tests specific to `using` statement syntax from #3866