### PR TITLE
[immutable-arraybuffer] Coverage for read-only TypedArray methods

### DIFF
--- a/test/built-ins/TypedArray/prototype/Symbol.toStringTag/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/Symbol.toStringTag/BigInt/detached-buffer.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, Symbol.toStringTag, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.sameValue(sample[Symbol.toStringTag], TA.name);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/Symbol.toStringTag/BigInt/return-typedarrayname.js
+++ b/test/built-ins/TypedArray/prototype/Symbol.toStringTag/BigInt/return-typedarrayname.js
@@ -15,7 +15,7 @@ includes: [testTypedArray.js]
 features: [BigInt, Symbol.toStringTag, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var ta = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var ta = new TA(makeCtorArg(0));
   assert.sameValue(ta[Symbol.toStringTag], TA.name, "property value");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/Symbol.toStringTag/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/Symbol.toStringTag/detached-buffer.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [Symbol.toStringTag, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.sameValue(sample[Symbol.toStringTag], TA.name);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/Symbol.toStringTag/return-typedarrayname.js
+++ b/test/built-ins/TypedArray/prototype/Symbol.toStringTag/return-typedarrayname.js
@@ -15,7 +15,7 @@ includes: [testTypedArray.js]
 features: [Symbol.toStringTag, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var ta = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var ta = new TA(makeCtorArg(0));
   assert.sameValue(ta[Symbol.toStringTag], TA.name, "property value");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/buffer/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/buffer/BigInt/detached-buffer.js
@@ -13,9 +13,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var buffer = new ArrayBuffer(8);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var buffer = makeCtorArg(8);
   var sample = new TA(buffer, 0, 1);
   $DETACHBUFFER(sample.buffer);
   assert.sameValue(sample.buffer, buffer);
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/buffer/BigInt/return-buffer.js
+++ b/test/built-ins/TypedArray/prototype/buffer/BigInt/return-buffer.js
@@ -14,9 +14,9 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var buffer = makeCtorArg(1);
   var ta = new TA(buffer);
 
   assert.sameValue(ta.buffer, buffer);
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"]);

--- a/test/built-ins/TypedArray/prototype/buffer/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/buffer/detached-buffer.js
@@ -13,9 +13,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var buffer = new ArrayBuffer(8);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var buffer = makeCtorArg(8);
   var sample = new TA(buffer, 0, 1);
   $DETACHBUFFER(sample.buffer);
   assert.sameValue(sample.buffer, buffer);
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/buffer/return-buffer.js
+++ b/test/built-ins/TypedArray/prototype/buffer/return-buffer.js
@@ -14,9 +14,9 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var buffer = new ArrayBuffer(TA.BYTES_PER_ELEMENT);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var buffer = makeCtorArg(1);
   var ta = new TA(buffer);
 
   assert.sameValue(ta.buffer, buffer);
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"]);

--- a/test/built-ins/TypedArray/prototype/byteLength/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/byteLength/BigInt/detached-buffer.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.sameValue(sample.byteLength, 0);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/byteLength/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/byteLength/detached-buffer.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.sameValue(sample.byteLength, 0);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/byteOffset/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/BigInt/detached-buffer.js
@@ -14,9 +14,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var buffer = new ArrayBuffer(128);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var buffer = makeCtorArg(128);
   var sample = new TA(buffer, 8, 1);
   $DETACHBUFFER(sample.buffer);
   assert.sameValue(sample.byteOffset, 0);
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/byteOffset/BigInt/return-byteoffset.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/BigInt/return-byteoffset.js
@@ -14,18 +14,18 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var ta1 = new TA();
   assert.sameValue(ta1.byteOffset, 0, "Regular typedArray");
 
   var offset = 4 * TA.BYTES_PER_ELEMENT;
 
-  var buffer1 = new ArrayBuffer(8 * TA.BYTES_PER_ELEMENT);
+  var buffer1 = makeCtorArg(8);
   var ta2 = new TA(buffer1, offset);
   assert.sameValue(ta2.byteOffset, offset, "TA(buffer, offset)");
 
-  var buffer2 = new ArrayBuffer(8 * TA.BYTES_PER_ELEMENT);
+  var buffer2 = makeCtorArg(8);
   var sample = new TA(buffer2, offset);
   var ta3 = new TA(sample);
   assert.sameValue(ta3.byteOffset, 0, "TA(typedArray)");
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"]);

--- a/test/built-ins/TypedArray/prototype/byteOffset/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/detached-buffer.js
@@ -14,9 +14,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var buffer = new ArrayBuffer(128);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var buffer = makeCtorArg(128);
   var sample = new TA(buffer, 8, 1);
   $DETACHBUFFER(sample.buffer);
   assert.sameValue(sample.byteOffset, 0);
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/byteOffset/return-byteoffset.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/return-byteoffset.js
@@ -14,18 +14,18 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var ta1 = new TA();
   assert.sameValue(ta1.byteOffset, 0, "Regular typedArray");
 
   var offset = 4 * TA.BYTES_PER_ELEMENT;
 
-  var buffer1 = new ArrayBuffer(8 * TA.BYTES_PER_ELEMENT);
+  var buffer1 = makeCtorArg(8);
   var ta2 = new TA(buffer1, offset);
   assert.sameValue(ta2.byteOffset, offset, "TA(buffer, offset)");
 
-  var buffer2 = new ArrayBuffer(8 * TA.BYTES_PER_ELEMENT);
+  var buffer2 = makeCtorArg(8);
   var sample = new TA(buffer2, offset);
   var ta3 = new TA(sample);
   assert.sameValue(ta3.byteOffset, 0, "TA(typedArray)");
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"]);

--- a/test/built-ins/TypedArray/prototype/entries/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/entries/BigInt/detached-buffer.js
@@ -18,10 +18,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.entries();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/entries/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/entries/detached-buffer.js
@@ -18,10 +18,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.entries();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/entries/return-itor.js
+++ b/test/built-ins/TypedArray/prototype/entries/return-itor.js
@@ -14,8 +14,8 @@ features: [TypedArray]
 
 var sample = [0, 42, 64];
 
-testWithTypedArrayConstructors(function(TA) {
-  var typedArray = new TA(sample);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var typedArray = new TA(makeCtorArg(sample));
   var itor = typedArray.entries();
 
   var next = itor.next();
@@ -33,4 +33,4 @@ testWithTypedArrayConstructors(function(TA) {
   next = itor.next();
   assert.sameValue(next.value, undefined);
   assert.sameValue(next.done, true);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/every/BigInt/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/every/BigInt/callbackfn-detachbuffer.js
@@ -25,9 +25,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.every(function() {
     if (loops === 0) {
@@ -38,4 +38,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/every/BigInt/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/every/BigInt/callbackfn-not-called-on-empty.js
@@ -25,12 +25,12 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().every(function() {
+  new TA(makeCtorArg(0)).every(function() {
     called++;
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/every/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/every/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.every(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/every/BigInt/returns-true-if-every-cb-returns-true.js
+++ b/test/built-ins/TypedArray/prototype/every/BigInt/returns-true-if-every-cb-returns-true.js
@@ -20,7 +20,7 @@ includes: [testTypedArray.js]
 features: [BigInt, Symbol, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
   var values = [
     true,
@@ -35,7 +35,7 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     0.1,
     -0.1
   ];
-  var sample = new TA(values.length);
+  var sample = new TA(makeCtorArg(values.length));
   var result = sample.every(function() {
     called++;
     return values.unshift();
@@ -43,4 +43,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.sameValue(called, sample.length, "callbackfn called for each index");
   assert.sameValue(result, true, "return is true");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/every/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/every/callbackfn-detachbuffer.js
@@ -25,9 +25,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.every(function() {
     if (loops === 0) {
@@ -38,4 +38,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/every/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/every/callbackfn-not-called-on-empty.js
@@ -25,12 +25,12 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().every(function() {
+  new TA(makeCtorArg(0)).every(function() {
     called++;
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/every/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/every/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.every(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/every/returns-true-if-every-cb-returns-true.js
+++ b/test/built-ins/TypedArray/prototype/every/returns-true-if-every-cb-returns-true.js
@@ -20,7 +20,7 @@ includes: [testTypedArray.js]
 features: [Symbol, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
   var values = [
     true,
@@ -35,7 +35,7 @@ testWithTypedArrayConstructors(function(TA) {
     0.1,
     -0.1
   ];
-  var sample = new TA(values.length);
+  var sample = new TA(makeCtorArg(values.length));
   var result = sample.every(function() {
     called++;
     return values.unshift();
@@ -43,4 +43,4 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.sameValue(called, sample.length, "callbackfn called for each index");
   assert.sameValue(result, true, "return is true");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-called-before-ctor.js
+++ b/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-called-before-ctor.js
@@ -17,9 +17,9 @@ includes: [testTypedArray.js]
 features: [BigInt, Symbol.species, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var length = 42;
-  var sample = new TA(length);
+  var sample = new TA(makeCtorArg(length));
   var calls = 0;
   var before = false;
 

--- a/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-called-before-species.js
+++ b/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-called-before-species.js
@@ -17,9 +17,9 @@ includes: [testTypedArray.js]
 features: [BigInt, Symbol.species, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var length = 42;
-  var sample = new TA(length);
+  var sample = new TA(makeCtorArg(length));
   var calls = 0;
   var before = false;
 

--- a/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-detachbuffer.js
@@ -18,9 +18,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.filter(function() {
     var flag = true;
@@ -34,4 +34,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-not-called-on-empty.js
@@ -16,12 +16,12 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().filter(function() {
+  new TA(makeCtorArg(0)).filter(function() {
     called++;
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/filter/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/filter/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.filter(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/filter/callbackfn-called-before-ctor.js
+++ b/test/built-ins/TypedArray/prototype/filter/callbackfn-called-before-ctor.js
@@ -17,9 +17,9 @@ includes: [testTypedArray.js]
 features: [Symbol.species, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var length = 42;
-  var sample = new TA(length);
+  var sample = new TA(makeCtorArg(length));
   var calls = 0;
   var before = false;
 

--- a/test/built-ins/TypedArray/prototype/filter/callbackfn-called-before-species.js
+++ b/test/built-ins/TypedArray/prototype/filter/callbackfn-called-before-species.js
@@ -17,9 +17,9 @@ includes: [testTypedArray.js]
 features: [Symbol.species, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var length = 42;
-  var sample = new TA(length);
+  var sample = new TA(makeCtorArg(length));
   var calls = 0;
   var before = false;
 

--- a/test/built-ins/TypedArray/prototype/filter/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/filter/callbackfn-detachbuffer.js
@@ -17,9 +17,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.filter(function() {
     if (loops === 0) {
@@ -30,4 +30,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/filter/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/filter/callbackfn-not-called-on-empty.js
@@ -16,12 +16,12 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().filter(function() {
+  new TA(makeCtorArg(0)).filter(function() {
     called++;
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/filter/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/filter/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.filter(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/filter/speciesctor-destination-backed-by-immutable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/filter/speciesctor-destination-backed-by-immutable-buffer.js
@@ -1,0 +1,82 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.filter
+description: >
+  Throws a TypeError exception when the receiver constructs an instance backed
+  by an immutable buffer
+info: |
+  %TypedArray%.prototype.filter ( callback [ , thisArg ] )
+  ...
+  8. Repeat, while k < len,
+     a. Let Pk be ! ToString(𝔽(k)).
+     b. Let kValue be ! Get(O, Pk).
+     c. Let selected be ToBoolean(? Call(callback, thisArg, « kValue, 𝔽(k), O »)).
+     d. If selected is true, then
+        i. Append kValue to kept.
+        ii. Set captured to captured + 1.
+     e. Set k to k + 1.
+  9. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(captured) », ~write~).
+  10. Assert: IsImmutableBuffer(A.[[ViewedArrayBuffer]]) is false.
+
+  TypedArraySpeciesCreate ( exemplar, argumentList [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to ~read~.
+  2. Let defaultConstructor be the intrinsic object associated with the constructor name exemplar.[[TypedArrayName]] in Table 73.
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Let result be ? TypedArrayCreateFromConstructor(constructor, argumentList, accessMode).
+
+  TypedArrayCreateFromConstructor ( constructor, argumentList [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to ~read~.
+  2. Let newTypedArray be ? Construct(constructor, argumentList).
+  3. Let taRecord be ? ValidateTypedArray(newTypedArray, seq-cst, accessMode).
+
+  ValidateTypedArray ( O, order [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to read.
+  2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+  3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
+  4. If accessMode is ~write~ and IsImmutableBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+features: [Symbol.species, TypedArray, immutable-arraybuffer]
+includes: [testTypedArray.js, compareArray.js]
+---*/
+
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var calls = [];
+
+  var ta = new TA(makeCtorArg(["1", "2"]));
+  var iab = (new TA(["3", "4"])).buffer.transferToImmutable();
+  var constructor = {};
+  Object.defineProperty(ta, "constructor", {
+    get: function() {
+      calls.push("get ta.constructor");
+      return constructor;
+    }
+  });
+  Object.defineProperty(constructor, Symbol.species, {
+    get: function() {
+      calls.push("get ta.constructor[Symbol.species]");
+      return function speciesCtor() {
+        calls.push("construct result");
+        var result = new TA(iab);
+        calls.push("return result");
+        return result;
+      };
+    }
+  });
+
+  assert.throws(TypeError, function() {
+    ta.filter(function(value, index) {
+      calls.push("filter index " + index);
+      return !index;
+    });
+  });
+  var expectCalls = [
+    "filter index 0",
+    "filter index 1",
+    "get ta.constructor",
+    "get ta.constructor[Symbol.species]",
+    "construct result",
+    "return result"
+  ];
+  assert.compareArray(calls, expectCalls, "Must visit elements before constructing the result.");
+});

--- a/test/built-ins/TypedArray/prototype/find/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/find/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ var predicate = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.find(predicate);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/find/BigInt/predicate-is-not-callable-throws.js
+++ b/test/built-ins/TypedArray/prototype/find/BigInt/predicate-is-not-callable-throws.js
@@ -25,8 +25,8 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.find({});
@@ -63,4 +63,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.find(/./);
   }, "regexp");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/find/BigInt/predicate-may-detach-buffer.js
+++ b/test/built-ins/TypedArray/prototype/find/BigInt/predicate-may-detach-buffer.js
@@ -42,9 +42,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.find(function() {
     if (loops === 0) {
@@ -54,4 +54,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/find/BigInt/predicate-not-called-on-empty-array.js
+++ b/test/built-ins/TypedArray/prototype/find/BigInt/predicate-not-called-on-empty-array.js
@@ -27,8 +27,8 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   var called = false;
 
   var result = sample.find(function() {
@@ -46,4 +46,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     undefined,
     "find returns undefined when predicate is not called"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/find/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/find/detached-buffer.js
@@ -23,10 +23,10 @@ var predicate = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.find(predicate);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/find/predicate-is-not-callable-throws.js
+++ b/test/built-ins/TypedArray/prototype/find/predicate-is-not-callable-throws.js
@@ -25,8 +25,8 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.find({});
@@ -63,4 +63,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.find(/./);
   }, "regexp");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/find/predicate-may-detach-buffer.js
+++ b/test/built-ins/TypedArray/prototype/find/predicate-may-detach-buffer.js
@@ -42,9 +42,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.find(function() {
     if (loops === 0) {
@@ -54,4 +54,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/find/predicate-not-called-on-empty-array.js
+++ b/test/built-ins/TypedArray/prototype/find/predicate-not-called-on-empty-array.js
@@ -27,8 +27,8 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   var called = false;
 
   var result = sample.find(function() {
@@ -46,4 +46,4 @@ testWithTypedArrayConstructors(function(TA) {
     undefined,
     "find returns undefined when predicate is not called"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/findIndex/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ var predicate = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.findIndex(predicate);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-is-not-callable-throws.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-is-not-callable-throws.js
@@ -23,8 +23,8 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.findIndex({});
   }, "{}");
@@ -60,5 +60,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.findIndex(/./);
   }, "/./");
-}, null, ["passthrough"]);
-
+});

--- a/test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-may-detach-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-may-detach-buffer.js
@@ -34,8 +34,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
   var loops = 0;
 
   sample.findIndex(function() {
@@ -45,4 +45,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     loops++;
   });
   assert.sameValue(loops, 2, "predicate is called once");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-not-called-on-empty-array.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-not-called-on-empty-array.js
@@ -26,8 +26,8 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   var called = false;
 
   var predicate = function() {
@@ -45,4 +45,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     result, -1,
     "returns -1 on an empty instance"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/findIndex/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/detached-buffer.js
@@ -23,10 +23,10 @@ var predicate = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.findIndex(predicate);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findIndex/predicate-is-not-callable-throws.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/predicate-is-not-callable-throws.js
@@ -23,8 +23,8 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.findIndex({});
   }, "{}");
@@ -60,5 +60,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.findIndex(/./);
   }, "/./");
-}, null, ["passthrough"]);
-
+});

--- a/test/built-ins/TypedArray/prototype/findIndex/predicate-may-detach-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/predicate-may-detach-buffer.js
@@ -31,8 +31,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
   var loops = 0;
 
   sample.findIndex(function() {
@@ -42,4 +42,4 @@ testWithTypedArrayConstructors(function(TA) {
     loops++;
   });
   assert.sameValue(loops, 2, "predicate is called once");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findIndex/predicate-not-called-on-empty-array.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/predicate-not-called-on-empty-array.js
@@ -26,8 +26,8 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   var called = false;
 
   var predicate = function() {
@@ -45,4 +45,4 @@ testWithTypedArrayConstructors(function(TA) {
     result, -1,
     "returns -1 on an empty instance"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/findLast/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findLast/BigInt/detached-buffer.js
@@ -21,10 +21,10 @@ var predicate = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.findLast(predicate);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLast/BigInt/predicate-is-not-callable-throws.js
+++ b/test/built-ins/TypedArray/prototype/findLast/BigInt/predicate-is-not-callable-throws.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray, array-find-from-last]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.findLast({});
@@ -52,4 +52,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.findLast(/./);
   }, "regexp");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/findLast/BigInt/predicate-may-detach-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findLast/BigInt/predicate-may-detach-buffer.js
@@ -24,9 +24,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray, array-find-from-last]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.findLast(function() {
     if (loops === 0) {
@@ -36,4 +36,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLast/BigInt/predicate-not-called-on-empty-array.js
+++ b/test/built-ins/TypedArray/prototype/findLast/BigInt/predicate-not-called-on-empty-array.js
@@ -15,8 +15,8 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray, array-find-from-last]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   var called = false;
 
   var result = sample.findLast(function() {
@@ -34,4 +34,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     undefined,
     "findLast returns undefined when predicate is not called"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/findLast/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findLast/detached-buffer.js
@@ -21,10 +21,10 @@ var predicate = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.findLast(predicate);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLast/predicate-is-not-callable-throws.js
+++ b/test/built-ins/TypedArray/prototype/findLast/predicate-is-not-callable-throws.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js]
 features: [TypedArray, array-find-from-last]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.findLast({});
@@ -52,4 +52,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.findLast(/./);
   }, "regexp");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/findLast/predicate-may-detach-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findLast/predicate-may-detach-buffer.js
@@ -24,9 +24,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray, array-find-from-last]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.findLast(function() {
     if (loops === 0) {
@@ -36,4 +36,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLast/predicate-not-called-on-empty-array.js
+++ b/test/built-ins/TypedArray/prototype/findLast/predicate-not-called-on-empty-array.js
@@ -15,8 +15,8 @@ includes: [testTypedArray.js]
 features: [TypedArray, array-find-from-last]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   var called = false;
 
   var result = sample.findLast(function() {
@@ -34,4 +34,4 @@ testWithTypedArrayConstructors(function(TA) {
     undefined,
     "findLast returns undefined when predicate is not called"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/findLastIndex/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ var predicate = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.findLastIndex(predicate);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLastIndex/BigInt/predicate-is-not-callable-throws.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/BigInt/predicate-is-not-callable-throws.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray, array-find-from-last]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.findLastIndex({});
   }, "{}");
@@ -51,5 +51,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.findLastIndex(/./);
   }, "/./");
-}, null, ["passthrough"]);
-
+});

--- a/test/built-ins/TypedArray/prototype/findLastIndex/BigInt/predicate-may-detach-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/BigInt/predicate-may-detach-buffer.js
@@ -23,8 +23,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray, array-find-from-last]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
   var loops = 0;
 
   sample.findLastIndex(function() {
@@ -34,4 +34,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     loops++;
   });
   assert.sameValue(loops, 2, "predicate is called once");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLastIndex/BigInt/predicate-not-called-on-empty-array.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/BigInt/predicate-not-called-on-empty-array.js
@@ -17,8 +17,8 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray, array-find-from-last]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   var called = false;
 
   var predicate = function() {
@@ -36,4 +36,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     result, -1,
     "returns -1 on an empty instance"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/findLastIndex/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/detached-buffer.js
@@ -23,10 +23,10 @@ var predicate = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.findLastIndex(predicate);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLastIndex/predicate-is-not-callable-throws.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/predicate-is-not-callable-throws.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js]
 features: [TypedArray, array-find-from-last]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.findLastIndex({});
   }, "{}");
@@ -51,5 +51,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.findLastIndex(/./);
   }, "/./");
-}, null, ["passthrough"]);
-
+});

--- a/test/built-ins/TypedArray/prototype/findLastIndex/predicate-may-detach-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/predicate-may-detach-buffer.js
@@ -23,8 +23,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray, array-find-from-last]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
   var loops = 0;
 
   sample.findLastIndex(function() {
@@ -34,4 +34,4 @@ testWithTypedArrayConstructors(function(TA) {
     loops++;
   });
   assert.sameValue(loops, 2, "predicate is called once");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/findLastIndex/predicate-not-called-on-empty-array.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/predicate-not-called-on-empty-array.js
@@ -17,8 +17,8 @@ includes: [testTypedArray.js]
 features: [TypedArray, array-find-from-last]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   var called = false;
 
   var predicate = function() {
@@ -36,4 +36,4 @@ testWithTypedArrayConstructors(function(TA) {
     result, -1,
     "returns -1 on an empty instance"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/forEach/BigInt/arraylength-internal.js
+++ b/test/built-ins/TypedArray/prototype/forEach/BigInt/arraylength-internal.js
@@ -43,5 +43,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   });
 
   assert.sameValue(loop, 7, "accessor descriptor");
-}, null, ["passthrough"]);
-
+});

--- a/test/built-ins/TypedArray/prototype/forEach/BigInt/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/forEach/BigInt/callbackfn-detachbuffer.js
@@ -25,9 +25,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.forEach(function() {
     if (loops === 0) {
@@ -37,4 +37,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/forEach/BigInt/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/forEach/BigInt/callbackfn-not-called-on-empty.js
@@ -25,12 +25,12 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().forEach(function() {
+  new TA(makeCtorArg(0)).forEach(function() {
     called++;
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/forEach/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/forEach/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.forEach(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/forEach/arraylength-internal.js
+++ b/test/built-ins/TypedArray/prototype/forEach/arraylength-internal.js
@@ -43,5 +43,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   });
 
   assert.sameValue(loop, 7, "accessor descriptor");
-}, null, ["passthrough"]);
-
+});

--- a/test/built-ins/TypedArray/prototype/forEach/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/forEach/callbackfn-detachbuffer.js
@@ -25,9 +25,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.forEach(function() {
     if (loops === 0) {
@@ -37,4 +37,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/forEach/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/forEach/callbackfn-not-called-on-empty.js
@@ -25,12 +25,12 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().forEach(function() {
+  new TA(makeCtorArg(0)).forEach(function() {
     called++;
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/forEach/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/forEach/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.forEach(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/includes/BigInt/detached-buffer-during-fromIndex-returns-false-for-zero.js
+++ b/test/built-ins/TypedArray/prototype/includes/BigInt/detached-buffer-during-fromIndex-returns-false-for-zero.js
@@ -33,8 +33,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -43,4 +43,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.includes(0n, fromIndex), false);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/includes/BigInt/detached-buffer-during-fromIndex-returns-true-for-undefined.js
+++ b/test/built-ins/TypedArray/prototype/includes/BigInt/detached-buffer-during-fromIndex-returns-true-for-undefined.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-%typedarray%.prototype.includes
 description: >
-  Returns false if buffer is detached after ValidateTypedArray and searchElement is a value
+  Returns true if buffer is detached after ValidateTypedArray and searchElement is undefined
 info: |
   %TypedArray%.prototype.includes ( searchElement [ , fromIndex ] )
 
@@ -34,8 +34,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -44,4 +44,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.includes(undefined, fromIndex), true);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/includes/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/includes/BigInt/detached-buffer.js
@@ -19,10 +19,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.includes(0n);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/includes/BigInt/length-zero-returns-false.js
+++ b/test/built-ins/TypedArray/prototype/includes/BigInt/length-zero-returns-false.js
@@ -28,12 +28,12 @@ var fromIndex = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.sameValue(sample.includes(0), false, "returns false");
   assert.sameValue(sample.includes(), false, "returns false - no arg");
   assert.sameValue(
     sample.includes(0n, fromIndex), false,
     "length is checked before ToInteger(fromIndex)"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/includes/detached-buffer-during-fromIndex-returns-false-for-zero.js
+++ b/test/built-ins/TypedArray/prototype/includes/detached-buffer-during-fromIndex-returns-false-for-zero.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-%typedarray%.prototype.includes
 description: >
-  Returns false if buffer is detached after ValidateTypedArray and searchElement is a value
+  Returns false if buffer is detached after ValidateTypedArray and searchElement is not undefined
 info: |
   %TypedArray%.prototype.includes ( searchElement [ , fromIndex ] )
 
@@ -34,8 +34,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -44,4 +44,4 @@ testWithTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.includes(0, fromIndex), false);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/includes/detached-buffer-during-fromIndex-returns-true-for-undefined.js
+++ b/test/built-ins/TypedArray/prototype/includes/detached-buffer-during-fromIndex-returns-true-for-undefined.js
@@ -34,8 +34,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -44,4 +44,4 @@ testWithTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.includes(undefined, fromIndex), true);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/includes/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/includes/detached-buffer.js
@@ -19,10 +19,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.includes(0);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/includes/length-zero-returns-false.js
+++ b/test/built-ins/TypedArray/prototype/includes/length-zero-returns-false.js
@@ -28,12 +28,12 @@ var fromIndex = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.sameValue(sample.includes(0), false, "returns false");
   assert.sameValue(sample.includes(), false, "returns false - no arg");
   assert.sameValue(
     sample.includes(0, fromIndex), false,
     "length is checked before ToInteger(fromIndex)"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/indexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%typedarray%.prototype.indexof
-description: Throws a TypeError if this has a detached buffer
+description: Returns -1 if buffer is detached after ValidateTypedArray
 info: |
   %TypedArray%.prototype.indexOf ( searchElement [ , fromIndex ] )
 
@@ -36,8 +36,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -46,4 +46,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.indexOf(undefined, fromIndex), -1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/indexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%typedarray%.prototype.indexof
-description: Throws a TypeError if this has a detached buffer
+description: Returns -1 if buffer is detached after ValidateTypedArray
 info: |
   %TypedArray%.prototype.indexOf ( searchElement [ , fromIndex ] )
 
@@ -36,8 +36,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -46,4 +46,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.indexOf(0n, fromIndex), -1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/indexOf/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/BigInt/detached-buffer.js
@@ -19,10 +19,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.indexOf(0n);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/indexOf/BigInt/length-zero-returns-minus-one.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/BigInt/length-zero-returns-minus-one.js
@@ -27,11 +27,11 @@ var fromIndex = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.sameValue(sample.indexOf(0n), -1, "returns -1");
   assert.sameValue(
     sample.indexOf(0n, fromIndex), -1,
     "length is checked before ToInteger(fromIndex)"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
@@ -36,8 +36,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -46,4 +46,4 @@ testWithTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.indexOf(undefined, fromIndex), -1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
@@ -36,8 +36,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -46,4 +46,4 @@ testWithTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.indexOf(0, fromIndex), -1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/indexOf/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/detached-buffer.js
@@ -19,10 +19,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.indexOf(0);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/indexOf/length-zero-returns-minus-one.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/length-zero-returns-minus-one.js
@@ -27,11 +27,11 @@ var fromIndex = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.sameValue(sample.indexOf(0), -1, "returns -1");
   assert.sameValue(
     sample.indexOf(0, fromIndex), -1,
     "length is checked before ToInteger(fromIndex)"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/join/BigInt/detached-buffer-during-fromIndex-returns-single-comma.js
+++ b/test/built-ins/TypedArray/prototype/join/BigInt/detached-buffer-during-fromIndex-returns-single-comma.js
@@ -29,8 +29,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  const sample = new TA([1n,2n,3n]);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg([1n,2n,3n]));
   const separator = {
     toString() {
       $DETACHBUFFER(sample.buffer);
@@ -39,4 +39,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.join(separator), ',,');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/join/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/join/BigInt/detached-buffer.js
@@ -24,10 +24,10 @@ let obj = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  let sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  let sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, () => {
     sample.join(obj);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/join/BigInt/empty-instance-empty-string.js
+++ b/test/built-ins/TypedArray/prototype/join/BigInt/empty-instance-empty-string.js
@@ -21,9 +21,9 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.sameValue(sample.join(), "");
   assert.sameValue(sample.join("test262"), "");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/join/BigInt/return-abrupt-from-separator-symbol.js
+++ b/test/built-ins/TypedArray/prototype/join/BigInt/return-abrupt-from-separator-symbol.js
@@ -23,10 +23,10 @@ features: [BigInt, Symbol, TypedArray]
 
 var s = Symbol("");
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.join(s);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/join/BigInt/return-abrupt-from-separator.js
+++ b/test/built-ins/TypedArray/prototype/join/BigInt/return-abrupt-from-separator.js
@@ -27,10 +27,10 @@ var obj = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.join(obj);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/join/custom-separator-result-from-tostring-on-each-value.js
+++ b/test/built-ins/TypedArray/prototype/join/custom-separator-result-from-tostring-on-each-value.js
@@ -31,8 +31,8 @@ features: [TypedArray]
 
 var arr = [-2, Infinity, NaN, -Infinity, 0.6, 9007199254740992];
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   var result, separator, expected;
 
   separator = ",";
@@ -132,4 +132,4 @@ testWithTypedArrayConstructors(function(TA) {
   }).join(separator);
   result = sample.join(separator);
   assert.sameValue(result, expected, "using: " + separator);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/join/detached-buffer-during-fromIndex-returns-single-comma.js
+++ b/test/built-ins/TypedArray/prototype/join/detached-buffer-during-fromIndex-returns-single-comma.js
@@ -29,8 +29,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  const sample = new TA([1,2,3]);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg([1,2,3]));
   const separator = {
     toString() {
       $DETACHBUFFER(sample.buffer);
@@ -39,4 +39,4 @@ testWithTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.join(separator), ',,');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/join/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/join/detached-buffer.js
@@ -24,10 +24,10 @@ let obj = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  let sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  let sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, () => {
     sample.join(obj);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/join/empty-instance-empty-string.js
+++ b/test/built-ins/TypedArray/prototype/join/empty-instance-empty-string.js
@@ -21,9 +21,9 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.sameValue(sample.join(), "");
   assert.sameValue(sample.join("test262"), "");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/join/result-from-tostring-on-each-value.js
+++ b/test/built-ins/TypedArray/prototype/join/result-from-tostring-on-each-value.js
@@ -30,8 +30,8 @@ features: [TypedArray]
 
 var arr = [-2, Infinity, NaN, -Infinity, 0.6, 9007199254740992];
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
 
   // Use converted values using Array methods as helpers
   var expected = arr.map(function(_, i) {
@@ -41,4 +41,4 @@ testWithTypedArrayConstructors(function(TA) {
   var result = sample.join();
 
   assert.sameValue(result, expected);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/join/return-abrupt-from-separator-symbol.js
+++ b/test/built-ins/TypedArray/prototype/join/return-abrupt-from-separator-symbol.js
@@ -23,10 +23,10 @@ features: [Symbol, TypedArray]
 
 var s = Symbol("");
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.join(s);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/join/return-abrupt-from-separator.js
+++ b/test/built-ins/TypedArray/prototype/join/return-abrupt-from-separator.js
@@ -27,10 +27,10 @@ var obj = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.join(obj);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/keys/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/keys/BigInt/detached-buffer.js
@@ -18,10 +18,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.keys();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/keys/BigInt/return-itor.js
+++ b/test/built-ins/TypedArray/prototype/keys/BigInt/return-itor.js
@@ -14,8 +14,8 @@ features: [BigInt, TypedArray]
 
 var sample = [0n, 42n, 64n];
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var typedArray = new TA(sample);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var typedArray = new TA(makeCtorArg(sample));
   var itor = typedArray.keys();
 
   var next = itor.next();
@@ -33,4 +33,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   next = itor.next();
   assert.sameValue(next.value, undefined);
   assert.sameValue(next.done, true);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/keys/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/keys/detached-buffer.js
@@ -18,10 +18,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.keys();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/keys/return-itor.js
+++ b/test/built-ins/TypedArray/prototype/keys/return-itor.js
@@ -14,8 +14,8 @@ features: [TypedArray]
 
 var sample = [0, 42, 64];
 
-testWithTypedArrayConstructors(function(TA) {
-  var typedArray = new TA(sample);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var typedArray = new TA(makeCtorArg(sample));
   var itor = typedArray.keys();
 
   var next = itor.next();
@@ -33,4 +33,4 @@ testWithTypedArrayConstructors(function(TA) {
   next = itor.next();
   assert.sameValue(next.value, undefined);
   assert.sameValue(next.done, true);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
@@ -33,8 +33,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -43,4 +43,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.lastIndexOf(undefined, fromIndex), -1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
@@ -33,8 +33,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -43,4 +43,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.lastIndexOf(0n, fromIndex), -1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/detached-buffer.js
@@ -19,10 +19,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.lastIndexOf(0n);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/length-zero-returns-minus-one.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/length-zero-returns-minus-one.js
@@ -27,11 +27,11 @@ var fromIndex = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.sameValue(sample.lastIndexOf(0), -1, "returns -1");
   assert.sameValue(
     sample.lastIndexOf(0n, fromIndex), -1,
     "length is checked before ToInteger(fromIndex)"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
@@ -33,8 +33,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -43,4 +43,4 @@ testWithTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.lastIndexOf(undefined, fromIndex), -1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
@@ -33,8 +33,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  const sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  const sample = new TA(makeCtorArg(1));
   const fromIndex = {
     valueOf() {
       $DETACHBUFFER(sample.buffer);
@@ -43,4 +43,4 @@ testWithTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(sample.lastIndexOf(0, fromIndex), -1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer.js
@@ -19,10 +19,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.lastIndexOf(0);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/length-zero-returns-minus-one.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/length-zero-returns-minus-one.js
@@ -27,11 +27,11 @@ var fromIndex = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.sameValue(sample.lastIndexOf(0), -1, "returns -1");
   assert.sameValue(
     sample.lastIndexOf(0, fromIndex), -1,
     "length is checked before ToInteger(fromIndex)"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/length/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/length/BigInt/detached-buffer.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(42);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(42));
   $DETACHBUFFER(sample.buffer);
   assert.sameValue(sample.length, 0);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/length/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/length/detached-buffer.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(42);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(42));
   $DETACHBUFFER(sample.buffer);
   assert.sameValue(sample.length, 0);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/map/BigInt/arraylength-internal.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/arraylength-internal.js
@@ -41,5 +41,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     return 0n;
   });
   assert.sameValue(loop, 4, "accessor descriptor");
-}, null, ["passthrough"]);
-
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/callbackfn-detachbuffer.js
@@ -17,9 +17,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.map(function() {
     if (loops === 0) {
@@ -30,4 +30,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/map/BigInt/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/callbackfn-not-called-on-empty.js
@@ -17,12 +17,12 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().map(function() {
+  new TA(makeCtorArg(0)).map(function() {
     called++;
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.map(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
@@ -42,4 +42,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     });
   });
   assert.sameValue(callCount, 0, "callback should not be called");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor.js
@@ -51,4 +51,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     TA,
     "use defaultCtor on an undefined return - .constructor check"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-abrupt.js
@@ -42,4 +42,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.map(function() { return 0n; });
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species.js
@@ -43,4 +43,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   sample.map(function() { return 0n; });
 
   assert.sameValue(calls, 1);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/map/arraylength-internal.js
+++ b/test/built-ins/TypedArray/prototype/map/arraylength-internal.js
@@ -41,5 +41,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     return 0;
   });
   assert.sameValue(loop, 4, "accessor descriptor");
-}, null, ["passthrough"]);
-
+});

--- a/test/built-ins/TypedArray/prototype/map/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/map/callbackfn-detachbuffer.js
@@ -17,9 +17,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.map(function() {
     if (loops === 0) {
@@ -30,4 +30,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/map/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/map/callbackfn-not-called-on-empty.js
@@ -17,12 +17,12 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().map(function() {
+  new TA(makeCtorArg(0)).map(function() {
     called++;
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/map/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/map/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.map(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-destination-backed-by-immutable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-destination-backed-by-immutable-buffer.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Throws a TypeError exception when the receiver constructs an instance backed
+  by an immutable buffer
+info: |
+  %TypedArray%.prototype.map ( callback [ , thisArg ] )
+  1. Let O be the this value.
+  2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+  3. Let len be TypedArrayLength(taRecord).
+  4. If IsCallable(callback) is false, throw a TypeError exception.
+  5. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(len) », ~write~).
+  6. Assert: IsImmutableBuffer(A.[[ViewedArrayBuffer]]) is false.
+
+  TypedArraySpeciesCreate ( exemplar, argumentList [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to ~read~.
+  2. Let defaultConstructor be the intrinsic object associated with the constructor name exemplar.[[TypedArrayName]] in Table 73.
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Let result be ? TypedArrayCreateFromConstructor(constructor, argumentList, accessMode).
+
+  TypedArrayCreateFromConstructor ( constructor, argumentList [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to ~read~.
+  2. Let newTypedArray be ? Construct(constructor, argumentList).
+  3. Let taRecord be ? ValidateTypedArray(newTypedArray, seq-cst, accessMode).
+
+  ValidateTypedArray ( O, order [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to read.
+  2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+  3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
+  4. If accessMode is ~write~ and IsImmutableBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+features: [Symbol.species, TypedArray, immutable-arraybuffer]
+includes: [testTypedArray.js, compareArray.js]
+---*/
+
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var calls = [];
+
+  var ta = new TA(makeCtorArg(["1", "2"]));
+  var iab = (new TA(["3", "4"])).buffer.transferToImmutable();
+  var constructor = {};
+  Object.defineProperty(ta, "constructor", {
+    get: function() {
+      calls.push("get ta.constructor");
+      return constructor;
+    }
+  });
+  Object.defineProperty(constructor, Symbol.species, {
+    get: function() {
+      calls.push("get ta.constructor[Symbol.species]");
+      return function speciesCtor() {
+        calls.push("construct result");
+        var result = new TA(iab);
+        calls.push("return result");
+        return result;
+      };
+    }
+  });
+
+  assert.throws(TypeError, function() {
+    ta.map(function(value, index) {
+      calls.push("map index " + index);
+      return value + value;
+    });
+  });
+  var expectCalls = [
+    "get ta.constructor",
+    "get ta.constructor[Symbol.species]",
+    "construct result",
+    "return result"
+  ];
+  assert.compareArray(calls, expectCalls, "Must construct the result before visiting elements.");
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor-abrupt.js
@@ -42,4 +42,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     });
   });
   assert.sameValue(callCount, 0, "callback should not be called");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor.js
@@ -51,4 +51,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     TA,
     "use defaultCtor on an undefined return - .constructor check"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-abrupt.js
@@ -42,4 +42,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.map(function() { return 0; });
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species.js
@@ -43,4 +43,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   sample.map(function() {});
 
   assert.sameValue(calls, 1);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduce/BigInt/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/reduce/BigInt/callbackfn-detachbuffer.js
@@ -26,9 +26,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.reduce(function() {
     if (loops === 0) {
@@ -39,4 +39,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   }, 0);
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduce/BigInt/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/reduce/BigInt/callbackfn-not-called-on-empty.js
@@ -28,12 +28,12 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().reduce(function() {
+  new TA(makeCtorArg(0)).reduce(function() {
     called++;
   }, undefined);
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduce/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reduce/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.reduce(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduce/BigInt/empty-instance-return-initialvalue.js
+++ b/test/built-ins/TypedArray/prototype/reduce/BigInt/empty-instance-return-initialvalue.js
@@ -30,12 +30,12 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = false;
-  var result = new TA().reduce(function() {
+  var result = new TA(makeCtorArg(0)).reduce(function() {
     called = true;
   }, 42);
 
   assert.sameValue(result, 42);
   assert.sameValue(called, false);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduce/BigInt/empty-instance-with-no-initialvalue-throws.js
+++ b/test/built-ins/TypedArray/prototype/reduce/BigInt/empty-instance-with-no-initialvalue-throws.js
@@ -21,14 +21,15 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
+  var ta = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
-    new TA().reduce(function() {
+    ta.reduce(function() {
       called++;
     });
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduce/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/reduce/callbackfn-detachbuffer.js
@@ -26,9 +26,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.reduce(function() {
     if (loops === 0) {
@@ -39,4 +39,4 @@ testWithTypedArrayConstructors(function(TA) {
   }, 0);
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduce/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/reduce/callbackfn-not-called-on-empty.js
@@ -28,12 +28,12 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().reduce(function() {
+  new TA(makeCtorArg(0)).reduce(function() {
     called++;
   }, undefined);
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduce/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reduce/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.reduce(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduce/empty-instance-return-initialvalue.js
+++ b/test/built-ins/TypedArray/prototype/reduce/empty-instance-return-initialvalue.js
@@ -30,12 +30,12 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = false;
-  var result = new TA().reduce(function() {
+  var result = new TA(makeCtorArg(0)).reduce(function() {
     called = true;
   }, 42);
 
   assert.sameValue(result, 42);
   assert.sameValue(called, false);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduce/empty-instance-with-no-initialvalue-throws.js
+++ b/test/built-ins/TypedArray/prototype/reduce/empty-instance-with-no-initialvalue-throws.js
@@ -21,14 +21,15 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
+  var ta = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
-    new TA().reduce(function() {
+    ta.reduce(function() {
       called++;
     });
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduceRight/BigInt/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/BigInt/callbackfn-detachbuffer.js
@@ -26,9 +26,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.reduceRight(function() {
     if (loops === 0) {
@@ -39,4 +39,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   }, 0);
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduceRight/BigInt/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/BigInt/callbackfn-not-called-on-empty.js
@@ -29,12 +29,12 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().reduceRight(function() {
+  new TA(makeCtorArg(0)).reduceRight(function() {
     called++;
   }, undefined);
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduceRight/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.reduceRight(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduceRight/BigInt/empty-instance-return-initialvalue.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/BigInt/empty-instance-return-initialvalue.js
@@ -31,12 +31,12 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = false;
-  var result = new TA().reduceRight(function() {
+  var result = new TA(makeCtorArg(0)).reduceRight(function() {
     called = true;
   }, 42);
 
   assert.sameValue(result, 42);
   assert.sameValue(called, false);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduceRight/BigInt/empty-instance-with-no-initialvalue-throws.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/BigInt/empty-instance-with-no-initialvalue-throws.js
@@ -21,14 +21,15 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
+  var ta = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
-    new TA().reduceRight(function() {
+    ta.reduceRight(function() {
       called++;
     });
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduceRight/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/callbackfn-detachbuffer.js
@@ -26,9 +26,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.reduceRight(function() {
     if (loops === 0) {
@@ -39,4 +39,4 @@ testWithTypedArrayConstructors(function(TA) {
   }, 0);
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduceRight/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/callbackfn-not-called-on-empty.js
@@ -29,12 +29,12 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().reduceRight(function() {
+  new TA(makeCtorArg(0)).reduceRight(function() {
     called++;
   }, undefined);
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduceRight/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/detached-buffer.js
@@ -29,4 +29,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.reduceRight(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reduceRight/empty-instance-return-initialvalue.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/empty-instance-return-initialvalue.js
@@ -31,12 +31,12 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = false;
-  var result = new TA().reduceRight(function() {
+  var result = new TA(makeCtorArg(0)).reduceRight(function() {
     called = true;
   }, 42);
 
   assert.sameValue(result, 42);
   assert.sameValue(called, false);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/reduceRight/empty-instance-with-no-initialvalue-throws.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/empty-instance-with-no-initialvalue-throws.js
@@ -21,14 +21,15 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
+  var ta = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
-    new TA().reduceRight(function() {
+    ta.reduceRight(function() {
       called++;
     });
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-custom-ctor-other-targettype.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-custom-ctor-other-targettype.js
@@ -31,15 +31,15 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, Symbol.species, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
-  var sample = new TA(1);
+  var sample = new TA(makeCtorArg(1));
 
   sample.constructor = {};
   sample.constructor[Symbol.species] = function(count) {
     var other = TA === BigInt64Array ? BigUint64Array : BigInt64Array;
-    counter++;
     $DETACHBUFFER(sample.buffer);
+    counter++;
     return new other(count);
   };
 
@@ -49,4 +49,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   }, '`sample.slice()` throws TypeError');
 
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-custom-ctor-same-targettype.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-custom-ctor-same-targettype.js
@@ -31,15 +31,15 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, Symbol.species, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
-  let sample = new TA(1);
+  let sample = new TA(makeCtorArg(1));
 
   sample.constructor = {};
   sample.constructor[Symbol.species] = function(count) {
-    counter++;
     $DETACHBUFFER(sample.buffer);
-    return new TA(count);
+    counter++;
+    return new TA(makeCtorArg(count));
   };
 
   assert.throws(TypeError, function() {
@@ -48,4 +48,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   }, '`sample.slice()` throws TypeError');
 
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-get-ctor.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-get-ctor.js
@@ -31,14 +31,14 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
-  let sample = new TA(1);
+  let sample = new TA(makeCtorArg(1));
 
   Object.defineProperty(sample, "constructor", {
     get() {
-      counter++;
       $DETACHBUFFER(sample.buffer);
+      counter++;
     }
   });
   assert.throws(TypeError, function() {
@@ -47,4 +47,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   }, '`sample.slice()` throws TypeError');
 
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
@@ -30,15 +30,15 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, Symbol.species, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
-  let sample = new TA(1);
+  let sample = new TA(makeCtorArg(1));
 
   sample.constructor = {};
   sample.constructor[Symbol.species] = function(count) {
     let other = new TA(count);
-    counter++;
     $DETACHBUFFER(other.buffer);
+    counter++;
     return other;
   };
 
@@ -48,4 +48,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   }, '`sample.slice()` throws TypeError');
 
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-other-targettype.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-other-targettype.js
@@ -17,19 +17,19 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, Symbol.species, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
   let sample, result, Other, other;
   let ctor = {};
   ctor[Symbol.species] = function(count) {
-    counter++;
     Other = TA === BigInt64Array ? BigUint64Array : BigInt64Array;
     $DETACHBUFFER(sample.buffer);
+    counter++;
     other = new Other(count);
     return other;
   };
 
-  sample = new TA(0);
+  sample = new TA(makeCtorArg(0));
   sample.constructor = ctor;
   result = sample.slice();
   assert.sameValue(result.length, 0, 'The value of result.length is 0');
@@ -38,8 +38,8 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.sameValue(result, other, 'The value of `result` is expected to equal the value of other');
   assert.sameValue(counter, 1, 'The value of `counter` is 1');
 
-  sample = new TA(4);
+  sample = new TA(makeCtorArg(4));
   sample.constructor = ctor;
   sample.slice(1, 1); // count = 0;
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-same-targettype.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-same-targettype.js
@@ -16,18 +16,18 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, BigInt, Symbol.species, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
   let sample, result, other;
   let ctor = {};
   ctor[Symbol.species] = function(count) {
-    counter++;
     $DETACHBUFFER(sample.buffer);
-    other = new TA(count);
+    counter++;
+    other = new TA(makeCtorArg(count));
     return other;
   };
 
-  sample = new TA(0);
+  sample = new TA(makeCtorArg(0));
   sample.constructor = ctor;
   result = sample.slice();
   assert.sameValue(result.length, 0, 'The value of result.length is 0');
@@ -35,7 +35,7 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.sameValue(result, other, 'The value of `result` is expected to equal the value of other');
   assert.sameValue(counter, 1, 'The value of `counter` is 1');
 
-  sample = new TA(4);
+  sample = new TA(makeCtorArg(4));
   sample.constructor = ctor;
   result = sample.slice(1, 1); // count = 0;
   assert.sameValue(result.length, 0, 'The value of result.length is 0');
@@ -46,4 +46,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   );
   assert.sameValue(result.constructor, TA, 'The value of result.constructor is expected to equal the value of TA');
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/detached-buffer.js
@@ -24,10 +24,10 @@ var obj = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.slice(obj, obj);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/return-abrupt-from-end-symbol.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/return-abrupt-from-end-symbol.js
@@ -16,10 +16,10 @@ features: [BigInt, Symbol, TypedArray]
 
 var s = Symbol("1");
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.slice(0, s);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/return-abrupt-from-end.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/return-abrupt-from-end.js
@@ -26,8 +26,8 @@ var o2 = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.slice(0, o1);
@@ -36,4 +36,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.slice(0, o2);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/return-abrupt-from-start-symbol.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/return-abrupt-from-start-symbol.js
@@ -15,10 +15,10 @@ features: [BigInt, Symbol, TypedArray]
 
 var s = Symbol("1");
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.slice(s);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/return-abrupt-from-start.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/return-abrupt-from-start.js
@@ -25,8 +25,8 @@ var o2 = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.slice(o1);
@@ -35,4 +35,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.slice(o2);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/set-values-from-different-ctor-type.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/set-values-from-different-ctor-type.js
@@ -32,8 +32,8 @@ features: [BigInt, Symbol.species, TypedArray]
 
 var arr = [42n, 43n, 44n];
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   var other = TA === BigInt64Array ? BigUint64Array : BigInt64Array;
 
   sample.constructor = {};
@@ -44,4 +44,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert(compareArray(result, arr), "values are set");
   assert.notSameValue(result.buffer, sample.buffer, "creates a new buffer");
   assert.sameValue(result.constructor, other, "used the custom ctor");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-get-ctor-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-get-ctor-abrupt.js
@@ -38,4 +38,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.slice();
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-get-ctor.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-get-ctor.js
@@ -51,4 +51,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     TA,
     "use defaultCtor on an undefined return - .constructor check"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-get-species-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-get-species-abrupt.js
@@ -42,4 +42,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.slice();
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-get-species.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-get-species.js
@@ -43,4 +43,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   sample.slice();
 
   assert.sameValue(calls, 1);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/detached-buffer-custom-ctor-other-targettype.js
+++ b/test/built-ins/TypedArray/prototype/slice/detached-buffer-custom-ctor-other-targettype.js
@@ -17,15 +17,15 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, Symbol.species, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
-  var sample = new TA(1);
+  var sample = new TA(makeCtorArg(1));
 
   sample.constructor = {};
   sample.constructor[Symbol.species] = function(count) {
     var other = TA === Int8Array ? Int16Array : Int8Array;
-    counter++;
     $DETACHBUFFER(sample.buffer);
+    counter++;
     return new other(count);
   };
 
@@ -35,4 +35,4 @@ testWithTypedArrayConstructors(function(TA) {
   }, '`sample.slice()` throws TypeError');
 
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/detached-buffer-custom-ctor-same-targettype.js
+++ b/test/built-ins/TypedArray/prototype/slice/detached-buffer-custom-ctor-same-targettype.js
@@ -15,15 +15,15 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, Symbol.species, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
-  let sample = new TA(1);
+  let sample = new TA(makeCtorArg(1));
 
   sample.constructor = {};
   sample.constructor[Symbol.species] = function(count) {
-    counter++;
     $DETACHBUFFER(sample.buffer);
-    return new TA(count);
+    counter++;
+    return new TA(makeCtorArg(count));
   };
 
   assert.throws(TypeError, function() {
@@ -32,4 +32,4 @@ testWithTypedArrayConstructors(function(TA) {
   }, '`sample.slice()` throws TypeError');
 
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/detached-buffer-get-ctor.js
+++ b/test/built-ins/TypedArray/prototype/slice/detached-buffer-get-ctor.js
@@ -15,14 +15,14 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, Symbol.species, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
-  let sample = new TA(1);
+  let sample = new TA(makeCtorArg(1));
 
   Object.defineProperty(sample, "constructor", {
     get() {
-      counter++;
       $DETACHBUFFER(sample.buffer);
+      counter++;
     }
   });
   assert.throws(TypeError, function() {
@@ -31,4 +31,4 @@ testWithTypedArrayConstructors(function(TA) {
   }, '`sample.slice()` throws TypeError');
 
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
+++ b/test/built-ins/TypedArray/prototype/slice/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
@@ -30,15 +30,15 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, Symbol.species, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
-  let sample = new TA(1);
+  let sample = new TA(makeCtorArg(1));
 
   sample.constructor = {};
   sample.constructor[Symbol.species] = function(count) {
     let other = new TA(count);
-    counter++;
     $DETACHBUFFER(other.buffer);
+    counter++;
     return other;
   };
 
@@ -48,4 +48,4 @@ testWithTypedArrayConstructors(function(TA) {
   }, '`sample.slice()` throws TypeError');
 
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
+++ b/test/built-ins/TypedArray/prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
@@ -17,19 +17,19 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, Symbol.species, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
   let sample, result, Other, other;
   let ctor = {};
   ctor[Symbol.species] = function(count) {
-    counter++;
     Other = TA === Int16Array ? Int8Array : Int16Array;
     $DETACHBUFFER(sample.buffer);
+    counter++;
     other = new Other(count);
     return other;
   };
 
-  sample = new TA(0);
+  sample = new TA(makeCtorArg(0));
   sample.constructor = ctor;
   result = sample.slice();
   assert.sameValue(result.length, 0, 'The value of result.length is 0');
@@ -38,8 +38,8 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result, other, 'The value of `result` is expected to equal the value of other');
   assert.sameValue(counter, 1, 'The value of `counter` is 1');
 
-  sample = new TA(4);
+  sample = new TA(makeCtorArg(4));
   sample.constructor = ctor;
   sample.slice(1, 1); // count = 0;
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js
+++ b/test/built-ins/TypedArray/prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js
@@ -16,18 +16,18 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [align-detached-buffer-semantics-with-web-reality, Symbol.species, TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   let counter = 0;
   let sample, result, other;
   let ctor = {};
   ctor[Symbol.species] = function(count) {
-    counter++;
     $DETACHBUFFER(sample.buffer);
-    other = new TA(count);
+    counter++;
+    other = new TA(makeCtorArg(count));
     return other;
   };
 
-  sample = new TA(0);
+  sample = new TA(makeCtorArg(0));
   sample.constructor = ctor;
   result = sample.slice();
   assert.sameValue(result.length, 0, 'The value of result.length is 0');
@@ -35,8 +35,8 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(result, other, 'The value of `result` is expected to equal the value of other');
   assert.sameValue(counter, 1, 'The value of `counter` is 1');
 
-  sample = new TA(4);
+  sample = new TA(makeCtorArg(4));
   sample.constructor = ctor;
   sample.slice(1, 1); // count = 0;
   assert.sameValue(counter, 2, 'The value of `counter` is 2');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/slice/detached-buffer.js
@@ -24,10 +24,10 @@ var obj = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.slice(obj, obj);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/slice/return-abrupt-from-end-symbol.js
+++ b/test/built-ins/TypedArray/prototype/slice/return-abrupt-from-end-symbol.js
@@ -16,10 +16,10 @@ features: [Symbol, TypedArray]
 
 var s = Symbol("1");
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.slice(0, s);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/return-abrupt-from-end.js
+++ b/test/built-ins/TypedArray/prototype/slice/return-abrupt-from-end.js
@@ -26,8 +26,8 @@ var o2 = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.slice(0, o1);
@@ -36,4 +36,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.slice(0, o2);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/return-abrupt-from-start-symbol.js
+++ b/test/built-ins/TypedArray/prototype/slice/return-abrupt-from-start-symbol.js
@@ -15,10 +15,10 @@ features: [Symbol, TypedArray]
 
 var s = Symbol("1");
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.slice(s);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/return-abrupt-from-start.js
+++ b/test/built-ins/TypedArray/prototype/slice/return-abrupt-from-start.js
@@ -25,8 +25,8 @@ var o2 = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.slice(o1);
@@ -35,4 +35,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.slice(o2);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/set-values-from-different-ctor-type.js
+++ b/test/built-ins/TypedArray/prototype/slice/set-values-from-different-ctor-type.js
@@ -32,8 +32,8 @@ features: [Symbol.species, TypedArray]
 
 var arr = [42, 43, 44];
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   var other = TA === Int8Array ? Uint8Array : Int8Array;
 
   sample.constructor = {};
@@ -44,4 +44,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert(compareArray(result, arr), "values are set");
   assert.notSameValue(result.buffer, sample.buffer, "creates a new buffer");
   assert.sameValue(result.constructor, other, "used the custom ctor");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/speciesctor-destination-backed-by-immutable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/slice/speciesctor-destination-backed-by-immutable-buffer.js
@@ -1,0 +1,95 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.slice
+description: >
+  Throws a TypeError exception when the receiver constructs an instance backed
+  by an immutable buffer
+info: |
+  %TypedArray%.prototype.slice ( start, end )
+  1. Let O be the this value.
+  2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+  3. Let srcArrayLength be TypedArrayLength(taRecord).
+  4. Let relativeStart be ? ToIntegerOrInfinity(start).
+  5. If relativeStart = -∞, let startIndex be 0.
+  6. Else if relativeStart < 0, let startIndex be max(srcArrayLength + relativeStart, 0).
+  7. Else, let startIndex be min(relativeStart, srcArrayLength).
+  8. If end is undefined, let relativeEnd be srcArrayLength; else let relativeEnd be ? ToIntegerOrInfinity(end).
+  9. If relativeEnd = -∞, let endIndex be 0.
+  10. Else if relativeEnd < 0, let endIndex be max(srcArrayLength + relativeEnd, 0).
+  11. Else, let endIndex be min(relativeEnd, srcArrayLength).
+  12. Let countBytes be max(endIndex - startIndex, 0).
+  13. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(countBytes) », ~write~).
+  14. Assert: IsImmutableBuffer(A.[[ViewedArrayBuffer]]) is false.
+
+  TypedArraySpeciesCreate ( exemplar, argumentList [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to ~read~.
+  2. Let defaultConstructor be the intrinsic object associated with the constructor name exemplar.[[TypedArrayName]] in Table 73.
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Let result be ? TypedArrayCreateFromConstructor(constructor, argumentList, accessMode).
+
+  TypedArrayCreateFromConstructor ( constructor, argumentList [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to ~read~.
+  2. Let newTypedArray be ? Construct(constructor, argumentList).
+  3. Let taRecord be ? ValidateTypedArray(newTypedArray, seq-cst, accessMode).
+
+  ValidateTypedArray ( O, order [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to read.
+  2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+  3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
+  4. If accessMode is ~write~ and IsImmutableBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+features: [Symbol.species, TypedArray, immutable-arraybuffer]
+includes: [testTypedArray.js, compareArray.js]
+---*/
+
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var calls = [];
+
+  var ta = new TA(makeCtorArg(["1", "2"]));
+  var iab = (new TA(["3", "4"])).buffer.transferToImmutable();
+  var constructor = {};
+  Object.defineProperty(ta, "constructor", {
+    get: function() {
+      calls.push("get ta.constructor");
+      return constructor;
+    }
+  });
+  Object.defineProperty(constructor, Symbol.species, {
+    get: function() {
+      calls.push("get ta.constructor[Symbol.species]");
+      return function speciesCtor() {
+        calls.push("construct result");
+        var result = new TA(iab);
+        calls.push("return result");
+        return result;
+      };
+    }
+  });
+
+  var start = {
+    valueOf() {
+      calls.push("start.valueOf");
+      return 0;
+    }
+  };
+  var end = {
+    valueOf() {
+      calls.push("end.valueOf");
+      return 2;
+    }
+  };
+
+  assert.throws(TypeError, function() {
+    ta.slice(start, end);
+  });
+  var expectCalls = [
+    "start.valueOf",
+    "end.valueOf",
+    "get ta.constructor",
+    "get ta.constructor[Symbol.species]",
+    "construct result",
+    "return result"
+  ];
+  assert.compareArray(calls, expectCalls, "Must read arguments before constructing the result.");
+});

--- a/test/built-ins/TypedArray/prototype/slice/speciesctor-get-ctor-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/slice/speciesctor-get-ctor-abrupt.js
@@ -38,4 +38,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.slice();
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/speciesctor-get-ctor.js
+++ b/test/built-ins/TypedArray/prototype/slice/speciesctor-get-ctor.js
@@ -51,4 +51,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     TA,
     "use defaultCtor on an undefined return - .constructor check"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/speciesctor-get-species-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/slice/speciesctor-get-species-abrupt.js
@@ -42,4 +42,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.slice();
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/speciesctor-get-species.js
+++ b/test/built-ins/TypedArray/prototype/slice/speciesctor-get-species.js
@@ -43,4 +43,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   sample.slice();
 
   assert.sameValue(calls, 1);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js
+++ b/test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js
@@ -17,7 +17,7 @@ info: |
         1. Let value be GetValueFromBuffer(srcBuffer, srcByteIndex, uint8, true, unordered).
         2. Perform SetValueInBuffer(targetBuffer, targetByteIndex, uint8, value, true, unordered).
         ...
-features: [TypedArray]
+features: [Symbol.species, TypedArray]
 includes: [testTypedArray.js, compareArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js
+++ b/test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js
@@ -21,15 +21,15 @@ features: [Symbol.species, TypedArray]
 includes: [testTypedArray.js, compareArray.js]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var ta = new TA([
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var ta = new TA(makeCtorArg([
     10,
     20,
     30,
     40,
     50,
     60,
-  ]);
+  ]));
 
   ta.constructor = {
     [Symbol.species]: function() {
@@ -42,4 +42,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.compareArray(result, [
     20, 20, 20, 60,
   ]);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/some/BigInt/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/some/BigInt/callbackfn-detachbuffer.js
@@ -25,9 +25,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.some(function() {
     if (loops === 0) {
@@ -38,4 +38,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/some/BigInt/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/some/BigInt/callbackfn-not-called-on-empty.js
@@ -25,12 +25,12 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().some(function() {
+  new TA(makeCtorArg(0)).some(function() {
     called++;
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/some/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/some/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.some(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/some/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/some/callbackfn-detachbuffer.js
@@ -25,9 +25,9 @@ includes: [detachArrayBuffer.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var loops = 0;
-  var sample = new TA(2);
+  var sample = new TA(makeCtorArg(2));
 
   sample.some(function() {
     if (loops === 0) {
@@ -38,4 +38,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(loops, 2);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/some/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/some/callbackfn-not-called-on-empty.js
@@ -25,12 +25,12 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var called = 0;
 
-  new TA().some(function() {
+  new TA(makeCtorArg(0)).some(function() {
     called++;
   });
 
   assert.sameValue(called, 0);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/some/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/some/detached-buffer.js
@@ -23,10 +23,10 @@ var callbackfn = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.some(callbackfn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/detached-buffer.js
@@ -50,8 +50,8 @@ var o2 = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
   begin = false;
   end = false;
 
@@ -62,4 +62,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert(begin, "observable ToInteger(begin)");
   assert(end, "observable ToInteger(end)");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/return-abrupt-from-begin-symbol.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/return-abrupt-from-begin-symbol.js
@@ -15,10 +15,10 @@ features: [BigInt, Symbol, TypedArray]
 
 var s = Symbol("1");
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.subarray(s);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/return-abrupt-from-begin.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/return-abrupt-from-begin.js
@@ -25,8 +25,8 @@ var o2 = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.subarray(o1);
@@ -35,4 +35,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.subarray(o2);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/return-abrupt-from-end-symbol.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/return-abrupt-from-end-symbol.js
@@ -16,10 +16,10 @@ features: [BigInt, Symbol, TypedArray]
 
 var s = Symbol("1");
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.subarray(0, s);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/return-abrupt-from-end.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/return-abrupt-from-end.js
@@ -26,8 +26,8 @@ var o2 = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.subarray(0, o1);
@@ -36,4 +36,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.subarray(0, o2);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/speciesctor-get-ctor-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/speciesctor-get-ctor-abrupt.js
@@ -37,4 +37,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.subarray(0);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/speciesctor-get-ctor.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/speciesctor-get-ctor.js
@@ -50,4 +50,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     TA,
     "use defaultCtor on an undefined return - .constructor check"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/speciesctor-get-species-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/speciesctor-get-species-abrupt.js
@@ -41,4 +41,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.subarray(0);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/speciesctor-get-species.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/speciesctor-get-species.js
@@ -42,4 +42,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   sample.subarray(0);
 
   assert.sameValue(calls, 1);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/byteoffset-with-detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/subarray/byteoffset-with-detached-buffer.js
@@ -20,8 +20,8 @@ features: [Symbol.species, TypedArray]
 includes: [testTypedArray.js, detachArrayBuffer.js]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var ab = new ArrayBuffer(2 * TA.BYTES_PER_ELEMENT);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var ab = makeCtorArg(2 * TA.BYTES_PER_ELEMENT);
   var ta = new TA(ab, TA.BYTES_PER_ELEMENT, 1);
   var result = new TA(0);
 
@@ -42,4 +42,4 @@ testWithTypedArrayConstructors(function(TA) {
   };
 
   assert.sameValue(ta.subarray(1, end), result);
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/subarray/byteoffset-with-detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/subarray/byteoffset-with-detached-buffer.js
@@ -16,7 +16,7 @@ info: |
     ...
     f. Let argumentsList be « buffer, 𝔽(beginByteOffset), 𝔽(newLength) ».
   17. Return ? TypedArraySpeciesCreate(O, argumentsList).
-features: [TypedArray]
+features: [Symbol.species, TypedArray]
 includes: [testTypedArray.js, detachArrayBuffer.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/subarray/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/subarray/detached-buffer.js
@@ -50,8 +50,8 @@ var o2 = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
   begin = false;
   end = false;
 
@@ -62,4 +62,4 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert(begin, "observable ToInteger(begin)");
   assert(end, "observable ToInteger(end)");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/subarray/return-abrupt-from-begin-symbol.js
+++ b/test/built-ins/TypedArray/prototype/subarray/return-abrupt-from-begin-symbol.js
@@ -15,10 +15,10 @@ features: [Symbol, TypedArray]
 
 var s = Symbol("1");
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   
   assert.throws(TypeError, function() {
     sample.subarray(s);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/return-abrupt-from-begin.js
+++ b/test/built-ins/TypedArray/prototype/subarray/return-abrupt-from-begin.js
@@ -25,8 +25,8 @@ var o2 = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   
   assert.throws(Test262Error, function() {
     sample.subarray(o1);
@@ -35,4 +35,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.subarray(o2);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/return-abrupt-from-end-symbol.js
+++ b/test/built-ins/TypedArray/prototype/subarray/return-abrupt-from-end-symbol.js
@@ -16,10 +16,10 @@ features: [Symbol, TypedArray]
 
 var s = Symbol("1");
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.subarray(0, s);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/return-abrupt-from-end.js
+++ b/test/built-ins/TypedArray/prototype/subarray/return-abrupt-from-end.js
@@ -26,8 +26,8 @@ var o2 = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   
   assert.throws(Test262Error, function() {
     sample.subarray(0, o1);
@@ -36,4 +36,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.subarray(0, o2);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-ctor-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-ctor-abrupt.js
@@ -37,4 +37,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.subarray(0);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-ctor.js
+++ b/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-ctor.js
@@ -50,4 +50,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     TA,
     "use defaultCtor on an undefined return - .constructor check"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-species-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-species-abrupt.js
@@ -41,4 +41,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.subarray(0);
   });
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-species.js
+++ b/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-species.js
@@ -42,4 +42,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   sample.subarray(0);
 
   assert.sameValue(calls, 1);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/BigInt/calls-tostring-from-each-value.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/BigInt/calls-tostring-from-each-value.js
@@ -50,9 +50,9 @@ BigInt.prototype.toLocaleString = function() {
 var arr = [42n, 0n];
 var expected = ["hacks1", "hacks2"].join(separator);
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   calls = 0;
   assert.sameValue(sample.toLocaleString(), expected, "returns expected value");
   assert.sameValue(calls, 2, "toString called once for each item");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/BigInt/detached-buffer.js
@@ -19,10 +19,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.toLocaleString();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/toLocaleString/BigInt/empty-instance-returns-empty-string.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/BigInt/empty-instance-returns-empty-string.js
@@ -20,7 +20,7 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.sameValue(sample.toLocaleString(), "");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/calls-tolocalestring-from-each-value.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/calls-tolocalestring-from-each-value.js
@@ -42,12 +42,12 @@ Number.prototype.toLocaleString = function() {
 var arr = [42, 0];
 var expected = ["hacks1", "hacks2"].join(separator);
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   calls = [];
   assert.sameValue(sample.toLocaleString(), expected, "returns expected value");
   assert(
     compareArray(new TA(calls), sample),
     "toLocaleString called for each item"
   );
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/calls-tostring-from-each-value.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/calls-tostring-from-each-value.js
@@ -50,9 +50,9 @@ Number.prototype.toLocaleString = function() {
 var arr = [42, 0];
 var expected = ["hacks1", "hacks2"].join(separator);
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   calls = 0;
   assert.sameValue(sample.toLocaleString(), expected, "returns expected value");
   assert.sameValue(calls, 2, "toString called once for each item");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/calls-valueof-from-each-value.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/calls-valueof-from-each-value.js
@@ -48,9 +48,9 @@ Number.prototype.toLocaleString = function() {
 var arr = [42, 0];
 var expected = ["hacks1", "hacks2"].join(separator);
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   calls = 0;
   assert.sameValue(sample.toLocaleString(), expected, "returns expected value");
   assert.sameValue(calls, 2, "valueOf called once for each item");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/detached-buffer.js
@@ -19,10 +19,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.toLocaleString();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/toLocaleString/empty-instance-returns-empty-string.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/empty-instance-returns-empty-string.js
@@ -20,7 +20,7 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.sameValue(sample.toLocaleString(), "");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-firstelement-tolocalestring.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-firstelement-tolocalestring.js
@@ -33,11 +33,11 @@ Number.prototype.toLocaleString = function() {
 
 var arr = [42, 0];
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   calls = 0;
-  var sample = new TA(arr);
+  var sample = new TA(makeCtorArg(arr));
   assert.throws(Test262Error, function() {
     sample.toLocaleString();
   });
   assert.sameValue(calls, 1, "abrupt from first element");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-firstelement-tostring.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-firstelement-tostring.js
@@ -45,11 +45,11 @@ Number.prototype.toLocaleString = function() {
 
 var arr = [42, 0];
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   calls = 0;
   assert.throws(Test262Error, function() {
     sample.toLocaleString();
   });
   assert.sameValue(calls, 1, "toString called once");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-firstelement-valueof.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-firstelement-valueof.js
@@ -46,11 +46,11 @@ Number.prototype.toLocaleString = function() {
 
 var arr = [42, 0];
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   calls = 0;
   assert.throws(Test262Error, function() {
     sample.toLocaleString();
   });
   assert.sameValue(calls, 1, "toString called once");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-nextelement-tolocalestring.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-nextelement-tolocalestring.js
@@ -36,11 +36,11 @@ Number.prototype.toLocaleString = function() {
 
 var arr = [42, 0];
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   calls = 0;
-  var sample = new TA(arr);
+  var sample = new TA(makeCtorArg(arr));
   assert.throws(Test262Error, function() {
     sample.toLocaleString();
   });
   assert.sameValue(calls, 2, "abrupt from a next element");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-nextelement-tostring.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-nextelement-tostring.js
@@ -47,11 +47,11 @@ Number.prototype.toLocaleString = function() {
 
 var arr = [42, 0];
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   calls = 0;
   assert.throws(Test262Error, function() {
     sample.toLocaleString();
   });
   assert.sameValue(calls, 2, "abrupt from a nextElement");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-nextelement-valueof.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-nextelement-valueof.js
@@ -48,11 +48,11 @@ Number.prototype.toLocaleString = function() {
 
 var arr = [42, 0];
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   calls = 0;
   assert.throws(Test262Error, function() {
     sample.toLocaleString();
   });
   assert.sameValue(calls, 2, "abrupt from a nextElement");
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/return-result.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/return-result.js
@@ -35,8 +35,8 @@ var separator = ["", ""].toLocaleString();
 
 var arr = [42, 0, 43];
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(arr);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(arr));
   var expected =
     sample[0].toLocaleString().toString() +
     separator +
@@ -44,4 +44,4 @@ testWithTypedArrayConstructors(function(TA) {
     separator +
     sample[2].toLocaleString().toString();
   assert.sameValue(sample.toLocaleString(), expected);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toReversed/ignores-species.js
+++ b/test/built-ins/TypedArray/prototype/toReversed/ignores-species.js
@@ -17,7 +17,7 @@ info: |
   2. Let constructor be the intrinsic object listed in column one of Table 63 for exemplar.[[TypedArrayName]].
   ...
 includes: [testTypedArray.js]
-features: [TypedArray, change-array-by-copy]
+features: [Symbol.species, TypedArray, change-array-by-copy]
 ---*/
 
 testWithTypedArrayConstructors(TA => {

--- a/test/built-ins/TypedArray/prototype/toReversed/ignores-species.js
+++ b/test/built-ins/TypedArray/prototype/toReversed/ignores-species.js
@@ -20,22 +20,22 @@ includes: [testTypedArray.js]
 features: [Symbol.species, TypedArray, change-array-by-copy]
 ---*/
 
-testWithTypedArrayConstructors(TA => {
-  var ta = new TA();
+testWithTypedArrayConstructors((TA, makeCtorArg) => {
+  var ta = new TA(makeCtorArg(0));
   ta.constructor = TA === Uint8Array ? Int32Array : Uint8Array;
   assert.sameValue(Object.getPrototypeOf(ta.toReversed()), TA.prototype);
 
-  ta = new TA();
+  ta = new TA(makeCtorArg(0));
   ta.constructor = {
     [Symbol.species]: TA === Uint8Array ? Int32Array : Uint8Array,
   };
   assert.sameValue(Object.getPrototypeOf(ta.toReversed()), TA.prototype);
 
-  ta = new TA();
+  ta = new TA(makeCtorArg(0));
   Object.defineProperty(ta, "constructor", {
     get() {
       throw new Test262Error("Should not get .constructor");
     }
   });
   ta.toReversed();
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toReversed/length-property-ignored.js
+++ b/test/built-ins/TypedArray/prototype/toReversed/length-property-ignored.js
@@ -27,9 +27,9 @@ testWithTypedArrayConstructors((TA, makeCtorArg) => {
   res = ta.toReversed();
   assert.compareArray(res, [2, 1, 0]);
   assert.sameValue(res.length, 3);
-}, null, ["passthrough"]);
+});
 
-function setLength(length) {
+function setLengthOnPrototype(length) {
     Object.defineProperty(TypedArray.prototype, "length", {
         get: () => length,
     });
@@ -38,13 +38,13 @@ function setLength(length) {
 testWithTypedArrayConstructors((TA, makeCtorArg) => {
   var ta = new TA(makeCtorArg([0, 1, 2]));
 
-  setLength(2);
+  setLengthOnPrototype(2);
   var res = ta.toReversed();
-  setLength(3);
+  setLengthOnPrototype(3);
   assert.compareArray(res, [2, 1, 0]);
 
-  setLength(5);
+  setLengthOnPrototype(5);
   res = ta.toReversed();
-  setLength(3);
+  setLengthOnPrototype(3);
   assert.compareArray(res, [2, 1, 0]);
 }, null, ["passthrough"]);

--- a/test/built-ins/TypedArray/prototype/toReversed/this-value-invalid.js
+++ b/test/built-ins/TypedArray/prototype/toReversed/this-value-invalid.js
@@ -34,11 +34,11 @@ Object.entries(invalidValues).forEach(value => {
   }, `${value[0]} is not a valid TypedArray`);
 });
 
-testWithTypedArrayConstructors(function(TA) {
-  let buffer = new ArrayBuffer(8);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  let buffer = makeCtorArg(8);
   let sample = new TA(buffer, 0, 1);
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, () => {
     sample.toReversed();
   }, `array has a detached buffer`);
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/toSorted/ignores-species.js
+++ b/test/built-ins/TypedArray/prototype/toSorted/ignores-species.js
@@ -20,22 +20,22 @@ includes: [testTypedArray.js]
 features: [Symbol.species, TypedArray, change-array-by-copy]
 ---*/
 
-testWithTypedArrayConstructors(TA => {
-  var ta = new TA();
+testWithTypedArrayConstructors((TA, makeCtorArg) => {
+  var ta = new TA(makeCtorArg(0));
   ta.constructor = TA === Uint8Array ? Int32Array : Uint8Array;
   assert.sameValue(Object.getPrototypeOf(ta.toSorted()), TA.prototype);
 
-  ta = new TA();
+  ta = new TA(makeCtorArg(0));
   ta.constructor = {
     [Symbol.species]: TA === Uint8Array ? Int32Array : Uint8Array,
   };
   assert.sameValue(Object.getPrototypeOf(ta.toSorted()), TA.prototype);
 
-  ta = new TA();
+  ta = new TA(makeCtorArg(0));
   Object.defineProperty(ta, "constructor", {
     get() {
       throw new Test262Error("Should not get .constructor");
     }
   });
   ta.toSorted();
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/toSorted/ignores-species.js
+++ b/test/built-ins/TypedArray/prototype/toSorted/ignores-species.js
@@ -17,7 +17,7 @@ info: |
   2. Let constructor be the intrinsic object listed in column one of Table 63 for exemplar.[[TypedArrayName]].
   ...
 includes: [testTypedArray.js]
-features: [TypedArray, change-array-by-copy]
+features: [Symbol.species, TypedArray, change-array-by-copy]
 ---*/
 
 testWithTypedArrayConstructors(TA => {

--- a/test/built-ins/TypedArray/prototype/toSorted/length-property-ignored.js
+++ b/test/built-ins/TypedArray/prototype/toSorted/length-property-ignored.js
@@ -27,9 +27,9 @@ testWithTypedArrayConstructors((TA, makeCtorArg) => {
   res = ta.toSorted();
   assert.compareArray(res, [1, 2, 3]);
   assert.sameValue(res.length, 3);
-}, null, ["passthrough"]);
+});
 
-function setLength(length) {
+function setLengthOnPrototype(length) {
     Object.defineProperty(TypedArray.prototype, "length", {
         get: () => length,
     });
@@ -38,14 +38,14 @@ function setLength(length) {
 testWithTypedArrayConstructors((TA, makeCtorArg) => {
   var ta = new TA(makeCtorArg([3, 1, 2]));
 
-  setLength(2);
+  setLengthOnPrototype(2);
   var res = ta.toSorted();
-  setLength(3);
+  setLengthOnPrototype(3);
   assert.compareArray(res, [1, 2, 3]);
 
-  setLength(5);
+  setLengthOnPrototype(5);
   res = ta.toSorted();
-  setLength(3);
+  setLengthOnPrototype(3);
 
   assert.compareArray(res, [1, 2, 3]);
 }, null, ["passthrough"]);

--- a/test/built-ins/TypedArray/prototype/toSorted/this-value-invalid.js
+++ b/test/built-ins/TypedArray/prototype/toSorted/this-value-invalid.js
@@ -34,11 +34,11 @@ Object.entries(invalidValues).forEach(value => {
   }, `${value[0]} is not a valid TypedArray`);
 });
 
-testWithTypedArrayConstructors(function(TA) {
-  let buffer = new ArrayBuffer(8);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  let buffer = makeCtorArg(8);
   let sample = new TA(buffer, 0, 1);
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, () => {
     sample.toSorted();
   }, `array has a detached buffer`);
-}, null, ["passthrough"]);
+}, null, ["arraybuffer"], ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/toString/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/toString/BigInt/detached-buffer.js
@@ -23,10 +23,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.toString();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/toString/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/toString/detached-buffer.js
@@ -23,10 +23,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.toString();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/values/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/values/BigInt/detached-buffer.js
@@ -18,10 +18,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.values();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/values/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/values/detached-buffer.js
@@ -18,10 +18,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.values();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/values/return-itor.js
+++ b/test/built-ins/TypedArray/prototype/values/return-itor.js
@@ -14,8 +14,8 @@ features: [TypedArray]
 
 var sample = [0, 42, 64];
 
-testWithTypedArrayConstructors(function(TA) {
-  var typedArray = new TA(sample);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var typedArray = new TA(makeCtorArg(sample));
   var itor = typedArray.values();
 
   var next = itor.next();
@@ -33,4 +33,4 @@ testWithTypedArrayConstructors(function(TA) {
   next = itor.next();
   assert.sameValue(next.value, undefined);
   assert.sameValue(next.done, true);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/with/ignores-species.js
+++ b/test/built-ins/TypedArray/prototype/with/ignores-species.js
@@ -38,4 +38,4 @@ testWithTypedArrayConstructors((TA, makeCtorArg) => {
     }
   });
   ta.with(0, 2);
-}, null, ["passthrough"]);
+});

--- a/test/built-ins/TypedArray/prototype/with/ignores-species.js
+++ b/test/built-ins/TypedArray/prototype/with/ignores-species.js
@@ -17,7 +17,7 @@ info: |
   2. Let constructor be the intrinsic object listed in column one of Table 63 for exemplar.[[TypedArrayName]].
   ...
 includes: [testTypedArray.js]
-features: [TypedArray, change-array-by-copy]
+features: [Symbol.species, TypedArray, change-array-by-copy]
 ---*/
 
 testWithTypedArrayConstructors((TA, makeCtorArg) => {

--- a/test/built-ins/TypedArray/prototype/with/length-property-ignored.js
+++ b/test/built-ins/TypedArray/prototype/with/length-property-ignored.js
@@ -27,9 +27,9 @@ testWithTypedArrayConstructors((TA, makeCtorArg) => {
   res = ta.with(0, 0);
   assert.compareArray(res, [0, 1, 2]);
   assert.sameValue(res.length, 3);
-}, null, ["passthrough"]);
+});
 
-function setLength(length) {
+function setLengthOnPrototype(length) {
     Object.defineProperty(TypedArray.prototype, "length", {
         get: () => length,
     });
@@ -38,13 +38,13 @@ function setLength(length) {
 testWithTypedArrayConstructors((TA, makeCtorArg) => {
   var ta = new TA(makeCtorArg([3, 1, 2]));
 
-  setLength(2);
+  setLengthOnPrototype(2);
   var res = ta.with(0, 0);
-  setLength(3);
+  setLengthOnPrototype(3);
   assert.compareArray(res, [0, 1, 2]);
 
-  setLength(5);
+  setLengthOnPrototype(5);
   res = ta.with(0, 0);
-  setLength(3);
+  setLengthOnPrototype(3);
   assert.compareArray(res, [0, 1, 2]);
 }, null, ["passthrough"]);


### PR DESCRIPTION
Ref #4509

> # %TypedArray%.prototype properties
> …
> - [x] read-only `%TypedArray%.prototype` properties
>   - [x] work as expected if the receiver is backed by an immutable ArrayBuffer
>   - [x] `%TypedArray%.prototype.filter` throws a TypeError if the receiver constructs an instance backed by an immutable ArrayBuffer, after determining contents
>   - [x] `%TypedArray%.prototype.map` throws a TypeError if the receiver constructs an instance backed by an immutable ArrayBuffer, after validating that _callback_ is callable but before invoking it
>   - [x] `%TypedArray%.prototype.slice` throws a TypeError if the receiver constructs an instance backed by an immutable ArrayBuffer, after coercing bounds

Note that the "Cover existing read-only TypedArray methods" commit is large but mostly mechanical, the others are small and actually specific to immutable ArrayBuffer.