### PR TITLE
Test iterator close behavior of Set methods

### DIFF
--- a/test/built-ins/Set/prototype/isDisjointFrom/set-like-iter-return.js
+++ b/test/built-ins/Set/prototype/isDisjointFrom/set-like-iter-return.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 Ben Noordhuis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-set.prototype.isdisjointfrom
+description: >
+  Set.prototype.isDisjointFrom calls return() on the set-like iterator, but
+  only if the iterator is not exhausted, i.e., the set-like is not disjoint.
+features: [set-methods, Array.prototype.includes]
+---*/
+
+const iter = {
+  a: [4, 5, 6],
+  nextCalls: 0,
+  returnCalls: 0,
+  next() {
+    const done = this.nextCalls >= this.a.length;
+    const value = this.a[this.nextCalls];
+    this.nextCalls++;
+    return {done, value};
+  },
+  return() {
+    this.returnCalls++;
+    return this;
+  },
+};
+
+const setlike = {
+  size: iter.a.length,
+  has(v) { return iter.a.includes(v); },
+  keys() { return iter; },
+};
+
+// Set must be bigger than iter.a to hit iter.next and iter.return.
+assert.sameValue(new Set([4, 5, 6, 7]).isDisjointFrom(setlike), false);
+assert.sameValue(iter.nextCalls, 1);
+assert.sameValue(iter.returnCalls, 1);
+iter.nextCalls = iter.returnCalls = 0;
+
+assert.sameValue(new Set([0, 1, 2, 3]).isDisjointFrom(setlike), true);
+assert.sameValue(iter.nextCalls, 4);
+assert.sameValue(iter.returnCalls, 0);
+iter.nextCalls = iter.returnCalls = 0;

--- a/test/built-ins/Set/prototype/isSupersetOf/set-like-iter-return.js
+++ b/test/built-ins/Set/prototype/isSupersetOf/set-like-iter-return.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 Ben Noordhuis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-set.prototype.issupersetof
+description: >
+  Set.prototype.isSupersetOf calls return() on the set-like iterator, but
+  only if the iterator is not exhausted, i.e., the set is not a superset
+  of the set-like.
+features: [set-methods, Array.prototype.includes]
+---*/
+
+const iter = {
+  a: [4, 5, 6],
+  nextCalls: 0,
+  returnCalls: 0,
+  next() {
+    const done = this.nextCalls >= this.a.length;
+    const value = this.a[this.nextCalls];
+    this.nextCalls++;
+    return {done, value};
+  },
+  return() {
+    this.returnCalls++;
+    return this;
+  },
+};
+
+const setlike = {
+  size: iter.a.length,
+  has(v) { return iter.a.includes(v); },
+  keys() { return iter; },
+};
+
+// Set must be bigger than iter.a to hit iter.next and iter.return.
+assert.sameValue(new Set([4, 5, 6, 7]).isSupersetOf(setlike), true);
+assert.sameValue(iter.nextCalls, 4);
+assert.sameValue(iter.returnCalls, 0);
+iter.nextCalls = iter.returnCalls = 0;
+
+assert.sameValue(new Set([0, 1, 2, 3]).isSupersetOf(setlike), false);
+assert.sameValue(iter.nextCalls, 1);
+assert.sameValue(iter.returnCalls, 1);
+iter.nextCalls = iter.returnCalls = 0;


### PR DESCRIPTION
Set.prototype.isDisjointFrom and Set.prototype.isSupersetOf should call return() on the set-like iterator but only when it is not exhausted.

Port of the downstream tests I added in quickjs-ng/quickjs@6167dcb127.

<hr>

Ed.: the other set methods don't have special cases for when set size > set-like size and where iteration can stop before exhaustion, only isDisjointFrom and isSupersetOf.