### PR TITLE
Temporal: Add coverage for adding large microseconds/nanoseconds values

### DIFF
--- a/test/built-ins/Temporal/PlainDateTime/prototype/add/add-large-subseconds.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/add/add-large-subseconds.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: Adding unbalanced durations with large subsecond values to a date
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const pdt = new Temporal.PlainDateTime(2020, 2, 29, 0, 57, 27, 747, 612, 578);
+TemporalHelpers.assertPlainDateTime(pdt.add(Temporal.Duration.from({nanoseconds: Number.MAX_SAFE_INTEGER})),
+                                    2020, 6, "M06", 12, 6, 57, 27, 2, 353, 569);
+TemporalHelpers.assertPlainDateTime(pdt.add(Temporal.Duration.from({microseconds: Number.MAX_SAFE_INTEGER})),
+                                   2305, 8, "M08", 4, 0, 45, 2, 488, 603, 578);
+assert.throws(RangeError, () => pdt.add(Temporal.Duration.from({milliseconds: Number.MAX_SAFE_INTEGER})));
+assert.throws(RangeError, () => pdt.add(Temporal.Duration.from({seconds: Number.MAX_SAFE_INTEGER})));
+

--- a/test/built-ins/Temporal/PlainDateTime/prototype/subtract/subtract-large-subseconds.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/subtract/subtract-large-subseconds.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: Subtracting unbalanced durations with large subsecond values from a date
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const pdt = new Temporal.PlainDateTime(2020, 2, 29, 0, 57, 27, 747, 612, 578);
+TemporalHelpers.assertPlainDateTime(pdt.subtract(Temporal.Duration.from({nanoseconds: Number.MAX_SAFE_INTEGER})),
+                                    2019, 11, "M11", 16, 18, 57, 28, 492, 871, 587);
+TemporalHelpers.assertPlainDateTime(pdt.subtract(Temporal.Duration.from({microseconds: Number.MAX_SAFE_INTEGER})),
+                                    1734, 9, "M09", 26, 1, 9, 53, 6, 621, 578);
+assert.throws(RangeError, () => pdt.subtract(Temporal.Duration.from({milliseconds: Number.MAX_SAFE_INTEGER})));
+assert.throws(RangeError, () => pdt.subtract(Temporal.Duration.from({seconds: Number.MAX_SAFE_INTEGER})));
+

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/add/add-large-subseconds.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/add/add-large-subseconds.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: Adding unbalanced durations with large subsecond values to a date
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+// const pdt = new Temporal.PlainDateTime(2020, 2, 29, 0, 57, 27, 747, 612, 578);
+const zdt = new Temporal.ZonedDateTime(1582966647747612578n, "America/Los_Angeles");
+
+TemporalHelpers.assertZonedDateTimesEqual(zdt.add(Temporal.Duration.from({nanoseconds: Number.MAX_SAFE_INTEGER})),
+                                          new Temporal.ZonedDateTime(1591973847002353569n, "America/Los_Angeles"));
+TemporalHelpers.assertZonedDateTimesEqual(zdt.add(Temporal.Duration.from({microseconds: Number.MAX_SAFE_INTEGER})),
+                                          new Temporal.ZonedDateTime(10590165902488603578n, "America/Los_Angeles"));
+assert.throws(RangeError, () => zdt.add(Temporal.Duration.from({milliseconds: Number.MAX_SAFE_INTEGER})));
+assert.throws(RangeError, () => zdt.add(Temporal.Duration.from({seconds: Number.MAX_SAFE_INTEGER})));
+

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/subtract-large-subseconds.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/subtract-large-subseconds.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: Subtracting unbalanced durations with large subsecond values from a date
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+// const pdt = new Temporal.PlainDateTime(2020, 2, 29, 0, 57, 27, 747, 612, 578);
+const zdt = new Temporal.ZonedDateTime(1582966647747612578n, "America/Los_Angeles");
+
+TemporalHelpers.assertZonedDateTimesEqual(zdt.subtract(Temporal.Duration.from({nanoseconds: Number.MAX_SAFE_INTEGER})),
+                                          new Temporal.ZonedDateTime(1573959448492871587n, "America/Los_Angeles"));
+TemporalHelpers.assertZonedDateTimesEqual(zdt.subtract(Temporal.Duration.from({microseconds: Number.MAX_SAFE_INTEGER})),
+                                          new Temporal.ZonedDateTime(-7424232606993378422n, "America/Los_Angeles"));
+assert.throws(RangeError, () => zdt.subtract(Temporal.Duration.from({milliseconds: Number.MAX_SAFE_INTEGER})));
+assert.throws(RangeError, () => zdt.subtract(Temporal.Duration.from({seconds: Number.MAX_SAFE_INTEGER})));
+


### PR DESCRIPTION
Add coverage for adding unbalanced durations with large microseconds or nanoseconds values to a PlainDateTime or ZonedDateTime.