### PR TITLE
Add missing tests for 'length' value of Intl.Locale.prototype methods

### DIFF
--- a/test/intl402/DisplayNames/prototype/of/length.js
+++ b/test/intl402/DisplayNames/prototype/of/length.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DisplayNames.prototype.of
+description: >
+  Intl.DisplayNames.prototype.of.length is 1.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.DisplayNames]
+---*/
+
+verifyProperty(Intl.DisplayNames.prototype.of, "length", {
+  value: 1,
+  enumerable: false,
+  writable: false,
+  configurable: true,
+});

--- a/test/intl402/DisplayNames/prototype/of/name.js
+++ b/test/intl402/DisplayNames/prototype/of/name.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DisplayNames.prototype.of
+description: >
+  Intl.DisplayNames.prototype.of.name is "of".
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "name" property
+  whose value is a String. Unless otherwise specified, this value is the name
+  that is given to the function in this specification.
+
+  Unless otherwise specified, the "name" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.DisplayNames]
+---*/
+
+verifyProperty(Intl.DisplayNames.prototype.of, "name", {
+  value: "of",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/baseName/length.js
+++ b/test/intl402/Locale/prototype/baseName/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.baseName
+description: >
+  get Intl.Locale.prototype.baseName.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "baseName").get;
+verifyProperty(getter, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/calendar/length.js
+++ b/test/intl402/Locale/prototype/calendar/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.calendar
+description: >
+  get Intl.Locale.prototype.calendar.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "calendar").get;
+verifyProperty(getter, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/caseFirst/length.js
+++ b/test/intl402/Locale/prototype/caseFirst/length.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.caseFirst
+description: >
+  get Intl.Locale.prototype.caseFirst.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "caseFirst");
+if (propdesc !== undefined) {
+  const getter = propdesc.get;
+  verifyProperty(getter, "length", {
+    value: 0,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+}

--- a/test/intl402/Locale/prototype/collation/length.js
+++ b/test/intl402/Locale/prototype/collation/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.collation
+description: >
+  get Intl.Locale.prototype.collation.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "collation").get;
+verifyProperty(getter, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/firstDayOfWeek/length.js
+++ b/test/intl402/Locale/prototype/firstDayOfWeek/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.firstDayOfWeek
+description: >
+  get Intl.Locale.prototype.firstDayOfWeek.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "firstDayOfWeek").get;
+verifyProperty(getter, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/getCalendars/length.js
+++ b/test/intl402/Locale/prototype/getCalendars/length.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getCalendars
+description: >
+  Intl.Locale.prototype.getCalendars.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+verifyProperty(Intl.Locale.prototype.getCalendars, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/getCollations/length.js
+++ b/test/intl402/Locale/prototype/getCollations/length.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getCollations
+description: >
+  Intl.Locale.prototype.getCollations.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+verifyProperty(Intl.Locale.prototype.getCollations, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/getHourCycles/length.js
+++ b/test/intl402/Locale/prototype/getHourCycles/length.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getHourCycles
+description: >
+  Intl.Locale.prototype.getHourCycles.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+verifyProperty(Intl.Locale.prototype.getHourCycles, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/getNumberingSystems/length.js
+++ b/test/intl402/Locale/prototype/getNumberingSystems/length.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getNumberingSystems
+description: >
+  Intl.Locale.prototype.getNumberingSystems.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+verifyProperty(Intl.Locale.prototype.getNumberingSystems, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/getTextInfo/length.js
+++ b/test/intl402/Locale/prototype/getTextInfo/length.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getTextInfo
+description: >
+  Intl.Locale.prototype.getTextInfo.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+verifyProperty(Intl.Locale.prototype.getTextInfo, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/getTimeZones/length.js
+++ b/test/intl402/Locale/prototype/getTimeZones/length.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getTimeZones
+description: >
+  Intl.Locale.prototype.getTimeZones.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+verifyProperty(Intl.Locale.prototype.getTimeZones, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/getWeekInfo/length.js
+++ b/test/intl402/Locale/prototype/getWeekInfo/length.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getWeekInfo
+description: >
+  Intl.Locale.prototype.getWeekInfo.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+verifyProperty(Intl.Locale.prototype.getWeekInfo, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/hourCycle/length.js
+++ b/test/intl402/Locale/prototype/hourCycle/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.hourCycle
+description: >
+  get Intl.Locale.prototype.hourCycle.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "hourCycle").get;
+verifyProperty(getter, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/language/length.js
+++ b/test/intl402/Locale/prototype/language/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.language
+description: >
+  get Intl.Locale.prototype.language.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "language").get;
+verifyProperty(getter, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/numberingSystem/length.js
+++ b/test/intl402/Locale/prototype/numberingSystem/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.numberingSystem
+description: >
+  get Intl.Locale.prototype.numberingSystem.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "numberingSystem").get;
+verifyProperty(getter, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/numeric/length.js
+++ b/test/intl402/Locale/prototype/numeric/length.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.numeric
+description: >
+  get Intl.Locale.prototype.numeric.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "numeric");
+if (propdesc !== undefined) {
+  const getter = propdesc.get;
+  verifyProperty(getter, "length", {
+    value: 0,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+}

--- a/test/intl402/Locale/prototype/region/length.js
+++ b/test/intl402/Locale/prototype/region/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.region
+description: >
+  get Intl.Locale.prototype.region.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "region").get;
+verifyProperty(getter, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/script/length.js
+++ b/test/intl402/Locale/prototype/script/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.script
+description: >
+  get Intl.Locale.prototype.script.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "script").get;
+verifyProperty(getter, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/toString/length.js
+++ b/test/intl402/Locale/prototype/toString/length.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.baseName
+description: >
+  Intl.Locale.prototype.toString.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+verifyProperty(Intl.Locale.prototype.toString, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/variants/length.js
+++ b/test/intl402/Locale/prototype/variants/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.variants
+description: >
+  get Intl.Locale.prototype.variants.length is 0.
+info: |
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length" property
+  whose value is a non-negative integral Number. Unless otherwise specified,
+  this value is the number of required parameters shown in the subclause heading
+  for the function description. Optional parameters and rest parameters are not
+  included in the parameter count.
+
+  Unless otherwise specified, the "length" property of a built-in function object
+  has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "variants").get;
+verifyProperty(getter, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});


### PR DESCRIPTION
I've noticed this when reviewing the tests for `Intl.Locale.prototype.variants`.