### PR TITLE
Add assertions for checking names of `resolve` and `reject` from `Promise.withResolvers`

### DIFF
--- a/test/built-ins/Promise/withResolvers/resolvers.js
+++ b/test/built-ins/Promise/withResolvers/resolvers.js
@@ -11,6 +11,8 @@ features: [promise-with-resolvers]
 var instance = Promise.withResolvers();
 
 assert.sameValue(typeof instance.resolve, 'function', 'type of resolve property');
+assert.sameValue(instance.resolve.name, "");
 assert.sameValue(instance.resolve.length, 1, 'length of resolve property');
 assert.sameValue(typeof instance.reject, 'function', 'type of reject property');
+assert.sameValue(instance.reject.name, "");
 assert.sameValue(instance.reject.length, 1, 'length of reject property');


### PR DESCRIPTION
`resolve` and `reject` from `Promise.withResolvers` are just Abstract Closure(https://tc39.es/ecma262/#sec-newpromisecapability), so those shouldn't have `Function.prototype.name`.

V8 and SM follows the spec, but JSC doesn't follow it (will be fixed).
