### PR TITLE
Move array/function Duration.with tests to the missing-property test

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/with/argument-invalid-property.js
+++ b/test/built-ins/Temporal/Duration/prototype/with/argument-invalid-property.js
@@ -17,6 +17,18 @@ assert.throws(
 
 assert.throws(
   TypeError,
+  () => instance.with([]),
+  "Throws TypeError if no property is present (with array)"
+);
+
+assert.throws(
+  TypeError,
+  () => instance.with(() => {}),
+  "Throws TypeError if no property is present (with function)"
+);
+
+assert.throws(
+  TypeError,
   () => instance.with({ nonsense: true }),
   "Throws TypeError if no recognized property is present"
 );

--- a/test/built-ins/Temporal/Duration/prototype/with/argument-not-object.js
+++ b/test/built-ins/Temporal/Duration/prototype/with/argument-not-object.js
@@ -15,6 +15,4 @@ assert.throws(TypeError, () => instance.with(""), "empty string");
 assert.throws(TypeError, () => instance.with(Symbol()), "Symbol");
 assert.throws(TypeError, () => instance.with(7), "number");
 assert.throws(TypeError, () => instance.with(7n), "bigint");
-assert.throws(TypeError, () => instance.with([]), "array");
-assert.throws(TypeError, () => instance.with(() => {}), "function");
 assert.throws(TypeError, () => instance.with("string"), "string");


### PR DESCRIPTION
Arrays and functions are Objects and are valid arguments to Duration.with.

They are only invalid if they are missing Durationlike properties.