### PR TITLE
Add coverage for some implementation bugs in Iterator helper methods

### DIFF
--- a/test/built-ins/Iterator/prototype/drop/next-method-called-with-zero-arguments.js
+++ b/test/built-ins/Iterator/prototype/drop/next-method-called-with-zero-arguments.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteratorprototype.drop
+description: >
+  Underlying iterator's next method is called with zero arguments.
+info: |
+  27.1.4.2 Iterator.prototype.drop ( limit )
+
+  ...
+  10. Let closure be a new Abstract Closure with no parameters that captures
+      iterated and integerLimit and performs the following steps when called:
+    ...
+    b. Repeat, while remaining > 0,
+      ...
+      ii. Let next be ? IteratorStep(iterated).
+      ...
+    c. Repeat,
+      i. Let value be ? IteratorStepValue(iterated).
+      ...
+  ...
+features: [iterator-helpers]
+---*/
+
+var counter = 0;
+
+var underlying = {
+  next() {
+    assert.sameValue(arguments.length, 0);
+
+    return {
+      done: false,
+      value: ++counter,
+    };
+  }
+};
+
+var it = Iterator.prototype.drop.call(underlying, 3);
+
+assert.sameValue(counter, 0);
+
+assert.sameValue(it.next().value, 4);
+assert.sameValue(it.next(1).value, 5);
+assert.sameValue(it.next(1, 2).value, 6);
+
+assert.sameValue(counter, 6);

--- a/test/built-ins/Iterator/prototype/drop/return-method-called-with-zero-arguments.js
+++ b/test/built-ins/Iterator/prototype/drop/return-method-called-with-zero-arguments.js
@@ -1,0 +1,100 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteratorprototype.drop
+description: >
+  Underlying iterator's return method is called with zero arguments.
+info: |
+  27.1.4.2 Iterator.prototype.drop ( limit )
+
+  ...
+  10. Let closure be a new Abstract Closure with no parameters that captures
+      iterated and integerLimit and performs the following steps when called:
+    ...
+    c. Repeat,
+      ...
+      iii. Let completion be Completion(Yield(value)).
+      iv. IfAbruptCloseIterator(completion, iterated).
+  ...
+
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+      ...
+      c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+      ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+features: [iterator-helpers]
+---*/
+
+var counter = 0;
+
+var underlying = {
+  next() {
+    return {
+      done: false,
+      value: 0,
+    };
+  },
+  return() {
+    assert.sameValue(arguments.length, 0);
+
+    counter += 1;
+    return {};
+  }
+};
+
+// Close from "suspended-start".
+{
+  var it = Iterator.prototype.drop.call(underlying, 0);
+
+  assert.sameValue(counter, 0);
+  it.return();
+  assert.sameValue(counter, 1);
+}
+
+{
+  var it = Iterator.prototype.drop.call(underlying, 0);
+
+  assert.sameValue(counter, 1);
+  it.return(1);
+  assert.sameValue(counter, 2);
+}
+
+{
+  var it = Iterator.prototype.drop.call(underlying, 0);
+
+  assert.sameValue(counter, 2);
+  it.return(1, 2);
+  assert.sameValue(counter, 3);
+}
+
+// Close from "suspended-yield".
+{
+  var it = Iterator.prototype.drop.call(underlying, 0);
+  it.next();
+
+  assert.sameValue(counter, 3);
+  it.return();
+  assert.sameValue(counter, 4);
+}
+
+{
+  var it = Iterator.prototype.drop.call(underlying, 0);
+  it.next();
+
+  assert.sameValue(counter, 4);
+  it.return(1);
+  assert.sameValue(counter, 5);
+}
+
+{
+  var it = Iterator.prototype.drop.call(underlying, 0);
+  it.next();
+
+  assert.sameValue(counter, 5);
+  it.return(1, 2);
+  assert.sameValue(counter, 6);
+}

--- a/test/built-ins/Iterator/prototype/drop/suspended-start-iterator-close-calls-next.js
+++ b/test/built-ins/Iterator/prototype/drop/suspended-start-iterator-close-calls-next.js
@@ -1,0 +1,72 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.drop
+description: >
+  Generator is closed from suspended-start state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+       a. Set O.[[GeneratorState]] to completed.
+       ...
+       c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+       d. Return CreateIteratorResultObject(undefined, true).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    2. If state is completed, return CreateIteratorResultObject(undefined, true).
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    throw new Test262Error("Unexpected call to next");
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is already set to "completed". The generator state is
+    // not "executing", so `GeneratorValidate` succeeds and `GeneratorResume`
+    // returns with `CreateIteratorResultObject()`.
+    var result = it.next();
+    assert.sameValue(result.value, undefined);
+    assert.sameValue(result.done, true);
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.drop.call(underlying, 0);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call sets the generator state to "completed" and then calls
+// `IteratorClose()`.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/drop/suspended-start-iterator-close-calls-return.js
+++ b/test/built-ins/Iterator/prototype/drop/suspended-start-iterator-close-calls-return.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.drop
+description: >
+  Generator is closed from suspended-start state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+       a. Set O.[[GeneratorState]] to completed.
+       ...
+       c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+       d. Return CreateIteratorResultObject(undefined, true).
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+    8. Return ? completion.
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    2. If state is suspended-start, then
+      ...
+    3. If state is completed, then
+      a. If abruptCompletion is a return completion, then
+        i. Return CreateIteratorResultObject(abruptCompletion.[[Value]], true).
+      ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    throw new Test262Error("Unexpected call to next");
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is already set to "completed", so this `return()`
+    // call proceeds to `GeneratorResumeAbrupt`. The generator state is not
+    // "executing", so `GeneratorValidate` succeeds and `GeneratorResumeAbrupt`
+    // returns with `CreateIteratorResultObject()`.
+    var result = it.return();
+    assert.sameValue(result.value, undefined);
+    assert.sameValue(result.done, true);
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.drop.call(underlying, 0);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call sets the generator state to "completed" and then calls
+// `IteratorClose()`.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/drop/suspended-yield-iterator-close-calls-next.js
+++ b/test/built-ins/Iterator/prototype/drop/suspended-yield-iterator-close-calls-next.js
@@ -1,0 +1,98 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.drop
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.2 Iterator.prototype.drop ( limit )
+    ...
+    10. Let closure be a new Abstract Closure with no parameters that captures
+        iterated and integerLimit and performs the following steps when called:
+      ...
+      c. Repeat,
+        ...
+        iii. Let completion be Completion(Yield(value)).
+        iv. IfAbruptCloseIterator(completion, iterated).
+    ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `next()` call throws
+    // a TypeError when `GeneratorResume` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.next();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.drop.call(underlying, 0);
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 123);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/drop/suspended-yield-iterator-close-calls-return.js
+++ b/test/built-ins/Iterator/prototype/drop/suspended-yield-iterator-close-calls-return.js
@@ -1,0 +1,91 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.drop
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.2 Iterator.prototype.drop ( limit )
+    ...
+    10. Let closure be a new Abstract Closure with no parameters that captures
+        iterated and integerLimit and performs the following steps when called:
+      ...
+      c. Repeat,
+        ...
+        iii. Let completion be Completion(Yield(value)).
+        iv. IfAbruptCloseIterator(completion, iterated).
+    ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `return()` call throws
+    // a TypeError when `GeneratorResumeAbrupt` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.return();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.drop.call(underlying, 0);
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 123);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/filter/next-method-called-with-zero-arguments.js
+++ b/test/built-ins/Iterator/prototype/filter/next-method-called-with-zero-arguments.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteratorprototype.filter
+description: >
+  Underlying iterator's next method is called with zero arguments.
+info: |
+  27.1.4.4 Iterator.prototype.filter ( predicate )
+
+  ...
+  6. Let closure be a new Abstract Closure with no parameters that captures
+     iterated and predicate and performs the following steps when called:
+    ...
+    b. Repeat,
+      i. Let value be ? IteratorStepValue(iterated).
+      ...
+features: [iterator-helpers]
+---*/
+
+var counter = 0;
+
+var underlying = {
+  next() {
+    assert.sameValue(arguments.length, 0);
+
+    return {
+      done: false,
+      value: ++counter,
+    };
+  }
+};
+
+var it = Iterator.prototype.filter.call(underlying, function() {
+  return true;
+});
+
+assert.sameValue(counter, 0);
+
+assert.sameValue(it.next().value, 1);
+assert.sameValue(it.next(1).value, 2);
+assert.sameValue(it.next(1, 2).value, 3);
+
+assert.sameValue(counter, 3);

--- a/test/built-ins/Iterator/prototype/filter/return-method-called-with-zero-arguments.js
+++ b/test/built-ins/Iterator/prototype/filter/return-method-called-with-zero-arguments.js
@@ -1,0 +1,105 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteratorprototype.filter
+description: >
+  Underlying iterator's return method is called with zero arguments.
+info: |
+  27.1.4.4 Iterator.prototype.filter ( predicate )
+
+  ...
+  6. Let closure be a new Abstract Closure with no parameters that captures
+     iterated and predicate and performs the following steps when called:
+    ...
+    b. Repeat,
+      ...
+      v. If ToBoolean(selected) is true, then
+        1. Let completion be Completion(Yield(value)).
+        2. IfAbruptCloseIterator(completion, iterated).
+      ...
+
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+      ...
+      c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+      ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+features: [iterator-helpers]
+---*/
+
+var counter = 0;
+
+var underlying = {
+  next() {
+    return {
+      done: false,
+      value: 0,
+    };
+  },
+  return() {
+    assert.sameValue(arguments.length, 0);
+
+    counter += 1;
+    return {};
+  }
+};
+
+function truePredicate() {
+  return true;
+}
+
+// Close from "suspended-start".
+{
+  var it = Iterator.prototype.filter.call(underlying, truePredicate);
+
+  assert.sameValue(counter, 0);
+  it.return();
+  assert.sameValue(counter, 1);
+}
+
+{
+  var it = Iterator.prototype.filter.call(underlying, truePredicate);
+
+  assert.sameValue(counter, 1);
+  it.return(1);
+  assert.sameValue(counter, 2);
+}
+
+{
+  var it = Iterator.prototype.filter.call(underlying, truePredicate);
+
+  assert.sameValue(counter, 2);
+  it.return(1, 2);
+  assert.sameValue(counter, 3);
+}
+
+// Close from "suspended-yield".
+{
+  var it = Iterator.prototype.filter.call(underlying, truePredicate);
+  it.next();
+
+  assert.sameValue(counter, 3);
+  it.return();
+  assert.sameValue(counter, 4);
+}
+
+{
+  var it = Iterator.prototype.filter.call(underlying, truePredicate);
+  it.next();
+
+  assert.sameValue(counter, 4);
+  it.return(1);
+  assert.sameValue(counter, 5);
+}
+
+{
+  var it = Iterator.prototype.filter.call(underlying, truePredicate);
+  it.next();
+
+  assert.sameValue(counter, 5);
+  it.return(1, 2);
+  assert.sameValue(counter, 6);
+}

--- a/test/built-ins/Iterator/prototype/filter/suspended-start-iterator-close-calls-next.js
+++ b/test/built-ins/Iterator/prototype/filter/suspended-start-iterator-close-calls-next.js
@@ -1,0 +1,74 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.filter
+description: >
+  Generator is closed from suspended-start state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+       a. Set O.[[GeneratorState]] to completed.
+       ...
+       c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+       d. Return CreateIteratorResultObject(undefined, true).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    2. If state is completed, return CreateIteratorResultObject(undefined, true).
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    throw new Test262Error("Unexpected call to next");
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is already set to "completed". The generator state is
+    // not "executing", so `GeneratorValidate` succeeds and `GeneratorResume`
+    // returns with `CreateIteratorResultObject()`.
+    var result = it.next();
+    assert.sameValue(result.value, undefined);
+    assert.sameValue(result.done, true);
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.filter.call(underlying, function() {
+  throw new Test262Error("Unexpected call to filter");
+});
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call sets the generator state to "completed" and then calls
+// `IteratorClose()`.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/filter/suspended-start-iterator-close-calls-return.js
+++ b/test/built-ins/Iterator/prototype/filter/suspended-start-iterator-close-calls-return.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.filter
+description: >
+  Generator is closed from suspended-start state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+       a. Set O.[[GeneratorState]] to completed.
+       ...
+       c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+       d. Return CreateIteratorResultObject(undefined, true).
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+    8. Return ? completion.
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    2. If state is suspended-start, then
+      ...
+    3. If state is completed, then
+      a. If abruptCompletion is a return completion, then
+        i. Return CreateIteratorResultObject(abruptCompletion.[[Value]], true).
+      ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    throw new Test262Error("Unexpected call to next");
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is already set to "completed", so this `return()`
+    // call proceeds to `GeneratorResumeAbrupt`. The generator state is not
+    // "executing", so `GeneratorValidate` succeeds and `GeneratorResumeAbrupt`
+    // returns with `CreateIteratorResultObject()`.
+    var result = it.return();
+    assert.sameValue(result.value, undefined);
+    assert.sameValue(result.done, true);
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.filter.call(underlying, function() {
+  throw new Test262Error("Unexpected call to filter");
+});
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call sets the generator state to "completed" and then calls
+// `IteratorClose()`.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/filter/suspended-yield-iterator-close-calls-next.js
+++ b/test/built-ins/Iterator/prototype/filter/suspended-yield-iterator-close-calls-next.js
@@ -1,0 +1,101 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.filter
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.4 Iterator.prototype.filter ( predicate )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and predicate and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        v. If ToBoolean(selected) is true, then
+          1. Let completion be Completion(Yield(value)).
+          2. IfAbruptCloseIterator(completion, iterated).
+        ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `next()` call throws
+    // a TypeError when `GeneratorResume` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.next();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.filter.call(underlying, function() {
+  return true;
+});
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 123);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/filter/suspended-yield-iterator-close-calls-return.js
+++ b/test/built-ins/Iterator/prototype/filter/suspended-yield-iterator-close-calls-return.js
@@ -1,0 +1,94 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.filter
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.4 Iterator.prototype.filter ( predicate )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and predicate and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        v. If ToBoolean(selected) is true, then
+          1. Let completion be Completion(Yield(value)).
+          2. IfAbruptCloseIterator(completion, iterated).
+        ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `return()` call throws
+    // a TypeError when `GeneratorResumeAbrupt` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.return();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.filter.call(underlying, function() {
+  return true;
+});
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 123);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/flatMap/next-method-called-with-zero-arguments.js
+++ b/test/built-ins/Iterator/prototype/flatMap/next-method-called-with-zero-arguments.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteratorprototype.flatmap
+description: >
+  Underlying iterator's next method is called with zero arguments.
+info: |
+  27.1.4.6 Iterator.prototype.flatMap ( mapper )
+
+  ...
+  6. Let closure be a new Abstract Closure with no parameters that captures
+     iterated and mapper and performs the following steps when called:
+    ...
+    b. Repeat,
+      i. Let value be ? IteratorStepValue(iterated).
+      ...
+      viii. Repeat, while innerAlive is true,
+        1. Let innerValue be Completion(IteratorStepValue(innerIterator)).
+        ...
+features: [iterator-helpers]
+---*/
+
+var counter = 0;
+var innerCounter = 0;
+
+var underlying = {
+  next() {
+    assert.sameValue(arguments.length, 0);
+
+    return {
+      done: false,
+      value: ++counter,
+    };
+  }
+};
+
+var inner = {
+  [Symbol.iterator]() {
+    return this;
+  },
+  next() {
+    assert.sameValue(arguments.length, 0);
+
+    return {
+      done: false,
+      value: ++innerCounter,
+    };
+  }
+};
+
+var it = Iterator.prototype.flatMap.call(underlying, function(v) {
+  return inner;
+});
+
+assert.sameValue(counter, 0);
+assert.sameValue(innerCounter, 0);
+
+assert.sameValue(it.next().value, 1);
+assert.sameValue(it.next(1).value, 2);
+assert.sameValue(it.next(1, 2).value, 3);
+
+assert.sameValue(counter, 1);
+assert.sameValue(innerCounter, 3);

--- a/test/built-ins/Iterator/prototype/flatMap/return-method-called-with-zero-arguments.js
+++ b/test/built-ins/Iterator/prototype/flatMap/return-method-called-with-zero-arguments.js
@@ -1,0 +1,140 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteratorprototype.flatmap
+description: >
+  Underlying iterator's return method is called with zero arguments.
+info: |
+  27.1.4.6 Iterator.prototype.flatMap ( mapper )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and mapper and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        viii. Repeat, while innerAlive is true,
+          ...
+          4. Else,
+            a. Let completion be Completion(Yield(innerValue)).
+            b. If completion is an abrupt completion, then
+              i. Let backupCompletion be Completion(IteratorClose(innerIterator, completion)).
+              ii. IfAbruptCloseIterator(backupCompletion, iterated).
+              iii. Return ? IteratorClose(iterated, completion).
+        ...
+
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+      ...
+      c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+      ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+features: [iterator-helpers]
+---*/
+
+var counter = 0;
+var innerCounter = 0;
+
+var underlying = {
+  next() {
+    return {
+      done: false,
+      value: 0,
+    };
+  },
+  return() {
+    assert.sameValue(arguments.length, 0);
+
+    counter += 1;
+    return {};
+  }
+};
+
+var inner = {
+  [Symbol.iterator]() {
+    return this;
+  },
+  next() {
+    return {
+      done: false,
+      value: 0,
+    };
+  },
+  return() {
+    assert.sameValue(arguments.length, 0);
+
+    innerCounter += 1;
+    return {};
+  }
+};
+
+function mapToInner() {
+  return inner;
+}
+
+// Close from "suspended-start".
+{
+  var it = Iterator.prototype.flatMap.call(underlying, mapToInner);
+
+  assert.sameValue(counter, 0);
+  assert.sameValue(innerCounter, 0);
+  it.return();
+  assert.sameValue(counter, 1);
+  assert.sameValue(innerCounter, 0);
+}
+
+{
+  var it = Iterator.prototype.flatMap.call(underlying, mapToInner);
+
+  assert.sameValue(counter, 1);
+  assert.sameValue(innerCounter, 0);
+  it.return(1);
+  assert.sameValue(counter, 2);
+  assert.sameValue(innerCounter, 0);
+}
+
+{
+  var it = Iterator.prototype.flatMap.call(underlying, mapToInner);
+
+  assert.sameValue(counter, 2);
+  assert.sameValue(innerCounter, 0);
+  it.return(1, 2);
+  assert.sameValue(counter, 3);
+  assert.sameValue(innerCounter, 0);
+}
+
+// Close from "suspended-yield".
+{
+  var it = Iterator.prototype.flatMap.call(underlying, mapToInner);
+  it.next();
+
+  assert.sameValue(counter, 3);
+  assert.sameValue(innerCounter, 0);
+  it.return();
+  assert.sameValue(counter, 4);
+  assert.sameValue(innerCounter, 1);
+}
+
+{
+  var it = Iterator.prototype.flatMap.call(underlying, mapToInner);
+  it.next();
+
+  assert.sameValue(counter, 4);
+  assert.sameValue(innerCounter, 1);
+  it.return(1);
+  assert.sameValue(counter, 5);
+  assert.sameValue(innerCounter, 2);
+}
+
+{
+  var it = Iterator.prototype.flatMap.call(underlying, mapToInner);
+  it.next();
+
+  assert.sameValue(counter, 5);
+  assert.sameValue(innerCounter, 2);
+  it.return(1, 2);
+  assert.sameValue(counter, 6);
+  assert.sameValue(innerCounter, 3);
+}

--- a/test/built-ins/Iterator/prototype/flatMap/return-method-can-be-absent-for-inner.js
+++ b/test/built-ins/Iterator/prototype/flatMap/return-method-can-be-absent-for-inner.js
@@ -1,0 +1,80 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.flatmap
+description: >
+  Call "return" when inner iterator has no user-defined return method.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.1.4.6 Iterator.prototype.flatMap ( mapper )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and mapper and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        viii. Repeat, while innerAlive is true,
+          4. Else,
+            a. Let completion be Completion(Yield(innerValue)).
+            b. If completion is an abrupt completion, then
+              i. Let backupCompletion be Completion(IteratorClose(innerIterator, completion)).
+              ...
+        ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+    return {};
+  },
+};
+
+var inner = {
+  next() {
+    return {value: 456, done: false};
+  },
+  // NB: No return method here.
+};
+
+var it = Iterator.prototype.flatMap.call(underlying, function() {
+  return inner;
+});
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 456);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/flatMap/return-method-can-be-absent-for-underlying.js
+++ b/test/built-ins/Iterator/prototype/flatMap/return-method-can-be-absent-for-underlying.js
@@ -1,0 +1,80 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.flatmap
+description: >
+  Call "return" when underlying iterator has no user-defined return method.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.1.4.6 Iterator.prototype.flatMap ( mapper )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and mapper and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        viii. Repeat, while innerAlive is true,
+          4. Else,
+            a. Let completion be Completion(Yield(innerValue)).
+            b. If completion is an abrupt completion, then
+              ...
+              iii. Return ? IteratorClose(iterated, completion).
+        ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  // NB: No return method here.
+};
+
+var inner = {
+  next() {
+    return {value: 456, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+    return {};
+  },
+};
+
+var it = Iterator.prototype.flatMap.call(underlying, function() {
+  return inner;
+});
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 456);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/flatMap/suspended-start-iterator-close-calls-next.js
+++ b/test/built-ins/Iterator/prototype/flatMap/suspended-start-iterator-close-calls-next.js
@@ -1,0 +1,74 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.flatmap
+description: >
+  Generator is closed from suspended-start state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+       a. Set O.[[GeneratorState]] to completed.
+       ...
+       c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+       d. Return CreateIteratorResultObject(undefined, true).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    2. If state is completed, return CreateIteratorResultObject(undefined, true).
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    throw new Test262Error("Unexpected call to next");
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is already set to "completed". The generator state is
+    // not "executing", so `GeneratorValidate` succeeds and `GeneratorResume`
+    // returns with `CreateIteratorResultObject()`.
+    var result = it.next();
+    assert.sameValue(result.value, undefined);
+    assert.sameValue(result.done, true);
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.flatMap.call(underlying, function() {
+  throw new Test262Error("Unexpected call to map");
+});
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call sets the generator state to "completed" and then calls
+// `IteratorClose()`.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/flatMap/suspended-start-iterator-close-calls-return.js
+++ b/test/built-ins/Iterator/prototype/flatMap/suspended-start-iterator-close-calls-return.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.flatmap
+description: >
+  Generator is closed from suspended-start state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+       a. Set O.[[GeneratorState]] to completed.
+       ...
+       c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+       d. Return CreateIteratorResultObject(undefined, true).
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+    8. Return ? completion.
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    2. If state is suspended-start, then
+      ...
+    3. If state is completed, then
+      a. If abruptCompletion is a return completion, then
+        i. Return CreateIteratorResultObject(abruptCompletion.[[Value]], true).
+      ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    throw new Test262Error("Unexpected call to next");
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is already set to "completed", so this `return()`
+    // call proceeds to `GeneratorResumeAbrupt`. The generator state is not
+    // "executing", so `GeneratorValidate` succeeds and `GeneratorResumeAbrupt`
+    // returns with `CreateIteratorResultObject()`.
+    var result = it.return();
+    assert.sameValue(result.value, undefined);
+    assert.sameValue(result.done, true);
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.flatMap.call(underlying, function() {
+  throw new Test262Error("Unexpected call to map");
+});
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call sets the generator state to "completed" and then calls
+// `IteratorClose()`.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/flatMap/suspended-yield-iterator-close-calls-next-from-inner.js
+++ b/test/built-ins/Iterator/prototype/flatMap/suspended-yield-iterator-close-calls-next-from-inner.js
@@ -1,0 +1,111 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.flatmap
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.6 Iterator.prototype.flatMap ( mapper )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and mapper and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        viii. Repeat, while innerAlive is true,
+          4. Else,
+            a. Let completion be Completion(Yield(innerValue)).
+            b. If completion is an abrupt completion, then
+              i. Let backupCompletion be Completion(IteratorClose(innerIterator, completion)).
+              ...
+        ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  // NB: No return method here.
+};
+
+var inner = {
+  next() {
+    return {value: 456, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `next()` call throws
+    // a TypeError when `GeneratorResume` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.next();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.flatMap.call(underlying, function() {
+  return inner;
+});
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 456);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/flatMap/suspended-yield-iterator-close-calls-next.js
+++ b/test/built-ins/Iterator/prototype/flatMap/suspended-yield-iterator-close-calls-next.js
@@ -1,0 +1,104 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.flatmap
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.6 Iterator.prototype.flatMap ( mapper )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and mapper and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        viii. Repeat, while innerAlive is true,
+          4. Else,
+            a. Let completion be Completion(Yield(innerValue)).
+            b. If completion is an abrupt completion, then
+              i. Let backupCompletion be Completion(IteratorClose(innerIterator, completion)).
+              ...
+        ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `next()` call throws
+    // a TypeError when `GeneratorResume` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.next();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.flatMap.call(underlying, function(v) {
+  return [v];
+});
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 123);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/flatMap/suspended-yield-iterator-close-calls-return-from-inner.js
+++ b/test/built-ins/Iterator/prototype/flatMap/suspended-yield-iterator-close-calls-return-from-inner.js
@@ -1,0 +1,104 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.flatmap
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.6 Iterator.prototype.flatMap ( mapper )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and mapper and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        viii. Repeat, while innerAlive is true,
+          4. Else,
+            a. Let completion be Completion(Yield(innerValue)).
+            b. If completion is an abrupt completion, then
+              i. Let backupCompletion be Completion(IteratorClose(innerIterator, completion)).
+              ...
+        ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  // NB: No return method here.
+};
+
+var inner = {
+  next() {
+    return {value: 456, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `return()` call throws
+    // a TypeError when `GeneratorResumeAbrupt` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.return();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.flatMap.call(underlying, function() {
+  return inner;
+});
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 456);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/flatMap/suspended-yield-iterator-close-calls-return.js
+++ b/test/built-ins/Iterator/prototype/flatMap/suspended-yield-iterator-close-calls-return.js
@@ -1,0 +1,97 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.flatmap
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.6 Iterator.prototype.flatMap ( mapper )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and mapper and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        viii. Repeat, while innerAlive is true,
+          4. Else,
+            a. Let completion be Completion(Yield(innerValue)).
+            b. If completion is an abrupt completion, then
+              i. Let backupCompletion be Completion(IteratorClose(innerIterator, completion)).
+              ...
+        ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `return()` call throws
+    // a TypeError when `GeneratorResumeAbrupt` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.return();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.flatMap.call(underlying, function(v) {
+  return [v];
+});
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 123);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/map/next-method-called-with-zero-arguments.js
+++ b/test/built-ins/Iterator/prototype/map/next-method-called-with-zero-arguments.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteratorprototype.map
+description: >
+  Underlying iterator's next method is called with zero arguments.
+info: |
+  27.1.4.8 Iterator.prototype.map ( mapper )
+
+  ...
+  6. Let closure be a new Abstract Closure with no parameters that captures
+     iterated and mapper and performs the following steps when called:
+    ...
+    b. Repeat,
+      i. Let value be ? IteratorStepValue(iterated).
+      ...
+features: [iterator-helpers]
+---*/
+
+var counter = 0;
+
+var underlying = {
+  next() {
+    assert.sameValue(arguments.length, 0);
+
+    return {
+      done: false,
+      value: ++counter,
+    };
+  }
+};
+
+var it = Iterator.prototype.map.call(underlying, function(v) {
+  return v;
+});
+
+assert.sameValue(counter, 0);
+
+assert.sameValue(it.next().value, 1);
+assert.sameValue(it.next(1).value, 2);
+assert.sameValue(it.next(1, 2).value, 3);
+
+assert.sameValue(counter, 3);

--- a/test/built-ins/Iterator/prototype/map/return-method-called-with-zero-arguments.js
+++ b/test/built-ins/Iterator/prototype/map/return-method-called-with-zero-arguments.js
@@ -1,0 +1,100 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteratorprototype.map
+description: >
+  Underlying iterator's return method is called with zero arguments.
+info: |
+  27.1.4.8 Iterator.prototype.map ( mapper )
+
+  ...
+  6. Let closure be a new Abstract Closure with no parameters that captures
+     iterated and mapper and performs the following steps when called:
+    ...
+    b. Repeat,
+      ...
+      v. Let completion be Completion(Yield(mapped)).
+      vi. IfAbruptCloseIterator(completion, iterated).
+      ...
+
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+      ...
+      c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+      ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+features: [iterator-helpers]
+---*/
+
+var counter = 0;
+
+var underlying = {
+  next() {
+    return {
+      done: false,
+      value: 0,
+    };
+  },
+  return() {
+    assert.sameValue(arguments.length, 0);
+
+    counter += 1;
+    return {};
+  }
+};
+
+// Close from "suspended-start".
+{
+  var it = Iterator.prototype.map.call(underlying, function(){});
+
+  assert.sameValue(counter, 0);
+  it.return();
+  assert.sameValue(counter, 1);
+}
+
+{
+  var it = Iterator.prototype.map.call(underlying, function(){});
+
+  assert.sameValue(counter, 1);
+  it.return(1);
+  assert.sameValue(counter, 2);
+}
+
+{
+  var it = Iterator.prototype.map.call(underlying, function(){});
+
+  assert.sameValue(counter, 2);
+  it.return(1, 2);
+  assert.sameValue(counter, 3);
+}
+
+// Close from "suspended-yield".
+{
+  var it = Iterator.prototype.map.call(underlying, function(){});
+  it.next();
+
+  assert.sameValue(counter, 3);
+  it.return();
+  assert.sameValue(counter, 4);
+}
+
+{
+  var it = Iterator.prototype.map.call(underlying, function(){});
+  it.next();
+
+  assert.sameValue(counter, 4);
+  it.return(1);
+  assert.sameValue(counter, 5);
+}
+
+{
+  var it = Iterator.prototype.map.call(underlying, function(){});
+  it.next();
+
+  assert.sameValue(counter, 5);
+  it.return(1, 2);
+  assert.sameValue(counter, 6);
+}

--- a/test/built-ins/Iterator/prototype/map/suspended-start-iterator-close-calls-next.js
+++ b/test/built-ins/Iterator/prototype/map/suspended-start-iterator-close-calls-next.js
@@ -1,0 +1,74 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.map
+description: >
+  Generator is closed from suspended-start state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+       a. Set O.[[GeneratorState]] to completed.
+       ...
+       c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+       d. Return CreateIteratorResultObject(undefined, true).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    2. If state is completed, return CreateIteratorResultObject(undefined, true).
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    throw new Test262Error("Unexpected call to next");
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is already set to "completed". The generator state is
+    // not "executing", so `GeneratorValidate` succeeds and `GeneratorResume`
+    // returns with `CreateIteratorResultObject()`.
+    var result = it.next();
+    assert.sameValue(result.value, undefined);
+    assert.sameValue(result.done, true);
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.map.call(underlying, function() {
+  throw new Test262Error("Unexpected call to map");
+});
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call sets the generator state to "completed" and then calls
+// `IteratorClose()`.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/map/suspended-start-iterator-close-calls-return.js
+++ b/test/built-ins/Iterator/prototype/map/suspended-start-iterator-close-calls-return.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.map
+description: >
+  Generator is closed from suspended-start state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+       a. Set O.[[GeneratorState]] to completed.
+       ...
+       c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+       d. Return CreateIteratorResultObject(undefined, true).
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+    8. Return ? completion.
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    2. If state is suspended-start, then
+      ...
+    3. If state is completed, then
+      a. If abruptCompletion is a return completion, then
+        i. Return CreateIteratorResultObject(abruptCompletion.[[Value]], true).
+      ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    throw new Test262Error("Unexpected call to next");
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is already set to "completed", so this `return()`
+    // call proceeds to `GeneratorResumeAbrupt`. The generator state is not
+    // "executing", so `GeneratorValidate` succeeds and `GeneratorResumeAbrupt`
+    // returns with `CreateIteratorResultObject()`.
+    var result = it.return();
+    assert.sameValue(result.value, undefined);
+    assert.sameValue(result.done, true);
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.map.call(underlying, function() {
+  throw new Test262Error("Unexpected call to map");
+});
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call sets the generator state to "completed" and then calls
+// `IteratorClose()`.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/map/suspended-yield-iterator-close-calls-next.js
+++ b/test/built-ins/Iterator/prototype/map/suspended-yield-iterator-close-calls-next.js
@@ -1,0 +1,100 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.map
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.8 Iterator.prototype.map ( mapper )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and mapper and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        v. Let completion be Completion(Yield(mapped)).
+        vi. IfAbruptCloseIterator(completion, iterated).
+        ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `next()` call throws
+    // a TypeError when `GeneratorResume` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.next();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.map.call(underlying, function(v) {
+  return v;
+});
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 123);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/map/suspended-yield-iterator-close-calls-return.js
+++ b/test/built-ins/Iterator/prototype/map/suspended-yield-iterator-close-calls-return.js
@@ -1,0 +1,93 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.map
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.8 Iterator.prototype.map ( mapper )
+    ...
+    6. Let closure be a new Abstract Closure with no parameters that captures
+       iterated and mapper and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        v. Let completion be Completion(Yield(mapped)).
+        vi. IfAbruptCloseIterator(completion, iterated).
+        ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `return()` call throws
+    // a TypeError when `GeneratorResumeAbrupt` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.return();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.map.call(underlying, function(v) {
+  return v;
+});
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 123);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/take/next-method-called-with-zero-arguments.js
+++ b/test/built-ins/Iterator/prototype/take/next-method-called-with-zero-arguments.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteratorprototype.take
+description: >
+  Underlying iterator's next method is called with zero arguments.
+info: |
+  27.1.4.11 Iterator.prototype.take ( limit )
+
+  ...
+  10. Let closure be a new Abstract Closure with no parameters that captures
+      iterated and integerLimit and performs the following steps when called:
+    ...
+    b. Repeat,
+      ...
+      iii. Let value be ? IteratorStepValue(iterated).
+      ...
+  ...
+features: [iterator-helpers]
+---*/
+
+var counter = 0;
+
+var underlying = {
+  next() {
+    assert.sameValue(arguments.length, 0);
+
+    return {
+      done: false,
+      value: ++counter,
+    };
+  }
+};
+
+var it = Iterator.prototype.take.call(underlying, 3);
+
+assert.sameValue(counter, 0);
+
+assert.sameValue(it.next().value, 1);
+assert.sameValue(it.next(1).value, 2);
+assert.sameValue(it.next(1, 2).value, 3);
+
+assert.sameValue(counter, 3);

--- a/test/built-ins/Iterator/prototype/take/return-method-called-with-zero-arguments.js
+++ b/test/built-ins/Iterator/prototype/take/return-method-called-with-zero-arguments.js
@@ -1,0 +1,102 @@
+// Copyright (C) 2024 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iteratorprototype.take
+description: >
+  Underlying iterator's return method is called with zero arguments.
+info: |
+  27.1.4.11 Iterator.prototype.take ( limit )
+
+  ...
+  10. Let closure be a new Abstract Closure with no parameters that captures
+      iterated and integerLimit and performs the following steps when called:
+    ...
+    b. Repeat,
+      i. If remaining = 0, then
+        1. Return ? IteratorClose(iterated, ReturnCompletion(undefined)).
+      ...
+      v. Let completion be Completion(Yield(value)).
+      vi. IfAbruptCloseIterator(completion, iterated).
+  ...
+
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+      ...
+      c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+      ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+features: [iterator-helpers]
+---*/
+
+var counter = 0;
+
+var underlying = {
+  next() {
+    return {
+      done: false,
+      value: 0,
+    };
+  },
+  return() {
+    assert.sameValue(arguments.length, 0);
+
+    counter += 1;
+    return {};
+  }
+};
+
+// Close from "suspended-start".
+{
+  var it = Iterator.prototype.take.call(underlying, 0);
+
+  assert.sameValue(counter, 0);
+  it.return();
+  assert.sameValue(counter, 1);
+}
+
+{
+  var it = Iterator.prototype.take.call(underlying, 0);
+
+  assert.sameValue(counter, 1);
+  it.return(1);
+  assert.sameValue(counter, 2);
+}
+
+{
+  var it = Iterator.prototype.take.call(underlying, 0);
+
+  assert.sameValue(counter, 2);
+  it.return(1, 2);
+  assert.sameValue(counter, 3);
+}
+
+// Close from "suspended-yield".
+{
+  var it = Iterator.prototype.take.call(underlying, Infinity);
+  it.next();
+
+  assert.sameValue(counter, 3);
+  it.return();
+  assert.sameValue(counter, 4);
+}
+
+{
+  var it = Iterator.prototype.take.call(underlying, Infinity);
+  it.next();
+
+  assert.sameValue(counter, 4);
+  it.return(1);
+  assert.sameValue(counter, 5);
+}
+
+{
+  var it = Iterator.prototype.take.call(underlying, Infinity);
+  it.next();
+
+  assert.sameValue(counter, 5);
+  it.return(1, 2);
+  assert.sameValue(counter, 6);
+}

--- a/test/built-ins/Iterator/prototype/take/suspended-start-iterator-close-calls-next.js
+++ b/test/built-ins/Iterator/prototype/take/suspended-start-iterator-close-calls-next.js
@@ -1,0 +1,72 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.take
+description: >
+  Generator is closed from suspended-start state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+       a. Set O.[[GeneratorState]] to completed.
+       ...
+       c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+       d. Return CreateIteratorResultObject(undefined, true).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    2. If state is completed, return CreateIteratorResultObject(undefined, true).
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    throw new Test262Error("Unexpected call to next");
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is already set to "completed". The generator state is
+    // not "executing", so `GeneratorValidate` succeeds and `GeneratorResume`
+    // returns with `CreateIteratorResultObject()`.
+    var result = it.next();
+    assert.sameValue(result.value, undefined);
+    assert.sameValue(result.done, true);
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.take.call(underlying, 0);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call sets the generator state to "completed" and then calls
+// `IteratorClose()`.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/take/suspended-start-iterator-close-calls-return.js
+++ b/test/built-ins/Iterator/prototype/take/suspended-start-iterator-close-calls-return.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.take
+description: >
+  Generator is closed from suspended-start state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    4. If O.[[GeneratorState]] is suspended-start, then
+       a. Set O.[[GeneratorState]] to completed.
+       ...
+       c. Perform ? IteratorClose(O.[[UnderlyingIterator]], NormalCompletion(unused)).
+       d. Return CreateIteratorResultObject(undefined, true).
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+    8. Return ? completion.
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    2. If state is suspended-start, then
+      ...
+    3. If state is completed, then
+      a. If abruptCompletion is a return completion, then
+        i. Return CreateIteratorResultObject(abruptCompletion.[[Value]], true).
+      ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    throw new Test262Error("Unexpected call to next");
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is already set to "completed", so this `return()`
+    // call proceeds to `GeneratorResumeAbrupt`. The generator state is not
+    // "executing", so `GeneratorValidate` succeeds and `GeneratorResumeAbrupt`
+    // returns with `CreateIteratorResultObject()`.
+    var result = it.return();
+    assert.sameValue(result.value, undefined);
+    assert.sameValue(result.done, true);
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.take.call(underlying, 0);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call sets the generator state to "completed" and then calls
+// `IteratorClose()`.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/take/suspended-yield-iterator-close-calls-next.js
+++ b/test/built-ins/Iterator/prototype/take/suspended-yield-iterator-close-calls-next.js
@@ -1,0 +1,98 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.take
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls next.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.11 Iterator.prototype.take ( limit )
+    ...
+    10. Let closure be a new Abstract Closure with no parameters that captures
+        iterated and integerLimit and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        v. Let completion be Completion(Yield(value)).
+        vi. IfAbruptCloseIterator(completion, iterated).
+    ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+
+  27.1.2.1.1 %IteratorHelperPrototype%.next ( )
+    1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
+
+  27.5.3.3 GeneratorResume ( generator, value, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `next()` call throws
+    // a TypeError when `GeneratorResume` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.next();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.take.call(underlying, Infinity);
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 123);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);

--- a/test/built-ins/Iterator/prototype/take/suspended-yield-iterator-close-calls-return.js
+++ b/test/built-ins/Iterator/prototype/take/suspended-yield-iterator-close-calls-return.js
@@ -1,0 +1,91 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.take
+description: >
+  Generator is closed from suspended-yield state and IteratorClose calls return.
+info: |
+  27.1.2.1.2 %IteratorHelperPrototype%.return ( )
+    ...
+    5. Let C be ReturnCompletion(undefined).
+    6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
+
+  27.5.3.4 GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand )
+    1. Let state be ? GeneratorValidate(generator, generatorBrand).
+    ...
+    4. Assert: state is suspended-yield.
+    ...
+    8. Set generator.[[GeneratorState]] to executing.
+    ...
+    10. Resume the suspended evaluation of genContext using abruptCompletion as
+        the result of the operation that suspended it. Let result be the
+        Completion Record returned by the resumed computation.
+    ...
+
+  27.5.3.2 GeneratorValidate ( generator, generatorBrand )
+    ...
+    5. Let state be generator.[[GeneratorState]].
+    6. If state is executing, throw a TypeError exception.
+    7. Return state.
+
+  27.1.4.11 Iterator.prototype.take ( limit )
+    ...
+    10. Let closure be a new Abstract Closure with no parameters that captures
+        iterated and integerLimit and performs the following steps when called:
+      ...
+      b. Repeat,
+        ...
+        v. Let completion be Completion(Yield(value)).
+        vi. IfAbruptCloseIterator(completion, iterated).
+    ...
+
+  7.4.12 IfAbruptCloseIterator ( value, iteratorRecord )
+    ...
+    2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+    ...
+
+  7.4.11 IteratorClose ( iteratorRecord, completion )
+    ...
+    3. Let innerResult be Completion(GetMethod(iterator, "return")).
+    4. If innerResult is a normal completion, then
+       a. Let return be innerResult.[[Value]].
+       b. If return is undefined, return ? completion.
+       c. Set innerResult to Completion(Call(return, iterator)).
+    ...
+features: [iterator-helpers]
+---*/
+
+var returnCallCount = 0;
+
+var underlying = {
+  next() {
+    return {value: 123, done: false};
+  },
+  return() {
+    returnCallCount += 1;
+
+    // The generator state is set to "executing", so this `return()` call throws
+    // a TypeError when `GeneratorResumeAbrupt` performs `GeneratorValidate`.
+    assert.throws(TypeError, function() {
+      it.return();
+    });
+
+    return {};
+  },
+};
+
+var it = Iterator.prototype.take.call(underlying, Infinity);
+
+// Move generator into "suspended-yield" state.
+var result = it.next();
+assert.sameValue(result.value, 123);
+assert.sameValue(result.done, false);
+
+assert.sameValue(returnCallCount, 0);
+
+// This `return()` call continues execution in the suspended generator.
+var result = it.return();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+assert.sameValue(returnCallCount, 1);


### PR DESCRIPTION
- SM fails the "suspended-start" tests.
- V8 fails the "suspended-yield" tests.
- JSC fails the "flatMap/return-method-called-with-zero-arguments.js" test.
- JSC fails the "return-method-can-be-absent-for-underlying.js" test.