### PR TITLE
[immutable-arraybuffer] Include immutable ArrayBuffers in TypedArray testing

### DIFF
--- a/harness/testTypedArray.js
+++ b/harness/testTypedArray.js
@@ -333,9 +333,19 @@ var nonAtomicsFriendlyTypedArrayConstructors = floatArrayConstructors.concat([Ui
  *
  * @param {typedArrayConstructorCallback} f - the function to call for each typed array constructor.
  * @param {Array} selected - An optional Array with filtered typed arrays
+ * @param {typedArrayArgFactoryFeature[]} [includeArgFactories] - for selecting
+ *   initial constructor argument factory functions, rather than starting with
+ *   all argument factories
+ * @param {typedArrayArgFactoryFeature[]} [excludeArgFactories] - for excluding
+ *   constructor argument factory functions, after an initial selection
  */
-function testWithNonAtomicsFriendlyTypedArrayConstructors(f) {
-  testWithTypedArrayConstructors(f, nonAtomicsFriendlyTypedArrayConstructors);
+function testWithNonAtomicsFriendlyTypedArrayConstructors(f, includeArgFactories, excludeArgFactories) {
+  testWithAllTypedArrayConstructors(
+    f,
+    nonAtomicsFriendlyTypedArrayConstructors,
+    includeArgFactories,
+    excludeArgFactories
+  );
 }
 
 /**
@@ -343,16 +353,26 @@ function testWithNonAtomicsFriendlyTypedArrayConstructors(f) {
  *
  * @param {typedArrayConstructorCallback} f - the function to call for each typed array constructor.
  * @param {Array} selected - An optional Array with filtered typed arrays
+ * @param {typedArrayArgFactoryFeature[]} [includeArgFactories] - for selecting
+ *   initial constructor argument factory functions, rather than starting with
+ *   all argument factories
+ * @param {typedArrayArgFactoryFeature[]} [excludeArgFactories] - for excluding
+ *   constructor argument factory functions, after an initial selection
  */
-function testWithAtomicsFriendlyTypedArrayConstructors(f) {
-  testWithTypedArrayConstructors(f, [
-    Int32Array,
-    Int16Array,
-    Int8Array,
-    Uint32Array,
-    Uint16Array,
-    Uint8Array,
-  ]);
+function testWithAtomicsFriendlyTypedArrayConstructors(f, includeArgFactories, excludeArgFactories) {
+  testWithAllTypedArrayConstructors(
+    f,
+    [
+      Int32Array,
+      Int16Array,
+      Int8Array,
+      Uint32Array,
+      Uint16Array,
+      Uint8Array,
+    ],
+    includeArgFactories,
+    excludeArgFactories
+  );
 }
 
 /**
@@ -379,7 +399,7 @@ function testTypedArrayConversions(byteConversionValues, fn) {
       }
       fn(TA, value, exp, initial);
     });
-  });
+  }, null, ["passthrough"]);
 }
 
 /**

--- a/harness/testTypedArray.js
+++ b/harness/testTypedArray.js
@@ -102,7 +102,7 @@ function makeArrayBuffer(TA, primitiveOrIterable) {
   return new TA(arr).buffer;
 }
 
-var makeResizableArrayBuffer, makeGrownArrayBuffer, makeShrunkArrayBuffer;
+var makeResizableArrayBuffer, makeGrownArrayBuffer, makeShrunkArrayBuffer, makeImmutableArrayBuffer;
 if (ArrayBuffer.prototype.resize) {
   var copyIntoArrayBuffer = function(destBuffer, srcBuffer) {
     var destView = new Uint8Array(destBuffer);
@@ -152,6 +152,17 @@ if (ArrayBuffer.prototype.resize) {
     return shrunk;
   };
 }
+if (ArrayBuffer.prototype.transferToImmutable) {
+  makeImmutableArrayBuffer = function makeImmutableArrayBuffer(TA, primitiveOrIterable) {
+    if (isPrimitive(primitiveOrIterable)) {
+      var n = Number(primitiveOrIterable) * TA.BYTES_PER_ELEMENT;
+      if (!(n >= 0 && n < 9007199254740992)) return primitiveOrIterable;
+      return (new ArrayBuffer(n)).transferToImmutable();
+    }
+    var mutable = makeArrayBuffer(TA, primitiveOrIterable);
+    return mutable.transferToImmutable();
+  };
+}
 
 var typedArrayCtorArgFactories = [makePassthrough, makeArray, makeArrayLike];
 if (makeIterable) typedArrayCtorArgFactories.push(makeIterable);
@@ -159,9 +170,10 @@ typedArrayCtorArgFactories.push(makeArrayBuffer);
 if (makeResizableArrayBuffer) typedArrayCtorArgFactories.push(makeResizableArrayBuffer);
 if (makeGrownArrayBuffer) typedArrayCtorArgFactories.push(makeGrownArrayBuffer);
 if (makeShrunkArrayBuffer) typedArrayCtorArgFactories.push(makeShrunkArrayBuffer);
+if (makeImmutableArrayBuffer) typedArrayCtorArgFactories.push(makeImmutableArrayBuffer);
 
 /**
- * @typedef {"passthrough" | "arraylike" | "iterable" | "arraybuffer" | "resizable"} typedArrayArgFactoryFeature
+ * @typedef {"passthrough" | "arraylike" | "iterable" | "arraybuffer" | "resizable" | "immutable"} typedArrayArgFactoryFeature
  */
 
 /**
@@ -189,7 +201,8 @@ function ctorArgFactoryMatchesSome(argFactory, features) {
           argFactory === makeArrayBuffer ||
           argFactory === makeResizableArrayBuffer ||
           argFactory === makeGrownArrayBuffer ||
-          argFactory === makeShrunkArrayBuffer
+          argFactory === makeShrunkArrayBuffer ||
+          argFactory === makeImmutableArrayBuffer
         ) {
           return true;
         }
@@ -202,6 +215,9 @@ function ctorArgFactoryMatchesSome(argFactory, features) {
         ) {
           return true;
         }
+        break;
+      case "immutable":
+        if (argFactory === makeImmutableArrayBuffer) return true;
         break;
       default:
         throw Test262Error("unknown feature: " + features[i]);

--- a/test/built-ins/ArrayBuffer/isView/arg-is-typedarray-buffer.js
+++ b/test/built-ins/ArrayBuffer/isView/arg-is-typedarray-buffer.js
@@ -15,8 +15,8 @@ features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 
-testWithTypedArrayConstructors(function(ctor) {
-  var sample = new ctor().buffer;
+testWithAllTypedArrayConstructors(function(ctor, makeCtorArg) {
+  var sample = new ctor(makeCtorArg(0)).buffer;
 
   assert.sameValue(ArrayBuffer.isView(sample), false);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/ArrayBuffer/isView/arg-is-typedarray-constructor.js
+++ b/test/built-ins/ArrayBuffer/isView/arg-is-typedarray-constructor.js
@@ -15,6 +15,6 @@ features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 
-testWithTypedArrayConstructors(function(ctor) {
+testWithAllTypedArrayConstructors(function(ctor) {
   assert.sameValue(ArrayBuffer.isView(ctor), false);
 }, null, ["passthrough"]);

--- a/test/built-ins/ArrayBuffer/isView/arg-is-typedarray-subclass-instance.js
+++ b/test/built-ins/ArrayBuffer/isView/arg-is-typedarray-subclass-instance.js
@@ -15,10 +15,10 @@ features: [class, TypedArray]
 includes: [testTypedArray.js]
 ---*/
 
-testWithTypedArrayConstructors(function(ctor) {
+testWithAllTypedArrayConstructors(function(ctor, makeCtorArg) {
   class TA extends ctor {}
 
-  var sample = new TA();
+  var sample = new TA(makeCtorArg(0));
 
   assert(ArrayBuffer.isView(sample));
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/ArrayBuffer/isView/arg-is-typedarray.js
+++ b/test/built-ins/ArrayBuffer/isView/arg-is-typedarray.js
@@ -15,8 +15,8 @@ features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 
-testWithTypedArrayConstructors(function(ctor) {
-  var sample = new ctor();
+testWithAllTypedArrayConstructors(function(ctor, makeCtorArg) {
+  var sample = new ctor(makeCtorArg(0));
 
   assert.sameValue(ArrayBuffer.isView(sample), true);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/ArrayBuffer/isView/invoked-as-a-fn.js
+++ b/test/built-ins/ArrayBuffer/isView/invoked-as-a-fn.js
@@ -17,10 +17,10 @@ includes: [testTypedArray.js]
 
 var isView = ArrayBuffer.isView;
 
-testWithTypedArrayConstructors(function(ctor) {
-  var sample = new ctor();
+testWithAllTypedArrayConstructors(function(ctor, makeCtorArg) {
+  var sample = new ctor(makeCtorArg(0));
   assert.sameValue(isView(sample), true, "instance of TypedArray");
-}, null, ["passthrough"]);
+});
 
 var dv = new DataView(new ArrayBuffer(1), 0, 0);
 assert.sameValue(isView(dv), true, "instance of DataView");

--- a/test/built-ins/ArrayIteratorPrototype/next/detach-typedarray-in-progress.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/detach-typedarray-in-progress.js
@@ -13,8 +13,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(TA => {
-  var typedArray = new TA(5);
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var typedArray = new TA(makeCtorArg(5));
   var i = 0;
   assert.throws(TypeError, () => {
     for (let key of typedArray.keys()) {
@@ -23,4 +23,4 @@ testWithTypedArrayConstructors(TA => {
     }
   });
   assert.sameValue(i, 1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/Atomics/add/bad-range.js
+++ b/test/built-ins/Atomics/add/bad-range.js
@@ -19,4 +19,4 @@ testWithTypedArrayConstructors(function(TA) {
       Atomics.add(view, IdxGen(view), 10);
     });
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/add/bigint/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/add/bigint/non-shared-bufferdata.js
@@ -7,9 +7,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, BigInt, TypedArray]
 ---*/
-testWithBigIntTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithBigIntTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.sameValue(Atomics.add(view, 0, 1n), 0n, 'Atomics.add(view, 0, 1n) returns 0n');
   assert.sameValue(Atomics.load(view, 0), 1n, 'Atomics.load(view, 0) returns 1n');
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/add/good-views.js
+++ b/test/built-ins/Atomics/add/good-views.js
@@ -51,4 +51,4 @@ testWithTypedArrayConstructors(function(TA) {
     Atomics.store(view, Idx, 37);
     assert.sameValue(Atomics.add(view, Idx, 0), 37, 'Atomics.add(view, Idx, 0) returns 37');
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/add/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/add/non-shared-bufferdata.js
@@ -8,11 +8,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithAtomicsFriendlyTypedArrayConstructors(TA => {
-  const view = new TA(
-    new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4)
-  );
+testWithAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const view = new TA(makeCtorArg(4));
 
   assert.sameValue(Atomics.add(view, 0, 1), 0, 'Atomics.add(view, 0, 1) returns 0');
   assert.sameValue(Atomics.load(view, 0), 1, 'Atomics.load(view, 0) returns 1');
-}, null, ["passthrough"]);
+}, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/add/non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/add/non-shared-int-views-throws.js
@@ -8,11 +8,11 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithNonAtomicsFriendlyTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithNonAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
 
   assert.throws(TypeError, function() {
     Atomics.add(view, 0, 1);
   }, `Atomics.add(new ${TA.name}(buffer), 0, 1) throws TypeError`);
-}, null, ["passthrough"]);
+}, ["arraybuffer"]);

--- a/test/built-ins/Atomics/and/bad-range.js
+++ b/test/built-ins/Atomics/and/bad-range.js
@@ -19,4 +19,4 @@ testWithTypedArrayConstructors(function(TA) {
       Atomics.and(view, IdxGen(view), 10);
     });
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/and/bigint/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/and/bigint/non-shared-bufferdata.js
@@ -7,9 +7,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, BigInt, TypedArray]
 ---*/
-testWithBigIntTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithBigIntTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.sameValue(Atomics.and(view, 0, 1n), 0n, 'Atomics.and(view, 0, 1n) returns 0n');
   assert.sameValue(Atomics.load(view, 0), 0n, 'Atomics.load(view, 0) returns 0n');
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/and/good-views.js
+++ b/test/built-ins/Atomics/and/good-views.js
@@ -66,4 +66,4 @@ testWithTypedArrayConstructors(function(TA) {
     Atomics.store(view, Idx, 37);
     assert.sameValue(Atomics.and(view, Idx, 0), 37, 'Atomics.and(view, Idx, 0) returns 37');
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/and/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/and/non-shared-bufferdata.js
@@ -8,11 +8,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithAtomicsFriendlyTypedArrayConstructors(TA => {
-  const view = new TA(
-    new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4)
-  );
+testWithAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const view = new TA(makeCtorArg(4));
 
   assert.sameValue(Atomics.and(view, 0, 1), 0, 'Atomics.and(view, 0, 1) returns 0');
   assert.sameValue(Atomics.load(view, 0), 0, 'Atomics.load(view, 0) returns 0');
-}, null, ["passthrough"]);
+}, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/and/non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/and/non-shared-int-views-throws.js
@@ -8,11 +8,11 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithNonAtomicsFriendlyTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithNonAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
 
   assert.throws(TypeError, function() {
     Atomics.and(view, 0, 1);
   }, `Atomics.and(new ${TA.name}(buffer), 0, 1) throws TypeError`);
-}, null, ["passthrough"]);
+}, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/compareExchange/bad-range.js
+++ b/test/built-ins/Atomics/compareExchange/bad-range.js
@@ -19,4 +19,4 @@ testWithTypedArrayConstructors(function(TA) {
       Atomics.compareExchange(view, IdxGen(view), 10, 0);
     });
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/compareExchange/bigint/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/compareExchange/bigint/non-shared-bufferdata.js
@@ -7,9 +7,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, BigInt, TypedArray]
 ---*/
-testWithBigIntTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithBigIntTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.sameValue(Atomics.compareExchange(view, 0, 0n, 1n), 0n, 'Atomics.compareExchange(view, 0, 0n, 1n) returns 0n');
   assert.sameValue(Atomics.load(view, 0), 1n, 'Atomics.load(view, 0) returns 1n');
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/compareExchange/good-views.js
+++ b/test/built-ins/Atomics/compareExchange/good-views.js
@@ -71,4 +71,4 @@ testWithTypedArrayConstructors(function(TA) {
       'Atomics.compareExchange(view, Idx, 37, 0) returns 37'
     );
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/compareExchange/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/compareExchange/non-shared-bufferdata.js
@@ -8,11 +8,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithAtomicsFriendlyTypedArrayConstructors(TA => {
-  const view = new TA(
-    new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4)
-  );
+testWithAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const view = new TA(makeCtorArg(4));
 
   assert.sameValue(Atomics.compareExchange(view, 0, 0, 1), 0, 'Atomics.compareExchange(view, 0, 0, 1) returns 0');
   assert.sameValue(Atomics.load(view, 0), 1, 'Atomics.load(view, 0) returns 1');
-}, null, ["passthrough"]);
+}, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/compareExchange/non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/compareExchange/non-shared-int-views-throws.js
@@ -8,11 +8,11 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithNonAtomicsFriendlyTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithNonAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
 
   assert.throws(TypeError, function() {
     Atomics.compareExchange(view, 0, 0, 0);
   }, `Atomics.compareExchange(new ${TA.name}(buffer), 0, 0, 0) throws TypeError`);
-}, null, ["passthrough"]);
+}, ["arraybuffer"]);

--- a/test/built-ins/Atomics/exchange/bad-range.js
+++ b/test/built-ins/Atomics/exchange/bad-range.js
@@ -19,4 +19,4 @@ testWithTypedArrayConstructors(function(TA) {
       Atomics.exchange(view, IdxGen(view), 10, 0);
     });
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/exchange/bigint/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/exchange/bigint/non-shared-bufferdata.js
@@ -7,9 +7,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, BigInt, TypedArray]
 ---*/
-testWithBigIntTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithBigIntTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.sameValue(Atomics.exchange(view, 0, 1n), 0n, 'Atomics.exchange(view, 0, 1n) returns 0n');
   assert.sameValue(Atomics.load(view, 0), 1n, 'Atomics.load(view, 0) returns 1n');
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/exchange/good-views.js
+++ b/test/built-ins/Atomics/exchange/good-views.js
@@ -52,4 +52,4 @@ testWithTypedArrayConstructors(function(TA) {
     Atomics.store(view, Idx, 37);
     assert.sameValue(Atomics.exchange(view, Idx, 0), 37, 'Atomics.exchange(view, Idx, 0) returns 37');
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/exchange/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/exchange/non-shared-bufferdata.js
@@ -8,11 +8,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithAtomicsFriendlyTypedArrayConstructors(TA => {
-  const view = new TA(
-    new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4)
-  );
+testWithAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const view = new TA(makeCtorArg(4));
 
   assert.sameValue(Atomics.exchange(view, 0, 1), 0, 'Atomics.exchange(view, 0, 1) returns 0');
   assert.sameValue(Atomics.load(view, 0), 1, 'Atomics.load(view, 0) returns 1');
-}, null, ["passthrough"]);
+}, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/exchange/non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/exchange/non-shared-int-views-throws.js
@@ -8,10 +8,10 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithNonAtomicsFriendlyTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithNonAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.throws(TypeError, function() {
     Atomics.exchange(view, 0, 1);
   }, `Atomics.exchange(new ${TA.name}(buffer), 0, 1) throws TypeError`);
-}, null, ["passthrough"]);
+}, ["arraybuffer"]);

--- a/test/built-ins/Atomics/exchange/nonshared-int-views.js
+++ b/test/built-ins/Atomics/exchange/nonshared-int-views.js
@@ -9,11 +9,11 @@ includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
 
-testWithNonAtomicsFriendlyTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithNonAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
 
   assert.throws(TypeError, function() {
     Atomics.exchange(view, 0, 0);
   }, `Atomics.exchange(new ${TA.name}(buffer), 0, 0) throws TypeError`);
-}, null, ["passthrough"]);
+}, ["arraybuffer"]);

--- a/test/built-ins/Atomics/isLockFree/bigint/expected-return-value.js
+++ b/test/built-ins/Atomics/isLockFree/bigint/expected-return-value.js
@@ -31,5 +31,3 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     'Atomics.isLockFree(TA.BYTES_PER_ELEMENT) returns the value of `observed` (Atomics.isLockFree(TA.BYTES_PER_ELEMENT))'
   );
 }, null, ["passthrough"]);
-
-

--- a/test/built-ins/Atomics/load/bad-range.js
+++ b/test/built-ins/Atomics/load/bad-range.js
@@ -19,4 +19,4 @@ testWithTypedArrayConstructors(function(TA) {
       Atomics.load(view, IdxGen(view));
     });
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/load/bigint/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/load/bigint/non-shared-bufferdata.js
@@ -7,8 +7,8 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, BigInt, TypedArray]
 ---*/
-testWithBigIntTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithBigIntTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.sameValue(Atomics.load(view, 0), 0n, 'Atomics.load(view, 0) returns 0n');
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/load/good-views.js
+++ b/test/built-ins/Atomics/load/good-views.js
@@ -43,4 +43,4 @@ testWithTypedArrayConstructors(function(TA) {
     Atomics.store(view, Idx, 37);
     assert.sameValue(Atomics.load(view, Idx), 37, 'Atomics.load(view, Idx) returns 37');
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/load/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/load/non-shared-bufferdata.js
@@ -8,10 +8,8 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithAtomicsFriendlyTypedArrayConstructors(TA => {
-  const view = new TA(
-    new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4)
-  );
+testWithAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const view = new TA(makeCtorArg(4));
 
   assert.sameValue(Atomics.load(view, 0), 0, 'Atomics.load(view, 0) returns 0');
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/load/non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/load/non-shared-int-views-throws.js
@@ -8,10 +8,10 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithNonAtomicsFriendlyTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithNonAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.throws(TypeError, function() {
     Atomics.load(view, 0);
   }, `Atomics.load(new ${TA.name}(buffer), 0) throws TypeError`);
-}, null, ["passthrough"]);
+}, ["arraybuffer"]);

--- a/test/built-ins/Atomics/or/bad-range.js
+++ b/test/built-ins/Atomics/or/bad-range.js
@@ -19,4 +19,4 @@ testWithTypedArrayConstructors(function(TA) {
       Atomics.or(view, IdxGen(view), 10);
     });
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/or/bigint/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/or/bigint/non-shared-bufferdata.js
@@ -7,9 +7,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, BigInt, TypedArray]
 ---*/
-testWithBigIntTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithBigIntTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.sameValue(Atomics.or(view, 0, 1n), 0n, 'Atomics.or(view, 0, 1n) returns 0n');
   assert.sameValue(Atomics.load(view, 0), 1n, 'Atomics.load(view, 0) returns 1n');
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/or/good-views.js
+++ b/test/built-ins/Atomics/or/good-views.js
@@ -78,4 +78,4 @@ testWithTypedArrayConstructors(function(TA) {
     Atomics.store(view, Idx, 37);
     assert.sameValue(Atomics.or(view, Idx, 0), 37, 'Atomics.or(view, Idx, 0) returns 37');
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/or/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/or/non-shared-bufferdata.js
@@ -8,11 +8,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithAtomicsFriendlyTypedArrayConstructors(TA => {
-  const view = new TA(
-    new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4)
-  );
+testWithAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const view = new TA(makeCtorArg(4));
 
   assert.sameValue(Atomics.or(view, 0, 1), 0, 'Atomics.or(view, 0, 1) returns 0');
   assert.sameValue(Atomics.load(view, 0), 1, 'Atomics.load(view, 0) returns 1');
-}, null, ["passthrough"]);
+}, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/or/non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/or/non-shared-int-views-throws.js
@@ -8,11 +8,11 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithNonAtomicsFriendlyTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithNonAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
 
   assert.throws(TypeError, function() {
     Atomics.or(view, 0, 1);
   }, `Atomics.or(new ${TA.name}(buffer), 0, 1) throws TypeError`);
-}, null, ["passthrough"]);
+}, ["arraybuffer"]);

--- a/test/built-ins/Atomics/store/bad-range.js
+++ b/test/built-ins/Atomics/store/bad-range.js
@@ -19,4 +19,4 @@ testWithTypedArrayConstructors(function(TA) {
       Atomics.store(view, IdxGen(view), 10);
     });
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/store/bigint/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/store/bigint/non-shared-bufferdata.js
@@ -7,9 +7,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, BigInt, TypedArray]
 ---*/
-testWithBigIntTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithBigIntTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.sameValue(Atomics.store(view, 0, 1n), 1n, 'Atomics.store(view, 0, 1n) returns 1n');
   assert.sameValue(Atomics.load(view, 0), 1n, 'Atomics.load(view, 0) returns 1n');
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/store/good-views.js
+++ b/test/built-ins/Atomics/store/good-views.js
@@ -51,7 +51,7 @@ testWithTypedArrayConstructors(function(TA) {
     Atomics.store(view, Idx, 37);
     assert.sameValue(Atomics.load(view, Idx), 37, 'Atomics.load(view, Idx) returns 37');
   });
-}, views);
+}, views, ["passthrough"]);
 
 function ToInteger(v) {
   v = +v;

--- a/test/built-ins/Atomics/store/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/store/non-shared-bufferdata.js
@@ -8,11 +8,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithAtomicsFriendlyTypedArrayConstructors(TA => {
-  const view = new TA(
-    new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4)
-  );
+testWithAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const view = new TA(makeCtorArg(4));
 
   assert.sameValue(Atomics.store(view, 0, 1), 1, 'Atomics.store(view, 0, 1) returns 1');
   assert.sameValue(Atomics.load(view, 0), 1, 'Atomics.load(view, 0) returns 1');
-}, null, ["passthrough"]);
+}, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/store/non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/store/non-shared-int-views-throws.js
@@ -8,11 +8,11 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithNonAtomicsFriendlyTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithNonAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
 
   assert.throws(TypeError, function() {
     Atomics.store(view, 0, 1);
   }, `Atomics.store(new ${TA.name}(buffer), 0, 1) throws TypeError`);
-}, null, ["passthrough"]);
+}, ["arraybuffer"]);

--- a/test/built-ins/Atomics/sub/bad-range.js
+++ b/test/built-ins/Atomics/sub/bad-range.js
@@ -19,4 +19,4 @@ testWithTypedArrayConstructors(function(TA) {
       Atomics.sub(view, IdxGen(view), 10);
     });
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/sub/bigint/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/sub/bigint/non-shared-bufferdata.js
@@ -7,10 +7,10 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, BigInt, TypedArray]
 ---*/
-testWithBigIntTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithBigIntTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.sameValue(Atomics.store(view, 0, 1n), 1n, 'Atomics.store(view, 0, 1n) returns 1n');
   assert.sameValue(Atomics.sub(view, 0, 1n), 1n, 'Atomics.sub(view, 0, 1n) returns 1n');
   assert.sameValue(Atomics.load(view, 0), 0n, 'Atomics.load(view, 0) returns 0n');
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/sub/good-views.js
+++ b/test/built-ins/Atomics/sub/good-views.js
@@ -51,4 +51,4 @@ testWithTypedArrayConstructors(function(TA) {
     Atomics.store(view, Idx, 37);
     assert.sameValue(Atomics.sub(view, Idx, 0), 37, 'Atomics.sub(view, Idx, 0) returns 37');
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/sub/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/sub/non-shared-bufferdata.js
@@ -8,12 +8,10 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithAtomicsFriendlyTypedArrayConstructors(TA => {
-  const view = new TA(
-    new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4)
-  );
+testWithAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const view = new TA(makeCtorArg(4));
 
   assert.sameValue(Atomics.store(view, 0, 1), 1, 'Atomics.store(view, 0, 1) returns 1');
   assert.sameValue(Atomics.sub(view, 0, 1), 1, 'Atomics.sub(view, 0, 1) returns 1');
   assert.sameValue(Atomics.load(view, 0), 0, 'Atomics.load(view, 0) returns 0');
-}, null, ["passthrough"]);
+}, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/sub/non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/sub/non-shared-int-views-throws.js
@@ -8,11 +8,11 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithNonAtomicsFriendlyTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(16);
+testWithNonAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
 
   assert.throws(TypeError, function() {
     Atomics.sub(view, 0, 1);
   }, `Atomics.sub(new ${TA.name}(buffer), 0, 1) throws TypeError`);
-}, null, ["passthrough"]);
+}, ["arraybuffer"]);

--- a/test/built-ins/Atomics/xor/bad-range.js
+++ b/test/built-ins/Atomics/xor/bad-range.js
@@ -19,4 +19,4 @@ testWithTypedArrayConstructors(function(TA) {
       Atomics.xor(view, IdxGen(view), 0);
     });
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/xor/bigint/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/xor/bigint/non-shared-bufferdata.js
@@ -7,9 +7,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, BigInt, TypedArray]
 ---*/
-testWithBigIntTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithBigIntTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
   assert.sameValue(Atomics.xor(view, 0, 1n), 0n, 'Atomics.xor(view, 0, 1n) returns 0n');
   assert.sameValue(Atomics.load(view, 0), 1n, 'Atomics.load(view, 0) returns 1n');
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/xor/good-views.js
+++ b/test/built-ins/Atomics/xor/good-views.js
@@ -79,4 +79,4 @@ testWithTypedArrayConstructors(function(TA) {
     Atomics.store(view, Idx, 37);
     assert.sameValue(Atomics.xor(view, Idx, 0), 37, 'Atomics.xor(view, Idx, 0) returns 37');
   });
-}, views);
+}, views, ["passthrough"]);

--- a/test/built-ins/Atomics/xor/non-shared-bufferdata.js
+++ b/test/built-ins/Atomics/xor/non-shared-bufferdata.js
@@ -8,11 +8,9 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithAtomicsFriendlyTypedArrayConstructors(TA => {
-  const view = new TA(
-    new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4)
-  );
+testWithAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const view = new TA(makeCtorArg(4));
 
   assert.sameValue(Atomics.xor(view, 0, 1), 0, 'Atomics.xor(view, 0, 1) returns 0');
   assert.sameValue(Atomics.load(view, 0), 1, 'Atomics.load(view, 0) returns 1');
-}, null, ["passthrough"]);
+}, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/Atomics/xor/non-shared-int-views-throws.js
+++ b/test/built-ins/Atomics/xor/non-shared-int-views-throws.js
@@ -8,11 +8,11 @@ description: >
 includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
-testWithNonAtomicsFriendlyTypedArrayConstructors(TA => {
-  const buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT * 4);
+testWithNonAtomicsFriendlyTypedArrayConstructors((TA, makeCtorArg) => {
+  const buffer = makeCtorArg(4);
   const view = new TA(buffer);
 
   assert.throws(TypeError, function() {
     Atomics.xor(view, 0, 1);
   }, `Atomics.xor(new ${TA.name}(buffer), 0, 1) throws TypeError`);
-}, null, ["passthrough"]);
+}, ["arraybuffer"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/coerced-values-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/coerced-values-end.js
@@ -74,4 +74,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     'float -2.5 value coerced to integer -2'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/coerced-values-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/coerced-values-start.js
@@ -89,4 +89,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '1.5 float value coerced to integer 1'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/coerced-values-target.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/coerced-values-target.js
@@ -89,4 +89,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '1.5 float value coerced to integer 1'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-end.js
@@ -92,4 +92,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[0, 1, 2, 3, 4].copyWithin(-5, -2, -1) -> [3, 1, 2, 3, 4]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-out-of-bounds-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-out-of-bounds-end.js
@@ -108,4 +108,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[1, 2, 3, 4, 5].copyWithin(-7, -8, -Infinity) -> [1, 2, 3, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-out-of-bounds-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-out-of-bounds-start.js
@@ -90,4 +90,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[1, 2, 3, 4, 5].copyWithin(-9, -Infinity) -> [1, 2, 3, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-out-of-bounds-target.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-out-of-bounds-target.js
@@ -58,4 +58,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[1, 2, 3, 4, 5].copyWithin(-Infinity, 2) -> [3, 4, 5, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-start.js
@@ -74,4 +74,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[0, 1, 2, 3, 4].copyWithin(-5, -2) -> [3, 4, 2, 3, 4]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-target.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/negative-target.js
@@ -50,4 +50,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[0, 1, 2, 3].copyWithin(-1, 2) -> [0, 1, 2, 2]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/non-negative-out-of-bounds-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/non-negative-out-of-bounds-end.js
@@ -51,4 +51,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[1, 2, 3, 4, 5].copyWithin(1, 3, Infinity) -> [1, 4, 5, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/non-negative-out-of-bounds-target-and-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/non-negative-out-of-bounds-target-and-start.js
@@ -71,4 +71,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[1, 2, 3, 4, 5].copyWithin(Infinity, Infinity) -> [1, 2, 3, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/non-negative-target-and-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/non-negative-target-and-start.js
@@ -47,4 +47,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
       [0n, 4n, 5n, 3n, 4n, 5n]
     )
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/non-negative-target-start-and-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/non-negative-target-start-and-end.js
@@ -70,4 +70,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[0, 1, 2, 3, 4, 5].copyWithin(1, 3, 5) -> [0, 3, 4, 3, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-this.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-this.js
@@ -33,4 +33,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var result2 = sample2.copyWithin(1, 0);
 
   assert.sameValue(result2, sample2);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/undefined-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/undefined-end.js
@@ -42,4 +42,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[0, 1, 2, 3].copyWithin(0, 1) -> [1, 2, 3, 3]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/byteoffset.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/byteoffset.js
@@ -30,4 +30,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     [0, 1, 2, 1],
     'underlying arraybuffer should have been updated'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end.js
@@ -74,4 +74,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     'float -2.5 value coerced to integer -2'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start.js
@@ -89,4 +89,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '1.5 float value coerced to integer 1'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-target.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-target.js
@@ -97,4 +97,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     'object value coerced to integer 0'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/negative-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/negative-end.js
@@ -92,4 +92,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[0, 1, 2, 3, 4].copyWithin(-5, -2, -1) -> [3, 1, 2, 3, 4]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/negative-out-of-bounds-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/negative-out-of-bounds-end.js
@@ -108,4 +108,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[1, 2, 3, 4, 5].copyWithin(-7, -8, -Infinity) -> [1, 2, 3, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/negative-out-of-bounds-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/negative-out-of-bounds-start.js
@@ -90,4 +90,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[1, 2, 3, 4, 5].copyWithin(-9, -Infinity) -> [1, 2, 3, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/negative-out-of-bounds-target.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/negative-out-of-bounds-target.js
@@ -58,4 +58,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[1, 2, 3, 4, 5].copyWithin(-Infinity, 2) -> [3, 4, 5, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/negative-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/negative-start.js
@@ -74,4 +74,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[0, 1, 2, 3, 4].copyWithin(-5, -2) -> [3, 4, 2, 3, 4]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/negative-target.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/negative-target.js
@@ -50,4 +50,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[0, 1, 2, 3].copyWithin(-1, 2) -> [0, 1, 2, 2]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/non-negative-out-of-bounds-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/non-negative-out-of-bounds-end.js
@@ -51,4 +51,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[1, 2, 3, 4, 5].copyWithin(1, 3, Infinity) -> [1, 4, 5, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/non-negative-out-of-bounds-target-and-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/non-negative-out-of-bounds-target-and-start.js
@@ -71,4 +71,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[1, 2, 3, 4, 5].copyWithin(Infinity, Infinity) -> [1, 2, 3, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/non-negative-target-and-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/non-negative-target-and-start.js
@@ -47,4 +47,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
       [0, 4, 5, 3, 4, 5]
     )
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/non-negative-target-start-and-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/non-negative-target-start-and-end.js
@@ -70,4 +70,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[0, 1, 2, 3, 4, 5].copyWithin(1, 3, 5) -> [0, 3, 4, 3, 4, 5]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/return-this.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/return-this.js
@@ -33,4 +33,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var result2 = sample2.copyWithin(1, 0);
 
   assert.sameValue(result2, sample2);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/undefined-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/undefined-end.js
@@ -42,4 +42,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     ),
     '[0, 1, 2, 3].copyWithin(0, 1) -> [1, 2, 3, 3]'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/every/BigInt/callbackfn-set-value-during-interaction.js
+++ b/test/built-ins/TypedArray/prototype/every/BigInt/callbackfn-set-value-during-interaction.js
@@ -55,4 +55,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7n, "changed values after iteration [0] == 7");
   assert.sameValue(sample[1], 1n, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 2n, "changed values after iteration [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/every/BigInt/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/every/BigInt/values-are-not-cached.js
@@ -39,4 +39,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     );
     return true;
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/every/callbackfn-set-value-during-interaction.js
+++ b/test/built-ins/TypedArray/prototype/every/callbackfn-set-value-during-interaction.js
@@ -55,4 +55,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7, "changed values after iteration [0] == 7");
   assert.sameValue(sample[1], 1, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 2, "changed values after iteration [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/every/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/every/values-are-not-cached.js
@@ -39,4 +39,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     );
     return true;
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/coerced-indexes.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/coerced-indexes.js
@@ -101,4 +101,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(new TA(makeCtorArg([0n, 0n])).fill(1n, 0, 1.5), [1n, 0n]),
     'end as a float number coerced'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-conversion-once.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-conversion-once.js
@@ -24,5 +24,5 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(n, 2n, "additional unexpected ToBigInt() calls");
   assert.sameValue(sample[0], 1n, "incorrect ToNumber result in index 0");
   assert.sameValue(sample[1], 1n, "incorrect ToNumber result in index 1");
-});
+}, null, null, ["immutable"]);
 

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-custom-start-and-end.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-custom-start-and-end.js
@@ -39,4 +39,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert(compareArray(new TA(makeCtorArg([0n, 0n, 0n, 0n, 0n])).fill(8n, -2, -1), [0n, 0n, 0n, 8n, 0n]));
   assert(compareArray(new TA(makeCtorArg([0n, 0n, 0n, 0n, 0n])).fill(8n, -1, -3), [0n, 0n, 0n, 0n, 0n]));
   assert(compareArray(new TA(makeCtorArg([0n, 0n, 0n, 0n, 0n])).fill(8n, 1, 3), [0n, 8n, 8n, 0n, 0n]));
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-non-numeric-throw.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-non-numeric-throw.js
@@ -64,4 +64,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     sample.fill("nonsense");
   }, "abrupt completion from string");
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-non-numeric.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-non-numeric.js
@@ -80,4 +80,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   });
   assert.sameValue(sample[0], 7n, "object toString when valueOf is absent");
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-relative-end.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-relative-end.js
@@ -50,4 +50,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(new TA(makeCtorArg([0n, 0n, 0n])).fill(8n, 0, -4), [0n, 0n, 0n]),
     "end position is 0 when (len + relativeEnd) < 0"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-relative-start.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-relative-start.js
@@ -48,4 +48,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(new TA(makeCtorArg([0n, 0n, 0n])).fill(8n, -5), [8n, 8n, 8n]),
     "start position is 0 when (len + relativeStart) < 0"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-symbol-throws.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values-symbol-throws.js
@@ -55,4 +55,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     sample.fill(s);
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/fill-values.js
@@ -41,4 +41,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(new TA(makeCtorArg([0n, 0n, 0n])).fill(8n), [8n, 8n, 8n]),
     "Default start and end indexes are 0 and this.length"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-set-value.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-set-value.js
@@ -58,4 +58,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.fill(obj);
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/return-this.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/return-this.js
@@ -17,4 +17,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample2 = new TA(makeCtorArg(42));
   var result2 = sample2.fill(7n);
   assert.sameValue(result2, sample2);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/coerced-indexes.js
+++ b/test/built-ins/TypedArray/prototype/fill/coerced-indexes.js
@@ -101,4 +101,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(new TA(makeCtorArg([0, 0])).fill(1, 0, 1.5), [1, 0]),
     'end as a float number coerced'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-once.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-once.js
@@ -23,5 +23,5 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(n, 2, "additional unexpected ToNumber() calls");
   assert.sameValue(sample[0], 1, "incorrect ToNumber result in index 0");
   assert.sameValue(sample[1], 1, "incorrect ToNumber result in index 1");
-});
+}, null, null, ["immutable"]);
 

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-operations-consistent-nan.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-operations-consistent-nan.js
@@ -98,4 +98,4 @@ testWithTypedArrayConstructors(function(FA, makeCtorArg) {
       );
     }
   }
-}, floatArrayConstructors);
+}, floatArrayConstructors, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-custom-start-and-end.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-custom-start-and-end.js
@@ -39,4 +39,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert(compareArray(new TA(makeCtorArg([0, 0, 0, 0, 0])).fill(8, -2, -1), [0, 0, 0, 8, 0]));
   assert(compareArray(new TA(makeCtorArg([0, 0, 0, 0, 0])).fill(8, -1, -3), [0, 0, 0, 0, 0]));
   assert(compareArray(new TA(makeCtorArg([0, 0, 0, 0, 0])).fill(8, 1, 3), [0, 8, 8, 0, 0]));
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-non-numeric.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-non-numeric.js
@@ -84,4 +84,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     }
   });
   assert.sameValue(sample[0], 7, "object toString when valueOf is absent");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-relative-end.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-relative-end.js
@@ -50,4 +50,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(new TA(makeCtorArg([0, 0, 0])).fill(8, 0, -4), [0, 0, 0]),
     "end position is 0 when (len + relativeEnd) < 0"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-relative-start.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-relative-start.js
@@ -48,4 +48,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(new TA(makeCtorArg([0, 0, 0])).fill(8, -5), [8, 8, 8]),
     "start position is 0 when (len + relativeStart) < 0"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-symbol-throws.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-symbol-throws.js
@@ -55,4 +55,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     sample.fill(s);
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/fill-values.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values.js
@@ -41,4 +41,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(new TA(makeCtorArg([0, 0, 0])).fill(8), [8, 8, 8]),
     "Default start and end indexes are 0 and this.length"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-set-value.js
+++ b/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-set-value.js
@@ -58,4 +58,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.fill(obj);
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/return-this.js
+++ b/test/built-ins/TypedArray/prototype/fill/return-this.js
@@ -17,4 +17,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample2 = new TA(makeCtorArg(42));
   var result2 = sample2.fill(7);
   assert.sameValue(result2, sample2);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-return-does-not-change-instance.js
+++ b/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-return-does-not-change-instance.js
@@ -9,9 +9,7 @@ features: [BigInt, TypedArray]
 ---*/
 
 testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
-  var sample1 = new TA(makeCtorArg(3));
-
-  sample1[1] = 1n;
+  var sample1 = new TA(makeCtorArg(["0", "1", "0"]));
 
   sample1.filter(function() {
     return 42;

--- a/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-set-value-during-iteration.js
+++ b/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-set-value-during-iteration.js
@@ -44,4 +44,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7n, "changed values after interaction [0] == 7");
   assert.sameValue(sample[1], 1n, "changed values after interaction [1] == 1");
   assert.sameValue(sample[2], 2n, "changed values after interaction [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/filter/BigInt/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/filter/BigInt/values-are-not-cached.js
@@ -28,4 +28,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
       v, 42n, "method does not cache values before callbackfn calls"
     );
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/filter/callbackfn-return-does-not-change-instance.js
+++ b/test/built-ins/TypedArray/prototype/filter/callbackfn-return-does-not-change-instance.js
@@ -9,9 +9,7 @@ features: [TypedArray]
 ---*/
 
 testWithTypedArrayConstructors(function(TA, makeCtorArg) {
-  var sample1 = new TA(makeCtorArg(3));
-
-  sample1[1] = 1;
+  var sample1 = new TA(makeCtorArg(["0", "1", "0"]));
 
   sample1.filter(function() {
     return 42;

--- a/test/built-ins/TypedArray/prototype/filter/callbackfn-set-value-during-iteration.js
+++ b/test/built-ins/TypedArray/prototype/filter/callbackfn-set-value-during-iteration.js
@@ -44,4 +44,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7, "changed values after interaction [0] == 7");
   assert.sameValue(sample[1], 1, "changed values after interaction [1] == 1");
   assert.sameValue(sample[2], 2, "changed values after interaction [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/filter/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/filter/values-are-not-cached.js
@@ -28,4 +28,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
       v, 42, "method does not cache values before callbackfn calls"
     );
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/find/BigInt/predicate-call-changes-value.js
+++ b/test/built-ins/TypedArray/prototype/find/BigInt/predicate-call-changes-value.js
@@ -75,4 +75,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     return true;
   });
   assert.sameValue(result, 1n, "find() returns previous found value");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/find/predicate-call-changes-value.js
+++ b/test/built-ins/TypedArray/prototype/find/predicate-call-changes-value.js
@@ -75,4 +75,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     return true;
   });
   assert.sameValue(result, 1, "find() returns previous found value");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-call-changes-value.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-call-changes-value.js
@@ -64,4 +64,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     return val === 7n;
   });
   assert.sameValue(result, -1, "value not found - changed after call");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findIndex/predicate-call-changes-value.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/predicate-call-changes-value.js
@@ -64,4 +64,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     return val === 7;
   });
   assert.sameValue(result, -1, "value not found - changed after call");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLast/BigInt/predicate-call-changes-value.js
+++ b/test/built-ins/TypedArray/prototype/findLast/BigInt/predicate-call-changes-value.js
@@ -63,4 +63,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     return true;
   });
   assert.sameValue(result, 3n, "findLast() returns previous found value");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLast/predicate-call-changes-value.js
+++ b/test/built-ins/TypedArray/prototype/findLast/predicate-call-changes-value.js
@@ -63,4 +63,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     return true;
   });
   assert.sameValue(result, 3, "findLast() returns previous found value");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLastIndex/BigInt/predicate-call-changes-value.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/BigInt/predicate-call-changes-value.js
@@ -55,4 +55,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     return val === 7n;
   });
   assert.sameValue(result, -1, "value not found - changed after call");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLastIndex/predicate-call-changes-value.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/predicate-call-changes-value.js
@@ -55,4 +55,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     return val === 7;
   });
   assert.sameValue(result, -1, "value not found - changed after call");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/forEach/BigInt/callbackfn-return-does-not-change-instance.js
+++ b/test/built-ins/TypedArray/prototype/forEach/BigInt/callbackfn-return-does-not-change-instance.js
@@ -16,9 +16,7 @@ features: [BigInt, TypedArray]
 ---*/
 
 testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
-  var sample1 = new TA(makeCtorArg(3));
-
-  sample1[1] = 1n;
+  var sample1 = new TA(makeCtorArg(["0", "1", "0"]));
 
   sample1.forEach(function() {
     return 42;

--- a/test/built-ins/TypedArray/prototype/forEach/BigInt/callbackfn-set-value-during-interaction.js
+++ b/test/built-ins/TypedArray/prototype/forEach/BigInt/callbackfn-set-value-during-interaction.js
@@ -44,4 +44,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7n, "changed values after iteration [0] == 7");
   assert.sameValue(sample[1], 1n, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 2n, "changed values after iteration [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/forEach/BigInt/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/forEach/BigInt/values-are-not-cached.js
@@ -28,4 +28,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
       v, 42n, "method does not cache values before callbackfn calls"
     );
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/forEach/callbackfn-return-does-not-change-instance.js
+++ b/test/built-ins/TypedArray/prototype/forEach/callbackfn-return-does-not-change-instance.js
@@ -16,9 +16,7 @@ features: [TypedArray]
 ---*/
 
 testWithTypedArrayConstructors(function(TA, makeCtorArg) {
-  var sample1 = new TA(makeCtorArg(3));
-
-  sample1[1] = 1;
+  var sample1 = new TA(makeCtorArg(["0", "1", "0"]));
 
   sample1.forEach(function() {
     return 42;

--- a/test/built-ins/TypedArray/prototype/forEach/callbackfn-set-value-during-interaction.js
+++ b/test/built-ins/TypedArray/prototype/forEach/callbackfn-set-value-during-interaction.js
@@ -44,4 +44,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7, "changed values after iteration [0] == 7");
   assert.sameValue(sample[1], 1, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 2, "changed values after iteration [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/forEach/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/forEach/values-are-not-cached.js
@@ -28,4 +28,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
       v, 42, "method does not cache values before callbackfn calls"
     );
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/map/BigInt/callbackfn-return-does-not-change-instance.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/callbackfn-return-does-not-change-instance.js
@@ -11,9 +11,7 @@ features: [BigInt, TypedArray]
 ---*/
 
 testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
-  var sample1 = new TA(makeCtorArg(3));
-
-  sample1[1] = 1n;
+  var sample1 = new TA(makeCtorArg(["0", "1", "0"]));
 
   sample1.map(function() {
     return 42n;

--- a/test/built-ins/TypedArray/prototype/map/BigInt/callbackfn-set-value-during-interaction.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/callbackfn-set-value-during-interaction.js
@@ -40,4 +40,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7n, "changed values after iteration [0] == 7");
   assert.sameValue(sample[1], 1n, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 2n, "changed values after iteration [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/map/BigInt/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/values-are-not-cached.js
@@ -25,4 +25,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
 
     return 0n;
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/map/callbackfn-return-does-not-change-instance.js
+++ b/test/built-ins/TypedArray/prototype/map/callbackfn-return-does-not-change-instance.js
@@ -11,9 +11,7 @@ features: [TypedArray]
 ---*/
 
 testWithTypedArrayConstructors(function(TA, makeCtorArg) {
-  var sample1 = new TA(makeCtorArg(3));
-
-  sample1[1] = 1;
+  var sample1 = new TA(makeCtorArg(["0", "1", "0"]));
 
   sample1.map(function() {
     return 42;

--- a/test/built-ins/TypedArray/prototype/map/callbackfn-set-value-during-interaction.js
+++ b/test/built-ins/TypedArray/prototype/map/callbackfn-set-value-during-interaction.js
@@ -40,4 +40,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7, "changed values after iteration [0] == 7");
   assert.sameValue(sample[1], 1, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 2, "changed values after iteration [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/map/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/map/values-are-not-cached.js
@@ -25,4 +25,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
 
     return 0;
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduce/BigInt/callbackfn-set-value-during-iteration.js
+++ b/test/built-ins/TypedArray/prototype/reduce/BigInt/callbackfn-set-value-during-iteration.js
@@ -46,4 +46,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7n, "changed values after iteration [0] == 7");
   assert.sameValue(sample[1], 1n, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 2n, "changed values after iteration [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduce/BigInt/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/reduce/BigInt/values-are-not-cached.js
@@ -38,4 +38,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
       v, 42n, "method does not cache values before callbackfn calls"
     );
   }, 0);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduce/callbackfn-set-value-during-iteration.js
+++ b/test/built-ins/TypedArray/prototype/reduce/callbackfn-set-value-during-iteration.js
@@ -46,4 +46,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7, "changed values after iteration [0] == 7");
   assert.sameValue(sample[1], 1, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 2, "changed values after iteration [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduce/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/reduce/values-are-not-cached.js
@@ -38,4 +38,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
       v, 42, "method does not cache values before callbackfn calls"
     );
   }, 0);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduceRight/BigInt/callbackfn-set-value-during-iteration.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/BigInt/callbackfn-set-value-during-iteration.js
@@ -46,4 +46,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 2n, "changed values after iteration [0] == 2");
   assert.sameValue(sample[1], 1n, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 7n, "changed values after iteration [2] == 7");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduceRight/BigInt/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/BigInt/values-are-not-cached.js
@@ -39,4 +39,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
       v, 42n, "method does not cache values before callbackfn calls"
     );
   }, 0);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduceRight/callbackfn-set-value-during-iteration.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/callbackfn-set-value-during-iteration.js
@@ -46,4 +46,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 2, "changed values after iteration [0] == 2");
   assert.sameValue(sample[1], 1, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 7, "changed values after iteration [2] == 7");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduceRight/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/values-are-not-cached.js
@@ -39,4 +39,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
       v, 42, "method does not cache values before callbackfn calls"
     );
   }, 0);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reverse/BigInt/preserves-non-numeric-properties.js
+++ b/test/built-ins/TypedArray/prototype/reverse/BigInt/preserves-non-numeric-properties.js
@@ -32,4 +32,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(result.foo, 42, "sample.foo === 42");
   assert.sameValue(result.bar, "bar", "sample.bar === 'bar'");
   assert.sameValue(result[s], 1, "sample[s] === 1");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reverse/preserves-non-numeric-properties.js
+++ b/test/built-ins/TypedArray/prototype/reverse/preserves-non-numeric-properties.js
@@ -32,4 +32,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(result.foo, 42, "sample.foo === 42");
   assert.sameValue(result.bar, "bar", "sample.bar === 'bar'");
   assert.sameValue(result[s], 1, "sample[s] === 1");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-negative-integer-offset-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-negative-integer-offset-throws.js
@@ -32,4 +32,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(RangeError, function() {
     sample.set([1n], -Infinity);
   }, "-Infinity");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-offset-tointeger.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-offset-tointeger.js
@@ -92,4 +92,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   sample = new TA(makeCtorArg([1n, 2n]));
   sample.set([42n], { toString: function() {return 1;} });
   assert(compareArray(sample, [1n, 42n]), "toString");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-primitive-toobject.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-primitive-toobject.js
@@ -46,4 +46,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var ta5 = new TA(makeCtorArg([1n, 2n]));
   ta5.set(4n, 1);
   assert.compareArray(ta5, [1n, 2n], "bigint");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-length-symbol.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-length-symbol.js
@@ -27,4 +27,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     sample.set(obj);
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-length.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-length.js
@@ -43,4 +43,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.set(obj2);
   }, "toString");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
@@ -41,4 +41,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(sample, [42n, 43n, 3n, 4n]),
     "values are set until exception"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value.js
@@ -45,4 +45,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(sample, [42n, 43n, 3n, 4n]),
     "values are set until exception"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset-symbol.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset-symbol.js
@@ -24,4 +24,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     sample.set([1n], s);
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-toobject-offset.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-toobject-offset.js
@@ -27,4 +27,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     sample.set(null);
   }, "null");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-set-values.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-set-values.js
@@ -60,4 +60,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(srcObj, 2);
   assert(compareArray(sample, [1n, 2n, 7n, 17n]), "offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-src-tonumber-value-type-conversions.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-src-tonumber-value-type-conversions.js
@@ -46,4 +46,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(sample, expected),
     "sample: [" + sample + "], expected: [" + expected + "]"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/boolean-tobigint.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/boolean-tobigint.js
@@ -43,4 +43,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
 
   assert.sameValue(typedArray[0], 0n, "False converts to BigInt");
   assert.sameValue(typedArray[1], 1n, "True converts to BigInt");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/null-tobigint.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/null-tobigint.js
@@ -44,4 +44,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray.set([null]);
   }, "abrupt completion from Null");
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/number-tobigint.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/number-tobigint.js
@@ -69,4 +69,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray.set([NaN]);
   }, "abrupt completion from Number: NaN");
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/src-typedarray-big.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/src-typedarray-big.js
@@ -34,5 +34,5 @@ testWithBigIntTypedArrayConstructors(function(BTA1, makeCtorArg) {
     assert.sameValue(targetTypedArray[0], testValue,
                      "Setting BigInt TypedArray with BigInt TypedArray should succeed.")
   });
-});
+}, null, null, ["immutable"]);
 

--- a/test/built-ins/TypedArray/prototype/set/BigInt/src-typedarray-not-big-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/src-typedarray-not-big-throws.js
@@ -34,4 +34,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     });
   });
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/string-nan-tobigint.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/string-nan-tobigint.js
@@ -47,4 +47,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray.set(["definately not a number"]);
   }, "StringToBigInt(prim) == NaN");
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/string-tobigint.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/string-tobigint.js
@@ -63,4 +63,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray.set(["1e7"]);
   }, "Replace the StrUnsignedDecimalLiteral production with DecimalDigits to not allow... exponents...");
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/symbol-tobigint.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/symbol-tobigint.js
@@ -47,4 +47,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray.set([s]);
   }, "abrupt completion from Symbol");
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-offset-tointeger.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-offset-tointeger.js
@@ -90,4 +90,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   sample = new TA(makeCtorArg([1n, 2n]));
   sample.set(src, { toString: function() {return 1;} });
   assert(compareArray(sample, [1n, 42n]), "toString");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type-sab.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type-sab.js
@@ -101,4 +101,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(src, 2);
   assert(compareArray(sample, [1n, 2n, 42n, 43n]), "src and sample are SAB-backed, offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type.js
@@ -45,4 +45,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(src, 2);
   assert(compareArray(sample, [1n, 2n, 42n, 43n]), "offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type-sab.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type-sab.js
@@ -101,4 +101,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(src, 2);
   assert(compareArray(sample, [1n, 2n, 42n, 43n]), "src and sample are SAB-backed, offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type.js
@@ -47,4 +47,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(src, 2);
   assert(compareArray(sample, [1n, 2n, 42n, 43n]), "offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type.js
@@ -50,4 +50,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(src, 2);
   assert(compareArray(sample, [1n, 2n, 1n, 2n]), "offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
@@ -48,4 +48,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(RangeError, function() {
     sample.set(src, Infinity);
   }, "2 + Infinity > 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/undefined-tobigint.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/undefined-tobigint.js
@@ -44,4 +44,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray.set([undefined]);
   }, "abrupt completion from undefined");
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-negative-integer-offset-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-negative-integer-offset-throws.js
@@ -32,4 +32,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(RangeError, function() {
     sample.set([1], -Infinity);
   }, "-Infinity");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-offset-tointeger.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-offset-tointeger.js
@@ -92,4 +92,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   sample = new TA(makeCtorArg([1, 2]));
   sample.set([42], { toString: function() {return 1;} });
   assert(compareArray(sample, [1, 42]), "toString");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-primitive-toobject.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-primitive-toobject.js
@@ -43,4 +43,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var ta4 = new TA(makeCtorArg([1]));
   ta4.set(Symbol());
   assert.compareArray(ta4, [1], "symbol");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-length-symbol.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-length-symbol.js
@@ -27,4 +27,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     sample.set(obj);
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-length.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-length.js
@@ -43,4 +43,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.set(obj2);
   }, "toString");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
@@ -41,4 +41,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(sample, [42, 43, 3, 4]),
     "values are set until exception"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-tonumber-value.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-tonumber-value.js
@@ -45,4 +45,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(sample, [42, 43, 3, 4]),
     "values are set until exception"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-tointeger-offset-symbol.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-tointeger-offset-symbol.js
@@ -24,4 +24,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     sample.set([1], s);
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-toobject-offset.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-toobject-offset.js
@@ -27,4 +27,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     sample.set(null);
   }, "null");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-set-values.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-set-values.js
@@ -60,4 +60,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(srcObj, 2);
   assert(compareArray(sample, [1, 2, 7, 17]), "offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-src-tonumber-value-type-conversions.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-src-tonumber-value-type-conversions.js
@@ -46,4 +46,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(sample, expected),
     "sample: [" + sample + "], expected: [" + expected + "]"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/src-typedarray-big-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/src-typedarray-big-throws.js
@@ -34,4 +34,4 @@ testWithBigIntTypedArrayConstructors(function(BTA, makeCtorArg) {
     });
   });
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-offset-tointeger.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-offset-tointeger.js
@@ -90,4 +90,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   sample = new TA(makeCtorArg([1, 2]));
   sample.set(src, { toString: function() {return 1;} });
   assert(compareArray(sample, [1, 42]), "toString");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js
@@ -104,4 +104,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(src, 2);
   assert(compareArray(sample, [1, 2, 42, 43]), "src and sample are SAB-backed, offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-}, int_views);
+}, int_views, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type.js
@@ -45,4 +45,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(src, 2);
   assert(compareArray(sample, [1, 2, 42, 43]), "offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js
@@ -104,4 +104,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(src, 2);
   assert(compareArray(sample, [1, 2, 42, 43]), "src and sample are SAB-backed, offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-}, int_views);
+}, int_views, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-same-type.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-same-type.js
@@ -47,4 +47,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(src, 2);
   assert(compareArray(sample, [1, 2, 42, 43]), "offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
@@ -57,4 +57,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
 
   assert(compareArray(sample, expected[TA.name]), sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-same-type.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-same-type.js
@@ -50,4 +50,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   result = sample.set(src, 2);
   assert(compareArray(sample, [1, 2, 1, 2]), "offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
@@ -48,4 +48,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(RangeError, function() {
     sample.set(src, Infinity);
   }, "2 + Infinity > 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/some/BigInt/callbackfn-set-value-during-interaction.js
+++ b/test/built-ins/TypedArray/prototype/some/BigInt/callbackfn-set-value-during-interaction.js
@@ -53,4 +53,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7n, "changed values after iteration [0] == 7");
   assert.sameValue(sample[1], 1n, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 2n, "changed values after iteration [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/some/BigInt/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/some/BigInt/values-are-not-cached.js
@@ -37,4 +37,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
       v, 42n, "method does not cache values before callbackfn calls"
     );
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/some/callbackfn-set-value-during-interaction.js
+++ b/test/built-ins/TypedArray/prototype/some/callbackfn-set-value-during-interaction.js
@@ -53,4 +53,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[0], 7, "changed values after iteration [0] == 7");
   assert.sameValue(sample[1], 1, "changed values after iteration [1] == 1");
   assert.sameValue(sample[2], 2, "changed values after iteration [2] == 2");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/some/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/some/values-are-not-cached.js
@@ -37,4 +37,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
       v, 42, "method does not cache values before callbackfn calls"
     );
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/BigInt/comparefn-call-throws.js
+++ b/test/built-ins/TypedArray/prototype/sort/BigInt/comparefn-call-throws.js
@@ -39,4 +39,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   });
 
   assert.sameValue(calls, 1, "immediately returned");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/BigInt/comparefn-calls.js
+++ b/test/built-ins/TypedArray/prototype/sort/BigInt/comparefn-calls.js
@@ -39,4 +39,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     assert.sameValue(args[1][0], 42n, "x is a listed value");
     assert.sameValue(args[1][0], 42n, "y is a listed value");
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/BigInt/comparefn-is-undefined.js
+++ b/test/built-ins/TypedArray/prototype/sort/BigInt/comparefn-is-undefined.js
@@ -20,4 +20,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
 
   assert.compareArray(explicit, [42n, 43n, 44n, 45n, 46n], 'The value of `explicit` is [42n, 43n, 44n, 45n, 46n]');
   assert.compareArray(implicit, [42n, 43n, 44n, 45n, 46n], 'The value of `implicit` is [42n, 43n, 44n, 45n, 46n]');
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/BigInt/comparefn-nonfunction-call-throws.js
+++ b/test/built-ins/TypedArray/prototype/sort/BigInt/comparefn-nonfunction-call-throws.js
@@ -52,4 +52,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     sample.sort({});
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/BigInt/return-same-instance.js
+++ b/test/built-ins/TypedArray/prototype/sort/BigInt/return-same-instance.js
@@ -22,4 +22,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
 
   result = sample.sort(function() { return 0; });
   assert.sameValue(sample, result, "with comparefn");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/BigInt/sortcompare-with-no-tostring.js
+++ b/test/built-ins/TypedArray/prototype/sort/BigInt/sortcompare-with-no-tostring.js
@@ -28,4 +28,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var result = sample.sort();
   assert.sameValue(toStringCalled, false, "BigInt.prototype.toString will not be called");
   assert(compareArray(result, [3n, 20n, 100n]));
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/BigInt/sorted-values.js
+++ b/test/built-ins/TypedArray/prototype/sort/BigInt/sorted-values.js
@@ -25,7 +25,7 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
 
   sample = new TA(makeCtorArg([3n, 4n, 3n, 1n, 0n, 1n, 2n])).sort();
   assert(compareArray(sample, [0n, 1n, 1n, 2n, 3n, 3n, 4n]), "repeating numbers");
-});
+}, null, null, ["immutable"]);
 
 var sample = new BigInt64Array([-4n, 3n, 4n, -3n, 2n, -2n, 1n, 0n]).sort();
 assert(compareArray(sample, [-4n, -3n, -2n, 0n, 1n, 2n, 3n, 4n]), "negative values");

--- a/test/built-ins/TypedArray/prototype/sort/comparefn-call-throws.js
+++ b/test/built-ins/TypedArray/prototype/sort/comparefn-call-throws.js
@@ -39,4 +39,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   });
 
   assert.sameValue(calls, 1, "immediately returned");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/comparefn-calls.js
+++ b/test/built-ins/TypedArray/prototype/sort/comparefn-calls.js
@@ -39,4 +39,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     assert.sameValue(args[1][0], 42, "x is a listed value");
     assert.sameValue(args[1][0], 42, "y is a listed value");
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/comparefn-is-undefined.js
+++ b/test/built-ins/TypedArray/prototype/sort/comparefn-is-undefined.js
@@ -20,4 +20,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
 
   assert.compareArray(explicit, [42, 43, 44, 45, 46], 'The value of `explicit` is [42, 43, 44, 45, 46]');
   assert.compareArray(implicit, [42, 43, 44, 45, 46], 'The value of `implicit` is [42, 43, 44, 45, 46]');
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/comparefn-nonfunction-call-throws.js
+++ b/test/built-ins/TypedArray/prototype/sort/comparefn-nonfunction-call-throws.js
@@ -52,4 +52,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     sample.sort({});
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/return-same-instance.js
+++ b/test/built-ins/TypedArray/prototype/sort/return-same-instance.js
@@ -22,4 +22,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
 
   result = sample.sort(function() { return 0; });
   assert.sameValue(sample, result, "with comparefn");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/sortcompare-with-no-tostring.js
+++ b/test/built-ins/TypedArray/prototype/sort/sortcompare-with-no-tostring.js
@@ -28,4 +28,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var result = sample.sort();
   assert.sameValue(toStringCalled, false, "Number.prototype.toString will not be called");
   assert(compareArray(result, [3, 20, 100]), "Default sorting by value");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/sorted-values-nan.js
+++ b/test/built-ins/TypedArray/prototype/sort/sorted-values-nan.js
@@ -35,4 +35,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample[4], Infinity, "#2 [4]");
   assert.sameValue(sample[5], NaN, "#2 [5]");
   assert.sameValue(sample[6], NaN, "#2 [6]");
-}, floatArrayConstructors);
+}, floatArrayConstructors, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/sorted-values.js
+++ b/test/built-ins/TypedArray/prototype/sort/sorted-values.js
@@ -30,17 +30,22 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
 testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample = new TA(makeCtorArg([1, 0, -0, 2])).sort();
   assert(compareArray(sample, [-0, 0, 1, 2]), "0s");
-}, floatArrayConstructors);
+}, floatArrayConstructors, null, ["immutable"]);
 
 testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample = new TA(makeCtorArg([1, 0, -0, 2])).sort();
   assert(compareArray(sample, [0, 0, 1, 2]), "0s");
-}, intArrayConstructors);
+}, intArrayConstructors, null, ["immutable"]);
 
-testWithTypedArrayConstructors(function(TA, makeCtorArg) {
-  var sample = new TA(makeCtorArg([-4, 3, 4, -3, 2, -2, 1, 0])).sort();
-  assert(compareArray(sample, [-4, -3, -2, 0, 1, 2, 3, 4]), "negative values");
-}, floatArrayConstructors.concat([Int8Array, Int16Array, Int32Array]));
+testWithTypedArrayConstructors(
+  function(TA, makeCtorArg) {
+    var sample = new TA(makeCtorArg([-4, 3, 4, -3, 2, -2, 1, 0])).sort();
+    assert(compareArray(sample, [-4, -3, -2, 0, 1, 2, 3, 4]), "negative values");
+  },
+  floatArrayConstructors.concat([Int8Array, Int16Array, Int32Array]),
+  null,
+  ["immutable"]
+);
 
 testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample;
@@ -54,4 +59,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   sample = new TA(makeCtorArg([3, 4, Infinity, -Infinity, 1, 2])).sort();
   assert(compareArray(sample, [-Infinity, 1, 2, 3, 4, Infinity]), "infinities");
 
-}, floatArrayConstructors);
+}, floatArrayConstructors, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/sorted-values.js
+++ b/test/built-ins/TypedArray/prototype/sort/sorted-values.js
@@ -25,7 +25,7 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
 
   sample = new TA(makeCtorArg([3, 4, 3, 1, 0, 1, 2])).sort();
   assert(compareArray(sample, [0, 1, 1, 2, 3, 3, 4]), "repeating numbers");
-});
+}, null, null, ["immutable"]);
 
 testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample = new TA(makeCtorArg([1, 0, -0, 2])).sort();

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/result-is-new-instance-with-shared-buffer.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/result-is-new-instance-with-shared-buffer.js
@@ -32,4 +32,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(sample, [40n, 100n, 111n, 43n]),
     "changes on the new instance values affect the original sample"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/subarray/result-is-new-instance-with-shared-buffer.js
+++ b/test/built-ins/TypedArray/prototype/subarray/result-is-new-instance-with-shared-buffer.js
@@ -32,4 +32,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(sample, [40, 100, 111, 43]),
     "changes on the new instance values affect the original sample"
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/with/BigInt/early-type-coercion-bigint.js
+++ b/test/built-ins/TypedArray/prototype/with/BigInt/early-type-coercion-bigint.js
@@ -28,4 +28,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
 
   assert.compareArray(arr.with(1, value), [3n, 4n, 2n]);
   assert.compareArray(arr, [3n, 1n, 2n]);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/with/early-type-coercion.js
+++ b/test/built-ins/TypedArray/prototype/with/early-type-coercion.js
@@ -28,4 +28,4 @@ testWithTypedArrayConstructors((TA, makeCtorArg) => {
 
   assert.compareArray(arr.with(1, value), [3, 4, 2]);
   assert.compareArray(arr, [3, 1, 2]);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/from/BigInt/custom-ctor-returns-other-instance.js
+++ b/test/built-ins/TypedArrayConstructors/from/BigInt/custom-ctor-returns-other-instance.js
@@ -49,4 +49,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
 
   result = TypedArray.from.call(ctor, sourceObj);
   assert.sameValue(result, custom, "not using iterator, higher length");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/from/custom-ctor-returns-other-instance.js
+++ b/test/built-ins/TypedArrayConstructors/from/custom-ctor-returns-other-instance.js
@@ -47,4 +47,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
 
   result = TypedArray.from.call(ctor, sourceObj);
   assert.sameValue(result, custom, "not using iterator, higher length");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/conversion-operation-consistent-nan.js
@@ -94,5 +94,4 @@ testWithTypedArrayConstructors(function(FA, makeCtorArg) {
       );
     }
   }
-}, floatArrayConstructors);
-
+}, floatArrayConstructors, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/boolean-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/boolean-tobigint.js
@@ -56,4 +56,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   typedArray[1] = true;
   assert.sameValue(typedArray[0], 0n, 'The value of typedArray[0] is 0n');
   assert.sameValue(typedArray[1], 1n, 'The value of typedArray[1] is 1n');
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-minus-zero.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-minus-zero.js
@@ -21,4 +21,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample = new TA(makeCtorArg([42n]));
   assert.sameValue(Reflect.set(sample, '-0', 1n), true, 'Reflect.set("new TA(makeCtorArg([42n]))", "-0", 1n) must return true');
   assert.sameValue(sample.hasOwnProperty('-0'), false, 'sample.hasOwnProperty("-0") must return false');
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-not-integer.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-not-integer.js
@@ -30,4 +30,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
 
   assert.sameValue(sample.hasOwnProperty('1.1'), false, 'sample.hasOwnProperty("1.1") must return false');
   assert.sameValue(sample.hasOwnProperty('0.0001'), false, 'sample.hasOwnProperty("0.0001") must return false');
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-out-of-bounds.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-out-of-bounds.js
@@ -32,4 +32,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample.hasOwnProperty('-1'), false, 'sample.hasOwnProperty("-1") must return false');
   assert.sameValue(sample.hasOwnProperty('1'), false, 'sample.hasOwnProperty("1") must return false');
   assert.sameValue(sample.hasOwnProperty('2'), false, 'sample.hasOwnProperty("2") must return false');
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/string-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/string-tobigint.js
@@ -82,4 +82,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(SyntaxError, function() {
     typedArray[0] = '1e7';
   }, '`typedArray[0] = "1e7"` throws SyntaxError');
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/conversion-operation-consistent-nan.js
@@ -101,5 +101,4 @@ testWithTypedArrayConstructors(function(FA, makeCtorArg) {
       );
     }
   }
-}, floatArrayConstructors);
-
+}, floatArrayConstructors, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/key-is-minus-zero.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/key-is-minus-zero.js
@@ -24,4 +24,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
 
   assert.sameValue(Reflect.set(sample, "-0", 1), true, 'Reflect.set(sample, "-0", 1) must return true');
   assert.sameValue(sample.hasOwnProperty("-0"), false, 'sample.hasOwnProperty("-0") must return false');
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/key-is-not-integer.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/key-is-not-integer.js
@@ -31,4 +31,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     false,
     'sample.hasOwnProperty("0.0001") must return false'
   );
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/key-is-out-of-bounds.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/key-is-out-of-bounds.js
@@ -29,4 +29,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(sample.hasOwnProperty("-1"), false, 'sample.hasOwnProperty("-1") must return false');
   assert.sameValue(sample.hasOwnProperty("1"), false, 'sample.hasOwnProperty("1") must return false');
   assert.sameValue(sample.hasOwnProperty("2"), false, 'sample.hasOwnProperty("2") must return false');
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/of/BigInt/custom-ctor-returns-other-instance.js
+++ b/test/built-ins/TypedArrayConstructors/of/BigInt/custom-ctor-returns-other-instance.js
@@ -29,4 +29,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
 
   result = TypedArray.of.call(ctor, 1n, 2n);
   assert.sameValue(result, custom, "using iterator, higher length");
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/of/custom-ctor-returns-other-instance.js
+++ b/test/built-ins/TypedArrayConstructors/of/custom-ctor-returns-other-instance.js
@@ -29,4 +29,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
 
   result = TypedArray.of.call(ctor, 1, 2);
   assert.sameValue(result, custom, "using iterator, higher length");
-});
+}, null, null, ["immutable"]);


### PR DESCRIPTION
Extends #4921 ([diff](https://github.com/gibson042/test262/compare/2026-02-generalize-testwithtypedarrayconstructors...gibson042:test262:2025-07-generalize-testwithtypedarrayconstructors))

This is foundational for many remaining tests of #4509, particularly coverage of existing %TypedArray%.prototype properties.

Best reviewed commit-by-commit, because much of the work is mechanical text replacement.