### PR TITLE
Temporal: Add test coverage for sub-minute UTC offsets in strings

### DIFF
--- a/test/intl402/Temporal/Duration/compare/relativeto-sub-minute-offset.js
+++ b/test/intl402/Temporal/Duration/compare/relativeto-sub-minute-offset.js
@@ -7,8 +7,8 @@ description: relativeTo string accepts an inexact UTC offset rounded to hours an
 features: [Temporal]
 ---*/
 
-const duration1 = new Temporal.Duration(0, 0, 0, 31);
-const duration2 = new Temporal.Duration(0, 1);
+let duration1 = new Temporal.Duration(0, 0, 0, 31);
+let duration2 = new Temporal.Duration(0, 1);
 
 let result;
 let relativeTo;
@@ -23,5 +23,33 @@ relativeTo = "1970-01-01T00:00:00-00:44:30[Africa/Monrovia]";
 result = action(relativeTo);
 assert.sameValue(result, 0, "unrounded HH:MM:SS is accepted in string offset");
 
-relativeTo = { year: 1970, month: 1, day: 1, offset: "+00:45", timeZone: "Africa/Monrovia" };
+relativeTo = "1970-01-01T00:00:00-00:44:40[Africa/Monrovia]";
+assert.throws(RangeError, () => action(relativeTo), "wrong :SS not accepted in string offset");
+
+relativeTo = "1970-01-01T00:00:00-00:45:00[Africa/Monrovia]";
+assert.throws(RangeError, () => action(relativeTo), "rounded HH:MM:SS not accepted in string offset");
+
+relativeTo = { year: 1970, month: 1, day: 1, offset: "-00:45", timeZone: "Africa/Monrovia" };
 assert.throws(RangeError, () => action(relativeTo), "rounded HH:MM not accepted as offset in property bag");
+
+// Pacific/Niue edge case
+
+duration1 = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 24);
+duration2 = new Temporal.Duration(0, 0, 0, /* days = */ 1);
+
+assert.sameValue(
+  action("1952-10-15T23:59:59-11:19:40[Pacific/Niue]"), -1,
+  "-11:19:40 is accepted as -11:19:40 in Pacific/Niue edge case"
+);
+assert.sameValue(
+  action("1952-10-15T23:59:59-11:20[Pacific/Niue]"), -1,
+  "-11:20 matches the first candidate -11:19:40 in the Pacific/Niue edge case"
+);
+assert.sameValue(
+  action("1952-10-15T23:59:59-11:20:00[Pacific/Niue]"), 0,
+  "-11:20:00 is accepted as -11:20:00 in the Pacific/Niue edge case"
+);
+assert.throws(
+  RangeError, () => action("1952-10-15T23:59:59-11:19:50[Pacific/Niue]"),
+  "wrong :SS not accepted in the Pacific/Niue edge case"
+);

--- a/test/intl402/Temporal/Duration/prototype/round/relativeto-sub-minute-offset.js
+++ b/test/intl402/Temporal/Duration/prototype/round/relativeto-sub-minute-offset.js
@@ -8,12 +8,12 @@ includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+let instance = new Temporal.Duration(1, 0, 0, 0, 24);
 
 let result;
 let relativeTo;
 
-const action = (relativeTo) => instance.round({ largestUnit: "years", relativeTo });
+let action = (relativeTo) => instance.round({ largestUnit: "years", relativeTo });
 
 relativeTo = "1970-01-01T00:00-00:45:00[-00:45]";
 result = action(relativeTo);
@@ -31,8 +31,39 @@ relativeTo = "1970-01-01T00:00:00-00:44:30[Africa/Monrovia]";
 result = action(relativeTo);
 TemporalHelpers.assertDateDuration(result, 1, 0, 0, 1, "unrounded HH:MM:SS is accepted in string offset");
 
+relativeTo = "1970-01-01T00:00:00-00:44:40[Africa/Monrovia]";
+assert.throws(RangeError, () => action(relativeTo), "wrong :SS not accepted in string offset");
+
+relativeTo = "1970-01-01T00:00:00-00:45:00[Africa/Monrovia]";
+assert.throws(RangeError, () => action(relativeTo), "rounded HH:MM:SS not accepted in string offset");
+
 relativeTo = "1970-01-01T00:00+00:44:30.123456789[+00:45]";
 assert.throws(RangeError, () => action(relativeTo), "rounding is not accepted between ISO offset and time zone");
 
-relativeTo = { year: 1970, month: 1, day: 1, offset: "+00:45", timeZone: "Africa/Monrovia" };
+relativeTo = { year: 1970, month: 1, day: 1, offset: "-00:45", timeZone: "Africa/Monrovia" };
 assert.throws(RangeError, () => action(relativeTo), "rounded HH:MM not accepted as offset in property bag");
+
+// Pacific/Niue edge case
+
+instance = new Temporal.Duration(0, 0, 0, /* days = */ 1);
+action = (relativeTo) => instance.round({ largestUnit: "seconds", relativeTo });
+
+TemporalHelpers.assertDuration(
+  action("1952-10-15T23:59:59-11:19:40[Pacific/Niue]"),
+  0, 0, 0, 0, 0, 0, /* seconds = */ 86420, 0, 0, 0,
+  "-11:19:40 is accepted as -11:19:40 in Pacific/Niue edge case"
+);
+TemporalHelpers.assertDuration(
+  action("1952-10-15T23:59:59-11:20[Pacific/Niue]"),
+  0, 0, 0, 0, 0, 0, /* seconds = */ 86420, 0, 0, 0,
+  "-11:20 matches the first candidate -11:19:40 in the Pacific/Niue edge case"
+);
+TemporalHelpers.assertDuration(
+  action("1952-10-15T23:59:59-11:20:00[Pacific/Niue]"),
+  0, 0, 0, 0, 0, 0, /* seconds = */ 86400, 0, 0, 0,
+  "-11:20:00 is accepted as -11:20:00 in the Pacific/Niue edge case"
+);
+assert.throws(
+  RangeError, () => action("1952-10-15T23:59:59-11:19:50[Pacific/Niue]"),
+  "wrong :SS not accepted in the Pacific/Niue edge case"
+);

--- a/test/intl402/Temporal/Duration/prototype/total/relativeto-sub-minute-offset.js
+++ b/test/intl402/Temporal/Duration/prototype/total/relativeto-sub-minute-offset.js
@@ -7,12 +7,12 @@ description: relativeTo string accepts an inexact UTC offset rounded to hours an
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+let instance = new Temporal.Duration(1, 0, 0, 0, 24);
 
 let result;
 let relativeTo;
 
-const action = (relativeTo) => instance.total({ unit: "days", relativeTo });
+let action = (relativeTo) => instance.total({ unit: "days", relativeTo });
 
 relativeTo = "1970-01-01T00:00-00:45:00[-00:45]";
 result = action(relativeTo);
@@ -30,8 +30,36 @@ relativeTo = "1970-01-01T00:00:00-00:44:30[Africa/Monrovia]";
 result = action(relativeTo);
 assert.sameValue(result, 366, "unrounded HH:MM:SS is accepted in string offset");
 
+relativeTo = "1970-01-01T00:00:00-00:44:40[Africa/Monrovia]";
+assert.throws(RangeError, () => action(relativeTo), "wrong :SS not accepted in string offset");
+
+relativeTo = "1970-01-01T00:00:00-00:45:00[Africa/Monrovia]";
+assert.throws(RangeError, () => action(relativeTo), "rounded HH:MM:SS not accepted in string offset");
+
 relativeTo = "1970-01-01T00:00+00:44:30.123456789[+00:45]";
 assert.throws(RangeError, () => action(relativeTo), "rounding is not accepted between ISO offset and time zone");
 
-relativeTo = { year: 1970, month: 1, day: 1, offset: "+00:45", timeZone: "Africa/Monrovia" };
+relativeTo = { year: 1970, month: 1, day: 1, offset: "-00:45", timeZone: "Africa/Monrovia" };
 assert.throws(RangeError, () => action(relativeTo), "rounded HH:MM not accepted as offset in property bag");
+
+// Pacific/Niue edge case
+
+instance = new Temporal.Duration(0, 0, 0, /* days = */ 1);
+action = (relativeTo) => instance.total({ unit: "seconds", relativeTo });
+
+assert.sameValue(
+  action("1952-10-15T23:59:59-11:19:40[Pacific/Niue]"), 86420,
+  "-11:19:40 is accepted as -11:19:40 in Pacific/Niue edge case"
+);
+assert.sameValue(
+  action("1952-10-15T23:59:59-11:20[Pacific/Niue]"), 86420,
+  "-11:20 matches the first candidate -11:19:40 in the Pacific/Niue edge case"
+);
+assert.sameValue(
+  action("1952-10-15T23:59:59-11:20:00[Pacific/Niue]"), 86400,
+  "-11:20:00 is accepted as -11:20:00 in the Pacific/Niue edge case"
+);
+assert.throws(
+  RangeError, () => action("1952-10-15T23:59:59-11:19:50[Pacific/Niue]"),
+  "wrong :SS not accepted in the Pacific/Niue edge case"
+);

--- a/test/intl402/Temporal/ZonedDateTime/compare/sub-minute-offset.js
+++ b/test/intl402/Temporal/ZonedDateTime/compare/sub-minute-offset.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: ZonedDateTime string accepts an inexact UTC offset rounded to hours and minutes
+features: [Temporal]
+includes: [compareArray.js]
+---*/
+
+let reference = new Temporal.ZonedDateTime(2670_000_000_000n, "Africa/Monrovia");
+
+function action(string) {
+  const result1 = Temporal.ZonedDateTime.compare(string, reference);
+  const result2 = Temporal.ZonedDateTime.compare(reference, string);
+  return [result1, result2];
+};
+
+assert.compareArray(
+  action("1970-01-01T00:00-00:45[Africa/Monrovia]"), [0, 0],
+  "rounded HH:MM is accepted in string offset"
+);
+assert.compareArray(
+  action("1970-01-01T00:00:00-00:44:30[Africa/Monrovia]"), [0, 0],
+  "unrounded HH:MM:SS is accepted in string offset"
+);
+assert.throws(
+  RangeError, () => action("1970-01-01T00:00:00-00:44:40[Africa/Monrovia]"),
+  "wrong :SS not accepted in string offset"
+);
+assert.throws(
+  RangeError, () => action("1970-01-01T00:00:00-00:45:00[Africa/Monrovia]"),
+  "rounded HH:MM:SS not accepted in string offset"
+);
+assert.throws(
+  RangeError, () => action({ year: 1970, month: 1, day: 1, offset: "-00:45", timeZone: "Africa/Monrovia" }),
+  "rounded HH:MM not accepted as offset in property bag"
+);
+
+// Pacific/Niue edge case
+
+reference = new Temporal.ZonedDateTime(-543069621_000_000_000n, "Pacific/Niue");
+
+assert.compareArray(
+  action("1952-10-15T23:59:59-11:19:40[Pacific/Niue]"), [0, 0],
+  "-11:19:40 is accepted as -11:19:40 in Pacific/Niue edge case"
+);
+assert.compareArray(
+  action("1952-10-15T23:59:59-11:20[Pacific/Niue]"), [0, 0],
+  "-11:20 matches the first candidate -11:19:40 in the Pacific/Niue edge case"
+);
+assert.compareArray(
+  action("1952-10-15T23:59:59-11:20:00[Pacific/Niue]"), [1, -1],
+  "-11:20:00 is accepted as -11:20:00 in the Pacific/Niue edge case"
+);
+assert.throws(
+  RangeError, () => action("1952-10-15T23:59:59-11:19:50[Pacific/Niue]"),
+  "wrong :SS not accepted in the Pacific/Niue edge case"
+);

--- a/test/intl402/Temporal/ZonedDateTime/from/zoneddatetime-sub-minute-offset.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/zoneddatetime-sub-minute-offset.js
@@ -78,6 +78,112 @@ TemporalHelpers.assertPlainDateTime(
   "wall time is shifted by the difference between exact and rounded offset"
 );
 
+const wrongSeconds = "1970-01-01T12-00:44:40[Africa/Monrovia]";
+const roundedSeconds = "1970-01-01T12-00:45:00[Africa/Monrovia]";
+
+const useResultWrongSeconds = Temporal.ZonedDateTime.from(wrongSeconds, { offset: "use" });
+assert.sameValue(
+  useResultWrongSeconds.epochNanoseconds,
+  45880_000_000_000n,
+  "uses the wrong offset with HH:MM:SS precision when offset=use"
+);
+assert.sameValue(useResultWrongSeconds.offset, "-00:44:30", "offset property is still the full precision");
+TemporalHelpers.assertPlainDateTime(
+  useResultWrongSeconds.toPlainDateTime(),
+  1970,
+  1,
+  "M01",
+  1,
+  12,
+  0,
+  10,
+  0,
+  0,
+  0,
+  "wall time is shifted by the difference between exact and given offset"
+);
+
+
+const useResultRoundedSeconds = Temporal.ZonedDateTime.from(roundedSeconds, { offset: "use" });
+assert.sameValue(
+  useResultRoundedSeconds.epochNanoseconds,
+  45900_000_000_000n,
+  "uses the rounded offset with HH:MM:SS precision when offset=use"
+);
+assert.sameValue(useResultRoundedSeconds.offset, "-00:44:30", "offset property is still the full precision");
+TemporalHelpers.assertPlainDateTime(
+  useResultRoundedSeconds.toPlainDateTime(),
+  1970,
+  1,
+  "M01",
+  1,
+  12,
+  0,
+  30,
+  0,
+  0,
+  0,
+  "wall time is shifted by the difference between exact and given offset"
+);
+
+["ignore", "prefer"].forEach((offset) => {
+  const resultWrongSeconds = Temporal.ZonedDateTime.from(wrongSeconds, { offset });
+  assert.sameValue(
+    resultWrongSeconds.epochNanoseconds,
+    45870_000_000_000n,
+    `does not use the offset string with wrong :SS (offset=${offset})`
+  );
+  assert.sameValue(resultWrongSeconds.offset, "-00:44:30", "offset property is still the full precision");
+  TemporalHelpers.assertPlainDateTime(
+    resultWrongSeconds.toPlainDateTime(),
+    1970,
+    1,
+    "M01",
+    1,
+    12,
+    0,
+    0,
+    0,
+    0,
+    0,
+    "wall time is preserved"
+  );
+
+  const resultRoundedSeconds = Temporal.ZonedDateTime.from(roundedSeconds, { offset });
+  assert.sameValue(
+    resultRoundedSeconds.epochNanoseconds,
+    45870_000_000_000n,
+    `does not use the offset string with rounded HH:MM:SS (offset=${offset})`
+  );
+  assert.sameValue(resultRoundedSeconds.offset, "-00:44:30", "offset property is still the full precision");
+  TemporalHelpers.assertPlainDateTime(
+    resultRoundedSeconds.toPlainDateTime(),
+    1970,
+    1,
+    "M01",
+    1,
+    12,
+    0,
+    0,
+    0,
+    0,
+    0,
+    "wall time is preserved"
+  );
+});
+
+assert.throws(
+  RangeError,
+  () => Temporal.ZonedDateTime.from(wrongSeconds, { offset: "reject" }),
+  "wrong :SS not accepted in string offset (offset=reject)"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.ZonedDateTime.from(roundedSeconds, { offset: "reject" }),
+  "rounded HH:MM:SS not accepted in string offset (offset=reject)"
+);
+
 const properties = { year: 1970, month: 1, day: 1, hour: 12, offset: "-00:45", timeZone: "Africa/Monrovia" };
 
 ["ignore", "prefer"].forEach((offset) => {
@@ -100,4 +206,28 @@ assert.throws(
   RangeError,
   () => Temporal.ZonedDateTime.from(properties, { offset: "reject" }),
   "no fuzzy matching is done on offset in property bag (offset=reject)"
+);
+
+// Pacific/Niue edge case
+
+const reference = -543069621_000_000_000n;
+
+assert.sameValue(
+  Temporal.ZonedDateTime.from("1952-10-15T23:59:59-11:19:40[Pacific/Niue]").epochNanoseconds,
+  reference,
+  "-11:19:40 is accepted as -11:19:40 in Pacific/Niue edge case"
+);
+assert.sameValue(
+  Temporal.ZonedDateTime.from("1952-10-15T23:59:59-11:20[Pacific/Niue]").epochNanoseconds,
+  reference,
+  "-11:20 matches the first candidate -11:19:40 in the Pacific/Niue edge case"
+);
+assert.sameValue(
+  Temporal.ZonedDateTime.from("1952-10-15T23:59:59-11:20:00[Pacific/Niue]").epochNanoseconds,
+  reference + 20_000_000_000n,
+  "-11:20:00 is accepted as -11:20:00 in the Pacific/Niue edge case"
+);
+assert.throws(
+  RangeError, () => Temporal.ZonedDateTime.from("1952-10-15T23:59:59-11:19:50[Pacific/Niue]"),
+  "wrong :SS not accepted in the Pacific/Niue edge case"
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/equals/sub-minute-offset.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/equals/sub-minute-offset.js
@@ -11,10 +11,22 @@ const expectedNanoseconds = BigInt((44 * 60 + 30) * 1e9);
 const instance = new Temporal.ZonedDateTime(expectedNanoseconds, "Africa/Monrovia");
 
 let result = instance.equals("1970-01-01T00:00:00-00:45[Africa/Monrovia]");
-assert.sameValue(result, true, "UTC offset rounded to minutes is accepted");
+assert.sameValue(result, true, "UTC HH:MM offset rounded to minutes is accepted");
 
 result = instance.equals("1970-01-01T00:00:00-00:44:30[Africa/Monrovia]");
 assert.sameValue(result, true, "Unrounded sub-minute UTC offset also accepted");
+
+assert.throws(
+  RangeError,
+  () => instance.equals("1970-01-01T00:00:00-00:44:40[Africa/Monrovia]"),
+  "wrong :SS not accepted in string offset"
+);
+
+assert.throws(
+  RangeError,
+  () => instance.equals("1970-01-01T00:00:00-00:45:00[Africa/Monrovia]"),
+  "rounded HH:MM:SS not accepted in string offset"
+);
 
 assert.throws(
   RangeError,
@@ -32,3 +44,24 @@ const properties = {
   timeZone: "Africa/Monrovia"
 };
 assert.throws(RangeError, () => instance.equals(properties), "no fuzzy matching is done on offset in property bag");
+
+// Pacific/Niue edge case
+
+const reference = new Temporal.ZonedDateTime(-543069621_000_000_000n, "Pacific/Niue");
+
+assert(
+  reference.equals("1952-10-15T23:59:59-11:19:40[Pacific/Niue]"),
+  "-11:19:40 is accepted as -11:19:40 in Pacific/Niue edge case"
+);
+assert(
+  reference.equals("1952-10-15T23:59:59-11:20[Pacific/Niue]"),
+  "-11:20 matches the first candidate -11:19:40 in the Pacific/Niue edge case"
+);
+assert(
+  !reference.equals("1952-10-15T23:59:59-11:20:00[Pacific/Niue]"),
+  "-11:20:00 is accepted as -11:20:00 in the Pacific/Niue edge case"
+);
+assert.throws(
+  RangeError, () => reference.equals("1952-10-15T23:59:59-11:19:50[Pacific/Niue]"),
+  "wrong :SS not accepted in the Pacific/Niue edge case"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/sub-minute-offset.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/sub-minute-offset.js
@@ -32,7 +32,19 @@ TemporalHelpers.assertDuration(
 
 assert.throws(
   RangeError,
-  () => instance.since("1970-01-01T00:44:30+00:44:30[+00:45"),
+  () => instance.since("1970-01-01T00:00:00-00:44:40[Africa/Monrovia]"),
+  "wrong :SS not accepted in string offset"
+);
+
+assert.throws(
+  RangeError,
+  () => instance.since("1970-01-01T00:00:00-00:45:00[Africa/Monrovia]"),
+  "rounded HH:MM:SS not accepted in string offset"
+);
+
+assert.throws(
+  RangeError,
+  () => instance.since("1970-01-01T00:44:30+00:44:30[+00:45]"),
   "minute rounding not supported for offset time zones"
 );
 
@@ -46,3 +58,28 @@ const properties = {
   timeZone
 };
 assert.throws(RangeError, () => instance.since(properties), "no fuzzy matching is done on offset in property bag");
+
+
+// Pacific/Niue edge case
+
+const reference = new Temporal.ZonedDateTime(-543069621_000_000_000n, "Pacific/Niue");
+
+TemporalHelpers.assertDuration(
+  reference.since("1952-10-15T23:59:59-11:19:40[Pacific/Niue]"),
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "-11:19:40 is accepted as -11:19:40 in Pacific/Niue edge case"
+);
+TemporalHelpers.assertDuration(
+  reference.since("1952-10-15T23:59:59-11:20[Pacific/Niue]"),
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "-11:20 matches the first candidate -11:19:40 in the Pacific/Niue edge case"
+);
+TemporalHelpers.assertDuration(
+  reference.since("1952-10-15T23:59:59-11:20:00[Pacific/Niue]"),
+  0, 0, 0, 0, 0, 0, -20, 0, 0, 0,
+  "-11:20:00 is accepted as -11:20:00 in the Pacific/Niue edge case"
+);
+assert.throws(
+  RangeError, () => reference.since("1952-10-15T23:59:59-11:19:50[Pacific/Niue]"),
+  "wrong :SS not accepted in the Pacific/Niue edge case"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/sub-minute-offset.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/sub-minute-offset.js
@@ -18,7 +18,19 @@ TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 1, 29, 0, 0, 0, 0, "Unrounded
 
 assert.throws(
   RangeError,
-  () => instance.until("1970-01-01T00:44:30+00:44:30[+00:45"),
+  () => instance.until("1970-01-01T00:00:00-00:44:40[Africa/Monrovia]"),
+  "wrong :SS not accepted in string offset"
+);
+
+assert.throws(
+  RangeError,
+  () => instance.until("1970-01-01T00:00:00-00:45:00[Africa/Monrovia]"),
+  "rounded HH:MM:SS not accepted in string offset"
+);
+
+assert.throws(
+  RangeError,
+  () => instance.until("1970-01-01T00:44:30+00:44:30[+00:45]"),
   "minute rounding not supported for offset time zones"
 );
 
@@ -32,3 +44,27 @@ const properties = {
   timeZone: "Africa/Monrovia"
 };
 assert.throws(RangeError, () => instance.until(properties), "no fuzzy matching is done on offset in property bag");
+
+// Pacific/Niue edge case
+
+const reference = new Temporal.ZonedDateTime(-543069621_000_000_000n, "Pacific/Niue");
+
+TemporalHelpers.assertDuration(
+  reference.until("1952-10-15T23:59:59-11:19:40[Pacific/Niue]"),
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "-11:19:40 is accepted as -11:19:40 in Pacific/Niue edge case"
+);
+TemporalHelpers.assertDuration(
+  reference.until("1952-10-15T23:59:59-11:20[Pacific/Niue]"),
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "-11:20 matches the first candidate -11:19:40 in the Pacific/Niue edge case"
+);
+TemporalHelpers.assertDuration(
+  reference.until("1952-10-15T23:59:59-11:20:00[Pacific/Niue]"),
+  0, 0, 0, 0, 0, 0, 20, 0, 0, 0,
+  "-11:20:00 is accepted as -11:20:00 in the Pacific/Niue edge case"
+);
+assert.throws(
+  RangeError, () => reference.until("1952-10-15T23:59:59-11:19:50[Pacific/Niue]"),
+  "wrong :SS not accepted in the Pacific/Niue edge case"
+);


### PR DESCRIPTION
Expands and updates (following the normative change in https://github.com/tc39/proposal-temporal/pull/3107, approved May 2025) the current coverage with cases where the number of seconds is incorrect, or rounded.

Adds missing coverage for sub-minute offsets in strings passed to Temporal.ZonedDateTime.compare.

Adds the unusual test case of Pacific/Niue on October 15, 1952, where the offset shifted by 20 seconds to a whole-minute boundary.

Fixes a few minor errors in the existing tests such as a missing ] in a string, and the wrong sign for the offset in Africa/Monrovia in property bags.