### PR TITLE
Fix %ThrowTypeError% cross-realm error check

### DIFF
--- a/test/built-ins/ThrowTypeError/distinct-cross-realm.js
+++ b/test/built-ins/ThrowTypeError/distinct-cross-realm.js
@@ -24,6 +24,9 @@ var otherThrowTypeError = Object.getOwnPropertyDescriptor(otherArgs, "callee").g
 var otherThrowTypeError2 = Object.getOwnPropertyDescriptor(otherArgs, "callee").get;
 
 assert.throws(TypeError, function() {
+  localThrowTypeError();
+});
+assert.throws(other.TypeError, function() {
   otherThrowTypeError();
 });
 


### PR DESCRIPTION
See https://github.com/tc39/test262/pull/4604#pullrequestreview-3402010945. Currently this test throws `Expected a TypeError but got a different error constructor with the same name`.