### PR TITLE
Add coverage for resolved locale when Unicode extensions and options are present

### DIFF
--- a/test/intl402/Collator/prototype/resolvedOptions/resolved-case-first-unicode-extensions-and-options.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/resolved-case-first-unicode-extensions-and-options.js
@@ -1,0 +1,56 @@
+// Copyright 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.collator.prototype.resolvedoptions
+description: >
+  Resolved caseFirst when using Unicode extension values and options.
+locale: [en]
+---*/
+
+var tests = [
+  // Unicode extension value is present and supported. Different options value
+  // present and supported. Unicode extension value is ignored and not reflected
+  // in the resolved locale.
+  {
+    locale: "en-u-kf-lower",
+    caseFirst: "upper",
+    resolved: {
+      locale: "en",
+      caseFirst: "upper",
+    }
+  },
+
+  // Unicode extension value is present and supported. Options value present and
+  // supported. Unicode extension value is equal to options value. Unicode
+  // extension value is reflected in the resolved locale.
+  {
+    locale: "en-u-kf-lower",
+    caseFirst: "lower",
+    resolved: {
+      locale: "en-u-kf-lower",
+      caseFirst: "lower",
+    }
+  },
+];
+
+for (var {locale, caseFirst, resolved} of tests) {
+  var coll = new Intl.Collator(locale, {caseFirst});
+  var resolvedOptions = coll.resolvedOptions();
+
+  // Skip if this implementation doesn't support the optional "kf" extension key.
+  if (!resolvedOptions.hasOwnProperty("caseFirst")) {
+    continue;
+  }
+
+  assert.sameValue(
+    resolvedOptions.locale,
+    resolved.locale,
+    `Resolved locale for locale=${locale} with caseFirst=${caseFirst}`
+  );
+  assert.sameValue(
+    resolvedOptions.caseFirst,
+    resolved.caseFirst,
+    `Resolved numeric for locale=${locale} with caseFirst=${caseFirst}`
+  );
+}

--- a/test/intl402/Collator/prototype/resolvedOptions/resolved-collation-unicode-extensions-and-options.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/resolved-collation-unicode-extensions-and-options.js
@@ -1,0 +1,74 @@
+// Copyright 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.collator.prototype.resolvedoptions
+description: >
+  Resolved collation when using Unicode extension values and options.
+locale: [en, de]
+---*/
+
+var tests = [
+  // Unicode extension value is present and supported. Options value present,
+  // but unsupported. Unicode extension value is used and reflected in the
+  // resolved locale.
+  {
+    locale: "de-u-co-phonebk",
+    collation: "pinyin",
+    resolved: {
+      locale: "de-u-co-phonebk",
+      collation: "phonebk",
+    },
+  },
+
+  // Unicode extension value is present, but unsupported. Options value present,
+  // but also unsupported. Default collation is used.
+  {
+    locale: "en-u-co-phonebk",
+    collation: "pinyin",
+    resolved: {
+      locale: "en",
+      collation: "default",
+    },
+  },
+
+  // Unicode extension value is present and supported. Different options value
+  // present and supported. Unicode extension value is ignored and not reflected
+  // in the resolved locale.
+  {
+    locale: "de-u-co-phonebk",
+    collation: "eor",
+    resolved: {
+      locale: "de",
+      collation: "eor",
+    }
+  },
+
+  // Unicode extension value is present and supported. Options value present and
+  // supported. Unicode extension value is equal to options value. Unicode
+  // extension value is reflected in the resolved locale.
+  {
+    locale: "de-u-co-phonebk",
+    collation: "phonebk",
+    resolved: {
+      locale: "de-u-co-phonebk",
+      collation: "phonebk",
+    }
+  },
+];
+
+for (var {locale, collation, resolved} of tests) {
+  var coll = new Intl.Collator(locale, {collation});
+  var resolvedOptions = coll.resolvedOptions();
+
+  assert.sameValue(
+    resolvedOptions.locale,
+    resolved.locale,
+    `Resolved locale for locale=${locale} with collation=${collation}`
+  );
+  assert.sameValue(
+    resolvedOptions.collation,
+    resolved.collation,
+    `Resolved collation for locale=${locale} with collation=${collation}`
+  );
+}

--- a/test/intl402/Collator/prototype/resolvedOptions/resolved-numeric-unicode-extensions-and-options.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/resolved-numeric-unicode-extensions-and-options.js
@@ -1,0 +1,56 @@
+// Copyright 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.collator.prototype.resolvedoptions
+description: >
+  Resolved numeric when using Unicode extension values and options.
+locale: [en]
+---*/
+
+var tests = [
+  // Unicode extension value is present and supported. Different options value
+  // present and supported. Unicode extension value is ignored and not reflected
+  // in the resolved locale.
+  {
+    locale: "en-u-kn-false",
+    numeric: true,
+    resolved: {
+      locale: "en",
+      numeric: true,
+    }
+  },
+
+  // Unicode extension value is present and supported. Options value present and
+  // supported. Unicode extension value is equal to options value. Unicode
+  // extension value is reflected in the resolved locale.
+  {
+    locale: "en-u-kn-true",
+    numeric: true,
+    resolved: {
+      locale: "en-u-kn",
+      numeric: true,
+    }
+  },
+];
+
+for (var {locale, numeric, resolved} of tests) {
+  var coll = new Intl.Collator(locale, {numeric});
+  var resolvedOptions = coll.resolvedOptions();
+
+  // Skip if this implementation doesn't support the optional "kn" extension key.
+  if (!resolvedOptions.hasOwnProperty("numeric")) {
+    continue;
+  }
+
+  assert.sameValue(
+    resolvedOptions.locale,
+    resolved.locale,
+    `Resolved locale for locale=${locale} with numeric=${numeric}`
+  );
+  assert.sameValue(
+    resolvedOptions.numeric,
+    resolved.numeric,
+    `Resolved numeric for locale=${locale} with numeric=${numeric}`
+  );
+}

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-calendar-unicode-extensions-and-options.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-calendar-unicode-extensions-and-options.js
@@ -1,0 +1,74 @@
+// Copyright 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.datetimeformat.prototype.resolvedoptions
+description: >
+  Resolved calendar when using Unicode extension values and options.
+locale: [en]
+---*/
+
+var tests = [
+  // Unicode extension value is present and supported. Options value present,
+  // but unsupported. Unicode extension value is used and reflected in the
+  // resolved locale.
+  {
+    locale: "en-u-ca-iso8601",
+    calendar: "invalid",
+    resolved: {
+      locale: "en-u-ca-iso8601",
+      calendar: "iso8601",
+    },
+  },
+
+  // Unicode extension value is present, but unsupported. Options value present,
+  // but also unsupported. Default calendar is used.
+  {
+    locale: "en-u-ca-invalid",
+    calendar: "invalid2",
+    resolved: {
+      locale: "en",
+      calendar: "gregory",
+    },
+  },
+
+  // Unicode extension value is present and supported. Different options value
+  // present and supported. Unicode extension value is ignored and not reflected
+  // in the resolved locale.
+  {
+    locale: "en-u-ca-gregory",
+    calendar: "iso8601",
+    resolved: {
+      locale: "en",
+      calendar: "iso8601",
+    }
+  },
+
+  // Unicode extension value is present and supported. Options value present and
+  // supported. Unicode extension value is equal to options value. Unicode
+  // extension value is reflected in the resolved locale.
+  {
+    locale: "en-u-ca-iso8601",
+    calendar: "iso8601",
+    resolved: {
+      locale: "en-u-ca-iso8601",
+      calendar: "iso8601",
+    }
+  },
+];
+
+for (var {locale, calendar, resolved} of tests) {
+  var dtf = new Intl.DateTimeFormat(locale, {calendar});
+  var resolvedOptions = dtf.resolvedOptions();
+
+  assert.sameValue(
+    resolvedOptions.locale,
+    resolved.locale,
+    `Resolved locale for locale=${locale} with calendar=${calendar}`
+  );
+  assert.sameValue(
+    resolvedOptions.calendar,
+    resolved.calendar,
+    `Resolved calendar for locale=${locale} with calendar=${calendar}`
+  );
+}

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-hour-cycle-unicode-extensions-and-options.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-hour-cycle-unicode-extensions-and-options.js
@@ -1,0 +1,51 @@
+// Copyright 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.datetimeformat.prototype.resolvedoptions
+description: >
+  Resolved hour-cycle when using Unicode extension values and options.
+locale: [en]
+---*/
+
+var tests = [
+  // Unicode extension value is present and supported. Different options value
+  // present and supported. Unicode extension value is ignored and not reflected
+  // in the resolved locale.
+  {
+    locale: "en-u-hc-h23",
+    hourCycle: "h11",
+    resolved: {
+      locale: "en",
+      hourCycle: "h11",
+    }
+  },
+
+  // Unicode extension value is present and supported. Options value present and
+  // supported. Unicode extension value is equal to options value. Unicode
+  // extension value is reflected in the resolved locale.
+  {
+    locale: "en-u-hc-h23",
+    hourCycle: "h23",
+    resolved: {
+      locale: "en-u-hc-h23",
+      hourCycle: "h23",
+    }
+  },
+];
+
+for (var {locale, hourCycle, resolved} of tests) {
+  var dtf = new Intl.DateTimeFormat(locale, {hour: "numeric", hourCycle});
+  var resolvedOptions = dtf.resolvedOptions();
+
+  assert.sameValue(
+    resolvedOptions.locale,
+    resolved.locale,
+    `Resolved locale for locale=${locale} with hourCycle=${hourCycle}`
+  );
+  assert.sameValue(
+    resolvedOptions.hourCycle,
+    resolved.hourCycle,
+    `Resolved hourCycle for locale=${locale} with hourCycle=${hourCycle}`
+  );
+}

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js
@@ -1,0 +1,74 @@
+// Copyright 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.datetimeformat.prototype.resolvedoptions
+description: >
+  Resolved numbering system when using Unicode extension values and options.
+locale: [en]
+---*/
+
+var tests = [
+  // Unicode extension value is present and supported. Options value present,
+  // but unsupported. Unicode extension value is used and reflected in the
+  // resolved locale.
+  {
+    locale: "en-u-nu-arab",
+    numberingSystem: "invalid",
+    resolved: {
+      locale: "en-u-nu-arab",
+      numberingSystem: "arab",
+    },
+  },
+
+  // Unicode extension value is present, but unsupported. Options value present,
+  // but also unsupported. Default numbering system is used.
+  {
+    locale: "en-u-nu-invalid",
+    numberingSystem: "invalid2",
+    resolved: {
+      locale: "en",
+      numberingSystem: "latn",
+    },
+  },
+
+  // Unicode extension value is present and supported. Different options value
+  // present and supported. Unicode extension value is ignored and not reflected
+  // in the resolved locale.
+  {
+    locale: "en-u-nu-latn",
+    numberingSystem: "arab",
+    resolved: {
+      locale: "en",
+      numberingSystem: "arab",
+    }
+  },
+
+  // Unicode extension value is present and supported. Options value present and
+  // supported. Unicode extension value is equal to options value. Unicode
+  // extension value is reflected in the resolved locale.
+  {
+    locale: "en-u-nu-arab",
+    numberingSystem: "arab",
+    resolved: {
+      locale: "en-u-nu-arab",
+      numberingSystem: "arab",
+    }
+  },
+];
+
+for (var {locale, numberingSystem, resolved} of tests) {
+  var dtf = new Intl.DateTimeFormat(locale, {numberingSystem});
+  var resolvedOptions = dtf.resolvedOptions();
+
+  assert.sameValue(
+    resolvedOptions.locale,
+    resolved.locale,
+    `Resolved locale for locale=${locale} with numberingSystem=${numberingSystem}`
+  );
+  assert.sameValue(
+    resolvedOptions.numberingSystem,
+    resolved.numberingSystem,
+    `Resolved numberingSystem for locale=${locale} with numberingSystem=${numberingSystem}`
+  );
+}

--- a/test/intl402/DurationFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js
+++ b/test/intl402/DurationFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js
@@ -1,0 +1,74 @@
+// Copyright 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DurationFormat.prototype.resolvedOptions
+description: >
+  Resolved numbering system when using Unicode extension values and options.
+locale: [en]
+---*/
+
+var tests = [
+  // Unicode extension value is present and supported. Options value present,
+  // but unsupported. Unicode extension value is used and reflected in the
+  // resolved locale.
+  {
+    locale: "en-u-nu-arab",
+    numberingSystem: "invalid",
+    resolved: {
+      locale: "en-u-nu-arab",
+      numberingSystem: "arab",
+    },
+  },
+
+  // Unicode extension value is present, but unsupported. Options value present,
+  // but also unsupported. Default numbering system is used.
+  {
+    locale: "en-u-nu-invalid",
+    numberingSystem: "invalid2",
+    resolved: {
+      locale: "en",
+      numberingSystem: "latn",
+    },
+  },
+
+  // Unicode extension value is present and supported. Different options value
+  // present and supported. Unicode extension value is ignored and not reflected
+  // in the resolved locale.
+  {
+    locale: "en-u-nu-latn",
+    numberingSystem: "arab",
+    resolved: {
+      locale: "en",
+      numberingSystem: "arab",
+    }
+  },
+
+  // Unicode extension value is present and supported. Options value present and
+  // supported. Unicode extension value is equal to options value. Unicode
+  // extension value is reflected in the resolved locale.
+  {
+    locale: "en-u-nu-arab",
+    numberingSystem: "arab",
+    resolved: {
+      locale: "en-u-nu-arab",
+      numberingSystem: "arab",
+    }
+  },
+];
+
+for (var {locale, numberingSystem, resolved} of tests) {
+  var df = new Intl.DurationFormat(locale, {numberingSystem});
+  var resolvedOptions = df.resolvedOptions();
+
+  assert.sameValue(
+    resolvedOptions.locale,
+    resolved.locale,
+    `Resolved locale for locale=${locale} with numberingSystem=${numberingSystem}`
+  );
+  assert.sameValue(
+    resolvedOptions.numberingSystem,
+    resolved.numberingSystem,
+    `Resolved numberingSystem for locale=${locale} with numberingSystem=${numberingSystem}`
+  );
+}

--- a/test/intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js
@@ -1,0 +1,74 @@
+// Copyright 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.resolvedoptions
+description: >
+  Resolved numbering system when using Unicode extension values and options.
+locale: [en]
+---*/
+
+var tests = [
+  // Unicode extension value is present and supported. Options value present,
+  // but unsupported. Unicode extension value is used and reflected in the
+  // resolved locale.
+  {
+    locale: "en-u-nu-arab",
+    numberingSystem: "invalid",
+    resolved: {
+      locale: "en-u-nu-arab",
+      numberingSystem: "arab",
+    },
+  },
+
+  // Unicode extension value is present, but unsupported. Options value present,
+  // but also unsupported. Default numbering system is used.
+  {
+    locale: "en-u-nu-invalid",
+    numberingSystem: "invalid2",
+    resolved: {
+      locale: "en",
+      numberingSystem: "latn",
+    },
+  },
+
+  // Unicode extension value is present and supported. Different options value
+  // present and supported. Unicode extension value is ignored and not reflected
+  // in the resolved locale.
+  {
+    locale: "en-u-nu-latn",
+    numberingSystem: "arab",
+    resolved: {
+      locale: "en",
+      numberingSystem: "arab",
+    }
+  },
+
+  // Unicode extension value is present and supported. Options value present and
+  // supported. Unicode extension value is equal to options value. Unicode
+  // extension value is reflected in the resolved locale.
+  {
+    locale: "en-u-nu-arab",
+    numberingSystem: "arab",
+    resolved: {
+      locale: "en-u-nu-arab",
+      numberingSystem: "arab",
+    }
+  },
+];
+
+for (var {locale, numberingSystem, resolved} of tests) {
+  var nf = new Intl.NumberFormat(locale, {numberingSystem});
+  var resolvedOptions = nf.resolvedOptions();
+
+  assert.sameValue(
+    resolvedOptions.locale,
+    resolved.locale,
+    `Resolved locale for locale=${locale} with numberingSystem=${numberingSystem}`
+  );
+  assert.sameValue(
+    resolvedOptions.numberingSystem,
+    resolved.numberingSystem,
+    `Resolved numberingSystem for locale=${locale} with numberingSystem=${numberingSystem}`
+  );
+}

--- a/test/intl402/RelativeTimeFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js
+++ b/test/intl402/RelativeTimeFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js
@@ -1,0 +1,74 @@
+// Copyright 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.relativetimeformat.prototype.resolvedoptions
+description: >
+  Resolved numbering system when using Unicode extension values and options.
+locale: [en]
+---*/
+
+var tests = [
+  // Unicode extension value is present and supported. Options value present,
+  // but unsupported. Unicode extension value is used and reflected in the
+  // resolved locale.
+  {
+    locale: "en-u-nu-arab",
+    numberingSystem: "invalid",
+    resolved: {
+      locale: "en-u-nu-arab",
+      numberingSystem: "arab",
+    },
+  },
+
+  // Unicode extension value is present, but unsupported. Options value present,
+  // but also unsupported. Default numbering system is used.
+  {
+    locale: "en-u-nu-invalid",
+    numberingSystem: "invalid2",
+    resolved: {
+      locale: "en",
+      numberingSystem: "latn",
+    },
+  },
+
+  // Unicode extension value is present and supported. Different options value
+  // present and supported. Unicode extension value is ignored and not reflected
+  // in the resolved locale.
+  {
+    locale: "en-u-nu-latn",
+    numberingSystem: "arab",
+    resolved: {
+      locale: "en",
+      numberingSystem: "arab",
+    }
+  },
+
+  // Unicode extension value is present and supported. Options value present and
+  // supported. Unicode extension value is equal to options value. Unicode
+  // extension value is reflected in the resolved locale.
+  {
+    locale: "en-u-nu-arab",
+    numberingSystem: "arab",
+    resolved: {
+      locale: "en-u-nu-arab",
+      numberingSystem: "arab",
+    }
+  },
+];
+
+for (var {locale, numberingSystem, resolved} of tests) {
+  var rtf = new Intl.RelativeTimeFormat(locale, {numberingSystem});
+  var resolvedOptions = rtf.resolvedOptions();
+
+  assert.sameValue(
+    resolvedOptions.locale,
+    resolved.locale,
+    `Resolved locale for locale=${locale} with numberingSystem=${numberingSystem}`
+  );
+  assert.sameValue(
+    resolvedOptions.numberingSystem,
+    resolved.numberingSystem,
+    `Resolved numberingSystem for locale=${locale} with numberingSystem=${numberingSystem}`
+  );
+}


### PR DESCRIPTION
These tests currently fail in V8, but pass in JSC and SM.