### PR TITLE
Remove unnecessary call to compareArray in this-value-boolean.js

### DIFF
--- a/test/built-ins/Array/prototype/with/this-value-boolean.js
+++ b/test/built-ins/Array/prototype/with/this-value-boolean.js
@@ -32,8 +32,8 @@ delete Boolean.prototype.length;
 Boolean.prototype[0] = "monkeys";
 Boolean.prototype[2] = "bogus";
 assert.throws(RangeError,
-              () => compareArray(Array.prototype.with.call(true, 0, 2)),
+              () => Array.prototype.with.call(true, 0, 2),
               "Array.prototype.with on object with undefined length");
 assert.throws(RangeError,
-              () => compareArray(Array.prototype.with.call(false, 0, 2)),
+              () => Array.prototype.with.call(false, 0, 2),
               "Array.prototype.with on object with undefined length");


### PR DESCRIPTION
This assertion throws before `compareArray` is called. In addition, `compareArray` takes two parameters, not one.

It's unclear to me why it was added in the first place.