### PR TITLE
Allow "bound" in bound native function toString()

### DIFF
--- a/harness/nativeFunctionMatcher.js
+++ b/harness/nativeFunctionMatcher.js
@@ -172,7 +172,7 @@ const validateNativeFunctionSource = function(source) {
   expect('function');
 
   // NativeFunctionAccessor
-  eat('get') || eat('set');
+  eat('get') || eat('set') || eat('bound');
 
   // PropertyName
   if (!eatIdentifier() && eat('[')) {


### PR DESCRIPTION
Allow "bound" to appear in the native function `toString()` result.

Some engines like V8 don't have a "bound" part:

```
> g = function fn(){}.bind();
ƒ fn(){}

> g.toString()
'function () { [native code] }'

> g.name
'bound fn'
```

QuickJS has `bound` part there:

```
qjs > g = function fn(){}.bind();
[Function bound fn]
qjs > g.toString()
"function bound fn() {\n    [native code]\n}"
qjs > g.name
"bound fn"
```

Spidermonkey 91 does have it:

```
js> g = function fn(){}.bind();
function bound fn() {
    [native code]
}
js> g.toString()
"function() {\n    [native code]\n}"
js> g.name
"bound fn"
```