### PR TITLE
Remove usage of Object.hasOwn in helper files

### DIFF
--- a/harness/asyncHelpers.js
+++ b/harness/asyncHelpers.js
@@ -15,7 +15,7 @@ defines: [asyncTest, assert.throwsAsync]
  * @returns {void}
  */
 function asyncTest(testFunc) {
-  if (!Object.hasOwn(globalThis, "$DONE")) {
+  if (!Object.prototype.hasOwnProperty.call(globalThis, "$DONE")) {
     throw new Test262Error("asyncTest called without async flag");
   }
   if (typeof testFunc !== "function") {

--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -133,7 +133,7 @@ var TemporalHelpers = {
       assert.sameValue(eraName, undefined);
       return undefined;
     }
-    assert(Object.hasOwn(TemporalHelpers.CalendarEras, calendarId));
+    assert(Object.prototype.hasOwnProperty.call(TemporalHelpers.CalendarEras, calendarId));
 
     if (eraName === undefined) {
       return undefined;


### PR DESCRIPTION
Instead use the easily available old-fashioned way, calling the method on Object.prototype.