### PR TITLE
Update ESMeta version to v0.6.2

### DIFF
--- a/.github/workflows/esmeta-test262.yml
+++ b/.github/workflows/esmeta-test262.yml
@@ -7,7 +7,7 @@ jobs:
     name: 'esmeta test262'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Setup JDK
         uses: actions/setup-java@v3
@@ -25,7 +25,7 @@ jobs:
       - name: download esmeta
         run: |
           mkdir -p "${ESMETA_HOME}"
-          git clone --branch v0.4.2 --depth 1 https://github.com/es-meta/esmeta.git "${ESMETA_HOME}"
+          git clone --branch v0.6.2 --depth 1 https://github.com/es-meta/esmeta.git "${ESMETA_HOME}"
           cd "${ESMETA_HOME}" && git submodule update --init --depth 1
       - name: build esmeta
         working-directory: ${{ env.ESMETA_HOME }}


### PR DESCRIPTION
The latest version [v0.6.2](https://github.com/es-meta/esmeta/releases/tag/v0.6.2) of ESMeta supports ES2025 and Unicode 16.0. This update could cover more tests.

Additionally, it can prevent possible ESMeta errors related to licensing issues with the Akka library, which were caused in CI for ecma262 (https://github.com/es-meta/esmeta/pull/290).