### PR TITLE
Temporal: Add tests for PlainMonthDay.from with month and invalid monthCode

### DIFF
--- a/test/built-ins/Temporal/PlainMonthDay/from/monthcode-invalid.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/monthcode-invalid.js
@@ -9,7 +9,9 @@ features: [Temporal]
 
 ["m1", "M1", "m01"].forEach((monthCode) => {
   assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ monthCode, day: 17 }),
-    `monthCode '${monthCode}' is not well-formed`);
+    `monthCode '${monthCode}' is not well-formed (without numeric month)`);
+  assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: 1, monthCode, day: 17 }),
+    `monthCode '${monthCode}' is not well-formed (with numeric month)`);
 });
 
 assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ year: 2021, month: 12, monthCode: "M11", day: 17 }),
@@ -17,7 +19,19 @@ assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ year: 2021, month:
 
 ["M00", "M19", "M99", "M13", "M00L", "M05L", "M13L"].forEach((monthCode) => {
   assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ monthCode, day: 17 }),
-    `monthCode '${monthCode}' is not valid for ISO 8601 calendar`);
+    `monthCode '${monthCode}' is not valid for ISO 8601 calendar (without numeric month)`);
+  var monthNumber = Number(monthCode.slice(1, 3)) + (monthCode.length - 3);
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainMonthDay.from({ month: monthNumber, monthCode, day: 17 }),
+    `monthCode '${monthCode}' is not valid for ISO 8601 calendar (with numeric month)`
+  );
+  var clampedMonthNumber = monthNumber < 1 ? 1 : monthNumber > 12 ? 12 : monthNumber;
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainMonthDay.from({ month: clampedMonthNumber, monthCode, day: 17 }),
+    `monthCode '${monthCode}' is not valid for ISO 8601 calendar (with clamped numeric month)`
+  );
 });
 
 assert.throws(


### PR DESCRIPTION
Prompted by discussion in Matrix.