### PR TITLE
[explicit-resource-management] Mark using within default clause as negative

### DIFF
--- a/test/language/statements/using/syntax/with-initializer-default-statement-list.js
+++ b/test/language/statements/using/syntax/with-initializer-default-statement-list.js
@@ -11,7 +11,9 @@ info: |
 
   - It is a Syntax Error if AwaitUsingDeclaration is contained directly within the StatementList of either a CaseClause or
     DefaultClause.
-
+negative:
+  phase: parse
+  type: SyntaxError
 features: [explicit-resource-management]
 ---*/
 $DONOTEVALUATE();


### PR DESCRIPTION
Similar to CaseClause, it is a syntax error if `using`is directly within a default clause.

See also https://github.com/tc39/test262/blob/f1433632af8b42379e8ec0f7b0ef65e1a9754d99/test/language/statements/using/syntax/with-initializer-case-expression-statement-list.js#L1-L19

Spot this issue in weekly test262 update in the Babal repo: https://github.com/babel/babel/pull/17588.