### PR TITLE
Fix module specifiers in toplevel await test

### DIFF
--- a/test/staging/top-level-await/grandparent-tla_FIXTURE.js
+++ b/test/staging/top-level-await/grandparent-tla_FIXTURE.js
@@ -1,4 +1,4 @@
 // Copyright (C) 2024 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-import "parent-tla_FIXTURE.js";
+import "./parent-tla_FIXTURE.js";

--- a/test/staging/top-level-await/parent-tla_FIXTURE.js
+++ b/test/staging/top-level-await/parent-tla_FIXTURE.js
@@ -1,4 +1,4 @@
 // Copyright (C) 2024 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-import "tla_FIXTURE.js"
+import "./tla_FIXTURE.js"

--- a/test/staging/top-level-await/tla-hang-entry.js
+++ b/test/staging/top-level-await/tla-hang-entry.js
@@ -7,7 +7,7 @@ flags: [module, async]
 features: [top-level-await]
 ---*/
 
-import "parent-tla_FIXTURE.js";
-await import("grandparent-tla_FIXTURE.js");
+import "./parent-tla_FIXTURE.js";
+await import("./grandparent-tla_FIXTURE.js");
 
 $DONE();


### PR DESCRIPTION
These should be relative paths, starting with "./". Bare specifiers are not allowed in test262.