### PR TITLE
Change test for ECMA402 PR 1019 to valid the order of the compactDisplay

### DIFF
--- a/test/intl402/PluralRules/prototype/resolvedOptions/return-keys-order-default.js
+++ b/test/intl402/PluralRules/prototype/resolvedOptions/return-keys-order-default.js
@@ -11,6 +11,7 @@ const allKeys = [
     'locale',
     'type',
     'notation',
+    'compactDisplay',
     'minimumIntegerDigits',
     'minimumFractionDigits',
     'maximumFractionDigits',


### PR DESCRIPTION
PR 1019 is approved by TG1 in 2025-9 meeting 
and should be merged soon. 
https://github.com/tc39/ecma402/pull/1019

@gibson042 @ben-allen 