### PR TITLE
[immutable-arraybuffer] DataView.prototype.set$Type

### DIFF
--- a/test/built-ins/DataView/prototype/setBigInt64/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setBigInt64/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setbigint64
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setBigInt64 ( byteOffset, value [ , littleEndian ] )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getBigInt64(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getBigInt64(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setBigInt64(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");

--- a/test/built-ins/DataView/prototype/setBigUint64/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setBigUint64/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setbiguint64
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setBigUint64 ( byteOffset, value [ , littleEndian ] )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getBigUint64(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getBigUint64(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setBigUint64(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");

--- a/test/built-ins/DataView/prototype/setFloat16/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setFloat16/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setfloat16
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setFloat16 ( byteOffset, value [ , littleEndian ] )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getFloat16(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getFloat16(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setFloat16(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");

--- a/test/built-ins/DataView/prototype/setFloat32/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setFloat32/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setfloat32
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setFloat32 ( byteOffset, value [ , littleEndian ] )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getFloat32(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getFloat32(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setFloat32(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");

--- a/test/built-ins/DataView/prototype/setFloat64/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setFloat64/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setfloat64
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setFloat64 ( byteOffset, value [ , littleEndian ] )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getFloat64(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getFloat64(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setFloat64(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");

--- a/test/built-ins/DataView/prototype/setInt16/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setInt16/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setint16
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setInt16 ( byteOffset, value [ , littleEndian ] )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getInt16(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getInt16(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setInt16(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");

--- a/test/built-ins/DataView/prototype/setInt32/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setInt32/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setint32
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setInt32 ( byteOffset, value [ , littleEndian ] )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getInt32(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getInt32(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setInt32(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");

--- a/test/built-ins/DataView/prototype/setInt8/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setInt8/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setint8
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setInt8 ( byteOffset, value )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getInt8(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getInt8(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setInt8(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");

--- a/test/built-ins/DataView/prototype/setUint16/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setUint16/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setuint16
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setUint16 ( byteOffset, value [ , littleEndian ] )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getUint16(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getUint16(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setUint16(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");

--- a/test/built-ins/DataView/prototype/setUint32/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setUint32/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setuint32
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setUint32 ( byteOffset, value [ , littleEndian ] )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getUint32(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getUint32(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setUint32(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");

--- a/test/built-ins/DataView/prototype/setUint8/immutable-buffer.js
+++ b/test/built-ins/DataView/prototype/setUint8/immutable-buffer.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.setuint8
+description: >
+  Throws a TypeError exception when the backing buffer is immutable
+info: |
+  DataView.prototype.setUint8 ( byteOffset, value )
+  1. Let view be the this value.
+  2. Return ? SetViewValue(view, byteOffset, true, ~uint8~, value).
+
+  SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+  1. Perform ? RequireInternalSlot(view, [[DataView]]).
+  2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
+  3. If IsImmutableBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  4. Let getIndex be ? ToIndex(requestIndex).
+  5. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
+  6. Otherwise, let numberValue be ? ToNumber(value).
+features: [DataView, immutable-arraybuffer]
+includes: [compareArray.js]
+---*/
+
+var iab = (new ArrayBuffer(8)).transferToImmutable();
+var view = new DataView(iab);
+
+var calls = [];
+var byteOffset = {
+  valueOf() {
+    calls.push("byteOffset.valueOf");
+    return 0;
+  }
+};
+var value = {
+  valueOf() {
+    calls.push("value.valueOf");
+    return "1";
+  }
+};
+
+assert.sameValue(
+  view.getUint8(byteOffset),
+  (new DataView(new ArrayBuffer(8))).getUint8(byteOffset),
+  "read an initial zero"
+);
+calls = [];
+assert.throws(TypeError, function() {
+  view.setUint8(byteOffset, value);
+});
+assert.compareArray(calls, [], "Must verify mutability before reading arguments.");


### PR DESCRIPTION
Ref #4509

> # DataView
> 
> - [x] `DataView.prototype.set…`
>   - [x] throws a TypeError if the receiver is backed by an immutable ArrayBuffer, before touching any argument