### PR TITLE
[immutable-arraybuffer] ArrayBuffer.prototype.transferToImmutable

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -3,9 +3,17 @@
 /*---
 description: |
     Collection of assertion functions used throughout test262
-defines: [assert, isPrimitive]
+defines: [assert, isNegativeZero, isPrimitive]
 ---*/
 
+
+function isNegativeZero(value) {
+  return value === 0 && 1 / value === -Infinity;
+}
+
+function isPrimitive(value) {
+  return !value || (typeof value !== 'object' && typeof value !== 'function');
+}
 
 function assert(mustBeTrue, message) {
   if (mustBeTrue === true) {
@@ -101,10 +109,6 @@ assert.throws = function (expectedErrorConstructor, func, message) {
   throw new Test262Error(message);
 };
 
-function isPrimitive(value) {
-  return !value || (typeof value !== 'object' && typeof value !== 'function');
-}
-
 assert.compareArray = function (actual, expected, message) {
   message = message === undefined ? '' : message;
 
@@ -147,7 +151,7 @@ assert._formatIdentityFreeValue = function formatIdentityFreeValue(value) {
     case 'bigint':
       return String(value) + "n";
     case 'number':
-      if (value === 0 && 1 / value === -Infinity) return '-0';
+      if (isNegativeZero(value)) return '-0';
       // falls through
     case 'boolean':
     case 'undefined':

--- a/harness/assert.js
+++ b/harness/assert.js
@@ -3,7 +3,12 @@
 /*---
 description: |
     Collection of assertion functions used throughout test262
-defines: [assert, isNegativeZero, isPrimitive]
+defines:
+  - assert
+  - formatIdentityFreeValue
+  - formatSimpleValue
+  - isNegativeZero
+  - isPrimitive
 ---*/
 
 
@@ -13,6 +18,35 @@ function isNegativeZero(value) {
 
 function isPrimitive(value) {
   return !value || (typeof value !== 'object' && typeof value !== 'function');
+}
+
+function formatIdentityFreeValue(value) {
+  switch (value === null ? 'null' : typeof value) {
+    case 'string':
+      return typeof JSON !== "undefined" ? JSON.stringify(value) : '"' + value + '"';
+    case 'bigint':
+      return String(value) + "n";
+    case 'number':
+      if (isNegativeZero(value)) return '-0';
+      // falls through
+    case 'boolean':
+    case 'undefined':
+    case 'null':
+      return String(value);
+  }
+}
+
+function formatSimpleValue(value) {
+  var basic = formatIdentityFreeValue(value);
+  if (basic) return basic;
+  try {
+    return String(value);
+  } catch (err) {
+    if (err.name === 'TypeError') {
+      return Object.prototype.toString.call(value);
+    }
+    throw err;
+  }
 }
 
 function assert(mustBeTrue, message) {
@@ -144,31 +178,6 @@ compareArray.format = function (arrayLike) {
   return "[" + Array.prototype.map.call(arrayLike, String).join(", ") + "]";
 };
 
-assert._formatIdentityFreeValue = function formatIdentityFreeValue(value) {
-  switch (value === null ? 'null' : typeof value) {
-    case 'string':
-      return typeof JSON !== "undefined" ? JSON.stringify(value) : '"' + value + '"';
-    case 'bigint':
-      return String(value) + "n";
-    case 'number':
-      if (isNegativeZero(value)) return '-0';
-      // falls through
-    case 'boolean':
-    case 'undefined':
-    case 'null':
-      return String(value);
-  }
-};
+assert._formatIdentityFreeValue = formatIdentityFreeValue;
 
-assert._toString = function (value) {
-  var basic = assert._formatIdentityFreeValue(value);
-  if (basic) return basic;
-  try {
-    return String(value);
-  } catch (err) {
-    if (err.name === 'TypeError') {
-      return Object.prototype.toString.call(value);
-    }
-    throw err;
-  }
-};
+assert._toString = formatSimpleValue;

--- a/test/built-ins/ArrayBuffer/prototype/sliceToImmutable/argument-coercion.js
+++ b/test/built-ins/ArrayBuffer/prototype/sliceToImmutable/argument-coercion.js
@@ -118,7 +118,7 @@ for (var i = 0; i < goodInputs.length; i++) {
     var source = make32ByteArrayBuffer();
     var expectContents = Array.from(new Uint8Array(source)).slice(rawStart, rawEnd);
     var dest = source.sliceToImmutable(rawStart, rawEnd);
-    var label = "sliceToImmutable(" + assert._toString(rawStart) + ", " + assert._toString(rawEnd) + ")";
+    var label = "sliceToImmutable(" + formatSimpleValue(rawStart) + ", " + formatSimpleValue(rawEnd) + ")";
     assert.sameValue(dest.byteLength, intLength, label + ".byteLength");
     assert.compareArray(new Uint8Array(dest), expectContents, label + " contents");
     assert.sameValue(dest.immutable, true, label + ".immutable");
@@ -154,7 +154,7 @@ for (var i = 0; i < goodInputs.length; i++) {
     var source = make32ByteArrayBuffer();
     var expectContents = Array.from(new Uint8Array(source)).slice(rawStart, rawEnd);
     var dest = source.sliceToImmutable(paddedStart.string, paddedEnd.string);
-    var label = "sliceToImmutable(" + assert._toString(paddedStart.string) + ", " + assert._toString(paddedEnd.string) + ")";
+    var label = "sliceToImmutable(" + formatSimpleValue(paddedStart.string) + ", " + formatSimpleValue(paddedEnd.string) + ")";
     assert.sameValue(dest.byteLength, intLength, label + ".byteLength");
     assert.compareArray(new Uint8Array(dest), expectContents, label + " contents");
     assert.sameValue(dest.immutable, true, label + ".immutable");
@@ -199,8 +199,8 @@ for (var i = 0; i < goodInputs.length; i++) {
       }
     };
     function reprArgs(startMethodName, endMethodName) {
-      var startRepr = "{ " + startMethodName + ": () => " + assert._toString(rawStart) + " }";
-      var endRepr = "{ " + endMethodName + ": () => " + assert._toString(rawEnd) + " }";
+      var startRepr = "{ " + startMethodName + ": () => " + formatSimpleValue(rawStart) + " }";
+      var endRepr = "{ " + endMethodName + ": () => " + formatSimpleValue(rawEnd) + " }";
       return "(" + startRepr + ", " + endRepr + ")";
     }
 
@@ -324,10 +324,10 @@ for (var i = 0; i < badInputs.length; i++) {
     function() {
       ab.sliceToImmutable(rawBad, objGood);
     },
-    "sliceToImmutable(" + assert._toString(rawBad) + ", { valueOf: () => " + assert._toString(rawGood) + " })"
+    "sliceToImmutable(" + formatSimpleValue(rawBad) + ", { valueOf: () => " + formatSimpleValue(rawGood) + " })"
   );
   assert.compareArray(calls, [],
-    "sliceToImmutable(" + assert._toString(rawBad) + ", { valueOf: () => " + assert._toString(rawGood) + " }) calls");
+    "sliceToImmutable(" + formatSimpleValue(rawBad) + ", { valueOf: () => " + formatSimpleValue(rawGood) + " }) calls");
 
   calls = [];
   assert.throws(
@@ -335,10 +335,10 @@ for (var i = 0; i < badInputs.length; i++) {
     function() {
       ab.sliceToImmutable(objGood, rawBad);
     },
-    "sliceToImmutable({ valueOf: () => " + assert._toString(rawGood) + " }, " + assert._toString(rawBad) + ")"
+    "sliceToImmutable({ valueOf: () => " + formatSimpleValue(rawGood) + " }, " + formatSimpleValue(rawBad) + ")"
   );
   assert.compareArray(calls, ["good.valueOf"],
-    "sliceToImmutable({ valueOf: () => " + assert._toString(rawGood) + " }, " + assert._toString(rawBad) + ") calls");
+    "sliceToImmutable({ valueOf: () => " + formatSimpleValue(rawGood) + " }, " + formatSimpleValue(rawBad) + ") calls");
 }
 
 var calls = [];

--- a/test/built-ins/ArrayBuffer/prototype/sliceToImmutable/argument-coercion.js
+++ b/test/built-ins/ArrayBuffer/prototype/sliceToImmutable/argument-coercion.js
@@ -50,13 +50,6 @@ ab = new ArrayBuffer(8);
 assert.sameValue(ab.sliceToImmutable(undefined, undefined).byteLength, 8,
   "Must default (undefined, undefined) to receiver byteLength.");
 
-function repr(value) {
-  if (typeof value === "string") return JSON.stringify(value);
-  if (typeof value === "bigint") return String(value) + "n";
-  if (!value && 1/value === -Infinity) return "-0";
-  return String(value);
-}
-
 function make32ByteArrayBuffer() {
   var ab = new ArrayBuffer(32);
   var view = new Uint8Array(ab);
@@ -125,7 +118,7 @@ for (var i = 0; i < goodInputs.length; i++) {
     var source = make32ByteArrayBuffer();
     var expectContents = Array.from(new Uint8Array(source)).slice(rawStart, rawEnd);
     var dest = source.sliceToImmutable(rawStart, rawEnd);
-    var label = "sliceToImmutable(" + repr(rawStart) + ", " + repr(rawEnd) + ")";
+    var label = "sliceToImmutable(" + assert._toString(rawStart) + ", " + assert._toString(rawEnd) + ")";
     assert.sameValue(dest.byteLength, intLength, label + ".byteLength");
     assert.compareArray(new Uint8Array(dest), expectContents, label + " contents");
     assert.sameValue(dest.immutable, true, label + ".immutable");
@@ -137,7 +130,10 @@ function pad(rawInput) {
   if (typeof rawInput === "string") {
     return { skip: false, string: whitespace + rawInput + whitespace };
   } else if (typeof rawInput === "number") {
-    return { skip: false, string: whitespace + repr(rawInput) + whitespace };
+    return {
+      skip: false,
+      string: whitespace + (isNegativeZero(rawInput) ? "-0" : rawInput) + whitespace
+    };
   }
   return { skip: true };
 }
@@ -158,7 +154,7 @@ for (var i = 0; i < goodInputs.length; i++) {
     var source = make32ByteArrayBuffer();
     var expectContents = Array.from(new Uint8Array(source)).slice(rawStart, rawEnd);
     var dest = source.sliceToImmutable(paddedStart.string, paddedEnd.string);
-    var label = "sliceToImmutable(" + repr(paddedStart.string) + ", " + repr(paddedEnd.string) + ")";
+    var label = "sliceToImmutable(" + assert._toString(paddedStart.string) + ", " + assert._toString(paddedEnd.string) + ")";
     assert.sameValue(dest.byteLength, intLength, label + ".byteLength");
     assert.compareArray(new Uint8Array(dest), expectContents, label + " contents");
     assert.sameValue(dest.immutable, true, label + ".immutable");
@@ -203,8 +199,8 @@ for (var i = 0; i < goodInputs.length; i++) {
       }
     };
     function reprArgs(startMethodName, endMethodName) {
-      var startRepr = "{ " + startMethodName + ": () => " + repr(rawStart) + " }";
-      var endRepr = "{ " + endMethodName + ": () => " + repr(rawEnd) + " }";
+      var startRepr = "{ " + startMethodName + ": () => " + assert._toString(rawStart) + " }";
+      var endRepr = "{ " + endMethodName + ": () => " + assert._toString(rawEnd) + " }";
       return "(" + startRepr + ", " + endRepr + ")";
     }
 
@@ -323,18 +319,26 @@ for (var i = 0; i < badInputs.length; i++) {
       return rawGood;
     }
   };
-  assert.throws(expectedErr, function() {
-    ab.sliceToImmutable(rawBad, objGood);
-  }, "sliceToImmutable(" + repr(rawBad) + ", { valueOf: () => " + repr(rawGood) + " })");
+  assert.throws(
+    expectedErr,
+    function() {
+      ab.sliceToImmutable(rawBad, objGood);
+    },
+    "sliceToImmutable(" + assert._toString(rawBad) + ", { valueOf: () => " + assert._toString(rawGood) + " })"
+  );
   assert.compareArray(calls, [],
-    "sliceToImmutable(" + repr(rawBad) + ", { valueOf: () => " + repr(rawGood) + " }) calls");
+    "sliceToImmutable(" + assert._toString(rawBad) + ", { valueOf: () => " + assert._toString(rawGood) + " }) calls");
 
   calls = [];
-  assert.throws(expectedErr, function() {
-    ab.sliceToImmutable(objGood, rawBad);
-  }, "sliceToImmutable({ valueOf: () => " + repr(rawGood) + " }, " + repr(rawBad) + ")");
+  assert.throws(
+    expectedErr,
+    function() {
+      ab.sliceToImmutable(objGood, rawBad);
+    },
+    "sliceToImmutable({ valueOf: () => " + assert._toString(rawGood) + " }, " + assert._toString(rawBad) + ")"
+  );
   assert.compareArray(calls, ["good.valueOf"],
-    "sliceToImmutable({ valueOf: () => " + repr(rawGood) + " }, " + repr(rawBad) + ") calls");
+    "sliceToImmutable({ valueOf: () => " + assert._toString(rawGood) + " }, " + assert._toString(rawBad) + ") calls");
 }
 
 var calls = [];

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/new-length-coercion.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/new-length-coercion.js
@@ -1,0 +1,254 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertoimmutable
+description: Requested length is coerced to an integer and checked for validity
+info: |
+  ArrayBuffer.prototype.transferToImmutable ( [ newLength ] )
+  1. Let O be the this value.
+  2. Return ? ArrayBufferCopyAndDetach(O, newLength, ~immutable~).
+
+  ArrayBufferCopyAndDetach ( arrayBuffer, newLength, preserveResizability )
+  1. Perform ? RequireInternalSlot(arrayBuffer, [[ArrayBufferData]]).
+  2. If IsSharedArrayBuffer(arrayBuffer) is true, throw a TypeError exception.
+  3. If newLength is undefined, then
+     a. Let newByteLength be arrayBuffer.[[ArrayBufferByteLength]].
+  4. Else,
+     a. Let newByteLength be ? ToIndex(newLength).
+
+  ToIndex ( value )
+  1. Let integer be ? ToIntegerOrInfinity(value).
+  2. If integer is not in the inclusive interval from 0 to 2**53 - 1, throw a RangeError exception.
+  3. Return integer.
+
+  ToIntegerOrInfinity ( argument )
+  1. Let number be ? ToNumber(argument).
+  2. If number is one of NaN, +0𝔽, or -0𝔽, return 0.
+  3. If number is +∞𝔽, return +∞.
+  4. If number is -∞𝔽, return -∞.
+  5. Return truncate(ℝ(number)).
+features: [immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var ab = new ArrayBuffer(8);
+assert.sameValue(ab.transferToImmutable().byteLength, 8,
+  "Must default to receiver byteLength.");
+ab = new ArrayBuffer(8);
+assert.sameValue(ab.transferToImmutable(undefined).byteLength, 8,
+  "Must default undefined to receiver byteLength.");
+
+var goodLengths = [
+  // Unmodified integral numbers
+  [0, 0],
+  [1, 1],
+  [10, 10],
+  // Truncated integral numbers
+  [0.9, 0],
+  [1.9, 1],
+  [-0.9, 0],
+  // Coerced to integral numbers
+  [-0, 0],
+  [null, 0],
+  [false, 0],
+  [true, 1],
+  ["", 0],
+  ["8", 8],
+  ["+9", 9],
+  ["10e0", 10],
+  ["+1.1E+1", 11],
+  ["+.12e2", 12],
+  ["130e-1", 13],
+  ["0b1110", 14],
+  ["0XF", 15],
+  ["0xf", 15],
+  ["0o20", 16],
+  // Coerced to NaN and mapped to 0
+  [NaN, 0],
+  ["7up", 0],
+  ["1_0", 0],
+  ["0x00_ff", 0]
+];
+
+for (var i = 0; i < goodLengths.length; i++) {
+  var rawLength = goodLengths[i][0];
+  var intLength = goodLengths[i][1];
+  var ab = new ArrayBuffer(8);
+  assert.sameValue(ab.transferToImmutable(rawLength).byteLength, intLength,
+    "transferToImmutable(" + assert._toString(rawLength) + ").byteLength");
+}
+
+var whitespace = "\t\v\f\uFEFF\u3000\n\r\u2028\u2029";
+for (var i = 0; i < goodLengths.length; i++) {
+  var rawLength = goodLengths[i][0];
+  var intLength = goodLengths[i][1];
+  if (typeof rawLength === "number") {
+    rawLength = isNegativeZero(rawLength) ? "-0" : String(rawLength);
+  } else if (typeof rawLength !== "string") {
+    continue;
+  }
+  var paddedLength = whitespace + rawLength + whitespace;
+  var ab = new ArrayBuffer(8);
+  assert.sameValue(ab.transferToImmutable(paddedLength).byteLength, intLength,
+    "transferToImmutable(" + assert._toString(paddedLength) + ").byteLength");
+}
+
+for (var i = 0; i < goodLengths.length; i++) {
+  var rawLength = goodLengths[i][0];
+  var intLength = goodLengths[i][1];
+  var calls = [];
+  var badValueOf = false;
+  var badToString = false;
+  var objLength = {
+    valueOf() {
+      calls.push("valueOf");
+      return badValueOf ? {} : rawLength;
+    },
+    toString() {
+      calls.push("toString");
+      return badToString ? {} : rawLength;
+    }
+  };
+
+  var ab = new ArrayBuffer(8);
+  assert.sameValue(ab.transferToImmutable(objLength).byteLength, intLength,
+    "transferToImmutable({ valueOf: () => " + assert._toString(rawLength) + " }).byteLength");
+  assert.compareArray(calls, ["valueOf"],
+    "transferToImmutable({ valueOf: () => " + assert._toString(rawLength) + " }) calls");
+
+  badValueOf = true;
+  calls = [];
+  ab = new ArrayBuffer(8);
+  assert.sameValue(ab.transferToImmutable(objLength).byteLength, intLength,
+    "transferToImmutable({ toString: () => " + assert._toString(rawLength) + " }).byteLength");
+  assert.compareArray(calls, ["valueOf", "toString"],
+    "transferToImmutable({ toString: () => " + assert._toString(rawLength) + " }) calls");
+
+  badToString = true;
+  if (typeof Symbol === undefined || !Symbol.toPrimitive) continue;
+  calls = [];
+  objLength[Symbol.toPrimitive] = function(hint) {
+    calls.push("Symbol.toPrimitive(" + hint + ")");
+    return rawLength;
+  };
+  ab = new ArrayBuffer(8);
+  assert.sameValue(ab.transferToImmutable(objLength).byteLength, intLength,
+    "transferToImmutable({ [Symbol.toPrimitive]: () => " + assert._toString(rawLength) + " }).byteLength");
+  assert.compareArray(calls, ["Symbol.toPrimitive(number)"],
+    "transferToImmutable({ [Symbol.toPrimitive]: () => " + assert._toString(rawLength) + " }) calls");
+}
+
+var badLengths = [
+  // Out of range numbers
+  [-1, RangeError],
+  [9007199254740992, RangeError], // Math.pow(2, 53) = 9007199254740992
+  [Infinity, RangeError],
+  [-Infinity, RangeError],
+  // non-numbers
+  typeof Symbol === undefined ? undefined : [Symbol("1"), TypeError],
+  typeof Symbol === undefined || !Symbol.for ? undefined : [Symbol.for("1"), TypeError],
+  typeof BigInt === undefined ? undefined : [BigInt(1), TypeError],
+];
+
+for (var i = 0; i < badLengths.length; i++) {
+  if (!badLengths[i]) continue;
+  var rawLength = badLengths[i][0];
+  var expectedErr = badLengths[i][1];
+  var ab = new ArrayBuffer(8);
+  assert.throws(expectedErr, function() {
+    ab.transferToImmutable(rawLength);
+  }, "transferToImmutable(" + assert._toString(rawLength) + ")");
+}
+
+for (var i = 0; i < badLengths.length; i++) {
+  if (!badLengths[i]) continue;
+  var rawLength = badLengths[i][0];
+  var expectedErr = badLengths[i][1];
+  if (typeof rawLength !== "number") continue;
+  var paddedLength = whitespace + rawLength + whitespace;
+  var ab = new ArrayBuffer(8);
+  assert.throws(expectedErr, function() {
+    ab.transferToImmutable(paddedLength);
+  }, "transferToImmutable(" + assert._toString(paddedLength) + ")");
+}
+
+for (var i = 0; i < badLengths.length; i++) {
+  if (!badLengths[i]) continue;
+  var rawLength = badLengths[i][0];
+  var expectedErr = badLengths[i][1];
+  var calls = [];
+  var badValueOf = false;
+  var badToString = false;
+  var objLength = {
+    valueOf() {
+      calls.push("valueOf");
+      return badValueOf ? {} : rawLength;
+    },
+    toString() {
+      calls.push("toString");
+      return badToString ? {} : rawLength;
+    }
+  };
+
+  var ab = new ArrayBuffer(8);
+  assert.throws(expectedErr, function() {
+    ab.transferToImmutable(objLength);
+  }, "transferToImmutable({ valueOf: () => " + assert._toString(rawLength) + " })");
+  assert.compareArray(calls, ["valueOf"],
+    "transferToImmutable({ valueOf: () => " + assert._toString(rawLength) + " }) calls");
+
+  badValueOf = true;
+  calls = [];
+  ab = new ArrayBuffer(8);
+  assert.throws(expectedErr, function() {
+    ab.transferToImmutable(objLength);
+  }, "transferToImmutable({ toString: () => " + assert._toString(rawLength) + " })");
+  assert.compareArray(calls, ["valueOf", "toString"],
+    "transferToImmutable({ toString: () => " + assert._toString(rawLength) + " }) calls");
+
+  badToString = true;
+  if (typeof Symbol === undefined || !Symbol.toPrimitive) continue;
+  calls = [];
+  objLength[Symbol.toPrimitive] = function(hint) {
+    calls.push("Symbol.toPrimitive(" + hint + ")");
+    return rawLength;
+  };
+  ab = new ArrayBuffer(8);
+  assert.throws(expectedErr, function() {
+    ab.transferToImmutable(objLength);
+  }, "transferToImmutable({ [Symbol.toPrimitive]: () => " + assert._toString(rawLength) + " })");
+  assert.compareArray(calls, ["Symbol.toPrimitive(number)"],
+    "transferToImmutable({ [Symbol.toPrimitive]: () => " + assert._toString(rawLength) + " }) calls");
+}
+
+var calls = [];
+var objLength = {
+  toString() {
+    calls.push("toString");
+    return {};
+  },
+  valueOf() {
+    calls.push("valueOf");
+    return {};
+  }
+};
+ab = new ArrayBuffer(8);
+assert.throws(TypeError, function() {
+  ab.transferToImmutable(objLength);
+}, "transferToImmutable(badOrdinaryToPrimitive)");
+assert.compareArray(calls, ["valueOf", "toString"],
+  "transferToImmutable(badOrdinaryToPrimitive) calls");
+if (typeof Symbol !== undefined && Symbol.toPrimitive) {
+  calls = [];
+  objLength[Symbol.toPrimitive] = function(hint) {
+    calls.push("Symbol.toPrimitive(" + hint + ")");
+    return {};
+  };
+  ab = new ArrayBuffer(8);
+  assert.throws(TypeError, function() {
+    ab.transferToImmutable(objLength);
+  }, "transferToImmutable(badExoticToPrimitive)");
+  assert.compareArray(calls, ["Symbol.toPrimitive(number)"],
+    "transferToImmutable(badExoticToPrimitive) calls");
+}

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/new-length-coercion.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/new-length-coercion.js
@@ -76,7 +76,7 @@ for (var i = 0; i < goodLengths.length; i++) {
   var intLength = goodLengths[i][1];
   var ab = new ArrayBuffer(8);
   assert.sameValue(ab.transferToImmutable(rawLength).byteLength, intLength,
-    "transferToImmutable(" + assert._toString(rawLength) + ").byteLength");
+    "transferToImmutable(" + formatSimpleValue(rawLength) + ").byteLength");
 }
 
 var whitespace = "\t\v\f\uFEFF\u3000\n\r\u2028\u2029";
@@ -91,7 +91,7 @@ for (var i = 0; i < goodLengths.length; i++) {
   var paddedLength = whitespace + rawLength + whitespace;
   var ab = new ArrayBuffer(8);
   assert.sameValue(ab.transferToImmutable(paddedLength).byteLength, intLength,
-    "transferToImmutable(" + assert._toString(paddedLength) + ").byteLength");
+    "transferToImmutable(" + formatSimpleValue(paddedLength) + ").byteLength");
 }
 
 for (var i = 0; i < goodLengths.length; i++) {
@@ -113,17 +113,17 @@ for (var i = 0; i < goodLengths.length; i++) {
 
   var ab = new ArrayBuffer(8);
   assert.sameValue(ab.transferToImmutable(objLength).byteLength, intLength,
-    "transferToImmutable({ valueOf: () => " + assert._toString(rawLength) + " }).byteLength");
+    "transferToImmutable({ valueOf: () => " + formatSimpleValue(rawLength) + " }).byteLength");
   assert.compareArray(calls, ["valueOf"],
-    "transferToImmutable({ valueOf: () => " + assert._toString(rawLength) + " }) calls");
+    "transferToImmutable({ valueOf: () => " + formatSimpleValue(rawLength) + " }) calls");
 
   badValueOf = true;
   calls = [];
   ab = new ArrayBuffer(8);
   assert.sameValue(ab.transferToImmutable(objLength).byteLength, intLength,
-    "transferToImmutable({ toString: () => " + assert._toString(rawLength) + " }).byteLength");
+    "transferToImmutable({ toString: () => " + formatSimpleValue(rawLength) + " }).byteLength");
   assert.compareArray(calls, ["valueOf", "toString"],
-    "transferToImmutable({ toString: () => " + assert._toString(rawLength) + " }) calls");
+    "transferToImmutable({ toString: () => " + formatSimpleValue(rawLength) + " }) calls");
 
   badToString = true;
   if (typeof Symbol === undefined || !Symbol.toPrimitive) continue;
@@ -134,9 +134,9 @@ for (var i = 0; i < goodLengths.length; i++) {
   };
   ab = new ArrayBuffer(8);
   assert.sameValue(ab.transferToImmutable(objLength).byteLength, intLength,
-    "transferToImmutable({ [Symbol.toPrimitive]: () => " + assert._toString(rawLength) + " }).byteLength");
+    "transferToImmutable({ [Symbol.toPrimitive]: () => " + formatSimpleValue(rawLength) + " }).byteLength");
   assert.compareArray(calls, ["Symbol.toPrimitive(number)"],
-    "transferToImmutable({ [Symbol.toPrimitive]: () => " + assert._toString(rawLength) + " }) calls");
+    "transferToImmutable({ [Symbol.toPrimitive]: () => " + formatSimpleValue(rawLength) + " }) calls");
 }
 
 var badLengths = [
@@ -158,7 +158,7 @@ for (var i = 0; i < badLengths.length; i++) {
   var ab = new ArrayBuffer(8);
   assert.throws(expectedErr, function() {
     ab.transferToImmutable(rawLength);
-  }, "transferToImmutable(" + assert._toString(rawLength) + ")");
+  }, "transferToImmutable(" + formatSimpleValue(rawLength) + ")");
 }
 
 for (var i = 0; i < badLengths.length; i++) {
@@ -170,7 +170,7 @@ for (var i = 0; i < badLengths.length; i++) {
   var ab = new ArrayBuffer(8);
   assert.throws(expectedErr, function() {
     ab.transferToImmutable(paddedLength);
-  }, "transferToImmutable(" + assert._toString(paddedLength) + ")");
+  }, "transferToImmutable(" + formatSimpleValue(paddedLength) + ")");
 }
 
 for (var i = 0; i < badLengths.length; i++) {
@@ -194,18 +194,18 @@ for (var i = 0; i < badLengths.length; i++) {
   var ab = new ArrayBuffer(8);
   assert.throws(expectedErr, function() {
     ab.transferToImmutable(objLength);
-  }, "transferToImmutable({ valueOf: () => " + assert._toString(rawLength) + " })");
+  }, "transferToImmutable({ valueOf: () => " + formatSimpleValue(rawLength) + " })");
   assert.compareArray(calls, ["valueOf"],
-    "transferToImmutable({ valueOf: () => " + assert._toString(rawLength) + " }) calls");
+    "transferToImmutable({ valueOf: () => " + formatSimpleValue(rawLength) + " }) calls");
 
   badValueOf = true;
   calls = [];
   ab = new ArrayBuffer(8);
   assert.throws(expectedErr, function() {
     ab.transferToImmutable(objLength);
-  }, "transferToImmutable({ toString: () => " + assert._toString(rawLength) + " })");
+  }, "transferToImmutable({ toString: () => " + formatSimpleValue(rawLength) + " })");
   assert.compareArray(calls, ["valueOf", "toString"],
-    "transferToImmutable({ toString: () => " + assert._toString(rawLength) + " }) calls");
+    "transferToImmutable({ toString: () => " + formatSimpleValue(rawLength) + " }) calls");
 
   badToString = true;
   if (typeof Symbol === undefined || !Symbol.toPrimitive) continue;
@@ -217,9 +217,9 @@ for (var i = 0; i < badLengths.length; i++) {
   ab = new ArrayBuffer(8);
   assert.throws(expectedErr, function() {
     ab.transferToImmutable(objLength);
-  }, "transferToImmutable({ [Symbol.toPrimitive]: () => " + assert._toString(rawLength) + " })");
+  }, "transferToImmutable({ [Symbol.toPrimitive]: () => " + formatSimpleValue(rawLength) + " })");
   assert.compareArray(calls, ["Symbol.toPrimitive(number)"],
-    "transferToImmutable({ [Symbol.toPrimitive]: () => " + assert._toString(rawLength) + " }) calls");
+    "transferToImmutable({ [Symbol.toPrimitive]: () => " + formatSimpleValue(rawLength) + " }) calls");
 }
 
 var calls = [];

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/not-a-constructor.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/not-a-constructor.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertoimmutable
+description: ArrayBuffer.prototype.transferToImmutable is not a constructor function
+info: |
+  ECMAScript Standard Built-in Objects
+  ...
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in the
+  description of a particular function.
+features: [Reflect.construct, immutable-arraybuffer]
+includes: [isConstructor.js]
+---*/
+
+assert(!isConstructor(ArrayBuffer.prototype.transferToImmutable),
+  "ArrayBuffer.prototype.transferToImmutable is not a constructor");
+
+var arrayBuffer = new ArrayBuffer(8);
+assert.throws(TypeError, function() {
+  new arrayBuffer.transferToImmutable();
+});

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/prop-desc.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/prop-desc.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertoimmutable
+description: Checks the "transferToImmutable" property of ArrayBuffer.prototype
+info: |
+  ECMAScript Standard Built-in Objects
+  ...
+  Every built-in function object, including constructors, has a "length"
+  property whose value is a non-negative integral Number. Unless otherwise
+  specified, this value is the number of required parameters shown in the
+  subclause heading for the function description. Optional parameters and rest
+  parameters are not included in the parameter count.
+  ...
+  For functions that are specified as properties of objects, the name value is
+  the property name string used to access the function.
+features: [immutable-arraybuffer]
+includes: [propertyHelper.js]
+---*/
+
+verifyPrimordialCallableProperty(
+  ArrayBuffer.prototype,
+  "transferToImmutable",
+  "transferToImmutable",
+  0
+);

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/this-has-no-arraybufferdata-internal.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/this-has-no-arraybufferdata-internal.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertoimmutable
+description: >
+  Throws a TypeError exception when `this` does not have a [[ArrayBufferData]]
+  internal slot
+info: |
+  ArrayBuffer.prototype.transferToImmutable ( [ newLength ] )
+  1. Let O be the this value.
+  2. Return ? ArrayBufferCopyAndDetach(O, newLength, ~immutable~).
+
+  ArrayBufferCopyAndDetach ( arrayBuffer, newLength, preserveResizability )
+  1. Perform ? RequireInternalSlot(arrayBuffer, [[ArrayBufferData]]).
+features: [DataView, Int8Array, ArrayBuffer, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var fn = ArrayBuffer.prototype.transferToImmutable;
+assert.sameValue(typeof fn, "function", "Method must exist.");
+
+var calls = [];
+var newLength = {
+  valueOf() {
+    calls.push("newLength.valueOf");
+    return 1;
+  }
+};
+
+var badReceivers = [
+  ["plain object", {}],
+  ["array", []],
+  ["function", function(){}],
+  ["ArrayBuffer.prototype", ArrayBuffer.prototype],
+  ["TypedArray", new Int8Array(8)],
+  ["DataView", new DataView(new ArrayBuffer(8), 0)]
+];
+
+for (var i = 0; i < badReceivers.length; i++) {
+  var label = badReceivers[i][0];
+  var value = badReceivers[i][1];
+  calls = [];
+  assert.throws(TypeError, function() {
+    fn.call(value, newLength);
+  }, label);
+  assert.compareArray(calls, [],
+    "[" + label + " receiver] Must verify internal slots before reading arguments.");
+}
+
+calls = [];
+assert.throws(TypeError, function() {
+  ArrayBuffer.prototype.transferToImmutable(newLength);
+}, "invoked as prototype method");
+assert.compareArray(calls, [],
+  "[invoked as prototype method] Must verify internal slots before reading arguments.");
+
+calls = [];
+assert.throws(TypeError, function() {
+  fn(newLength);
+}, "invoked as function");
+assert.compareArray(calls, [],
+  "[invoked as function] Must verify internal slots before reading arguments.");

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/this-is-not-detachable.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/this-is-not-detachable.js
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertoimmutable
+description: >
+  Throws a TypeError exception when `this` is already detached or immutable
+info: |
+  ArrayBuffer.prototype.transferToImmutable ( [ newLength ] )
+  1. Let O be the this value.
+  2. Return ? ArrayBufferCopyAndDetach(O, newLength, ~immutable~).
+
+  ArrayBufferCopyAndDetach ( arrayBuffer, newLength, preserveResizability )
+  1. Perform ? RequireInternalSlot(arrayBuffer, [[ArrayBufferData]]).
+  2. If IsSharedArrayBuffer(arrayBuffer) is true, throw a TypeError exception.
+  3. If newLength is undefined, then
+     a. Let newByteLength be arrayBuffer.[[ArrayBufferByteLength]].
+  4. Else,
+     a. Let newByteLength be ? ToIndex(newLength).
+  5. If IsDetachedBuffer(arrayBuffer) is true, throw a TypeError exception.
+  6. If IsImmutableBuffer(arrayBuffer) is true, throw a TypeError exception.
+features: [immutable-arraybuffer]
+includes: [compareArray.js, detachArrayBuffer.js]
+---*/
+
+var calls = [];
+var newLength = {
+  valueOf() {
+    calls.push("newLength.valueOf");
+    return 1;
+  }
+};
+
+var detached = new ArrayBuffer(8);
+$DETACHBUFFER(detached);
+var immutable = (new ArrayBuffer(8)).transferToImmutable();
+
+var badReceivers = [
+  ["detached ArrayBuffer", detached],
+  ["immutable ArrayBuffer", immutable]
+];
+
+for (var i = 0; i < badReceivers.length; i++) {
+  var label = badReceivers[i][0];
+  var value = badReceivers[i][1];
+  calls = [];
+  assert.throws(TypeError, function() {
+    value.transferToImmutable(newLength);
+  }, label);
+  assert.compareArray(calls, ["newLength.valueOf"],
+    "[" + label + "] Must read arguments before verifying detachability.");
+}
+
+calls = [];
+var becomesDetached = new ArrayBuffer(8);
+assert.throws(TypeError, function() {
+  becomesDetached.transferToImmutable({
+    valueOf() {
+      calls.push("newLength.valueOf");
+      $DETACHBUFFER(becomesDetached);
+      return 1;
+    }
+  });
+}, "becomes detached");
+assert.compareArray(calls, ["newLength.valueOf"],
+  "[becomes detached] Must read arguments before verifying detachability.");

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/this-is-not-object.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/this-is-not-object.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertoimmutable
+description: Throws a TypeError exception when `this` is not an object
+info: |
+  ArrayBuffer.prototype.transferToImmutable ( [ newLength ] )
+  1. Let O be the this value.
+  2. Return ? ArrayBufferCopyAndDetach(O, newLength, ~immutable~).
+
+  ArrayBufferCopyAndDetach ( arrayBuffer, newLength, preserveResizability )
+  1. Perform ? RequireInternalSlot(arrayBuffer, [[ArrayBufferData]]).
+features: [ArrayBuffer, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var fn = ArrayBuffer.prototype.transferToImmutable;
+assert.sameValue(typeof fn, "function", "Method must exist.");
+
+var calls = [];
+var newLength = {
+  valueOf() {
+    calls.push("newLength.valueOf");
+    return 1;
+  }
+};
+
+var badReceivers = [
+  ["undefined", undefined],
+  ["null", null],
+  ["number", 42],
+  ["string", "1"],
+  ["true", true],
+  ["false", false],
+  typeof Symbol === "undefined" ? undefined : ["unique symbol", Symbol("1")],
+  typeof Symbol === "undefined" || !Symbol.for ? undefined : ["registered symbol", Symbol.for("1")],
+  typeof BigInt === "undefined" ? undefined : ["bigint", BigInt(1)]
+];
+
+for (var i = 0; i < badReceivers.length; i++) {
+  var label = badReceivers[i][0];
+  var value = badReceivers[i][1];
+  calls = [];
+  assert.throws(TypeError, function() {
+    fn.call(value, newLength);
+  }, label);
+  assert.compareArray(calls, [],
+    "[" + label + " receiver] Must verify internal slots before reading arguments.");
+}

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/this-is-sharedarraybuffer.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/this-is-sharedarraybuffer.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertoimmutable
+description: Throws a TypeError exception when `this` is a SharedArrayBuffer
+info: |
+  ArrayBuffer.prototype.transferToImmutable ( [ newLength ] )
+  1. Let O be the this value.
+  2. Return ? ArrayBufferCopyAndDetach(O, newLength, ~immutable~).
+
+  ArrayBufferCopyAndDetach ( arrayBuffer, newLength, preserveResizability )
+  1. Perform ? RequireInternalSlot(arrayBuffer, [[ArrayBufferData]]).
+  2. If IsSharedArrayBuffer(arrayBuffer) is true, throw a TypeError exception.
+features: [SharedArrayBuffer, ArrayBuffer, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var fn = ArrayBuffer.prototype.transferToImmutable;
+assert.sameValue(typeof fn, "function", "Method must exist.");
+
+var calls = [];
+
+var sab = new SharedArrayBuffer(4);
+assert.throws(TypeError, function() {
+  fn.call(sab, {
+    valueOf() {
+      calls.push("newLength.valueOf");
+      return 1;
+    }
+  });
+});
+assert.compareArray(calls, [],
+  "Must verify non-SharedArrayBuffer receiver before reading arguments.");

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/to-larger.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/to-larger.js
@@ -1,0 +1,79 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertoimmutable
+description: >
+  `ab.transferToImmutable(largerByteLength)` detaches `ab` and returns an
+  immutable ArrayBuffer with contents equal to the concatenation of `ab` and
+  enough zeros to fill the specified length
+info: |
+  ArrayBuffer.prototype.transferToImmutable ( [ newLength ] )
+  1. Let O be the this value.
+  2. Return ? ArrayBufferCopyAndDetach(O, newLength, ~immutable~).
+
+  ArrayBufferCopyAndDetach ( arrayBuffer, newLength, preserveResizability )
+  1. Perform ? RequireInternalSlot(arrayBuffer, [[ArrayBufferData]]).
+  2. If IsSharedArrayBuffer(arrayBuffer) is true, throw a TypeError exception.
+  3. If newLength is undefined, then
+     a. Let newByteLength be arrayBuffer.[[ArrayBufferByteLength]].
+  4. Else,
+     a. Let newByteLength be ? ToIndex(newLength).
+  5. If IsDetachedBuffer(arrayBuffer) is true, throw a TypeError exception.
+  6. If IsImmutableBuffer(arrayBuffer) is true, throw a TypeError exception.
+  7. If arrayBuffer.[[ArrayBufferDetachKey]] is not undefined, throw a TypeError exception.
+  8. Let copyLength be min(newByteLength, arrayBuffer.[[ArrayBufferByteLength]]).
+  9. If preserveResizability is immutable, then
+     a. Let newBuffer be ? AllocateImmutableArrayBuffer(%ArrayBuffer%, newByteLength, arrayBuffer.[[ArrayBufferData]], 0, copyLength).
+  10. Else, ...
+  11. Perform ! DetachArrayBuffer(arrayBuffer).
+features: [Uint8Array, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var byteLength = 4;
+var newLengths = [5, 8, 9];
+var sourceMakers = [
+  function fixed() {
+    return new ArrayBuffer(byteLength);
+  },
+  ArrayBuffer.prototype.resize && function resizable() {
+    return new ArrayBuffer(byteLength, { maxByteLength: byteLength * 2 });
+  },
+  ArrayBuffer.prototype.resize && function shrunk() {
+    var ab = new ArrayBuffer(byteLength * 2, { maxByteLength: byteLength * 2 });
+    ab.resize(byteLength);
+    return ab;
+  },
+  ArrayBuffer.prototype.resize && function grown() {
+    var ab = new ArrayBuffer(byteLength / 2, { maxByteLength: byteLength });
+    ab.resize(byteLength);
+    return ab;
+  }
+];
+
+for (var i = 0; i < sourceMakers.length; i++) {
+  if (!sourceMakers[i]) continue;
+  var name = sourceMakers[i].name;
+  for (var j = 0; j < newLengths.length; j++) {
+    var newLength = newLengths[j];
+    var label = name + "(" + byteLength + ").transferToImmutable(" + newLength + ")";
+    var source = sourceMakers[i]();
+    var sourceView = new Uint8Array(source);
+    var expectDestContents = new Array(newLength);
+    for (var k = 0; k < newLength; k++) {
+      if (k < byteLength) sourceView[k] = k + 1;
+      expectDestContents[k] = k < byteLength ? k + 1 : 0;
+    }
+
+    var dest = source.transferToImmutable(newLength);
+    assert.sameValue(source.detached, true, label + " source detached");
+    assert.sameValue(dest.immutable, true, label + " is immutable");
+    assert.sameValue(dest.resizable, false, label + " is not resizable");
+    assert.sameValue(dest.byteLength, newLength, label + " byteLength");
+    assert.sameValue(dest.maxByteLength, newLength, label + " maxByteLength");
+
+    var destView = new Uint8Array(dest);
+    assert.compareArray(destView, expectDestContents, label + " contents");
+  }
+}

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/to-same-or-smaller.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/to-same-or-smaller.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertoimmutable
+description: >
+  `ab.transferToImmutable(sameOrSmallerByteLength)` detaches `ab` and returns an
+  immutable ArrayBuffer with contents equal to the specified-length prefix of
+  `ab`
+info: |
+  ArrayBuffer.prototype.transferToImmutable ( [ newLength ] )
+  1. Let O be the this value.
+  2. Return ? ArrayBufferCopyAndDetach(O, newLength, ~immutable~).
+
+  ArrayBufferCopyAndDetach ( arrayBuffer, newLength, preserveResizability )
+  1. Perform ? RequireInternalSlot(arrayBuffer, [[ArrayBufferData]]).
+  2. If IsSharedArrayBuffer(arrayBuffer) is true, throw a TypeError exception.
+  3. If newLength is undefined, then
+     a. Let newByteLength be arrayBuffer.[[ArrayBufferByteLength]].
+  4. Else,
+     a. Let newByteLength be ? ToIndex(newLength).
+  5. If IsDetachedBuffer(arrayBuffer) is true, throw a TypeError exception.
+  6. If IsImmutableBuffer(arrayBuffer) is true, throw a TypeError exception.
+  7. If arrayBuffer.[[ArrayBufferDetachKey]] is not undefined, throw a TypeError exception.
+  8. Let copyLength be min(newByteLength, arrayBuffer.[[ArrayBufferByteLength]]).
+  9. If preserveResizability is immutable, then
+     a. Let newBuffer be ? AllocateImmutableArrayBuffer(%ArrayBuffer%, newByteLength, arrayBuffer.[[ArrayBufferData]], 0, copyLength).
+  10. Else, ...
+  11. Perform ! DetachArrayBuffer(arrayBuffer).
+features: [Uint8Array, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var byteLength = 4;
+var sourceMakers = [
+  function fixed() {
+    return new ArrayBuffer(byteLength);
+  },
+  ArrayBuffer.prototype.resize && function resizable() {
+    return new ArrayBuffer(byteLength, { maxByteLength: byteLength * 2 });
+  },
+  ArrayBuffer.prototype.resize && function shrunk() {
+    var ab = new ArrayBuffer(byteLength * 2, { maxByteLength: byteLength * 2 });
+    ab.resize(byteLength);
+    return ab;
+  },
+  ArrayBuffer.prototype.resize && function grown() {
+    var ab = new ArrayBuffer(byteLength / 2, { maxByteLength: byteLength });
+    ab.resize(byteLength);
+    return ab;
+  }
+];
+
+for (var i = 0; i < sourceMakers.length; i++) {
+  if (!sourceMakers[i]) continue;
+  var name = sourceMakers[i].name;
+  for (var j = -1; j <= byteLength; j++) {
+    var newLength = j < 0 ? undefined : j;
+    var label = name + "(" + byteLength + ").transferToImmutable(" + newLength + ")";
+    var source = sourceMakers[i]();
+    var sourceView = new Uint8Array(source);
+    for (var k = 0; k < byteLength; k++) sourceView[k] = k + 1;
+    var expectDestContents = sourceView.slice(0, newLength);
+
+    var dest = source.transferToImmutable(newLength);
+    assert.sameValue(source.detached, true, label + " source detached");
+    assert.sameValue(dest.immutable, true, label + " is immutable");
+    assert.sameValue(dest.resizable, false, label + " is not resizable");
+    var resolvedNewLength = newLength === undefined ? byteLength : newLength;
+    assert.sameValue(dest.byteLength, resolvedNewLength, label + " byteLength");
+    assert.sameValue(dest.maxByteLength, resolvedNewLength, label + " maxByteLength");
+
+    var destView = new Uint8Array(dest);
+    assert.compareArray(destView, expectDestContents, label + " contents");
+  }
+}


### PR DESCRIPTION
Ref #4509

> # New ArrayBuffer.prototype properties
> 
> - [x] `ArrayBuffer.prototype.transferToImmutable`
>   - [x] `verifyPrimordialCallableProperty(ArrayBuffer.prototype, "transferToImmutable", "transferToImmutable", 0);`
>   - [x] brand-checking (throws TypeError unless receiver is an ArrayBuffer and not a SharedArrayBuffer), before coercing _newLength_
>   - [x] defaults _newLength_ to [[ArrayBufferByteLength]]
>   - [x] if _newLength_ is not undefined, casts it to an index (integral number from 0 to 2**53 - 1 inclusive) or throws a RangeError for out-of-range values, after brand-checking
>   - [x] throws TypeError if receiver is detached or immutable, after processing _newLength_ (_**note the unusual receiver-after-argument order**_)
>   - [x] detaches the receiver
>   - [x] returns an immutable ArrayBuffer with the correct length
>   - [x] if _newLength_ ≤ [[ArrayBufferByteLength]], returns an ArrayBuffer with contents matching the appropriate prefix of the receiver up to exclusive index _newLength_
>   - [x] if _newLength_ > [[ArrayBufferByteLength]], returns an ArrayBuffer with contents matching those of the receiver, followed by the appropriate count of zeros