### PR TITLE
Added Intl.Era-monthcode test verifying all calendars supported

### DIFF
--- a/test/intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js
+++ b/test/intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js
@@ -46,11 +46,6 @@ const requiredCalendars = [
 ]
 
 const supportedCalendars = Intl.supportedValuesOf("calendar");
-let currentCalendar = "";
-
-function containedInCalendar(requiredCalendar){
-  currentCalendar = requiredCalendar;
-  return supportedCalendars.includes(requiredCalendar);
+for (const calendar of requiredCalendars) {
+  assert(supportedCalendars.includes(calendar), "Required calendar: " + calendar + " must be supported");
 }
-
-assert.sameValue(requiredCalendars.every(containedInCalendar), true, "Required calendar: " + currentCalendar + " not supported");


### PR DESCRIPTION
Intl Era Monthcode requires support for the calendars given in [this table](https://tc39.es/proposal-intl-era-monthcode/#table-calendar-types). This tests for that. 