### PR TITLE
Add missing `async` flag to `AsyncIteratorPrototype` tests

### DIFF
--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/throw-rejected-return.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/throw-rejected-return.js
@@ -12,6 +12,7 @@ info: |
     b. IfAbruptRejectPromise(result, promiseCapability).
     ...
 
+flags: [async]
 features: [explicit-resource-management]
 includes: [asyncHelpers.js]
 ---*/

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/throw-return-getter.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/throw-return-getter.js
@@ -12,6 +12,7 @@ info: |
   4. IfAbruptRejectPromise(return, promiseCapability).
   ...
 
+flags: [async]
 features: [explicit-resource-management]
 includes: [asyncHelpers.js]
 ---*/

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/throw-return.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/throw-return.js
@@ -12,6 +12,7 @@ info: |
     b. IfAbruptRejectPromise(result, promiseCapability).
     ...
 
+flags: [async]
 features: [explicit-resource-management]
 includes: [asyncHelpers.js]
 ---*/


### PR DESCRIPTION
Tests added by https://github.com/tc39/test262/pull/4469 missing required `async` flag.