### PR TITLE
Temporal: Add tests for internal representation of Duration

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/add/float64-representable-integer.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/float64-representable-integer.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: Internal representation uses float64-representable integers
+features: [Temporal]
+---*/
+
+const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, /* µs = */ Number.MAX_SAFE_INTEGER, 0);
+const result = d.add({ microseconds: Number.MAX_SAFE_INTEGER - 1 });
+
+// ℝ(𝔽(18014398509481981)) = 18014398509481980
+assert.sameValue(result.microseconds, 18014398509481980,
+  "microseconds result should have FP precision loss");
+assert.sameValue(result.toString(), "PT18014398509.48198S",
+  "toString() should not use more precise internal representation than the spec prescribes");
+assert.sameValue(Temporal.Duration.compare(result.add({ microseconds: 1 }), result), 0,
+  "subsequent add() should not use more precise internal representation than the spec prescribes");

--- a/test/built-ins/Temporal/Duration/prototype/round/float64-representable-integer.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/float64-representable-integer.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: Internal representation uses float64-representable integers
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, /* ms = */ 18014398509481, /* µs = */ 981, 0);
+const result = d.round({ largestUnit: "microseconds" });
+
+// ℝ(𝔽(18014398509481981)) = 18014398509481980
+assert.sameValue(result.microseconds, 18014398509481980,
+  "microseconds result should have FP precision loss");
+assert.sameValue(result.toString(), "PT18014398509.48198S",
+  "toString() should not use more precise internal representation than the spec prescribes");
+// Rounding bounds of 8 µs are ...976 and ...984. halfTrunc will round down if
+// the µs component is ...980 and up if it is ...981
+TemporalHelpers.assertDuration(
+  result.round({ largestUnit: "seconds", smallestUnit: "microseconds", roundingMode: "halfTrunc", roundingIncrement: 8 }),
+  0, 0, 0, 0, 0, 0, 18014398509, 481, 976, 0,
+  "subsequent round() should not use more precise internal representation than the spec prescribes");

--- a/test/built-ins/Temporal/Duration/prototype/subtract/float64-representable-integer.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/float64-representable-integer.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: Internal representation uses float64-representable integers
+features: [Temporal]
+---*/
+
+const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, /* µs = */ Number.MAX_SAFE_INTEGER, 0);
+const result = d.subtract({ microseconds: Number.MIN_SAFE_INTEGER + 1 });
+
+// ℝ(𝔽(18014398509481981)) = 18014398509481980
+assert.sameValue(result.microseconds, 18014398509481980,
+  "microseconds result should have FP precision loss");
+assert.sameValue(result.toString(), "PT18014398509.48198S",
+  "toString() should not use more precise internal representation than the spec prescribes");
+assert.sameValue(Temporal.Duration.compare(result.subtract({ microseconds: 1 }), result), 0,
+  "subsequent subtract() should not use more precise internal representation than the spec prescribes");

--- a/test/built-ins/Temporal/Instant/prototype/since/float64-representable-integer.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/float64-representable-integer.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: Internal representation of Duration uses float64-representable integers
+features: [Temporal]
+---*/
+
+const i1 = new Temporal.Instant(0n);
+const i2 = new Temporal.Instant(18446744073_709_551_616n);
+const result = i1.since(i2, { largestUnit: "microseconds" });
+
+// ℝ(𝔽(-18446744073709551)) = -18446744073709552
+assert.sameValue(result.microseconds, -18446744073709552,
+  "microseconds result should have FP precision loss");
+assert.sameValue(result.toString(), "-PT18446744073.709552616S",
+  "Duration.p.toString() should not use more precise internal representation than the spec prescribes");
+assert.sameValue(Temporal.Duration.compare(result.add({ microseconds: 1 }), result), 0,
+  "subsequent ops on duration should not use more precise internal representation than the spec prescribes");

--- a/test/built-ins/Temporal/Instant/prototype/until/float64-representable-integer.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/float64-representable-integer.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: Internal representation of Duration uses float64-representable integers
+features: [Temporal]
+---*/
+
+const i1 = new Temporal.Instant(0n);
+const i2 = new Temporal.Instant(18446744073_709_551_616n);
+const result = i1.until(i2, { largestUnit: "microseconds" });
+
+// ℝ(𝔽(18446744073709551)) = 18446744073709552
+assert.sameValue(result.microseconds, 18446744073709552,
+  "microseconds result should have FP precision loss");
+assert.sameValue(result.toString(), "PT18446744073.709552616S",
+  "Duration.p.toString() should not use more precise internal representation than the spec prescribes");
+assert.sameValue(Temporal.Duration.compare(result.add({ microseconds: 1 }), result), 0,
+  "subsequent ops on duration should not use more precise internal representation than the spec prescribes");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/float64-representable-integer.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/float64-representable-integer.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: Internal representation of Duration uses float64-representable integers
+features: [Temporal]
+---*/
+
+const dt1 = new Temporal.PlainDateTime(1970, 1, 1);
+const dt2 = new Temporal.PlainDateTime(2554, 7, 21, 23, 34, 33, 709, 551, 616);
+const result = dt1.since(dt2, { largestUnit: "microseconds" });
+
+// ℝ(𝔽(-18446744073709551)) = -18446744073709552
+assert.sameValue(result.microseconds, -18446744073709552,
+  "microseconds result should have FP precision loss");
+assert.sameValue(result.toString(), "-PT18446744073.709552616S",
+  "Duration.p.toString() should not use more precise internal representation than the spec prescribes");
+assert.sameValue(Temporal.Duration.compare(result.add({ microseconds: 1 }), result), 0,
+  "subsequent ops on duration should not use more precise internal representation than the spec prescribes");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/float64-representable-integer.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/float64-representable-integer.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: Internal representation of Duration uses float64-representable integers
+features: [Temporal]
+---*/
+
+const dt1 = new Temporal.PlainDateTime(1970, 1, 1);
+const dt2 = new Temporal.PlainDateTime(2554, 7, 21, 23, 34, 33, 709, 551, 616);
+const result = dt1.until(dt2, { largestUnit: "microseconds" });
+
+// ℝ(𝔽(18446744073709551)) = 18446744073709552
+assert.sameValue(result.microseconds, 18446744073709552,
+  "microseconds result should have FP precision loss");
+assert.sameValue(result.toString(), "PT18446744073.709552616S",
+  "Duration.p.toString() should not use more precise internal representation than the spec prescribes");
+assert.sameValue(Temporal.Duration.compare(result.add({ microseconds: 1 }), result), 0,
+  "subsequent ops on duration should not use more precise internal representation than the spec prescribes");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/float64-representable-integer.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/float64-representable-integer.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Internal representation of Duration uses float64-representable integers
+features: [Temporal]
+---*/
+
+const z1 = new Temporal.ZonedDateTime(0n, "UTC");
+const z2 = new Temporal.ZonedDateTime(18446744073_709_551_616n, "UTC");
+const result = z1.since(z2, { largestUnit: "microseconds" });
+
+// ℝ(𝔽(-18446744073709551)) = -18446744073709552
+assert.sameValue(result.microseconds, -18446744073709552,
+  "microseconds result should have FP precision loss");
+assert.sameValue(result.toString(), "-PT18446744073.709552616S",
+  "Duration.p.toString() should not use more precise internal representation than the spec prescribes");
+assert.sameValue(Temporal.Duration.compare(result.add({ microseconds: 1 }), result), 0,
+  "subsequent ops on duration should not use more precise internal representation than the spec prescribes");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/float64-representable-integer.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/float64-representable-integer.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Internal representation of Duration uses float64-representable integers
+features: [Temporal]
+---*/
+
+const z1 = new Temporal.ZonedDateTime(0n, "UTC");
+const z2 = new Temporal.ZonedDateTime(18446744073_709_551_616n, "UTC");
+const result = z1.until(z2, { largestUnit: "microseconds" });
+
+// ℝ(𝔽(18446744073709551)) = 18446744073709552
+assert.sameValue(result.microseconds, 18446744073709552,
+  "microseconds result should have FP precision loss");
+assert.sameValue(result.toString(), "PT18446744073.709552616S",
+  "Duration.p.toString() should not use more precise internal representation than the spec prescribes");
+assert.sameValue(Temporal.Duration.compare(result.add({ microseconds: 1 }), result), 0,
+  "subsequent ops on duration should not use more precise internal representation than the spec prescribes");


### PR DESCRIPTION
The spec describes the internal representation of Duration as float64- representable integers. There are a few tricky ways that it is observable if an implementation does not do this correctly. Here are some tests for them.

This catches an implementation bug: https://github.com/boa-dev/temporal/issues/613