### PR TITLE
Check that callbackfn is not called if the key cannot be held weakly

### DIFF
--- a/test/built-ins/WeakMap/prototype/getOrInsertComputed/throw-if-key-cannot-be-held-weakly.js
+++ b/test/built-ins/WeakMap/prototype/getOrInsertComputed/throw-if-key-cannot-be-held-weakly.js
@@ -22,7 +22,7 @@ var s = new WeakMap();
 for (let invalidKey of invalidKeys) {
   assert.throws(TypeError, function () {
     s.getOrInsertComputed(invalidKey,
-      () => log.push(`Unexpected evaluation of callback function, key: ${typeof invalidKey}`));
+      () => log.push(`Unexpected evaluation of callback function, key: ${invalidKey}`));
   }, `${typeof invalidKey} not allowed as WeakMap key`);
 }
 

--- a/test/built-ins/WeakMap/prototype/getOrInsertComputed/throw-if-key-cannot-be-held-weakly.js
+++ b/test/built-ins/WeakMap/prototype/getOrInsertComputed/throw-if-key-cannot-be-held-weakly.js
@@ -13,29 +13,22 @@ info: |
   ...
 features: [Symbol, WeakMap, upsert]
 ---*/
+
+var log = [];
+var invalidKeys = [1, false, undefined, 'string', null];
+
 var s = new WeakMap();
 
-assert.throws(TypeError, function() {
-  s.getOrInsertComputed(1, () => 1);
-});
+for (let invalidKey of invalidKeys) {
+  assert.throws(TypeError, function () {
+    s.getOrInsertComputed(invalidKey,
+      () => log.push(`Unexpected evaluation of callback function, key: ${typeof invalidKey}`));
+  }, `${typeof invalidKey} not allowed as WeakMap key`);
+}
 
-assert.throws(TypeError, function() {
-  s.getOrInsertComputed(false, () => 1);
-});
-
-assert.throws(TypeError, function() {
-  s.getOrInsertComputed(undefined, () => 1);
-});
-
-assert.throws(TypeError, function() {
-  s.getOrInsertComputed('string', () => 1);
-});
-
-assert.throws(TypeError, function() {
-  s.getOrInsertComputed(null, () => 1);
-});
-
-assert.throws(TypeError, function() {
-  s.getOrInsertComputed(Symbol.for('registered symbol'), () => 1);
+assert.throws(TypeError, function () {
+  s.getOrInsertComputed(Symbol.for('registered symbol'),
+    () => log.push("Unexpected callback evaluation"));
 }, 'Registered symbol not allowed as WeakMap key');
 
+assert.compareArray(log, []);


### PR DESCRIPTION
There is no validation to check that the callback function is not called if the key cannot be held weakly.
This pull request modifies the throw-if-key-cannot-be-held-weakly test to also check for this.

Discovered here:
https://bugzilla.mozilla.org/show_bug.cgi?id=1988369