### PR TITLE
[immutable-arraybuffer] ArrayBuffer.prototype.immutable

### DIFF
--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -218,10 +218,12 @@ function isWritable(obj, name, verifyProp, value) {
  * @param {PropertyDescriptor} [desc] defaults to data property conventions (writable, non-enumerable, configurable)
  * @param {object} [options]
  * @param {boolean} [options.label]
+ * @param {typeof verifyProperty} [options.verifyProperty]
  * @param {boolean} [options.restore] revert mutations from verifying writable/configurable
  */
 function verifyCallableProperty(obj, name, functionName, functionLength, desc, options) {
   var label = options && options.label || String(name);
+  var propertyVerifier = options && options.verifyProperty || verifyProperty;
 
   var value = obj[name];
 
@@ -242,7 +244,7 @@ function verifyCallableProperty(obj, name, functionName, functionLength, desc, o
     desc.value = value;
   }
 
-  verifyProperty(obj, name, desc, options);
+  propertyVerifier(obj, name, desc, options);
 
   if (functionName === undefined) {
     if (typeof name === "symbol") {
@@ -256,7 +258,7 @@ function verifyCallableProperty(obj, name, functionName, functionLength, desc, o
   // [[Configurable]]: true }.
   // https://tc39.es/ecma262/multipage/ecmascript-standard-built-in-objects.html#sec-ecmascript-standard-built-in-objects
   // https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-setfunctionname
-  verifyProperty(value, "name", {
+  propertyVerifier(value, "name", {
     value: functionName,
     writable: false,
     enumerable: false,
@@ -268,7 +270,7 @@ function verifyCallableProperty(obj, name, functionName, functionLength, desc, o
   // [[Configurable]]: true }.
   // https://tc39.es/ecma262/multipage/ecmascript-standard-built-in-objects.html#sec-ecmascript-standard-built-in-objects
   // https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-setfunctionlength
-  verifyProperty(value, "length", {
+  propertyVerifier(value, "length", {
     value: functionLength,
     writable: false,
     enumerable: false,
@@ -367,5 +369,17 @@ var verifyPrimordialProperty = verifyProperty;
  * Use this function to verify the primordial function-valued properties.
  * For non-primordial functions, use verifyCallableProperty.
  * See: https://github.com/tc39/how-we-work/blob/main/terminology.md#primordial
+ *
+ * @type {typeof verifyCallableProperty}
  */
-var verifyPrimordialCallableProperty = verifyCallableProperty;
+function verifyPrimordialCallableProperty(obj, name, functionName, functionLength, desc, options) {
+  var resolvedOptions = {
+    verifyProperty: options && options.verifyProperty !== undefined
+      ? options.verifyProperty
+      : verifyPrimordialProperty
+  };
+  if (options && options.label !== undefined) resolvedOptions.label = options.label;
+  if (options && options.restore !== undefined) resolvedOptions.restore = options.restore;
+
+  return verifyCallableProperty(obj, name, functionName, functionLength, desc, resolvedOptions);
+}

--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -7,6 +7,7 @@ description: |
 defines:
   - verifyProperty
   - verifyCallableProperty
+  - verifyAccessorProperty
   - verifyEqualTo # deprecated
   - verifyWritable # deprecated
   - verifyNotWritable # deprecated
@@ -16,6 +17,7 @@ defines:
   - verifyNotConfigurable # deprecated
   - verifyPrimordialProperty
   - verifyPrimordialCallableProperty
+  - verifyPrimordialAccessorProperty
 ---*/
 
 // @ts-check
@@ -225,7 +227,7 @@ function verifyCallableProperty(obj, name, functionName, functionLength, desc, o
   var label = options && options.label || String(name);
   var propertyVerifier = options && options.verifyProperty || verifyProperty;
 
-  var value = obj[name];
+  var value = obj && obj[name];
 
   assert.sameValue(typeof value, "function", label + " should be a function");
 
@@ -276,6 +278,107 @@ function verifyCallableProperty(obj, name, functionName, functionLength, desc, o
     enumerable: false,
     configurable: desc.configurable
   }, { label: label + " length", restore: options && options.restore });
+}
+
+/**
+ * Verify that there is an accessor property associated with `obj[name]` and
+ * following the conventions for built-in objects.
+ *
+ * @param {object} obj
+ * @param {string|symbol} name
+ * @param {object} desc
+ * @param {boolean} [desc.enumerable] defaults to accessor property conventions (non-enumerable)
+ * @param {boolean} [desc.configurable] defaults to accessor property conventions (configurable)
+ * @param {undefined | Function | {name?: string|symbol, length?: number}} [desc.get] if an object,
+ *   absent fields default to getter conventions (name derived from the property key with a "get "
+ *   prefix, length 0)
+ * @param {undefined | Function | {name?: string|symbol, length?: number}} [desc.set] if an object,
+ *   absent fields default to getter conventions (name derived from the property key with a "set "
+ *   prefix, length 1)
+ * @param {object} [options]
+ * @param {boolean} [options.label]
+ * @param {typeof verifyProperty} [options.verifyProperty]
+ * @param {typeof verifyCallableProperty} [options.verifyCallableProperty]
+ * @param {boolean} [options.restore] revert mutations from verifying property attributes
+ */
+function verifyAccessorProperty(obj, name, desc, options) {
+  var checkGet = __hasOwnProperty(desc, "get");
+  var checkSet = __hasOwnProperty(desc, "set");
+  assert(
+    checkGet || checkSet,
+    'verifyAccessorProperty requires at least one of "get" and "set"'
+  );
+  var label = options && options.label || String(name);
+  var propertyVerifier = options && options.verifyProperty || verifyProperty;
+  var callabilityVerifier = options && options.verifyCallableProperty || verifyCallableProperty;
+
+  var originalDesc = __getOwnPropertyDescriptor(obj, name);
+
+  // Every built-in function object, including constructors, has a "name"
+  // property whose value is a String. Unless otherwise specified, this value is
+  // the name that is given to the function in this specification. Functions
+  // that are identified as anonymous functions use the empty String as the
+  // value of the "name" property. For functions that are specified as
+  // properties of objects, the name value is the property name string used to
+  // access the function. Functions that are specified as get or set accessor
+  // functions of built-in properties have "get" or "set" (respectively) passed
+  // to the prefix parameter when calling CreateBuiltinFunction.
+  //
+  // The value of the "name" property is explicitly specified for each built-in
+  // functions whose property key is a Symbol value. If such an explicitly
+  // specified value starts with the prefix "get " or "set " and the function
+  // for which it is specified is a get or set accessor function of a built-in
+  // property, the value without the prefix is passed to the name parameter, and
+  // the value "get" or "set" (respectively) is passed to the prefix parameter
+  // when calling CreateBuiltinFunction.
+  // https://tc39.es/ecma262/multipage/ecmascript-standard-built-in-objects.html
+  if (checkGet) {
+    var expectGetter = desc.get;
+    var getterLabel = label + " getter";
+    if (expectGetter === undefined || typeof expectGetter === "function") {
+      assert.sameValue(originalDesc.get, expectGetter, getterLabel);
+    } else {
+      var getterName = expectGetter.name;
+      if (getterName === undefined) {
+        getterName = "get " + (typeof name === "symbol" ? "[" + name.description + "]" : name);
+      }
+      var getterLength = expectGetter.length !== undefined ? expectGetter.length : 0;
+      var getterOptions = { label: getterLabel };
+      callabilityVerifier(originalDesc, "get", getterName, getterLength, {}, getterOptions);
+    }
+  }
+  if (checkSet) {
+    var expectSetter = desc.set;
+    var setterLabel = label + " setter";
+    if (expectSetter === undefined || typeof expectSetter === "function") {
+      assert.sameValue(originalDesc.set, expectSetter, setterLabel);
+    } else {
+      var setterName = expectSetter.name;
+      if (setterName === undefined) {
+        setterName = "set " + (typeof name === "symbol" ? "[" + name.description + "]" : name);
+      }
+      var setterLength = expectSetter.length !== undefined ? expectSetter.length : 1;
+      var setterOptions = { label: setterLabel };
+      callabilityVerifier(originalDesc, "set", setterName, setterLength, {}, setterOptions);
+    }
+  }
+
+  // Every accessor property described in clauses 19 through 28 and in Annex B.2
+  // has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless
+  // otherwise specified.
+  // https://tc39.es/ecma262/multipage/ecmascript-standard-built-in-objects.html
+  var resolvedDesc = { get: originalDesc.get, set: originalDesc.set };
+  if (!__hasOwnProperty(desc, "enumerable")) {
+    resolvedDesc.enumerable = false;
+  } else if (desc.enumerable !== undefined) {
+    resolvedDesc.enumerable = desc.enumerable;
+  }
+  if (!__hasOwnProperty(desc, "configurable")) {
+    resolvedDesc.configurable = true;
+  } else if (desc.configurable !== undefined) {
+    resolvedDesc.configurable = desc.configurable;
+  }
+  propertyVerifier(obj, name, resolvedDesc, options);
 }
 
 /**
@@ -382,4 +485,26 @@ function verifyPrimordialCallableProperty(obj, name, functionName, functionLengt
   if (options && options.restore !== undefined) resolvedOptions.restore = options.restore;
 
   return verifyCallableProperty(obj, name, functionName, functionLength, desc, resolvedOptions);
+}
+
+/**
+ * Use this function to verify the primordial accessor properties.
+ * For non-primordial functions, use verifyAccessorProperty.
+ * See: https://github.com/tc39/how-we-work/blob/main/terminology.md#primordial
+ *
+ * @type {typeof verifyAccessorProperty}
+ */
+function verifyPrimordialAccessorProperty(obj, name, desc, options) {
+  var resolvedOptions = {
+    verifyProperty: options && options.verifyProperty !== undefined
+      ? options.verifyProperty
+      : verifyPrimordialProperty,
+    verifyCallableProperty: options && options.verifyCallableProperty !== undefined
+      ? options.verifyCallableProperty
+      : verifyPrimordialCallableProperty
+  };
+  if (options && options.label !== undefined) resolvedOptions.label = options.label;
+  if (options && options.restore !== undefined) resolvedOptions.restore = options.restore;
+
+  return verifyAccessorProperty(obj, name, desc, resolvedOptions);
 }

--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -37,6 +37,7 @@ var nonIndexNumericPropertyName = Math.pow(2, 32) - 1;
  * @param {string|symbol} name
  * @param {PropertyDescriptor|undefined} desc
  * @param {object} [options]
+ * @param {boolean} [options.label]
  * @param {boolean} [options.restore] revert mutations from verifying writable/configurable
  */
 function verifyProperty(obj, name, desc, options) {
@@ -44,26 +45,23 @@ function verifyProperty(obj, name, desc, options) {
     arguments.length > 2,
     'verifyProperty should receive at least 3 arguments: obj, name, and descriptor'
   );
+  var label = options && options.label || String(name);
 
   var originalDesc = __getOwnPropertyDescriptor(obj, name);
-  var nameStr = String(name);
 
   // Allows checking for undefined descriptor if it's explicitly given.
   if (desc === undefined) {
     assert.sameValue(
       originalDesc,
       undefined,
-      "obj['" + nameStr + "'] descriptor should be undefined"
+      label + " descriptor should be undefined"
     );
 
     // desc and originalDesc are both undefined, problem solved;
     return true;
   }
 
-  assert(
-    __hasOwnProperty(obj, name),
-    "obj should have an own property " + nameStr
-  );
+  assert(__hasOwnProperty(obj, name), label + " should be an own property");
 
   assert.notSameValue(
     desc,
@@ -94,17 +92,17 @@ function verifyProperty(obj, name, desc, options) {
 
   if (__hasOwnProperty(desc, 'value')) {
     if (!isSameValue(desc.value, originalDesc.value)) {
-      __push(failures, "obj['" + nameStr + "'] descriptor value should be " + desc.value);
+      __push(failures, label + " descriptor value should be " + String(desc.value));
     }
     if (!isSameValue(desc.value, obj[name])) {
-      __push(failures, "obj['" + nameStr + "'] value should be " + desc.value);
+      __push(failures, label + " value should be " + String(desc.value));
     }
   }
 
   if (__hasOwnProperty(desc, 'enumerable') && desc.enumerable !== undefined) {
     if (desc.enumerable !== originalDesc.enumerable ||
         desc.enumerable !== isEnumerable(obj, name)) {
-      __push(failures, "obj['" + nameStr + "'] descriptor should " + (desc.enumerable ? '' : 'not ') + "be enumerable");
+      __push(failures, label + " descriptor should " + (desc.enumerable ? '' : 'not ') + "be enumerable");
     }
   }
 
@@ -113,14 +111,14 @@ function verifyProperty(obj, name, desc, options) {
   if (__hasOwnProperty(desc, 'writable') && desc.writable !== undefined) {
     if (desc.writable !== originalDesc.writable ||
         desc.writable !== isWritable(obj, name)) {
-      __push(failures, "obj['" + nameStr + "'] descriptor should " + (desc.writable ? '' : 'not ') + "be writable");
+      __push(failures, label + " descriptor should " + (desc.writable ? '' : 'not ') + "be writable");
     }
   }
 
   if (__hasOwnProperty(desc, 'configurable') && desc.configurable !== undefined) {
     if (desc.configurable !== originalDesc.configurable ||
         desc.configurable !== isConfigurable(obj, name)) {
-      __push(failures, "obj['" + nameStr + "'] descriptor should " + (desc.configurable ? '' : 'not ') + "be configurable");
+      __push(failures, label + " descriptor should " + (desc.configurable ? '' : 'not ') + "be configurable");
     }
   }
 
@@ -219,13 +217,15 @@ function isWritable(obj, name, verifyProp, value) {
  * @param {number} functionLength
  * @param {PropertyDescriptor} [desc] defaults to data property conventions (writable, non-enumerable, configurable)
  * @param {object} [options]
+ * @param {boolean} [options.label]
  * @param {boolean} [options.restore] revert mutations from verifying writable/configurable
  */
 function verifyCallableProperty(obj, name, functionName, functionLength, desc, options) {
+  var label = options && options.label || String(name);
+
   var value = obj[name];
 
-  assert.sameValue(typeof value, "function",
-    "obj['" + String(name) + "'] descriptor should be a function");
+  assert.sameValue(typeof value, "function", label + " should be a function");
 
   // Every other data property described in clauses 19 through 28 and in
   // Annex B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
@@ -261,7 +261,7 @@ function verifyCallableProperty(obj, name, functionName, functionLength, desc, o
     writable: false,
     enumerable: false,
     configurable: desc.configurable
-  }, options);
+  }, { label: label + " name", restore: options && options.restore });
 
   // Unless otherwise specified, the "length" property of a built-in function
   // object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
@@ -273,7 +273,7 @@ function verifyCallableProperty(obj, name, functionName, functionLength, desc, o
     writable: false,
     enumerable: false,
     configurable: desc.configurable
-  }, options);
+  }, { label: label + " length", restore: options && options.restore });
 }
 
 /**

--- a/test/built-ins/ArrayBuffer/prototype/immutable/prop-desc.js
+++ b/test/built-ins/ArrayBuffer/prototype/immutable/prop-desc.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-arraybuffer.prototype.immutable
+description: Checks the "immutable" property of ArrayBuffer.prototype.
+info: |
+  ArrayBuffer.prototype.immutable is an accessor property whose set accessor
+  function is undefined.
+
+  ECMAScript Standard Built-in Objects
+  ...
+  For functions that are specified as properties of objects, the name value is
+  the property name string used to access the function. Functions that are
+  specified as get or set accessor functions of built-in properties have "get"
+  or "set" (respectively) passed to the prefix parameter when calling
+  CreateBuiltinFunction.
+  ...
+  Every accessor property described in clauses 19 through 28 and in Annex B.2
+  has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless
+  otherwise specified. If only a get accessor function is described, the set
+  accessor function is the default value, undefined.
+features: [immutable-arraybuffer]
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "immutable");
+var isHardened = Object.isFrozen(Object);
+
+assert.sameValue(desc.value, undefined);
+assert.sameValue(desc.set, undefined);
+verifyCallableProperty(desc, "get", "get immutable", 0, { configurable: !isHardened });
+
+verifyPrimordialProperty(ArrayBuffer.prototype, "immutable", {
+  enumerable: false,
+  configurable: true
+});

--- a/test/built-ins/ArrayBuffer/prototype/immutable/prop-desc.js
+++ b/test/built-ins/ArrayBuffer/prototype/immutable/prop-desc.js
@@ -24,14 +24,7 @@ features: [immutable-arraybuffer]
 includes: [propertyHelper.js]
 ---*/
 
-var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "immutable");
-var isHardened = Object.isFrozen(Object);
-
-assert.sameValue(desc.value, undefined);
-assert.sameValue(desc.set, undefined);
-verifyCallableProperty(desc, "get", "get immutable", 0, { configurable: !isHardened });
-
-verifyPrimordialProperty(ArrayBuffer.prototype, "immutable", {
-  enumerable: false,
-  configurable: true
-});
+verifyPrimordialAccessorProperty(ArrayBuffer.prototype, "immutable", {
+  get: { name: "get immutable", length: 0 },
+  set: undefined,
+}, { label: "ArrayBuffer.prototype.immutable" });

--- a/test/built-ins/ArrayBuffer/prototype/immutable/return-immutable.js
+++ b/test/built-ins/ArrayBuffer/prototype/immutable/return-immutable.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-arraybuffer.prototype.immutable
+description: Return value according to the [[ArrayBufferIsImmutable]] internal slot.
+info: |
+  get ArrayBuffer.prototype.immutable
+  1. Let O be the this value.
+  2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+  3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+  4. Return IsImmutableBuffer(O).
+
+  IsImmutableBuffer ( arrayBuffer )
+  1. If arrayBuffer has an [[ArrayBufferIsImmutable]] internal slot, return true.
+  2. Return false.
+features: [ArrayBuffer, immutable-arraybuffer]
+includes: [detachArrayBuffer.js]
+---*/
+
+var ab = new ArrayBuffer(1);
+assert.sameValue(ab.immutable, false);
+
+var iab = ab.transferToImmutable();
+assert.sameValue(iab.immutable, true);
+
+$DETACHBUFFER(ab);
+assert.sameValue(ab.immutable, false);

--- a/test/built-ins/ArrayBuffer/prototype/immutable/this-has-no-arraybufferdata-internal.js
+++ b/test/built-ins/ArrayBuffer/prototype/immutable/this-has-no-arraybufferdata-internal.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-arraybuffer.prototype.immutable
+description: >
+  Throws a TypeError exception when `this` does not have a [[ArrayBufferData]]
+  internal slot
+info: |
+  get ArrayBuffer.prototype.immutable
+  1. Let O be the this value.
+  2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+features: [DataView, Int8Array, ArrayBuffer, immutable-arraybuffer]
+---*/
+
+var getter = Object.getOwnPropertyDescriptor(
+  ArrayBuffer.prototype, "immutable"
+).get;
+
+assert.sameValue(typeof getter, "function", "Getter must exist.");
+
+var badReceivers = [
+  ["plain object", {}],
+  ["array", []],
+  ["function", function(){}],
+  ["ArrayBuffer.prototype", ArrayBuffer.prototype],
+  ["TypedArray", new Int8Array(8)],
+  ["DataView", new DataView(new ArrayBuffer(8), 0)]
+];
+
+for (var i = 0; i < badReceivers.length; i++) {
+  var label = badReceivers[i][0];
+  var value = badReceivers[i][1];
+  assert.throws(TypeError, function() {
+    getter.call(value);
+  }, label);
+}
+
+assert.throws(TypeError, function() {
+  ArrayBuffer.prototype.immutable;
+}, "invoked as prototype property access");
+
+assert.throws(TypeError, function() {
+  getter();
+}, "invoked as function");

--- a/test/built-ins/ArrayBuffer/prototype/immutable/this-is-not-object.js
+++ b/test/built-ins/ArrayBuffer/prototype/immutable/this-is-not-object.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-arraybuffer.prototype.immutable
+description: Throws a TypeError exception when `this` is not an object
+info: |
+  get ArrayBuffer.prototype.immutable
+  1. Let O be the this value.
+  2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+features: [ArrayBuffer, immutable-arraybuffer]
+---*/
+
+var getter = Object.getOwnPropertyDescriptor(
+  ArrayBuffer.prototype, "immutable"
+).get;
+
+assert.sameValue(typeof getter, "function", "Getter must exist.");
+
+var badReceivers = [
+  ["undefined", undefined],
+  ["null", null],
+  ["number", 42],
+  ["string", "1"],
+  ["true", true],
+  ["false", false],
+  typeof Symbol === "undefined" ? undefined : ["unique symbol", Symbol("s")],
+  typeof Symbol === "undefined" || !Symbol.for ? undefined : ["registered symbol", Symbol.for("s")],
+  typeof BigInt === "undefined" ? undefined : ["bigint", BigInt(1)]
+];
+
+for (var i = 0; i < badReceivers.length; i++) {
+  if (!badReceivers[i]) continue;
+  var label = badReceivers[i][0];
+  var value = badReceivers[i][1];
+  assert.throws(TypeError, function() {
+    getter.call(value);
+  }, label);
+}

--- a/test/built-ins/ArrayBuffer/prototype/immutable/this-is-sharedarraybuffer.js
+++ b/test/built-ins/ArrayBuffer/prototype/immutable/this-is-sharedarraybuffer.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-arraybuffer.prototype.immutable
+description: Throws a TypeError exception when `this` is a SharedArrayBuffer
+info: |
+  get ArrayBuffer.prototype.immutable
+  1. Let O be the this value.
+  2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+  3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+features: [SharedArrayBuffer, ArrayBuffer, immutable-arraybuffer]
+---*/
+
+var getter = Object.getOwnPropertyDescriptor(
+  ArrayBuffer.prototype, "immutable"
+).get;
+
+assert.sameValue(typeof getter, "function", "Getter must exist.");
+
+var sab = new SharedArrayBuffer(4);
+assert.throws(TypeError, function() {
+  getter.call(sab);
+});

--- a/test/harness/verifyProperty-value-error.js
+++ b/test/harness/verifyProperty-value-error.js
@@ -29,7 +29,7 @@ try {
     );
   }
 
-  if (err.message !== "obj['prop'] descriptor value should be 2; obj['prop'] value should be 2") {
+  if (err.message !== "prop descriptor value should be 2; prop value should be 2") {
     throw new Error('The error thrown did not define the specified message');
   }
 }


### PR DESCRIPTION
Ref #4509

> # New ArrayBuffer.prototype properties
> 
> - [x] `ArrayBuffer.prototype.immutable`
>   - [x] getter-only accessor, enumerable false and configurable true
>   - [x] name "get immutable" and length 0
>   - [x] brand-checking (throws TypeError unless receiver is an ArrayBuffer and not a SharedArrayBuffer)
>   - [x] returns `true` for an immutable receiver and false for a non-immutable one
>   - [x] does not throw for a detached receiver