### PR TITLE
Revert "Allow alternative era for Chinese calendar"

### DIFF
--- a/test/intl402/Temporal/PlainDate/prototype/until/until-across-lunisolar-leap-months.js
+++ b/test/intl402/Temporal/PlainDate/prototype/until/until-across-lunisolar-leap-months.js
@@ -9,18 +9,8 @@ features: [Temporal, Intl.Era-monthcode]
 
 // 2001 is a leap year in the Chinese calendar with a M04L leap month.
 // Therefore, month: 6 is M05 in 2001 but M06 in 2000 which is not a leap year.
-
-const year2000 = new Temporal.PlainDate(2000, 3, 1).withCalendar("chinese").year;
-const year2001 = new Temporal.PlainDate(2001, 3, 1).withCalendar("chinese").year;
-
-const one = Temporal.PlainDate.from({ year: year2000, month: 6, day: 1, calendar: 'chinese' });
-const two = Temporal.PlainDate.from({ year: year2001, month: 6, day: 1, calendar: 'chinese' });
-
-assert.sameValue(one.inLeapYear, false, "year 2000 is not a leap year");
-assert.sameValue(one.monthCode, "M06", "sixth month in year 2000 has month code M06");
-
-assert.sameValue(two.inLeapYear, true, "year 2001 is a leap year");
-assert.sameValue(two.monthCode, "M05", "sixth month in year 2001 has month code M05");
+const one = Temporal.PlainDate.from({ year: 2000, month: 6, day: 1, calendar: 'chinese' });
+const two = Temporal.PlainDate.from({ year: 2001, month: 6, day: 1, calendar: 'chinese' });
 
 const expected = { years: 'P12M', months: 'P12M', weeks: 'P50W4D', days: 'P354D' };
 


### PR DESCRIPTION
This reverts commit d124e1486c007a737411ea7110458e93680b7953 (#4309). The Intl Era Monthcode proposal precludes this alternative era for the Chinese calendar, so implementations that have it should not pass the test.