### PR TITLE
Verify that Duration#with() doesn't accept duration strings

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/with/argument-not-object.js
+++ b/test/built-ins/Temporal/Duration/prototype/with/argument-not-object.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-temporal.duration.prototype.with
-description: Passing a primitive other than string to with() throws
+description: Passing a primitive to with() throws
 features: [Symbol, Temporal]
 ---*/
 
@@ -12,7 +12,8 @@ assert.throws(TypeError, () => instance.with(undefined), "undefined");
 assert.throws(TypeError, () => instance.with(null), "null");
 assert.throws(TypeError, () => instance.with(true), "boolean");
 assert.throws(TypeError, () => instance.with(""), "empty string");
+assert.throws(TypeError, () => instance.with("P1D"), "duration string");
+assert.throws(TypeError, () => instance.with("string"), "string");
 assert.throws(TypeError, () => instance.with(Symbol()), "Symbol");
 assert.throws(TypeError, () => instance.with(7), "number");
 assert.throws(TypeError, () => instance.with(7n), "bigint");
-assert.throws(TypeError, () => instance.with("string"), "string");


### PR DESCRIPTION
Also fix the description and put the string tests together.