### PR TITLE
String.prototype.toLocale{Lower,Upper}Case validates all locale identifiers

### DIFF
--- a/test/intl402/String/prototype/toLocaleLowerCase/validates-all-locale-identifiers.js
+++ b/test/intl402/String/prototype/toLocaleLowerCase/validates-all-locale-identifiers.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sup-string.prototype.tolocalelowercase
+description: >
+  All locale identifiers are validated, not just the first one.
+info: |
+  String.prototype.toLocaleLowerCase ( [ locales ] )
+    ...
+    3. Return ? TransformCase(S, locales, lower).
+
+  TransformCase ( S, locales, targetCase )
+    1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    ...
+---*/
+
+var locales = [
+  "en-US",
+  "this is not a valid locale",
+];
+
+assert.throws(RangeError, function() {
+  "".toLocaleLowerCase(locales);
+});

--- a/test/intl402/String/prototype/toLocaleUpperCase/validates-all-locale-identifiers.js
+++ b/test/intl402/String/prototype/toLocaleUpperCase/validates-all-locale-identifiers.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sup-string.prototype.tolocaleuppercase
+description: >
+  All locale identifiers are validated, not just the first one.
+info: |
+  String.prototype.toLocaleUpperCase ( [ locales ] )
+    ...
+    3. Return ? TransformCase(S, locales, upper).
+
+  TransformCase ( S, locales, targetCase )
+    1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    ...
+---*/
+
+var locales = [
+  "en-US",
+  "this is not a valid locale",
+];
+
+assert.throws(RangeError, function() {
+  "".toLocaleUpperCase(locales);
+});


### PR DESCRIPTION
Both tests pass in JSC and SM, but fail in V8. 