### PR TITLE
Make iterator sequencing test more explicit

### DIFF
--- a/test/built-ins/Iterator/concat/return-is-not-forwarded-before-initial-start.js
+++ b/test/built-ins/Iterator/concat/return-is-not-forwarded-before-initial-start.js
@@ -10,10 +10,7 @@ features: [iterator-sequencing]
 
 let testIterator = {
   next() {
-    return {
-      done: false,
-      value: 1,
-    };
+    throw new Test262Error();
   },
   return() {
     throw new Test262Error();


### PR DESCRIPTION
The next() method is not supposed to get called. Per discussion here: https://github.com/tc39/test262/pull/4326#discussion_r2371763680