### PR TITLE
update Iterator Sequencing tests to reflect May 2025 plenary updates

### DIFF
--- a/test/built-ins/Iterator/concat/fresh-iterator-result.js
+++ b/test/built-ins/Iterator/concat/fresh-iterator-result.js
@@ -46,4 +46,4 @@ let iterResult = iterator.next();
 assert.sameValue(iterResult.done, false);
 assert.sameValue(iterResult.value, 123);
 
-assert.sameValue(iterResult, oldIterResult);
+assert.notSameValue(iterResult, oldIterResult);

--- a/test/built-ins/Iterator/concat/get-value-after-done.js
+++ b/test/built-ins/Iterator/concat/get-value-after-done.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 Michael Ficarra. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.concat
+description: >
+  Iterator.concat does not access the value of a done IteratorResult, diverging from the behaviour of yield*
+features: [iterator-sequencing]
+---*/
+
+let valueAccesses = 0;
+let iter = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return {
+          get value() {
+            ++valueAccesses;
+          },
+          done: true,
+        };
+      },
+    };
+  }
+};
+
+Array.from(Iterator.concat(iter, iter, iter));
+
+assert.sameValue(valueAccesses, 0, 'Iterator.concat does not access value getter after each iterator is done');


### PR DESCRIPTION
These tests should match the spec changes in https://github.com/tc39/proposal-iterator-sequencing/pull/26.