### PR TITLE
Ensure typed array length is retrieved early in Atomics.{notify,wait}

### DIFF
--- a/test/built-ins/Atomics/notify/retrieve-length-before-index-coercion-non-shared-detached.js
+++ b/test/built-ins/Atomics/notify/retrieve-length-before-index-coercion-non-shared-detached.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.notify
+description: >
+  TypedArray length is retrieved before index parameter coercion.
+info: |
+  25.4.15 Atomics.notify ( typedArray, index, count )
+    ...
+    2. Let byteIndexInBuffer be ? ValidateAtomicAccess(taRecord, index).
+    ...
+
+  25.4.3.2 ValidateAtomicAccess ( taRecord, requestIndex )
+    1. Let length be TypedArrayLength(taRecord).
+    2. Let accessIndex be ? ToIndex(requestIndex).
+    3. Assert: accessIndex ≥ 0.
+    4. If accessIndex ≥ length, throw a RangeError exception.
+    ...
+features: [Atomics, TypedArray]
+includes: [detachArrayBuffer.js]
+---*/
+
+var ab = new ArrayBuffer(4);
+var ta = new Int32Array(ab);
+
+var index = {
+  valueOf() {
+    $DETACHBUFFER(ab);
+    return 0;
+  }
+};
+
+assert.sameValue(Atomics.notify(ta, index), 0);
+
+assert.sameValue(ab.byteLength, 0);

--- a/test/built-ins/Atomics/notify/retrieve-length-before-index-coercion-non-shared-resize-to-zero.js
+++ b/test/built-ins/Atomics/notify/retrieve-length-before-index-coercion-non-shared-resize-to-zero.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.notify
+description: >
+  TypedArray length is retrieved before index parameter coercion.
+info: |
+  25.4.15 Atomics.notify ( typedArray, index, count )
+    ...
+    2. Let byteIndexInBuffer be ? ValidateAtomicAccess(taRecord, index).
+    ...
+
+  25.4.3.2 ValidateAtomicAccess ( taRecord, requestIndex )
+    1. Let length be TypedArrayLength(taRecord).
+    2. Let accessIndex be ? ToIndex(requestIndex).
+    3. Assert: accessIndex ≥ 0.
+    4. If accessIndex ≥ length, throw a RangeError exception.
+    ...
+features: [Atomics, TypedArray, resizable-arraybuffer]
+---*/
+
+var rab = new ArrayBuffer(4, {maxByteLength: 4});
+var ta = new Int32Array(rab);
+
+var index = {
+  valueOf() {
+    rab.resize(0);
+    return 0;
+  }
+};
+
+assert.sameValue(Atomics.notify(ta, index), 0);
+
+assert.sameValue(rab.byteLength, 0);

--- a/test/built-ins/Atomics/notify/retrieve-length-before-index-coercion-non-shared.js
+++ b/test/built-ins/Atomics/notify/retrieve-length-before-index-coercion-non-shared.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.notify
+description: >
+  TypedArray length is retrieved before index parameter coercion.
+info: |
+  25.4.15 Atomics.notify ( typedArray, index, count )
+    ...
+    2. Let byteIndexInBuffer be ? ValidateAtomicAccess(taRecord, index).
+    ...
+
+  25.4.3.2 ValidateAtomicAccess ( taRecord, requestIndex )
+    1. Let length be TypedArrayLength(taRecord).
+    2. Let accessIndex be ? ToIndex(requestIndex).
+    3. Assert: accessIndex ≥ 0.
+    4. If accessIndex ≥ length, throw a RangeError exception.
+    ...
+features: [Atomics, TypedArray, resizable-arraybuffer]
+---*/
+
+var rab = new ArrayBuffer(0, {maxByteLength: 4});
+var ta = new Int32Array(rab);
+
+var index = {
+  valueOf() {
+    rab.resize(4);
+    return 0;
+  }
+};
+
+var count = {
+  valueOf() {
+    throw new Test262Error("Unexpected count coercion");
+  }
+};
+
+assert.throws(RangeError, function() {
+  Atomics.notify(ta, index, count);
+});
+
+assert.sameValue(rab.byteLength, 4);

--- a/test/built-ins/Atomics/notify/retrieve-length-before-index-coercion.js
+++ b/test/built-ins/Atomics/notify/retrieve-length-before-index-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.notify
+description: >
+  TypedArray length is retrieved before index parameter coercion.
+info: |
+  25.4.15 Atomics.notify ( typedArray, index, count )
+    ...
+    2. Let byteIndexInBuffer be ? ValidateAtomicAccess(taRecord, index).
+    ...
+
+  25.4.3.2 ValidateAtomicAccess ( taRecord, requestIndex )
+    1. Let length be TypedArrayLength(taRecord).
+    2. Let accessIndex be ? ToIndex(requestIndex).
+    3. Assert: accessIndex ≥ 0.
+    4. If accessIndex ≥ length, throw a RangeError exception.
+    ...
+features: [Atomics, TypedArray, resizable-arraybuffer]
+---*/
+
+var gsab = new SharedArrayBuffer(0, {maxByteLength: 4});
+var ta = new Int32Array(gsab);
+
+var index = {
+  valueOf() {
+    gsab.grow(4);
+    return 0;
+  }
+};
+
+var count = {
+  valueOf() {
+    throw new Test262Error("Unexpected count coercion");
+  }
+};
+
+assert.throws(RangeError, function() {
+  Atomics.notify(ta, index, count);
+});
+
+assert.sameValue(gsab.byteLength, 4);

--- a/test/built-ins/Atomics/wait/retrieve-length-before-index-coercion.js
+++ b/test/built-ins/Atomics/wait/retrieve-length-before-index-coercion.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.wait
+description: >
+  TypedArray length is retrieved before index parameter coercion.
+info: |
+  25.4.13 Atomics.wait ( typedArray, index, value, timeout )
+    1. Return ? DoWait(sync, typedArray, index, value, timeout).
+
+  25.4.3.14 DoWait ( mode, typedArray, index, value, timeout )
+    ...
+    4. Let i be ? ValidateAtomicAccess(taRecord, index).
+    ...
+
+  25.4.3.2 ValidateAtomicAccess ( taRecord, requestIndex )
+    1. Let length be TypedArrayLength(taRecord).
+    2. Let accessIndex be ? ToIndex(requestIndex).
+    3. Assert: accessIndex ≥ 0.
+    4. If accessIndex ≥ length, throw a RangeError exception.
+    ...
+features: [Atomics, TypedArray, resizable-arraybuffer]
+---*/
+
+var gsab = new SharedArrayBuffer(0, {maxByteLength: 4});
+var ta = new Int32Array(gsab);
+
+var index = {
+  valueOf() {
+    gsab.grow(4);
+    return 0;
+  }
+};
+
+var value = {
+  valueOf() {
+    throw new Test262Error("Unexpected value coercion");
+  }
+};
+
+var timeout = {
+  valueOf() {
+    throw new Test262Error("Unexpected timeout coercion");
+  }
+};
+
+assert.throws(RangeError, function() {
+  Atomics.wait(ta, index, value, timeout);
+});
+
+assert.sameValue(gsab.byteLength, 4);

--- a/test/built-ins/Atomics/waitAsync/retrieve-length-before-index-coercion.js
+++ b/test/built-ins/Atomics/waitAsync/retrieve-length-before-index-coercion.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.waitasync
+description: >
+  TypedArray length is retrieved before index parameter coercion.
+info: |
+  25.4.14 Atomics.waitAsync ( typedArray, index, value, timeout )
+    1. Return ? DoWait(async, typedArray, index, value, timeout).
+
+  25.4.3.14 DoWait ( mode, typedArray, index, value, timeout )
+    ...
+    4. Let i be ? ValidateAtomicAccess(taRecord, index).
+    ...
+
+  25.4.3.2 ValidateAtomicAccess ( taRecord, requestIndex )
+    1. Let length be TypedArrayLength(taRecord).
+    2. Let accessIndex be ? ToIndex(requestIndex).
+    3. Assert: accessIndex ≥ 0.
+    4. If accessIndex ≥ length, throw a RangeError exception.
+    ...
+features: [Atomics.waitAsync, Atomics, TypedArray, resizable-arraybuffer]
+---*/
+
+var gsab = new SharedArrayBuffer(0, {maxByteLength: 4});
+var ta = new Int32Array(gsab);
+
+var index = {
+  valueOf() {
+    gsab.grow(4);
+    return 0;
+  }
+};
+
+var value = {
+  valueOf() {
+    throw new Test262Error("Unexpected value coercion");
+  }
+};
+
+var timeout = {
+  valueOf() {
+    throw new Test262Error("Unexpected timeout coercion");
+  }
+};
+
+assert.throws(RangeError, function() {
+  Atomics.waitAsync(ta, index, value, timeout);
+});
+
+assert.sameValue(gsab.byteLength, 4);


### PR DESCRIPTION
The tests pass in JSC and SpiderMonkey, but fail in V8.