### PR TITLE
Add missing feature, symbols-as-weakmap-keys

### DIFF
--- a/test/built-ins/WeakMap/prototype/getOrInsertComputed/check-state-after-callback-fn-throws.js
+++ b/test/built-ins/WeakMap/prototype/getOrInsertComputed/check-state-after-callback-fn-throws.js
@@ -11,7 +11,7 @@ info: |
 
   6. Let value be ? Call(callbackfn, key).
   ...
-features: [upsert, WeakMap, Symbol]
+features: [upsert, WeakMap, Symbol, symbols-as-weakmap-keys]
 ---*/
 var map = new WeakMap();
 const obj0 = {};


### PR DESCRIPTION
The test `check-state-after-callback-fn-throws.js` is missing the feature `symbols-as-weakmap-keys`.
This was discovered after the last pull request was merged and is therefore done here.