### PR TITLE
Temporal: Add tests for observable order of options get and cast

### DIFF
--- a/test/built-ins/Temporal/Duration/compare/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/Duration/compare/options-read-before-algorithmic-validation.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: All options properties are read before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = ["get options.relativeTo"];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, { relativeTo: undefined }, "options");
+
+const d1 = new Temporal.Duration(0, 0, 0, /* days = */ 1);
+const d2 = new Temporal.Duration(1);
+
+assert.throws(RangeError, function () {
+  Temporal.Duration.compare(d1, d2, options);
+}, "exception thrown when calendar units provided without relativeTo");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/Duration/prototype/round/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/options-read-before-algorithmic-validation.js
@@ -1,0 +1,74 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.relativeTo",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "years",
+  largestUnit: "nanoseconds",
+  roundingIncrement: 1,
+  roundingMode: "halfCeil",
+  relativeTo: undefined,
+}, "options");
+
+const instance = new Temporal.Duration(1);
+
+assert.throws(RangeError, function () {
+  instance.round(options);
+}, "exception thrown when smallestUnit > largestUnit");
+assert.compareArray(actual, expected, "all options should be read first");
+actual.splice(0);  // clear
+
+// Test again, with largestUnit and smallestUnit undefined. The error that's
+// thrown in that case is the earliest algorithmic validation that takes place,
+// but we can't test it simultaneously with testing that largestUnit and
+// smallestUnit are cast at the right time.
+
+const expectedWithoutUnits = [
+  "get options.largestUnit",
+  "get options.relativeTo",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+];
+
+const optionsWithoutUnits = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: undefined,
+  largestUnit: undefined,
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+  relativeTo: undefined,
+}, "options");
+
+assert.throws(RangeError, function () {
+  instance.round(optionsWithoutUnits);
+}, "exception thrown when neither smallestUnit nor largestUnit present");
+assert.compareArray(actual, expectedWithoutUnits, "all options should be read first");
+actual.splice(0);  // clear

--- a/test/built-ins/Temporal/Duration/prototype/toString/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/options-read-before-algorithmic-validation.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.fractionalSecondDigits",
+  "get options.fractionalSecondDigits.toString",
+  "call options.fractionalSecondDigits.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "seconds",
+  fractionalSecondDigits: "auto",
+  roundingMode: "expand",
+}, "options");
+
+const instance = new Temporal.Duration(0, 0, 0, 0, 0, 0, /* seconds = */ Number.MAX_SAFE_INTEGER, 1);
+
+assert.throws(RangeError, function () {
+  instance.toString(options);
+}, "exception thrown when result is out of range");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/Duration/prototype/total/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/options-read-before-algorithmic-validation.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.relativeTo",
+  "get options.unit",
+  "get options.unit.toString",
+  "call options.unit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  unit: "weeks",
+  relativeTo: undefined,
+}, "options");
+
+const instance = new Temporal.Duration(1);
+
+assert.throws(RangeError, function () {
+  instance.total(options);
+}, "exception thrown when total of calendar unit requested without relativeTo");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/Instant/prototype/round/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/Instant/prototype/round/options-read-before-algorithmic-validation.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.round
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "hour",
+  roundingIncrement: 25,
+  roundingMode: "expand",
+}, "options");
+
+const instance = new Temporal.Instant(1n);
+
+assert.throws(RangeError, function () {
+  instance.round(options);
+}, "exception thrown when roundingIncrement invalid for smallestUnit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/Instant/prototype/since/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "nanosecond",
+  largestUnit: "week",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.Instant(0n);
+const other = new Temporal.Instant(1000n);
+
+assert.throws(RangeError, function () {
+  instance.since(other, options);
+}, "exception thrown when largestUnit disallowed");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/Instant/prototype/toString/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/options-read-before-algorithmic-validation.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.fractionalSecondDigits",
+  "get options.fractionalSecondDigits.toString",
+  "call options.fractionalSecondDigits.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+  "get options.timeZone",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "month",
+  fractionalSecondDigits: "auto",
+  roundingMode: "expand",
+  timeZone: undefined,
+}, "options");
+
+const instance = new Temporal.Instant(0n);
+
+assert.throws(RangeError, function () {
+  instance.toString(options);
+}, "exception thrown when unit is a date unit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/Instant/prototype/until/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "nanosecond",
+  largestUnit: "week",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.Instant(0n);
+const other = new Temporal.Instant(1000n);
+
+assert.throws(RangeError, function () {
+  instance.until(other, options);
+}, "exception thrown when largestUnit disallowed");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDate/from/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDate/from/options-read-before-algorithmic-validation.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+assert.throws(RangeError, function () {
+  Temporal.PlainDate.from({ year: 2025, monthCode: "M08L", day: 14 }, options);
+}, "exception thrown when month code is invalid for calendar");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDate/prototype/add/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/add/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.add
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "reject",
+}, "options");
+
+const instance = new Temporal.PlainDate(2025, 8, 31);
+
+assert.throws(RangeError, function () {
+  instance.add(new Temporal.Duration(0, 1), options);
+}, "overflow reject exception thrown");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDate/prototype/since/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "nanosecond",
+  largestUnit: "hour",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.PlainDate(2025, 8, 14);
+const other = new Temporal.PlainDate(2025, 3, 14);
+
+assert.throws(RangeError, function () {
+  instance.since(other, options);
+}, "exception thrown when largestUnit disallowed");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDate/prototype/subtract/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/subtract/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.subtract
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "reject",
+}, "options");
+
+const instance = new Temporal.PlainDate(2025, 7, 31);
+
+assert.throws(RangeError, function () {
+  instance.subtract(new Temporal.Duration(0, 1), options);
+}, "overflow reject exception thrown");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDate/prototype/until/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "nanosecond",
+  largestUnit: "hour",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.PlainDate(2025, 3, 14);
+const other = new Temporal.PlainDate(2025, 8, 14);
+
+assert.throws(RangeError, function () {
+  instance.until(other, options);
+}, "exception thrown when largestUnit disallowed");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDate/prototype/with/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/with/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.with
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+const instance = new Temporal.PlainDate(2025, 7, 31);
+
+assert.throws(RangeError, function () {
+  instance.with({ monthCode: "M08L" }, options);
+}, "exception thrown when month code incorrect for calendar");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDateTime/from/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/options-read-before-algorithmic-validation.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+assert.throws(RangeError, function () {
+  Temporal.PlainDateTime.from({ year: 2025, monthCode: "M08L", day: 14 }, options);
+}, "exception thrown when month code is invalid for calendar");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/add/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/add/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+const instance = new Temporal.PlainDateTime(2025, 8, 31, 23, 59, 59);
+
+assert.throws(RangeError, function () {
+  instance.add(new Temporal.Duration(0, 0, 0, /* days = */ 104249991374, 1), options);
+}, "RangeError thrown when time addition overflows days component");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/round/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/round/options-read-before-algorithmic-validation.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.round
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "hour",
+  roundingIncrement: 25,
+  roundingMode: "expand",
+}, "options");
+
+const instance = new Temporal.PlainDateTime(2025, 8, 14, 12);
+
+assert.throws(RangeError, function () {
+  instance.round(options);
+}, "exception thrown when roundingIncrement invalid for smallestUnit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "year",
+  largestUnit: "nanosecond",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.PlainDateTime(2025, 8, 14, 12);
+const other = new Temporal.PlainDateTime(2025, 3, 14, 17);
+
+assert.throws(RangeError, function () {
+  instance.since(other, options);
+}, "exception thrown when smallestUnit > largestUnit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/subtract/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/subtract/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+const instance = new Temporal.PlainDateTime(2025, 8, 31, 1);
+
+assert.throws(RangeError, function () {
+  instance.subtract(new Temporal.Duration(0, 0, 0, /* days = */ 104249991374, 2), options);
+}, "RangeError thrown when time addition overflows days component");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/options-read-before-algorithmic-validation.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.calendarName",
+  "get options.calendarName.toString",
+  "call options.calendarName.toString",
+  "get options.fractionalSecondDigits",
+  "get options.fractionalSecondDigits.toString",
+  "call options.fractionalSecondDigits.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  calendarName: "always",
+  smallestUnit: "month",
+  fractionalSecondDigits: "auto",
+  roundingMode: "expand",
+}, "options");
+
+const instance = new Temporal.PlainDateTime(2025, 8, 14, 12);
+
+assert.throws(RangeError, function () {
+  instance.toString(options);
+}, "exception thrown when smallestUnit is a date unit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tozoneddatetime
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.disambiguation",
+  "get options.disambiguation.toString",
+  "call options.disambiguation.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  disambiguation: "reject",
+}, "options");
+
+const instance = new Temporal.PlainDateTime(-271821, 4, 20, 0);
+
+assert.throws(RangeError, function () {
+  instance.toZonedDateTime("+23:59", options);
+}, "exception thrown when wall time out of range for exact time");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "year",
+  largestUnit: "nanosecond",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.PlainDateTime(2025, 8, 14, 12);
+const other = new Temporal.PlainDateTime(2025, 3, 14, 17);
+
+assert.throws(RangeError, function () {
+  instance.until(other, options);
+}, "exception thrown when smallestUnit > largestUnit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/with/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/with/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.with
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+const instance = new Temporal.PlainDateTime(2025, 7, 31, 12);
+
+assert.throws(RangeError, function () {
+  instance.with({ monthCode: "M08L" }, options);
+}, "exception thrown when month code incorrect for calendar");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainMonthDay/from/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/options-read-before-algorithmic-validation.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+assert.throws(RangeError, function () {
+  Temporal.PlainMonthDay.from({ monthCode: "M08L", day: 14 }, options);
+}, "exception thrown when month code is invalid for calendar");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/with/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/with/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.with
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+const instance = new Temporal.PlainMonthDay(7, 31);
+
+assert.throws(RangeError, function () {
+  instance.with({ monthCode: "M08L" }, options);
+}, "exception thrown when month code incorrect for calendar");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainTime/from/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainTime/from/options-read-before-algorithmic-validation.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.from
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "reject",
+}, "options");
+
+assert.throws(RangeError, function () {
+  Temporal.PlainTime.from({ hour: 24 }, options);
+}, "overflow reject exception thrown");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainTime/prototype/round/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/round/options-read-before-algorithmic-validation.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.round
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "hour",
+  roundingIncrement: 25,
+  roundingMode: "expand",
+}, "options");
+
+const instance = new Temporal.PlainTime(12);
+
+assert.throws(RangeError, function () {
+  instance.round(options);
+}, "exception thrown when roundingIncrement invalid for smallestUnit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainTime/prototype/since/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "hour",
+  largestUnit: "week",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.PlainTime(14);
+const other = new Temporal.PlainTime(16);
+
+assert.throws(RangeError, function () {
+  instance.since(other, options);
+}, "exception thrown when largestUnit disallowed");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/options-read-before-algorithmic-validation.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tostring
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.fractionalSecondDigits",
+  "get options.fractionalSecondDigits.toString",
+  "call options.fractionalSecondDigits.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "month",
+  fractionalSecondDigits: "auto",
+  roundingMode: "expand",
+}, "options");
+
+const instance = new Temporal.PlainTime(12);
+
+assert.throws(RangeError, function () {
+  instance.toString(options);
+}, "exception thrown when unit is a date unit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainTime/prototype/until/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "hour",
+  largestUnit: "week",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.PlainTime(14);
+const other = new Temporal.PlainTime(16);
+
+assert.throws(RangeError, function () {
+  instance.until(other, options);
+}, "exception thrown when largestUnit disallowed");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainTime/prototype/with/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/with/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.with
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "reject",
+}, "options");
+
+const instance = new Temporal.PlainTime(12);
+
+assert.throws(RangeError, function () {
+  instance.with({ hour: 25 }, options);
+}, "overflow reject exception thrown");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainYearMonth/from/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/options-read-before-algorithmic-validation.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+assert.throws(RangeError, function () {
+  Temporal.PlainYearMonth.from({ year: 2025, monthCode: "M08L" }, options);
+}, "exception thrown when month code is invalid for calendar");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+const instance = new Temporal.PlainYearMonth(-271821, 4);
+
+assert.throws(RangeError, function () {
+  instance.add(new Temporal.Duration(0, 1), options);
+}, "exception thrown when converting -271821-04 to date");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "day",
+  largestUnit: "day",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.PlainYearMonth(2025, 8);
+const other = new Temporal.PlainYearMonth(2025, 3);
+
+assert.throws(RangeError, function () {
+  instance.since(other, options);
+}, "exception thrown largestUnit disallowed");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+const instance = new Temporal.PlainYearMonth(-271821, 4);
+
+assert.throws(RangeError, function () {
+  instance.subtract(new Temporal.Duration(0, -1), options);
+}, "exception thrown when converting -271821-04 to date");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "day",
+  largestUnit: "day",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.PlainYearMonth(2025, 8);
+const other = new Temporal.PlainYearMonth(2025, 3);
+
+assert.throws(RangeError, function () {
+  instance.until(other, options);
+}, "exception thrown largestUnit disallowed");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/with/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/with/options-read-before-algorithmic-validation.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.with
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+const instance = new Temporal.PlainYearMonth(2025, 7);
+
+assert.throws(RangeError, function () {
+  instance.with({ monthCode: "M08L" }, options);
+}, "exception thrown when month code incorrect for calendar");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/ZonedDateTime/from/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/options-read-before-algorithmic-validation.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.disambiguation",
+  "get options.disambiguation.toString",
+  "call options.disambiguation.toString",
+  "get options.offset",
+  "get options.offset.toString",
+  "call options.offset.toString",
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+  offset: "prefer",
+  disambiguation: "compatible",
+}, "options");
+
+assert.throws(RangeError, function () {
+  Temporal.ZonedDateTime.from({ year: 2025, monthCode: "M08L", day: 14, timeZone: "UTC" }, options);
+}, "exception thrown when month code is invalid for calendar");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/add/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/add/options-read-before-algorithmic-validation.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "reject",
+}, "options");
+
+// 1970-01-31T00:00[UTC]
+const instance = new Temporal.ZonedDateTime(2592000_000_000_000n, "UTC");
+
+assert.throws(RangeError, function () {
+  instance.add(new Temporal.Duration(0, 1), options);
+}, "overflow reject exception thrown");
+assert.compareArray(actual, expected, "all options should be read first");
+actual.splice(0);  // clear
+
+// Try again, but this time test that the options are read before the first
+// possible throw completion in the time-units-only path
+
+assert.throws(RangeError, function () {
+  instance.add(new Temporal.Duration(0, 0, 0, 0, 0, 0, Number.MAX_SAFE_INTEGER), options);
+}, "exception thrown when resulting exact time out of range");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/options-read-before-algorithmic-validation.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.round
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "hour",
+  roundingIncrement: 25,
+  roundingMode: "expand",
+}, "options");
+
+const instance = new Temporal.ZonedDateTime(1n, "UTC");
+
+assert.throws(RangeError, function () {
+  instance.round(options);
+}, "exception thrown when roundingIncrement invalid for smallestUnit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "year",
+  largestUnit: "nanosecond",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
+const other = new Temporal.ZonedDateTime(1n, "UTC");
+
+assert.throws(RangeError, function () {
+  instance.since(other, options);
+}, "exception thrown when smallestUnit > largestUnit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/options-read-before-algorithmic-validation.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "reject",
+}, "options");
+
+// 1970-03-31T00:00[UTC]
+const instance = new Temporal.ZonedDateTime(7689600_000_000_000n, "UTC");
+
+assert.throws(RangeError, function () {
+  instance.subtract(new Temporal.Duration(0, 1), options);
+}, "overflow reject exception thrown");
+assert.compareArray(actual, expected, "all options should be read first");
+actual.splice(0);  // clear
+
+// Try again, but this time test that the options are read before the first
+// possible throw completion in the time-units-only path
+
+assert.throws(RangeError, function () {
+  instance.subtract(new Temporal.Duration(0, 0, 0, 0, 0, 0, Number.MAX_SAFE_INTEGER), options);
+}, "exception thrown when resulting exact time out of range");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/options-read-before-algorithmic-validation.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.calendarName",
+  "get options.calendarName.toString",
+  "call options.calendarName.toString",
+  "get options.fractionalSecondDigits",
+  "get options.fractionalSecondDigits.toString",
+  "call options.fractionalSecondDigits.toString",
+  "get options.offset",
+  "get options.offset.toString",
+  "call options.offset.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+  "get options.timeZoneName",
+  "get options.timeZoneName.toString",
+  "call options.timeZoneName.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  calendarName: "always",
+  timeZoneName: "always",
+  smallestUnit: "month",
+  fractionalSecondDigits: "auto",
+  roundingMode: "expand",
+  offset: "auto",
+}, "options");
+
+const instance = new Temporal.ZonedDateTime(2n, "UTC");
+
+assert.throws(RangeError, function () {
+  instance.toString(options);
+}, "exception thrown when unit is a date unit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/options-read-before-algorithmic-validation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "year",
+  largestUnit: "nanosecond",
+  roundingIncrement: 1,
+  roundingMode: "halfFloor",
+}, "options");
+
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
+const other = new Temporal.ZonedDateTime(1n, "UTC");
+
+assert.throws(RangeError, function () {
+  instance.until(other, options);
+}, "exception thrown when smallestUnit > largestUnit");
+assert.compareArray(actual, expected, "all options should be read first");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/options-read-before-algorithmic-validation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/options-read-before-algorithmic-validation.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.with
+description: >
+  All options properties are read and cast before any algorithmic validation
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.disambiguation",
+  "get options.disambiguation.toString",
+  "call options.disambiguation.toString",
+  "get options.offset",
+  "get options.offset.toString",
+  "call options.offset.toString",
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+  offset: "prefer",
+  disambiguation: "compatible",
+}, "options");
+
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
+
+assert.throws(RangeError, function () {
+  instance.with({ monthCode: "M08L" }, options);
+}, "exception thrown when month code incorrect for calendar");
+assert.compareArray(actual, expected, "all options should be read first");


### PR DESCRIPTION
These tests cover the normative change approved in the July 2025 TC39 plenary. See https://github.com/tc39/proposal-temporal/pull/3130. All properties of user-passed options objects should be read and cast before any "algorithmic validation" is done.

This is a lot of tests, that cover every entry point where an options object is passed in, where subsequently an exception can be thrown or user code can be called.

However, the normative change only affects 10 of these tests:

- Instant.p.since,until,toString
- PlainDate.p.since,until
- PlainTime.p.since,until
- PlainYearMonth.p.since,until
- ZonedDateTime.p.toString

The other 35 tests simply close a gap in coverage.