### PR TITLE
Classify tests for the stability of array sorting

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -214,6 +214,7 @@ rest-parameters
 Set
 set-methods
 SharedArrayBuffer
+stable-array-sort  # https://github.com/tc39/ecma262/pull/1340 & https://github.com/tc39/ecma262/pull/1433
 string-trimming
 String.fromCodePoint
 String.prototype.at

--- a/test/built-ins/Array/prototype/sort/stability-11-elements.js
+++ b/test/built-ins/Array/prototype/sort/stability-11-elements.js
@@ -11,6 +11,7 @@ info: |
   The array length of 11 was chosen because V8 used an unstable
   QuickSort for arrays with more than 10 elements until v7.0 (September
   2018). https://v8.dev/blog/array-sort
+features: [stable-array-sort]
 ---*/
 
 const array = [

--- a/test/built-ins/Array/prototype/sort/stability-2048-elements.js
+++ b/test/built-ins/Array/prototype/sort/stability-2048-elements.js
@@ -12,6 +12,7 @@ info: |
   uses merge sort for arrays with 2048 or more elements. It uses
   insertion sort for smaller arrays.
   https://github.com/Microsoft/ChakraCore/pull/5724/files#diff-85203ec16f5961eb4c18e4253bb42140R337
+features: [stable-array-sort]
 ---*/
 
 const array = [

--- a/test/built-ins/Array/prototype/sort/stability-5-elements.js
+++ b/test/built-ins/Array/prototype/sort/stability-5-elements.js
@@ -8,6 +8,7 @@ description: >
 info: |
   The sort is required to be stable (that is, elements that compare equal
   remain in their original order).
+features: [stable-array-sort]
 ---*/
 
 const array = [

--- a/test/built-ins/Array/prototype/sort/stability-513-elements.js
+++ b/test/built-ins/Array/prototype/sort/stability-513-elements.js
@@ -12,6 +12,7 @@ info: |
   used to apply an unstable QuickSort for arrays with more than 512
   elements, although it used a stable insertion sort for anything else.
   https://github.com/Microsoft/ChakraCore/pull/5724
+features: [stable-array-sort]
 ---*/
 
 const array = [

--- a/test/built-ins/TypedArray/prototype/sort/stability.js
+++ b/test/built-ins/TypedArray/prototype/sort/stability.js
@@ -6,7 +6,7 @@ description: Stability of %TypedArray%.prototype.sort.
 info: |
   https://github.com/tc39/ecma262/pull/1433
 includes: [testTypedArray.js, compareArray.js]
-features: [TypedArray]
+features: [TypedArray, stable-array-sort]
 ---*/
 
 // Treat 0..3, 4..7, etc. as equal.


### PR DESCRIPTION
These tests were originally introduced via https://github.com/tc39/test262/pull/1977 & https://github.com/tc39/test262/pull/2062 and subsequently modified via https://github.com/tc39/test262/pull/2169.