### PR TITLE
Temporal: Add tests for optional properties in property bags

### DIFF
--- a/test/built-ins/Temporal/Duration/compare/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/Duration/compare/argument-propertybag-optional-properties.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.compare
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = Temporal.Duration.compare(oneProperty, oneProperty);
+const resultWith = Temporal.Duration.compare(allProperties, allProperties);
+assert.sameValue(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-optional-properties.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.compare
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const duration1 = new Temporal.Duration(1);
+const duration2 = new Temporal.Duration(0, 1);
+
+let relativeTo = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  timeZone: "UTC",
+};
+const resultWithout = Temporal.Duration.compare(duration1, duration2, { relativeTo });
+relativeTo = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  offset: "+00:00",
+  timeZone: "UTC",
+  calendar: "iso8601",
+};
+const resultWith = Temporal.Duration.compare(duration1, duration2, { relativeTo });
+assert.sameValue(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/Duration/from/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/Duration/from/argument-propertybag-optional-properties.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.from
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = Temporal.Duration.from(oneProperty);
+const resultWith = Temporal.Duration.from(allProperties);
+TemporalHelpers.assertDurationsEqual(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/Duration/prototype/add/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/argument-propertybag-optional-properties.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration();
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.add(oneProperty);
+const resultWith = instance.add(allProperties);
+TemporalHelpers.assertDurationsEqual(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-optional-properties.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const timeZone = "UTC";
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+let relativeTo = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  timeZone,
+};
+const resultWithout = instance.round({ largestUnit: "years", relativeTo });
+relativeTo = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  offset: "+00:00",
+  timeZone,
+  calendar: "iso8601",
+};
+const resultWith = instance.round({ largestUnit: "years", relativeTo });
+TemporalHelpers.assertDurationsEqual(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/Duration/prototype/subtract/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/argument-propertybag-optional-properties.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration();
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.subtract(oneProperty);
+const resultWith = instance.subtract(allProperties);
+TemporalHelpers.assertDurationsEqual(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-optional-properties.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const timeZone = "UTC";
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+let relativeTo = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  timeZone,
+};
+const resultWithout = instance.total({ unit: "days", relativeTo });
+relativeTo = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  offset: "+00:00",
+  timeZone,
+  calendar: "iso8601",
+};
+const resultWith = instance.total({ unit: "days", relativeTo });
+assert.sameValue(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/Instant/prototype/add/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/Instant/prototype/add/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.add
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.add(oneProperty);
+const resultWith = instance.add(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/Instant/prototype/subtract/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/Instant/prototype/subtract/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.subtract
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.subtract(oneProperty);
+const resultWith = instance.subtract(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDate/prototype/add/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/add/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.add
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(1970, 1, 1);
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.add(oneProperty);
+const resultWith = instance.add(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDate/prototype/subtract/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/subtract/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.subtract
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(1970, 1, 1);
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.subtract(oneProperty);
+const resultWith = instance.subtract(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-propertybag-optional-properties.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplaindatetime
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const minimumProperties = {
+  hour: 0,
+};
+const allProperties = {
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+};
+const resultWithout = instance.toPlainDateTime(minimumProperties);
+const resultWith = instance.toPlainDateTime(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-propertybag-optional-properties.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const minimumProperties = {
+  hour: 0,
+};
+const allProperties = {
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+};
+const resultWithout = instance.toZonedDateTime({ plainTime: minimumProperties, timeZone: "UTC" });
+const resultWith = instance.toZonedDateTime({ plainTime: allProperties, timeZone: "UTC" });
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const minimumProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+};
+const allProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  calendar: "iso8601",
+};
+const resultWithout = Temporal.PlainDateTime.compare(minimumProperties, minimumProperties);
+const resultWith = Temporal.PlainDateTime.compare(allProperties, allProperties);
+assert.sameValue(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const minimumProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+};
+const allProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  calendar: "iso8601",
+};
+const resultWithout = Temporal.PlainDateTime.from(minimumProperties);
+const resultWith = Temporal.PlainDateTime.from(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/add/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/add/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(1970, 1, 1);
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.add(oneProperty);
+const resultWith = instance.add(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-optional-properties.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+const minimumProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+};
+const allProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  calendar: "iso8601",
+};
+const resultWithout = instance.equals(minimumProperties);
+const resultWith = instance.equals(allProperties);
+assert.sameValue(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-optional-properties.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+const minimumProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+};
+const allProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  calendar: "iso8601",
+};
+const resultWithout = instance.since(minimumProperties);
+const resultWith = instance.since(allProperties);
+TemporalHelpers.assertDurationsEqual(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/subtract/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/subtract/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(1970, 1, 1);
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.subtract(oneProperty);
+const resultWith = instance.subtract(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-optional-properties.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+const minimumProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+};
+const allProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  calendar: "iso8601",
+};
+const resultWithout = instance.until(minimumProperties);
+const resultWith = instance.until(allProperties);
+TemporalHelpers.assertDurationsEqual(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-propertybag-optional-properties.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaintime
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+const minimumProperties = {
+  hour: 0,
+};
+const allProperties = {
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+};
+const resultWithout = instance.withPlainTime(minimumProperties);
+const resultWith = instance.withPlainTime(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainTime/compare/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-propertybag-optional-properties.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.compare
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const minimumProperties = {
+  hour: 0,
+};
+const allProperties = {
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+};
+const resultWithout = Temporal.PlainTime.compare(minimumProperties, minimumProperties);
+const resultWith = Temporal.PlainTime.compare(allProperties, allProperties);
+assert.sameValue(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainTime/from/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-propertybag-optional-properties.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.from
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const minimumProperties = {
+  hour: 0,
+};
+const allProperties = {
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+};
+const resultWithout = Temporal.PlainTime.from(minimumProperties);
+const resultWith = Temporal.PlainTime.from(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainTime/prototype/add/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/add/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.add
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime();
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.add(oneProperty);
+const resultWith = instance.add(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-propertybag-optional-properties.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.equals
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const minimumProperties = {
+  hour: 0,
+};
+const allProperties = {
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+};
+const resultWithout = instance.equals(minimumProperties);
+const resultWith = instance.equals(allProperties);
+assert.sameValue(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-propertybag-optional-properties.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const minimumProperties = {
+  hour: 0,
+};
+const allProperties = {
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+};
+const resultWithout = instance.since(minimumProperties);
+const resultWith = instance.since(allProperties);
+TemporalHelpers.assertDurationsEqual(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainTime/prototype/subtract/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/subtract/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.subtract
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime();
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.subtract(oneProperty);
+const resultWith = instance.subtract(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-propertybag-optional-properties.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const minimumProperties = {
+  hour: 0,
+};
+const allProperties = {
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+};
+const resultWithout = instance.until(minimumProperties);
+const resultWith = instance.until(allProperties);
+TemporalHelpers.assertDurationsEqual(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(1970, 1);
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.add(oneProperty);
+const resultWith = instance.add(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(1970, 1);
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.subtract(oneProperty);
+const resultWith = instance.subtract(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-optional-properties.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const minimumProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  timeZone: "UTC",
+};
+const allProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  offset: "+00:00",
+  timeZone: "UTC",
+  calendar: "iso8601",
+};
+const resultWithout = Temporal.ZonedDateTime.compare(minimumProperties, minimumProperties);
+const resultWith = Temporal.ZonedDateTime.compare(allProperties, allProperties);
+assert.sameValue(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-optional-properties.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const minimumProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  timeZone: "UTC",
+};
+const allProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  offset: "+00:00",
+  timeZone: "UTC",
+  calendar: "iso8601",
+};
+const resultWithout = Temporal.ZonedDateTime.from(minimumProperties);
+const resultWith = Temporal.ZonedDateTime.from(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/add/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/add/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.add(oneProperty);
+const resultWith = instance.add(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-optional-properties.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const timeZone = "UTC";
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const minimumProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  timeZone,
+};
+const allProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  offset: "+00:00",
+  timeZone,
+  calendar: "iso8601",
+};
+const resultWithout = instance.equals(minimumProperties);
+const resultWith = instance.equals(allProperties);
+assert.sameValue(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-optional-properties.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const timeZone = "UTC";
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const minimumProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  timeZone,
+};
+const allProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  offset: "+00:00",
+  timeZone,
+  calendar: "iso8601",
+};
+const resultWithout = instance.since(minimumProperties);
+const resultWith = instance.since(allProperties);
+TemporalHelpers.assertDurationsEqual(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/argument-propertybag-optional-properties.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
+
+const oneProperty = {
+  hours: 1,
+};
+const allProperties = {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 1,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+  microseconds: 0,
+  nanoseconds: 0,
+};
+const resultWithout = instance.subtract(oneProperty);
+const resultWith = instance.subtract(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-optional-properties.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const timeZone = "UTC";
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const minimumProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  timeZone,
+};
+const allProperties = {
+  year: 2021,
+  month: 10,
+  day: 28,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  offset: "+00:00",
+  timeZone,
+  calendar: "iso8601",
+};
+const resultWithout = instance.until(minimumProperties);
+const resultWith = instance.until(allProperties);
+TemporalHelpers.assertDurationsEqual(resultWithout, resultWith, "results should be the same with and without optional properties");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-propertybag-optional-properties.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-propertybag-optional-properties.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaintime
+description: >
+  A property bag missing optional properties is equivalent to a property bag
+  with all the optional properties having their default values
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+const minimumProperties = {
+  hour: 0,
+};
+const allProperties = {
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+};
+const resultWithout = instance.withPlainTime(minimumProperties);
+const resultWith = instance.withPlainTime(allProperties);
+assert(resultWithout.equals(resultWith), "results should be the same with and without optional properties");


### PR DESCRIPTION
These tests confirm that Temporal-object-like property bags have the correct default values for their optional properties.

This provides coverage for a V8 bug: https://issues.chromium.org/issues/446728405