### PR TITLE
Fix and tighten up cross realm `%ThrowTypeError%` test.

### DIFF
--- a/test/built-ins/ThrowTypeError/distinct-cross-realm.js
+++ b/test/built-ins/ThrowTypeError/distinct-cross-realm.js
@@ -17,8 +17,15 @@ var localArgs = function() {
   "use strict";
   return arguments;
 }();
-var otherArgs = (new other.Function('return arguments;'))();
+var otherArgs = (new other.Function('"use strict"; return arguments;'))();
+var otherArgs2 = (new other.Function('"use strict"; return arguments;'))();
 var localThrowTypeError = Object.getOwnPropertyDescriptor(localArgs, "callee").get;
 var otherThrowTypeError = Object.getOwnPropertyDescriptor(otherArgs, "callee").get;
+var otherThrowTypeError2 = Object.getOwnPropertyDescriptor(otherArgs, "callee").get;
+
+assert.throws(TypeError, function() {
+  otherThrowTypeError();
+});
 
 assert.notSameValue(localThrowTypeError, otherThrowTypeError);
+assert.sameValue(otherThrowTypeError, otherThrowTypeError2);


### PR DESCRIPTION
The cross realm test for `%ThrowTypeError%` had a bug in that the function created in the other realm was not strict and so didn't have `%ThrowTypeError%` as the `callee` getter. The test passed because a regular getter was distinct from `ThrowTypeError` in the base realm.

I've expanded the test to check two functions on the other realm have identical callee getters, and that this function throws a TypeError. 