### PR TITLE
Revert "fix another test now that we don't access the IteratorResult …

### DIFF
--- a/test/built-ins/Iterator/concat/next-method-returns-throwing-value.js
+++ b/test/built-ins/Iterator/concat/next-method-returns-throwing-value.js
@@ -13,15 +13,8 @@ info: |
     a. For each Record iterable of iterables, do
       ...
       v. Repeat, while innerAlive is true,
-        1. Let iteratorResult be ? IteratorStep(iteratorRecord).
-        2. If iteratorResult is done, then
-          a. Perform ? IteratorValue(iteratorResult).
-          b. Set innerAlive to false.
-        3. Else,
-          a. Let completion be Completion(GeneratorYield(iteratorResult)).
-          b. If completion is an abrupt completion, then
-            i. Return ? IteratorClose(iteratorRecord, completion).
-    ...
+        1. Let innerValue be ? IteratorStepValue(iteratorRecord).
+        ...
 features: [iterator-sequencing]
 ---*/
 
@@ -46,8 +39,7 @@ let iterable = {
 };
 
 let iterator = Iterator.concat(iterable);
-let iteratorResult = iterator.next();
 
 assert.throws(Test262Error, function() {
-  iteratorResult.value;
+  iterator.next();
 });


### PR DESCRIPTION
…value"

This reverts commit 71794b138844536a36b341700f88ee91c5754431.

Follow up from #4523, missed reverting this commit.

Closes: #4581