### PR TITLE
Fix typo in frontmatter of `ctor-throws.js`

### DIFF
--- a/test/built-ins/Promise/prototype/then/ctor-throws.js
+++ b/test/built-ins/Promise/prototype/then/ctor-throws.js
@@ -18,7 +18,7 @@ info: |
     [...]
     6. Let promise be Construct(C, «executor»).
     7. ReturnIfAbrupt(promise).
-    features: [Symbol.species]
+features: [Symbol.species]
 ---*/
 
 var BadCtor = function() {


### PR DESCRIPTION
This PR fixes incorrect indentation in the test’s frontmatter, which was interfering with automated processing.