### PR TITLE
Temporal: Add test for CalendarYearMonthFromFields with Japanese dates

### DIFF
--- a/test/intl402/Temporal/PlainYearMonth/from/reference-day-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/reference-day-japanese.js
@@ -3,7 +3,9 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.calendaryearmonthfromfields
-description: Reference ISO day is chosen to be the first of the calendar month
+description: >
+  Reference ISO day is chosen to be the first of the calendar month
+  See https://github.com/tc39/proposal-temporal/issues/3150 for more context.
 info: |
   1. Let _firstDayIndex_ be the 1-based index of the first day of the month described by _fields_ (i.e., 1 unless the month's first day is skipped by this calendar.)
   2. Set _fields_.[[Day]] to _firstDayIndex_.


### PR DESCRIPTION
Japanese eras can begin in the middle of a month. This adds tests for the existing behavior, which is that PlainYearMonth.from returns a PlainYearMonth with an era matching the first day of the month, even when that conflicts with the era given by the argument.

See https://github.com/tc39/proposal-temporal/issues/3150 for more details.