### PR TITLE
Added test for Islamic calendar fallbacks [intl-era-monthcode]

### DIFF
--- a/test/intl402/DateTimeFormat/constructor-options-calendar-islamic-fallback.js
+++ b/test/intl402/DateTimeFormat/constructor-options-calendar-islamic-fallback.js
@@ -26,7 +26,6 @@ const availableCalendars = [
 	"dangi",
 	"ethioaa",
 	"ethiopic",
-	"ethiopic-amete-alem",
 	"gregory",
 	"hebrew",
 	"indian",


### PR DESCRIPTION
The Era Monthcode spec indicates that the fallback when "islamic" or "islamic-rgsa" calendars used must be "an implementation- and locale-defined [calendar type](https://tc39.es/proposal-intl-era-monthcode/#sec-ecma402-calendar-types) that is one of the values returned from [AvailableCalendars](https://tc39.es/proposal-intl-era-monthcode/#sup-availablecalendars)."

this PR replaces https://github.com/tc39/test262/pull/4612