### PR TITLE
Replace "closed" global variable in Math.sumPrecise test

### DIFF
--- a/test/built-ins/Math/sumPrecise/throws-on-non-number.js
+++ b/test/built-ins/Math/sumPrecise/throws-on-non-number.js
@@ -49,14 +49,14 @@ assert.throws(TypeError, function () {
 assert.sameValue(coercions, 0);
 
 var nextCalls = 0;
-var closed = false;
+var returnCalls = 0;
 var iterator = {
   next: function () {
     ++nextCalls;
     return { done: false, value: objectWithValueOf };
   },
   return: function () {
-    closed = true;
+    ++returnCalls;
     return {};
   }
 };
@@ -71,4 +71,4 @@ assert.throws(TypeError, function () {
 });
 assert.sameValue(coercions, 0);
 assert.sameValue(nextCalls, 1);
-assert.sameValue(closed, true);
+assert.sameValue(returnCalls, 1);


### PR DESCRIPTION
This allows running the test in browsers, too.

<https://developer.mozilla.org/en-US/docs/Web/API/Window/closed>.