### PR TITLE
Add missing include to WeakMap.prototype.getOrInsertComputed() test

### DIFF
--- a/test/built-ins/WeakMap/prototype/getOrInsertComputed/throw-if-key-cannot-be-held-weakly.js
+++ b/test/built-ins/WeakMap/prototype/getOrInsertComputed/throw-if-key-cannot-be-held-weakly.js
@@ -11,6 +11,7 @@ info: |
   ...
   4. If CanBeHeldWeakly(_key_) is *false*, throw a *TypeError* exception.
   ...
+includes: [compareArray.js]
 features: [Symbol, WeakMap, upsert]
 ---*/
 


### PR DESCRIPTION
Broken in #4578. @johauke you might want to check if the test runner you're using is including harness functions eagerly.