### PR TITLE
[explicit-resource-management] Add remaining tests specific to using in for-of and for-await-of syntax

### DIFF
--- a/test/language/statements/for-await-of/head-await-using-init.js
+++ b/test/language/statements/for-await-of/head-await-using-init.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteration-statements
+description: >
+  ForDeclaration containing 'await using' does not allow initializer.
+info: |
+  IterationStatement:
+    for await (ForDeclaration of AssignmentExpression) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [async-iteration, explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+async function fn() {
+  const obj = { async [Symbol.asyncDispose]() {} };
+  for await (await using x = obj of []) {}
+}

--- a/test/language/statements/for-await-of/head-using-init.js
+++ b/test/language/statements/for-await-of/head-using-init.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteration-statements
+description: >
+  ForDeclaration containing 'using' does not allow initializer.
+info: |
+  IterationStatement:
+    for await (ForDeclaration of AssignmentExpression) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [async-iteration, explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+async function fn() {
+  const obj = { [Symbol.dispose]() {} };
+  for await (using x = obj of []) {}
+}

--- a/test/language/statements/for-of/head-await-using-bound-names-fordecl-tdz.js
+++ b/test/language/statements/for-of/head-await-using-bound-names-fordecl-tdz.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.6.4.12_S2
+description: >
+    ForIn/Of: Bound names of ForDeclaration are in TDZ (for-of)
+flags: [async]
+includes: [asyncHelpers.js]
+features: [explicit-resource-management]
+---*/
+
+asyncTest(async function () {
+  await assert.throwsAsync(ReferenceError, async function() {
+    let x = { async [Symbol.asyncDispose]() { } };
+    for (await using x of [x]) {}
+  });
+});

--- a/test/language/statements/for-of/head-await-using-bound-names-fordecl-tdz.js
+++ b/test/language/statements/for-of/head-await-using-bound-names-fordecl-tdz.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 Ron Buckton. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-es6id: 13.6.4.12_S2
+esid: sec-for-in-and-for-of-statements
 description: >
     ForIn/Of: Bound names of ForDeclaration are in TDZ (for-of)
 flags: [async]

--- a/test/language/statements/for-of/head-await-using-bound-names-in-stmt.js
+++ b/test/language/statements/for-of/head-await-using-bound-names-in-stmt.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: The body may not re-declare variables declared in the head
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    It is a Syntax Error if any element of the BoundNames of ForDeclaration
+    also occurs in the VarDeclaredNames of Statement.
+esid: sec-for-in-and-for-of-statements
+es6id: 13.7.5
+flags: [module]
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+for (await using x of []) {
+  var x;
+}

--- a/test/language/statements/for-of/head-await-using-bound-names-in-stmt.js
+++ b/test/language/statements/for-of/head-await-using-bound-names-in-stmt.js
@@ -9,7 +9,6 @@ info: |
     It is a Syntax Error if any element of the BoundNames of ForDeclaration
     also occurs in the VarDeclaredNames of Statement.
 esid: sec-for-in-and-for-of-statements
-es6id: 13.7.5
 flags: [module]
 features: [explicit-resource-management]
 ---*/

--- a/test/language/statements/for-of/head-await-using-bound-names-let.js
+++ b/test/language/statements/for-of/head-await-using-bound-names-let.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-for-in-and-for-of-statements
+description: ForDeclaration containing 'await using' may not contain a binding for `let`
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+  It is a Syntax Error if the BoundNames of ForDeclaration contains "let".
+flags: [noStrict]
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+async function f() {
+  for (await using let of []) {}
+}

--- a/test/language/statements/for-of/head-await-using-fresh-binding-per-iteration.js
+++ b/test/language/statements/for-of/head-await-using-fresh-binding-per-iteration.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    ForDeclaration containing 'await using' creates a fresh binding per iteration
+flags: [module]
+features: [explicit-resource-management]
+---*/
+
+let f = [undefined, undefined, undefined];
+
+const obj1 = { async [Symbol.asyncDispose]() { } };
+const obj2 = { async [Symbol.asyncDispose]() { } };
+const obj3 = { async [Symbol.asyncDispose]() { } };
+
+let i = 0;
+for (await using x of [obj1, obj2, obj3]) {
+  f[i++] = function() { return x; };
+}
+assert.sameValue(f[0](), obj1, "`f[0]()` returns `obj1`");
+assert.sameValue(f[1](), obj2, "`f[1]()` returns `obj2`");
+assert.sameValue(f[2](), obj3, "`f[2]()` returns `obj3`");

--- a/test/language/statements/for-of/head-await-using-fresh-binding-per-iteration.js
+++ b/test/language/statements/for-of/head-await-using-fresh-binding-per-iteration.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 Ron Buckton. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: pending
+esid: sec-for-in-and-for-of-statements
 description: >
     ForDeclaration containing 'await using' creates a fresh binding per iteration
 flags: [module]

--- a/test/language/statements/for-of/head-await-using-init.js
+++ b/test/language/statements/for-of/head-await-using-init.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteration-statements
+description: >
+  ForDeclaration containing 'await using' does not support an initializer
+info: |
+  IterationStatement:
+    for (ForDeclaration of AssignmentExpression) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+const obj = { [Symbol.dispose]() { } };
+async function f() {
+  for (await using x = obj of []) {}
+}

--- a/test/language/statements/for-of/head-await-using-init.js
+++ b/test/language/statements/for-of/head-await-using-init.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-iteration-statements
+esid: sec-for-in-and-for-of-statements
 description: >
   ForDeclaration containing 'await using' does not support an initializer
 info: |

--- a/test/language/statements/for-of/head-using-bound-names-fordecl-tdz.js
+++ b/test/language/statements/for-of/head-using-bound-names-fordecl-tdz.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.6.4.12_S2
+description: >
+    ForIn/Of: Bound names of ForDeclaration are in TDZ (for-of)
+features: [explicit-resource-management]
+---*/
+
+assert.throws(ReferenceError, function() {
+  let x = { [Symbol.dispose]() { } };
+  for (using x of [x]) {}
+});

--- a/test/language/statements/for-of/head-using-bound-names-fordecl-tdz.js
+++ b/test/language/statements/for-of/head-using-bound-names-fordecl-tdz.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 Ron Buckton. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-es6id: 13.6.4.12_S2
+esid: sec-for-in-and-for-of-statements
 description: >
     ForIn/Of: Bound names of ForDeclaration are in TDZ (for-of)
 features: [explicit-resource-management]

--- a/test/language/statements/for-of/head-using-bound-names-in-stmt.js
+++ b/test/language/statements/for-of/head-using-bound-names-in-stmt.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: The body may not re-declare variables declared in the head
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    It is a Syntax Error if any element of the BoundNames of ForDeclaration
+    also occurs in the VarDeclaredNames of Statement.
+esid: sec-for-in-and-for-of-statements
+es6id: 13.7.5
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+for (using x of []) {
+  var x;
+}

--- a/test/language/statements/for-of/head-using-bound-names-in-stmt.js
+++ b/test/language/statements/for-of/head-using-bound-names-in-stmt.js
@@ -9,7 +9,6 @@ info: |
     It is a Syntax Error if any element of the BoundNames of ForDeclaration
     also occurs in the VarDeclaredNames of Statement.
 esid: sec-for-in-and-for-of-statements
-es6id: 13.7.5
 features: [explicit-resource-management]
 ---*/
 

--- a/test/language/statements/for-of/head-using-bound-names-let.js
+++ b/test/language/statements/for-of/head-using-bound-names-let.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-for-in-and-for-of-statements
+description: ForDeclaration containing 'using' may not contain a binding for `let`
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+  It is a Syntax Error if the BoundNames of ForDeclaration contains "let".
+flags: [noStrict]
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+for (using let of []) {}

--- a/test/language/statements/for-of/head-using-fresh-binding-per-iteration.js
+++ b/test/language/statements/for-of/head-using-fresh-binding-per-iteration.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    ForDeclaration containing 'using' creates a fresh binding per iteration
+features: [explicit-resource-management]
+---*/
+
+let f = [undefined, undefined, undefined];
+
+const obj1 = { [Symbol.dispose]() { } };
+const obj2 = { [Symbol.dispose]() { } };
+const obj3 = { [Symbol.dispose]() { } };
+
+let i = 0;
+for (using x of [obj1, obj2, obj3]) {
+  f[i++] = function() { return x; };
+}
+assert.sameValue(f[0](), obj1, "`f[0]()` returns `obj1`");
+assert.sameValue(f[1](), obj2, "`f[1]()` returns `obj2`");
+assert.sameValue(f[2](), obj3, "`f[2]()` returns `obj3`");

--- a/test/language/statements/for-of/head-using-fresh-binding-per-iteration.js
+++ b/test/language/statements/for-of/head-using-fresh-binding-per-iteration.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 Ron Buckton. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: pending
+esid: sec-for-in-and-for-of-statements
 description: >
     ForDeclaration containing 'using' creates a fresh binding per iteration
 features: [explicit-resource-management]

--- a/test/language/statements/for-of/head-using-init.js
+++ b/test/language/statements/for-of/head-using-init.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteration-statements
+description: >
+  ForDeclaration containing 'using' does not support an initializer
+info: |
+  IterationStatement:
+    for (ForDeclaration of AssignmentExpression) Statement
+negative:
+  phase: parse
+  type: SyntaxError
+features: [explicit-resource-management]
+---*/
+
+$DONOTEVALUATE();
+
+const obj = { [Symbol.dispose]() { } };
+for (using x = obj of []) {}

--- a/test/language/statements/for-of/head-using-init.js
+++ b/test/language/statements/for-of/head-using-init.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-iteration-statements
+esid: sec-for-in-and-for-of-statements
 description: >
   ForDeclaration containing 'using' does not support an initializer
 info: |


### PR DESCRIPTION
In an effort to make review more manageable, this extracts the remaining tests specific to `using`/`await using` in `for-of` and `for-await-of` statements from #3866