### PR TITLE
Temporal: Coverage for blank durations

### DIFF
--- a/test/built-ins/Temporal/Duration/compare/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/compare/blank-duration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: Behaviour with blank durations
+features: [Temporal]
+---*/
+
+const blank1 = new Temporal.Duration();
+const blank2 = new Temporal.Duration();
+const { compare } = Temporal.Duration;
+const plainRelativeTo = new Temporal.PlainDate(2025, 8, 22);
+const zonedRelativeTo = new Temporal.ZonedDateTime(1n, "UTC");
+
+assert.sameValue(compare(blank1, blank2), 0, "zero durations compared without relativeTo");
+assert.sameValue(compare(blank1, blank2, { relativeTo: plainRelativeTo }), 0,
+  "zero durations compared with PlainDate relativeTo");
+assert.sameValue(compare(blank1, blank2, { relativeTo: zonedRelativeTo }), 0,
+  "zero durations compared with ZonedDateTime relativeTo");

--- a/test/built-ins/Temporal/Duration/from/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/from/blank-duration.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.from
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const blank = new Temporal.Duration();
+const result = Temporal.Duration.from(blank);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "result is also blank");

--- a/test/built-ins/Temporal/Duration/prototype/abs/basic.js
+++ b/test/built-ins/Temporal/Duration/prototype/abs/basic.js
@@ -15,7 +15,7 @@ includes: [temporalHelpers.js]
 
 let d1 = new Temporal.Duration();
 TemporalHelpers.assertDuration(
-    d1.abs(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "empty");
+    d1.abs(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank");
 
 let d2 = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 TemporalHelpers.assertDuration(

--- a/test/built-ins/Temporal/Duration/prototype/add/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/blank-duration.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const blank1 = new Temporal.Duration();
+const blank2 = new Temporal.Duration();
+
+const result = blank1.add(blank2);
+
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "result is also blank");

--- a/test/built-ins/Temporal/Duration/prototype/blank/basic.js
+++ b/test/built-ins/Temporal/Duration/prototype/blank/basic.js
@@ -23,3 +23,4 @@ const zero = Temporal.Duration.from({
   nanoseconds: 0
 });
 assert.sameValue(zero.blank, true);
+assert(new Temporal.Duration().blank, "created via constructor");

--- a/test/built-ins/Temporal/Duration/prototype/days/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/days/blank-duration.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.days
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.days, 0);

--- a/test/built-ins/Temporal/Duration/prototype/hours/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/hours/blank-duration.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.hours
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.hours, 0);

--- a/test/built-ins/Temporal/Duration/prototype/microseconds/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/microseconds/blank-duration.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.microseconds
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.microseconds, 0);

--- a/test/built-ins/Temporal/Duration/prototype/milliseconds/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/milliseconds/blank-duration.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.milliseconds
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.milliseconds, 0);

--- a/test/built-ins/Temporal/Duration/prototype/minutes/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/minutes/blank-duration.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.minutes
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.minutes, 0);

--- a/test/built-ins/Temporal/Duration/prototype/months/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/months/blank-duration.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.months
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.months, 0);

--- a/test/built-ins/Temporal/Duration/prototype/nanoseconds/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/nanoseconds/blank-duration.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.nanoseconds
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.nanoseconds, 0);

--- a/test/built-ins/Temporal/Duration/prototype/negated/basic.js
+++ b/test/built-ins/Temporal/Duration/prototype/negated/basic.js
@@ -13,7 +13,7 @@ includes: [temporalHelpers.js]
 let d1 = new Temporal.Duration();
 TemporalHelpers.assertDuration(
   d1.negated(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  "zeros");
+  "blank");
 
 let d2 = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 TemporalHelpers.assertDuration(

--- a/test/built-ins/Temporal/Duration/prototype/round/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/blank-duration.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const blank = new Temporal.Duration();
+const plainRelativeTo = new Temporal.PlainDate(2025, 8, 22);
+const zonedRelativeTo = new Temporal.ZonedDateTime(1n, "UTC");
+
+for (const smallestUnit of ['days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds']) {
+  let result = blank.round(smallestUnit);
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `round to ${smallestUnit} without relativeTo`);
+
+  result = blank.round({ smallestUnit, relativeTo: plainRelativeTo });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `round to ${smallestUnit} with PlainDate relativeTo`);
+
+  result = blank.round({ smallestUnit, relativeTo: zonedRelativeTo });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `round to ${smallestUnit} with ZonedDateTime relativeTo`);
+}
+
+for (const smallestUnit of ['years', 'months', 'weeks']) {
+  let result = blank.round({ smallestUnit, relativeTo: plainRelativeTo });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `round to ${smallestUnit} with PlainDate relativeTo`);
+
+  result = blank.round({ smallestUnit, relativeTo: zonedRelativeTo });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `round to ${smallestUnit} with ZonedDateTime relativeTo`);
+}

--- a/test/built-ins/Temporal/Duration/prototype/seconds/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/seconds/blank-duration.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.seconds
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.seconds, 0);

--- a/test/built-ins/Temporal/Duration/prototype/sign/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/sign/blank-duration.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.sign
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.sign, 0);
+

--- a/test/built-ins/Temporal/Duration/prototype/subtract/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/blank-duration.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const blank1 = new Temporal.Duration();
+const blank2 = new Temporal.Duration();
+
+const result = blank1.subtract(blank2);
+
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "result is also blank");

--- a/test/built-ins/Temporal/Duration/prototype/toJSON/basic.js
+++ b/test/built-ins/Temporal/Duration/prototype/toJSON/basic.js
@@ -12,7 +12,7 @@ features: [Temporal]
 ---*/
 
 let d = new Temporal.Duration();
-assert.sameValue(d.toJSON(), "PT0S", "zero duration");
+assert.sameValue(d.toJSON(), "PT0S", "blank duration");
 
 d = new Temporal.Duration(1);
 assert.sameValue(d.toJSON(), "P1Y", "positive small years");

--- a/test/built-ins/Temporal/Duration/prototype/total/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/blank-duration.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+const plainRelativeTo = new Temporal.PlainDate(2025, 8, 22);
+const zonedRelativeTo = new Temporal.ZonedDateTime(1n, "UTC");
+
+for (const unit of ['days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds']) {
+  let result = blank.total(unit);
+  assert.sameValue(result, 0, `total of ${unit} without relativeTo`);
+
+  result = blank.total({ unit, relativeTo: plainRelativeTo });
+  assert.sameValue(result, 0, `total of ${unit} with PlainDate relativeTo`);
+
+  result = blank.total({ unit, relativeTo: zonedRelativeTo });
+  assert.sameValue(result, 0, `total of ${unit} with ZonedDateTime relativeTo`);
+}
+
+for (const unit of ['years', 'months', 'weeks']) {
+  let result = blank.total({ unit, relativeTo: plainRelativeTo });
+  assert.sameValue(result, 0, `total of ${unit} with PlainDate relativeTo`);
+
+  result = blank.total({ unit, relativeTo: zonedRelativeTo });
+  assert.sameValue(result, 0, `total of ${unit} with ZonedDateTime relativeTo`);
+}

--- a/test/built-ins/Temporal/Duration/prototype/weeks/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/weeks/blank-duration.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.weeks
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.weeks, 0);

--- a/test/built-ins/Temporal/Duration/prototype/with/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/with/blank-duration.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.with
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const blank = new Temporal.Duration();
+
+for (const val of [-1, 0, 1]) {
+  let result = blank.with({ years: val });
+  TemporalHelpers.assertDuration(result, val, 0, 0, 0, 0, 0, 0, 0, 0, 0, `with years ${val}`);
+  result = blank.with({ months: val });
+  TemporalHelpers.assertDuration(result, 0, val, 0, 0, 0, 0, 0, 0, 0, 0, `with months ${val}`);
+  result = blank.with({ weeks: val });
+  TemporalHelpers.assertDuration(result, 0, 0, val, 0, 0, 0, 0, 0, 0, 0, `with weeks ${val}`);
+  result = blank.with({ days: val });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, val, 0, 0, 0, 0, 0, 0, `with days ${val}`);
+  result = blank.with({ hours: val });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, val, 0, 0, 0, 0, 0, `with hours ${val}`);
+  result = blank.with({ minutes: val });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, val, 0, 0, 0, 0, `with minutes ${val}`);
+  result = blank.with({ seconds: val });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, val, 0, 0, 0, `with seconds ${val}`);
+  result = blank.with({ milliseconds: val });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, val, 0, 0, `with milliseconds ${val}`);
+  result = blank.with({ microseconds: val });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, val, 0, `with microseconds ${val}`);
+  result = blank.with({ nanoseconds: val });
+  TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, val, `with nanoseconds ${val}`);
+}

--- a/test/built-ins/Temporal/Duration/prototype/years/blank-duration.js
+++ b/test/built-ins/Temporal/Duration/prototype/years/blank-duration.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration.prototype.years
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+assert.sameValue(blank.years, 0);

--- a/test/built-ins/Temporal/Instant/prototype/add/blank-duration.js
+++ b/test/built-ins/Temporal/Instant/prototype/add/blank-duration.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.add
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const instant = new Temporal.Instant(1n);
+const blank = new Temporal.Duration();
+const result = instant.add(blank);
+assert.sameValue(result.epochNanoseconds, 1n, "result is unchanged");

--- a/test/built-ins/Temporal/Instant/prototype/since/blank-result.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const i1 = new Temporal.Instant(1n);
+const i2 = new Temporal.Instant(1n);
+const result = i1.since(i2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/Instant/prototype/subtract/blank-duration.js
+++ b/test/built-ins/Temporal/Instant/prototype/subtract/blank-duration.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.subtract
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const instant = new Temporal.Instant(1n);
+const blank = new Temporal.Duration();
+const result = instant.subtract(blank);
+assert.sameValue(result.epochNanoseconds, 1n, "result is unchanged");

--- a/test/built-ins/Temporal/Instant/prototype/until/blank-result.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const i1 = new Temporal.Instant(1n);
+const i2 = new Temporal.Instant(1n);
+const result = i1.until(i2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/PlainDate/prototype/add/blank-duration.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/add/blank-duration.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.add
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d = new Temporal.PlainDate(2025, 8, 22);
+const blank = new Temporal.Duration();
+const result = d.add(blank);
+TemporalHelpers.assertPlainDate(result, 2025, 8, "M08", 22, "result is unchanged");

--- a/test/built-ins/Temporal/PlainDate/prototype/since/blank-result.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d1 = new Temporal.PlainDate(2025, 8, 22);
+const d2 = new Temporal.PlainDate(2025, 8, 22);
+const result = d1.since(d2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/PlainDate/prototype/subtract/blank-duration.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/subtract/blank-duration.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.subtract
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d = new Temporal.PlainDate(2025, 8, 22);
+const blank = new Temporal.Duration();
+const result = d.subtract(blank);
+TemporalHelpers.assertPlainDate(result, 2025, 8, "M08", 22, "result is unchanged");

--- a/test/built-ins/Temporal/PlainDate/prototype/until/blank-result.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d1 = new Temporal.PlainDate(2025, 8, 22);
+const d2 = new Temporal.PlainDate(2025, 8, 22);
+const result = d1.until(d2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/add/blank-duration.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/add/blank-duration.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const dt = new Temporal.PlainDateTime(2025, 8, 22, 14, 1);
+const blank = new Temporal.Duration();
+const result = dt.add(blank);
+TemporalHelpers.assertPlainDateTime(result, 2025, 8, "M08", 22, 14, 1, 0, 0, 0, 0, "result is unchanged");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/blank-result.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d1 = new Temporal.PlainDateTime(2025, 8, 22, 13, 52);
+const d2 = new Temporal.PlainDateTime(2025, 8, 22, 13, 52);
+const result = d1.since(d2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/subtract/blank-duration.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/subtract/blank-duration.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const dt = new Temporal.PlainDateTime(2025, 8, 22, 14, 1);
+const blank = new Temporal.Duration();
+const result = dt.subtract(blank);
+TemporalHelpers.assertPlainDateTime(result, 2025, 8, "M08", 22, 14, 1, 0, 0, 0, 0, "result is unchanged");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/blank-result.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d1 = new Temporal.PlainDateTime(2025, 8, 22, 13, 52);
+const d2 = new Temporal.PlainDateTime(2025, 8, 22, 13, 52);
+const result = d1.until(d2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/PlainTime/prototype/add/blank-duration.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/add/blank-duration.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.add
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const t = new Temporal.PlainTime(14, 1);
+const blank = new Temporal.Duration();
+const result = t.add(blank);
+TemporalHelpers.assertPlainTime(result, 14, 1, 0, 0, 0, 0, "result is unchanged");

--- a/test/built-ins/Temporal/PlainTime/prototype/since/blank-result.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d1 = new Temporal.PlainTime(13, 52);
+const d2 = new Temporal.PlainTime(13, 52);
+const result = d1.since(d2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/PlainTime/prototype/subtract/blank-duration.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/subtract/blank-duration.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.subtract
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const t = new Temporal.PlainTime(14, 1);
+const blank = new Temporal.Duration();
+const result = t.subtract(blank);
+TemporalHelpers.assertPlainTime(result, 14, 1, 0, 0, 0, 0, "result is unchanged");

--- a/test/built-ins/Temporal/PlainTime/prototype/until/blank-result.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d1 = new Temporal.PlainTime(13, 52);
+const d2 = new Temporal.PlainTime(13, 52);
+const result = d1.until(d2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/blank-duration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/blank-duration.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const ym = new Temporal.PlainYearMonth(2025, 8);
+const blank = new Temporal.Duration();
+const result = ym.add(blank);
+TemporalHelpers.assertPlainYearMonth(result, 2025, 8, "M08", "result is unchanged");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/blank-result.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d1 = new Temporal.PlainYearMonth(2025, 8);
+const d2 = new Temporal.PlainYearMonth(2025, 8);
+const result = d1.since(d2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/blank-duration.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/blank-duration.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Behaviour with blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const ym = new Temporal.PlainYearMonth(2025, 8);
+const blank = new Temporal.Duration();
+const result = ym.subtract(blank);
+TemporalHelpers.assertPlainYearMonth(result, 2025, 8, "M08", "result is unchanged");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/blank-result.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d1 = new Temporal.PlainYearMonth(2025, 8);
+const d2 = new Temporal.PlainYearMonth(2025, 8);
+const result = d1.until(d2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/add/blank-duration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/add/blank-duration.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const dt = new Temporal.ZonedDateTime(1n, "UTC");
+const blank = new Temporal.Duration();
+const result = dt.add(blank);
+assert.sameValue(result.epochNanoseconds, 1n, "result is unchanged");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/blank-result.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d1 = new Temporal.ZonedDateTime(1n, "UTC");
+const d2 = new Temporal.ZonedDateTime(1n, "UTC");
+const result = d1.since(d2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/blank-duration.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/blank-duration.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: Behaviour with blank duration
+features: [Temporal]
+---*/
+
+const dt = new Temporal.ZonedDateTime(1n, "UTC");
+const blank = new Temporal.Duration();
+const result = dt.subtract(blank);
+assert.sameValue(result.epochNanoseconds, 1n, "result is unchanged");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/blank-result.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/blank-result.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Difference between equivalent objects returns blank duration
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const d1 = new Temporal.ZonedDateTime(1n, "UTC");
+const d2 = new Temporal.ZonedDateTime(1n, "UTC");
+const result = d1.until(d2);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "blank result");


### PR DESCRIPTION
Many methods did not test what happened when an input or return value was a blank (all fields 0) duration. This adds coverage for those code paths.