### PR TITLE
Add symbols-as-weakmap-keys to features

### DIFF
--- a/test/built-ins/WeakMap/prototype/getOrInsertComputed/check-callback-fn-args.js
+++ b/test/built-ins/WeakMap/prototype/getOrInsertComputed/check-callback-fn-args.js
@@ -11,7 +11,7 @@ info: |
 
   6. Let value be ? Call(callbackfn, key).
   ...
-features: [upsert, Symbol, WeakMap]
+features: [upsert, Symbol, WeakMap, symbols-as-weakmap-keys]
 flags: [onlyStrict]
 ---*/
 var map = new WeakMap();


### PR DESCRIPTION
I noticed this was missing when I imported the new tests into SpiderMonkey.