### PR TITLE
Temporal: Add tests for correct rounding of epoch milliseconds in toString()

### DIFF
--- a/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-negative.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-negative.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: Epoch milliseconds should be rounded down before adding negative micro/nanoseconds back in
+features: [BigInt, Temporal]
+---*/
+
+const instant = new Temporal.Instant(-1000000000000001000n);
+assert.sameValue(instant.toString(), "1938-04-24T22:13:19.999999Z",
+                 "epoch milliseconds should be rounded down to compute seconds");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-negative.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-negative.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: Epoch milliseconds should be rounded down before adding negative micro/nanoseconds back in
+features: [Temporal]
+---*/
+
+const pdt = new Temporal.PlainDateTime(1938, 4, 24, 22, 13, 19, 999, 999);
+assert.sameValue(pdt.toString(), "1938-04-24T22:13:19.999999",
+                 "epoch milliseconds should be rounded down to compute seconds");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-negative.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-negative.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: Epoch milliseconds should be rounded down before adding negative micro/nanoseconds back in
+features: [BigInt, Temporal]
+---*/
+
+const zdt = new Temporal.ZonedDateTime(-1000000000000001000n, "UTC");
+assert.sameValue(zdt.toString(), "1938-04-24T22:13:19.999999+00:00[UTC]",
+                 "epoch milliseconds should be rounded down to compute seconds");


### PR DESCRIPTION
This tests for a bug observed in JSC where `toString()` was off by one second for Instants due to rounding seconds up instead of down when extracting the time parts from the instant.