### PR TITLE
[immutable-arraybuffer] Coverage for mutating TypedArray methods

### DIFF
--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/detached-buffer.js
@@ -25,10 +25,10 @@ var obj = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.copyWithin(obj, obj);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-end-is-symbol.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-end-is-symbol.js
@@ -28,9 +28,9 @@ features: [BigInt, Symbol, TypedArray]
 
 var s = Symbol(1);
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.copyWithin(0, 0, s);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-end.js
@@ -26,14 +26,14 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var o1 = {
     valueOf: function() {
       throw new Test262Error();
     }
   };
-  var sample = new TA();
+  var sample = new TA(makeCtorArg(0));
   assert.throws(Test262Error, function() {
     sample.copyWithin(0, 0, o1);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-start-is-symbol.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-start-is-symbol.js
@@ -27,9 +27,9 @@ features: [BigInt, Symbol, TypedArray]
 
 var s = Symbol(1);
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.copyWithin(0, s);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-start.js
@@ -37,9 +37,9 @@ var err = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(Test262Error, function() {
     sample.copyWithin(0, o, err);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-target-is-symbol.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-target-is-symbol.js
@@ -27,9 +27,9 @@ features: [BigInt, Symbol, TypedArray]
 
 var s = Symbol(1);
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.copyWithin(s, 0);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-target.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-target.js
@@ -31,9 +31,9 @@ var o = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(Test262Error, function() {
     sample.copyWithin(o);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
@@ -16,8 +16,8 @@ includes: [nans.js, compareArray.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function body(FloatArray) {
-  var subject = new FloatArray(NaNs.length * 2);
+testWithTypedArrayConstructors(function body(FloatArray, makeCtorArg) {
+  var subject = new FloatArray(makeCtorArg(NaNs.length * 2));
 
   NaNs.forEach(function(v, i) {
     subject[i] = v;
@@ -39,4 +39,4 @@ testWithTypedArrayConstructors(function body(FloatArray) {
   );
 
   assert(compareArray(originalBytes, copiedBytes));
-}, floatArrayConstructors);
+}, floatArrayConstructors, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached-prototype.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached-prototype.js
@@ -21,7 +21,7 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var ta;
   var array = [];
 
@@ -33,8 +33,8 @@ testWithTypedArrayConstructors(function(TA) {
 
   array.length = 10000; // big arrays are more likely to cause a crash if they are accessed after they are freed
   array.fill(7, 0);
-  ta = new TA(array);
+  ta = new TA(makeCtorArg(array));
   assert.throws(TypeError, function(){
     ta.copyWithin(0, 100, {valueOf : detachAndReturnIndex});
   }, "should throw TypeError as array is detached");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached.js
@@ -21,7 +21,7 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var ta;
   function detachAndReturnIndex(){
       $DETACHBUFFER(ta.buffer);
@@ -31,8 +31,8 @@ testWithTypedArrayConstructors(function(TA) {
   var array = [];
   array.length = 10000; // big arrays are more likely to cause a crash if they are accessed after they are freed
   array.fill(7, 0);
-  ta = new TA(array);
+  ta = new TA(makeCtorArg(array));
   assert.throws(TypeError, function(){
     ta.copyWithin(0, 100, {valueOf : detachAndReturnIndex});
   }, "should throw TypeError as array is detached");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js
@@ -21,7 +21,7 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var ta;
   function detachAndReturnIndex(){
       $DETACHBUFFER(ta.buffer);
@@ -31,8 +31,8 @@ testWithTypedArrayConstructors(function(TA) {
   var array = [];
   array.length = 10000; // big arrays are more likely to cause a crash if they are accessed after they are freed
   array.fill(7, 0);
-  ta = new TA(array);
+  ta = new TA(makeCtorArg(array));
   assert.throws(TypeError, function(){
     ta.copyWithin(0, {valueOf : detachAndReturnIndex}, 1000);
   }, "should throw TypeError as array is detached");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/detached-buffer.js
@@ -25,10 +25,10 @@ var obj = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.copyWithin(obj, obj);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/immutable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/immutable-buffer.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.copywithin
+description: Throws a TypeError exception when the backing buffer is immutable
+info: |
+  %TypedArray%.prototype.copyWithin ( target, start [ , end ] )
+  1. Let O be the this value.
+  2. Let taRecord be ? ValidateTypedArray(O, ~seq-cst~, ~write~).
+  3. Let len be TypedArrayLength(taRecord).
+  4. Let relativeTarget be ? ToIntegerOrInfinity(target).
+  5. If relativeTarget = -∞, let targetIndex be 0.
+  6. Else if relativeTarget < 0, let targetIndex be max(len + relativeTarget, 0).
+  7. Else, let targetIndex be min(relativeTarget, len).
+  8. Let relativeStart be ? ToIntegerOrInfinity(start).
+  9. If relativeStart = -∞, let startIndex be 0.
+  10. Else if relativeStart < 0, let startIndex be max(len + relativeStart, 0).
+  11. Else, let startIndex be min(relativeStart, len).
+  12. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
+
+  ValidateTypedArray ( O, order [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to read.
+  2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+  3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
+  4. If accessMode is ~write~ and IsImmutableBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+features: [TypedArray, immutable-arraybuffer]
+includes: [testTypedArray.js, compareArray.js]
+---*/
+
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var calls = [];
+
+  var ta = new TA(makeCtorArg(["1", "2", "3", "4"]));
+  var target = {
+    valueOf() {
+      calls.push("target.valueOf");
+      return 1;
+    }
+  };
+  var start = {
+    valueOf() {
+      calls.push("start.valueOf");
+      return 2;
+    }
+  };
+  var end = {
+    valueOf() {
+      calls.push("end.valueOf");
+      return 2;
+    }
+  };
+
+  assert.throws(TypeError, function() {
+    ta.copyWithin(target, start, end);
+  });
+  assert.compareArray(calls, [], "Must verify mutability before reading arguments.");
+  assert.compareArray(ta, new TA(["1", "2", "3", "4"]), "Must not mutate contents.");
+}, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-end-is-symbol.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-end-is-symbol.js
@@ -28,9 +28,9 @@ features: [Symbol, TypedArray]
 
 var s = Symbol(1);
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.copyWithin(0, 0, s);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-end.js
@@ -26,14 +26,14 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var o1 = {
     valueOf: function() {
       throw new Test262Error();
     }
   };
-  var sample = new TA();
+  var sample = new TA(makeCtorArg(0));
   assert.throws(Test262Error, function() {
     sample.copyWithin(0, 0, o1);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-start-is-symbol.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-start-is-symbol.js
@@ -27,9 +27,9 @@ features: [Symbol, TypedArray]
 
 var s = Symbol(1);
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.copyWithin(0, s);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-start.js
@@ -37,9 +37,9 @@ var err = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(Test262Error, function() {
     sample.copyWithin(0, o, err);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-target-is-symbol.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-target-is-symbol.js
@@ -27,9 +27,9 @@ features: [Symbol, TypedArray]
 
 var s = Symbol(1);
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.copyWithin(s, 0);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-target.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-target.js
@@ -31,9 +31,9 @@ var o = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(Test262Error, function() {
     sample.copyWithin(o);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/detached-buffer.js
@@ -25,10 +25,10 @@ var obj = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.fill(obj);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-end-as-symbol.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-end-as-symbol.js
@@ -30,9 +30,9 @@ features: [BigInt, Symbol, TypedArray]
 
 var end = Symbol(1);
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.fill(1n, 0, end);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-end.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-end.js
@@ -34,9 +34,9 @@ var end = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(Test262Error, function() {
     sample.fill(1n, 0, end);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-start-as-symbol.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-start-as-symbol.js
@@ -29,9 +29,9 @@ features: [BigInt, Symbol, TypedArray]
 
 var start = Symbol(1);
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.fill(1n, start);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-start.js
+++ b/test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-start.js
@@ -33,9 +33,9 @@ var start = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(Test262Error, function() {
     sample.fill(1n, start);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/coerced-end-detach.js
+++ b/test/built-ins/TypedArray/prototype/fill/coerced-end-detach.js
@@ -14,8 +14,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(10);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(10));
 
   function detachAndReturnIndex(){
     $DETACHBUFFER(sample.buffer);
@@ -25,4 +25,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.fill(0x77, 0, {valueOf: detachAndReturnIndex});
   }, "Detachment when coercing end should throw TypeError");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/coerced-start-detach.js
+++ b/test/built-ins/TypedArray/prototype/fill/coerced-start-detach.js
@@ -15,8 +15,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(10);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(10));
 
   function detachAndReturnIndex(){
     $DETACHBUFFER(sample.buffer);
@@ -26,4 +26,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.fill(0x77, {valueOf: detachAndReturnIndex}, 10);
   }, "Detachment when coercing start should throw TypeError");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/coerced-value-detach.js
+++ b/test/built-ins/TypedArray/prototype/fill/coerced-value-detach.js
@@ -15,8 +15,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(10);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(10));
 
   function detachAndReturnIndex(){
     $DETACHBUFFER(sample.buffer);
@@ -26,4 +26,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.fill({valueOf: detachAndReturnIndex}, 0, 10);
   }, "Detachment when coercing value should throw TypeError");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/fill/detached-buffer.js
@@ -25,10 +25,10 @@ var obj = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.fill(obj);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/immutable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/fill/immutable-buffer.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.fill
+description: Throws a TypeError exception when the backing buffer is immutable
+info: |
+  %TypedArray%.prototype.fill ( value [ , start [ , end ] ] )
+  1. Let O be the this value.
+  2. Let taRecord be ? ValidateTypedArray(O, ~seq-cst~, ~write~).
+  3. Let len be TypedArrayLength(taRecord).
+  4. If O.[[ContentType]] is bigint, set value to ? ToBigInt(value).
+  5. Otherwise, set value to ? ToNumber(value).
+  6. Let relativeStart be ? ToIntegerOrInfinity(start).
+  7. If relativeStart = -∞, let startIndex be 0.
+  8. Else if relativeStart < 0, let startIndex be max(len + relativeStart, 0).
+  9. Else, let startIndex be min(relativeStart, len).
+  10. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
+
+  ValidateTypedArray ( O, order [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to read.
+  2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+  3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
+  4. If accessMode is ~write~ and IsImmutableBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+features: [TypedArray, immutable-arraybuffer]
+includes: [testTypedArray.js, compareArray.js]
+---*/
+
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var calls = [];
+
+  var ta = new TA(makeCtorArg(["1", "2", "3", "4"]));
+  var value = {
+    valueOf() {
+      calls.push("value.valueOf");
+      return "8";
+    }
+  };
+  var start = {
+    valueOf() {
+      calls.push("start.valueOf");
+      return 1;
+    }
+  };
+  var end = {
+    valueOf() {
+      calls.push("end.valueOf");
+      return 1;
+    }
+  };
+
+  assert.throws(TypeError, function() {
+    ta.fill(value, start, end);
+  });
+  assert.compareArray(calls, [], "Must verify mutability before reading arguments.");
+  assert.compareArray(ta, new TA(["1", "2", "3", "4"]), "Must not mutate contents.");
+}, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-end-as-symbol.js
+++ b/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-end-as-symbol.js
@@ -30,9 +30,9 @@ features: [Symbol, TypedArray]
 
 var end = Symbol(1);
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.fill(1, 0, end);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-end.js
+++ b/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-end.js
@@ -34,9 +34,9 @@ var end = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(Test262Error, function() {
     sample.fill(1, 0, end);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-start-as-symbol.js
+++ b/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-start-as-symbol.js
@@ -29,9 +29,9 @@ features: [Symbol, TypedArray]
 
 var start = Symbol(1);
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(TypeError, function() {
     sample.fill(1, start);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-start.js
+++ b/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-start.js
@@ -33,9 +33,9 @@ var start = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
   assert.throws(Test262Error, function() {
     sample.fill(1, start);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reverse/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reverse/BigInt/detached-buffer.js
@@ -19,10 +19,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.reverse();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reverse/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reverse/detached-buffer.js
@@ -19,10 +19,10 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.reverse();
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/reverse/immutable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reverse/immutable-buffer.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.reverse
+description: Throws a TypeError exception when the backing buffer is immutable
+info: |
+  %TypedArray%.prototype.reverse ( )
+  1. Let O be the this value.
+  2. Let taRecord be ? ValidateTypedArray(O, ~seq-cst~, ~write~).
+
+  ValidateTypedArray ( O, order [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to read.
+  2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+  3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
+  4. If accessMode is ~write~ and IsImmutableBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+features: [TypedArray, immutable-arraybuffer]
+includes: [testTypedArray.js, compareArray.js]
+---*/
+
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var ta = new TA(makeCtorArg(["1", "2", "3", "4"]));
+
+  assert.throws(TypeError, function() {
+    ta.reverse();
+  });
+  assert.compareArray(ta, new TA(["1", "2", "3", "4"]), "Must not mutate contents.");
+}, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-get-length.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-get-length.js
@@ -30,4 +30,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.set(obj);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-get-value.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-src-get-value.js
@@ -45,4 +45,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(sample, [42n, 43n, 3n, 4n]),
     "values are set until exception"
   );
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset.js
@@ -28,8 +28,8 @@ var obj2 = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.set([], obj1);
@@ -38,4 +38,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.set([], obj2);
   }, "abrupt from toString");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-set-values-in-order.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-set-values-in-order.js
@@ -69,4 +69,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(calls, [0, "0,0,0,0,0", 1, "0,42,0,0,0", 2, "0,42,43,0,0"]),
     "values are set in order"
   );
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-src-values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-src-values-are-not-cached.js
@@ -44,4 +44,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   sample.set(obj);
 
   assert(compareArray(sample, [42n, 43n, 44n, 45n, 46n]));
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
@@ -21,8 +21,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
   var calledOffset = 0;
   var obj = {
     valueOf: function() {
@@ -36,4 +36,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(calledOffset, 1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-targetbuffer-detached-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-targetbuffer-detached-throws.js
@@ -29,8 +29,8 @@ Object.defineProperty(obj, "length", {
   }
 });
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
   $DETACHBUFFER(sample.buffer);
 
   assert.throws(TypeError, function() {
@@ -40,4 +40,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.set(obj);
   }, "IsDetachedBuffer happens before Get(src.length)");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-negative-integer-offset-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-negative-integer-offset-throws.js
@@ -16,8 +16,8 @@ includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(RangeError, function() {
     sample.set(sample, -1);
@@ -30,4 +30,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(RangeError, function() {
     sample.set(sample, -Infinity);
   }, "-Infinity");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset-symbol.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset-symbol.js
@@ -17,10 +17,10 @@ features: [BigInt, Symbol, TypedArray]
 
 var s = Symbol("1");
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.set(sample, s);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset.js
@@ -27,8 +27,8 @@ var obj2 = {
   }
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.set(sample, obj1);
@@ -37,4 +37,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.set(sample, obj2);
   }, "abrupt from toString");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
@@ -20,9 +20,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample = new TA();
-  var target = new TA();
+  var target = new TA(makeCtorArg(0));
   var calledOffset = 0;
   var obj = {
     valueOf: function() {
@@ -36,4 +36,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(calledOffset, 1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-target-byteoffset-internal.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-target-byteoffset-internal.js
@@ -41,4 +41,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   sample.set(src3);
 
   assert.sameValue(getCalls, 0, "ignores byteoffset properties");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
@@ -20,9 +20,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [BigInt, TypedArray]
 ---*/
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
-  var src = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
+  var src = new TA(makeCtorArg(1));
   var calledOffset = 0;
   var obj = {
     valueOf: function() {
@@ -36,4 +36,4 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(calledOffset, 1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-get-length.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-get-length.js
@@ -30,4 +30,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample.set(obj);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-get-value.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-src-get-value.js
@@ -45,4 +45,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(sample, [42, 43, 3, 4]),
     "values are set until exception"
   );
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-tointeger-offset.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-return-abrupt-from-tointeger-offset.js
@@ -28,8 +28,8 @@ var obj2 = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.set([], obj1);
@@ -38,4 +38,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.set([], obj2);
   }, "abrupt from toString");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-set-values-in-order.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-set-values-in-order.js
@@ -69,4 +69,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
     compareArray(calls, [0, "0,0,0,0,0", 1, "0,42,0,0,0", 2, "0,42,43,0,0"]),
     "values are set in order"
   );
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-src-values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-src-values-are-not-cached.js
@@ -44,4 +44,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   sample.set(obj);
 
   assert(compareArray(sample, [42, 43, 44, 45, 46]));
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-targetbuffer-detached-on-get-src-value-no-throw.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-targetbuffer-detached-on-get-src-value-no-throw.js
@@ -8,8 +8,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA([1, 2, 3]);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg([1, 2, 3]));
   var obj = {
     length: 3,
     "0": 42
@@ -33,4 +33,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(0, sample.byteLength);
   assert.sameValue(0, sample.byteOffset);
   assert.sameValue(0, sample.length);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
@@ -21,8 +21,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
   var calledOffset = 0;
   var obj = {
     valueOf: function() {
@@ -36,4 +36,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(calledOffset, 1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/array-arg-targetbuffer-detached-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-targetbuffer-detached-throws.js
@@ -29,8 +29,8 @@ Object.defineProperty(obj, "length", {
   }
 });
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
   $DETACHBUFFER(sample.buffer);
 
   assert.throws(TypeError, function() {
@@ -40,4 +40,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     sample.set(obj);
   }, "IsDetachedBuffer happens before Get(src.length)");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/set/bit-precision.js
@@ -19,8 +19,8 @@ includes: [nans.js, compareArray.js, testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function body(FA) {
-  var source = new FA(NaNs);
+testWithTypedArrayConstructors(function body(FA, makeCtorArg) {
+  var source = new FA(makeCtorArg(NaNs));
   var target = new FA(NaNs.length);
   var sourceBytes, targetBytes;
 
@@ -30,4 +30,4 @@ testWithTypedArrayConstructors(function body(FA) {
   targetBytes = new Uint8Array(target.buffer);
 
   assert(compareArray(sourceBytes, targetBytes))
-}, floatArrayConstructors);
+}, floatArrayConstructors, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/immutable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/set/immutable-buffer.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.set
+description: Throws a TypeError exception when the backing buffer is immutable
+info: |
+  %TypedArray%.prototype.set ( source [ , offset ] )
+  1. Let target be the this value.
+  ...
+  3. Perform ? RequireInternalSlot(target, [[TypedArrayName]]).
+  4. Assert: target has a [[ViewedArrayBuffer]] internal slot.
+  5. If IsImmutableBuffer(target.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+  6. Let targetOffset be ? ToIntegerOrInfinity(offset).
+features: [TypedArray, immutable-arraybuffer]
+includes: [testTypedArray.js, compareArray.js]
+---*/
+
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var calls = [];
+
+  var ta = new TA(makeCtorArg(["1", "2", "3", "4"]));
+  var source = {
+    get length() {
+      calls.push("get source.length");
+      return 1;
+    },
+    get 0() {
+      calls.push("get source[0]");
+      return "8";
+    },
+  };
+  var offset = {
+    valueOf() {
+      calls.push("offset.valueOf");
+      return 1;
+    }
+  };
+
+  assert.throws(TypeError, function() {
+    ta.set(source, offset);
+  });
+  assert.compareArray(calls, [], "Must verify mutability before reading arguments.");
+  assert.compareArray(ta, new TA(["1", "2", "3", "4"]), "Must not mutate contents.");
+}, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-negative-integer-offset-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-negative-integer-offset-throws.js
@@ -16,8 +16,8 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(RangeError, function() {
     sample.set(sample, -1);
@@ -30,4 +30,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(RangeError, function() {
     sample.set(sample, -Infinity);
   }, "-Infinity");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-return-abrupt-from-tointeger-offset-symbol.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-return-abrupt-from-tointeger-offset-symbol.js
@@ -17,10 +17,10 @@ features: [Symbol, TypedArray]
 
 var s = Symbol("1");
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(TypeError, function() {
     sample.set(sample, s);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-return-abrupt-from-tointeger-offset.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-return-abrupt-from-tointeger-offset.js
@@ -27,8 +27,8 @@ var obj2 = {
   }
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA();
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(0));
 
   assert.throws(Test262Error, function() {
     sample.set(sample, obj1);
@@ -37,4 +37,4 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
     sample.set(sample, obj2);
   }, "abrupt from toString");
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
@@ -20,9 +20,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample = new TA();
-  var target = new TA();
+  var target = new TA(makeCtorArg(0));
   var calledOffset = 0;
   var obj = {
     valueOf: function() {
@@ -36,4 +36,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(calledOffset, 1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
@@ -20,9 +20,9 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(2);
-  var src = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(2));
+  var src = new TA(makeCtorArg(1));
   var calledOffset = 0;
   var obj = {
     valueOf: function() {
@@ -36,4 +36,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(calledOffset, 1);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/BigInt/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/sort/BigInt/detached-buffer.js
@@ -22,10 +22,10 @@ var comparefn = function() {
   throw new Test262Error();
 };
 
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.sort(comparefn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/sort/detached-buffer.js
@@ -22,10 +22,10 @@ var comparefn = function() {
   throw new Test262Error();
 };
 
-testWithTypedArrayConstructors(function(TA) {
-  var sample = new TA(1);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var sample = new TA(makeCtorArg(1));
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
     sample.sort(comparefn);
   });
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/immutable-buffer.js
+++ b/test/built-ins/TypedArray/prototype/sort/immutable-buffer.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.sort
+description: Throws a TypeError exception when the backing buffer is immutable
+info: |
+  %TypedArray%.prototype.sort ( comparator )
+  1. If comparator is not undefined and IsCallable(comparator) is false, throw a TypeError exception.
+  2. Let obj be the this value.
+  3. Let taRecord be ? ValidateTypedArray(obj, ~seq-cst~, ~write~).
+  4. Let len be TypedArrayLength(taRecord).
+  5. NOTE: The following closure performs a numeric comparison rather than the string comparison used in 23.1.3.30.
+  6. Let SortCompare be a new Abstract Closure with parameters (x, y) that captures comparator and performs the following steps when called:
+     a. Return ? CompareTypedArrayElements(x, y, comparator).
+  7. Let sortedList be ? SortIndexedProperties(obj, len, SortCompare, ~read-through-holes~).
+
+  ValidateTypedArray ( O, order [ , accessMode ] )
+  1. If accessMode is not present, set accessMode to read.
+  2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+  3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
+  4. If accessMode is ~write~ and IsImmutableBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+features: [TypedArray, immutable-arraybuffer]
+includes: [testTypedArray.js, compareArray.js]
+---*/
+
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var calls = [];
+
+  var ta = new TA(makeCtorArg(["1", "2", "3", "4"]));
+  function comparator() {
+    calls.push("compare");
+    return 0;
+  }
+
+  assert.throws(TypeError, function() {
+    ta.sort(comparator);
+  });
+  assert.compareArray(calls, [], "Must verify mutability before comparing.");
+  assert.compareArray(ta, new TA(["1", "2", "3", "4"]), "Must not mutate contents.");
+
+  calls = [];
+  var empty = new TA(makeCtorArg(0));
+  assert.throws(TypeError, function() {
+    empty.sort(comparator);
+  }, "Must verify mutability even when receiver is length 0");
+}, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/sort-tonumber.js
+++ b/test/built-ins/TypedArray/prototype/sort/sort-tonumber.js
@@ -16,8 +16,8 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
-testWithTypedArrayConstructors(function(TA) {
-  var ta = new TA(4);
+testWithTypedArrayConstructors(function(TA, makeCtorArg) {
+  var ta = new TA(makeCtorArg(4));
   var ab = ta.buffer;
 
   var called = false;
@@ -30,4 +30,4 @@ testWithTypedArrayConstructors(function(TA) {
   });
 
   assert.sameValue(true, called);
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArray/prototype/sort/stability.js
+++ b/test/built-ins/TypedArray/prototype/sort/stability.js
@@ -12,11 +12,11 @@ features: [TypedArray, stable-typedarray-sort]
 // Treat 0..3, 4..7, etc. as equal.
 const compare = (a, b) => (a / 4 | 0) - (b / 4 | 0);
 
-testWithTypedArrayConstructors(TA => {
+testWithTypedArrayConstructors((TA, makeCtorArg) => {
   // Create an array of the form `[0, 1, …, 126, 127]`.
   const array = Array.from({ length: 128 }, (_, i) => i);
 
-  const typedArray1 = new TA(array);
+  const typedArray1 = new TA(makeCtorArg(array));
   assert(compareArray(
     typedArray1.sort(compare),
     array
@@ -25,7 +25,7 @@ testWithTypedArrayConstructors(TA => {
   // Reverse `array` in-place so it becomes `[127, 126, …, 1, 0]`.
   array.reverse();
 
-  const typedArray2 = new TA(array);
+  const typedArray2 = new TA(makeCtorArg(array));
   assert(compareArray(
     typedArray2.sort(compare),
     [
@@ -42,4 +42,4 @@ testWithTypedArrayConstructors(TA => {
       123, 122, 121, 120,   127, 126, 125, 124,
     ]
   ), 'not presorted');
-}, null, ["passthrough"]);
+}, null, null, ["immutable"]);

--- a/test/built-ins/Uint8Array/prototype/setFromBase64/throws-when-target-is-backed-by-immutable-arraybuffer.js
+++ b/test/built-ins/Uint8Array/prototype/setFromBase64/throws-when-target-is-backed-by-immutable-arraybuffer.js
@@ -1,19 +1,52 @@
-// Copyright (C) 2026 Kevin Gibbons. All rights reserved.
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 esid: sec-uint8array.prototype.setfrombase64
-description: Uint8Array.prototype.setFromBase64 throws a TypeError when the target is backed by an immutable ArrayBuffer.
-features: [ArrayBuffer, TypedArray, uint8array-base64, immutable-arraybuffer]
+description: Throws a TypeError exception when the backing buffer is immutable
+info: |
+  Uint8Array.prototype.setFromBase64 ( string [ , options ] )
+  1. Let into be the this value.
+  2. Perform ? ValidateUint8Array(into).
+  3. If string is not a String, throw a TypeError exception.
+  4. Let opts be ? GetOptionsObject(options).
+  5. Let alphabet be ? Get(opts, "alphabet").
+  6. If alphabet is undefined, set alphabet to "base64".
+  7. If alphabet is neither "base64" nor "base64url", throw a TypeError exception.
+  8. Let lastChunkHandling be ? Get(opts, "lastChunkHandling").
+features: [TypedArray, uint8array-base64, immutable-arraybuffer]
+includes: [testTypedArray.js, compareArray.js]
 ---*/
 
-var iab = (new ArrayBuffer(10)).transferToImmutable();
-var target = new Uint8Array(iab);
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var calls = [];
 
-assert.throws(TypeError, function () {
-  target.setFromBase64('Zg==');
-});
+  var ta = new TA(makeCtorArg(["1", "2", "3", "4"]));
+  var options = {
+    get alphabet() {
+      calls.push("get options.alphabet");
+      return undefined;
+    },
+    get lastChunkHandling() {
+      calls.push("get options.lastChunkHandling");
+      return undefined;
+    },
+  };
 
-assert.throws(TypeError, function () {
-  target.setFromBase64('');
-});
+  assert.throws(TypeError, function() {
+    ta.setFromBase64("Zm9v", options);
+  }, "non-empty base64");
+  assert.compareArray(calls, [],
+    "Must verify mutability before reading arguments (non-empty base64).");
+  assert.compareArray(ta, new TA(["1", "2", "3", "4"]),
+    "Must not mutate contents (non-empty base64).");
+
+  calls = [];
+  assert.throws(TypeError, function() {
+    ta.setFromBase64("", options);
+  }, "empty base64");
+  assert.compareArray(calls, [],
+    "Must verify mutability before reading arguments (empty base64).");
+  assert.compareArray(ta, new TA(["1", "2", "3", "4"]),
+    "Must not mutate contents (empty base64).");
+}, [Uint8Array], ["immutable"]);

--- a/test/built-ins/Uint8Array/prototype/setFromHex/throws-when-target-is-backed-by-immutable-arraybuffer.js
+++ b/test/built-ins/Uint8Array/prototype/setFromHex/throws-when-target-is-backed-by-immutable-arraybuffer.js
@@ -1,19 +1,29 @@
-// Copyright (C) 2026 Kevin Gibbons. All rights reserved.
+// Copyright (C) 2025 Richard Gibson. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 esid: sec-uint8array.prototype.setfromhex
-description: Uint8Array.prototype.setFromHex throws a TypeError when the target is backed by an immutable ArrayBuffer.
-features: [ArrayBuffer, TypedArray, uint8array-base64, immutable-arraybuffer]
+description: Throws a TypeError exception when the backing buffer is immutable
+info: |
+  Uint8Array.prototype.setFromHex ( string )
+  1. Let into be the this value.
+  2. Perform ? ValidateUint8Array(into).
+features: [TypedArray, uint8array-base64, immutable-arraybuffer]
+includes: [testTypedArray.js, compareArray.js]
 ---*/
 
-var iab = (new ArrayBuffer(10)).transferToImmutable();
-var target = new Uint8Array(iab);
+testWithAllTypedArrayConstructors((TA, makeCtorArg) => {
+  var ta = new TA(makeCtorArg(["1", "2", "3", "4"]));
 
-assert.throws(TypeError, function () {
-  target.setFromHex('aa');
-});
+  assert.throws(TypeError, function() {
+    ta.setFromHex("666f6f");
+  }, "non-empty hex");
+  assert.compareArray(ta, new TA(["1", "2", "3", "4"]),
+    "Must not mutate contents (non-empty hex).");
 
-assert.throws(TypeError, function () {
-  target.setFromHex('');
-});
+  assert.throws(TypeError, function() {
+    ta.setFromHex("");
+  }, "empty hex");
+  assert.compareArray(ta, new TA(["1", "2", "3", "4"]),
+    "Must not mutate contents (empty hex).");
+}, [Uint8Array], ["immutable"]);


### PR DESCRIPTION
Ref #4509

> # %TypedArray%.prototype properties
> 
> - [x] `%TypedArray%.prototype.{copyWithin,fill,reverse,set}`
>   - [x] throws a TypeError if the receiver is backed by an immutable ArrayBuffer, before touching any argument
>   - [x] ...even if the targeted range is of length 0
> 
> - [x] `%TypedArray%.prototype.sort`
>   - [x] throws a TypeError if the receiver is backed by an immutable ArrayBuffer, after validating that _comparator_ is callable (_**note the unusual receiver-after-argument order**_)
>   - [x] ...even if the receiver is of length 0
> 
> - [x] `Uint8Array.prototype.{setFromBase64,setFromHex}`
>   - [x] throws a TypeError if the receiver is backed by an immutable ArrayBuffer, before touching any argument