### PR TITLE
Intl Era Monthcode: Add tests for Hebrew lunisolar leap month difference

### DIFF
--- a/test/intl402/Temporal/PlainDate/prototype/since/leap-months-hebrew.js
+++ b/test/intl402/Temporal/PlainDate/prototype/since/leap-months-hebrew.js
@@ -1,0 +1,168 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in hebrew calendar
+esid: sec-temporal.plaindate.prototype.since
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 5784 is a leap year.
+// M05 - Shevat
+// M05L - Adar I
+// M06 - Adar II
+// M07 - Nisan
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+const common1Shevat = Temporal.PlainDate.from({ year: 5783, monthCode: "M05", day: 1, calendar }, options);
+const common1Adar = Temporal.PlainDate.from({ year: 5783, monthCode: "M06", day: 1, calendar }, options);
+const common1Nisan = Temporal.PlainDate.from({ year: 5783, monthCode: "M07", day: 1, calendar }, options);
+const leapShevat = Temporal.PlainDate.from({ year: 5784, monthCode: "M05", day: 1, calendar }, options);
+const leapAdarI = Temporal.PlainDate.from({ year: 5784, monthCode: "M05L", day: 1, calendar }, options);
+const leapAdarII = Temporal.PlainDate.from({ year: 5784, monthCode: "M06", day: 1, calendar }, options);
+const common2Shevat = Temporal.PlainDate.from({ year: 5785, monthCode: "M05", day: 1, calendar }, options);
+const common2Adar = Temporal.PlainDate.from({ year: 5785, monthCode: "M06", day: 1, calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, weeks, days, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+// For largestUnit of days and weeks, the results should be identical to what
+// the ISO calendar gives for the corresponding ISO dates
+const tests = [
+  [
+    common1Shevat, leapShevat,
+    [-1, 0, 0, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -12, 0, 0, "M05-M05 common-leap backwards is -12mo"],
+  ],
+  [
+    leapShevat, common2Shevat,
+    [-1, 0, 0, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -13, 0, 0, "M05-M05 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common1Shevat, common2Shevat,
+    [-2, 0, 0, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Adar, leapAdarII,
+    [-1, 0, 0, 0, "M06-M06 common-leap backwards is -1y"],
+    [0, -13, 0, 0, "M06-M06 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapAdarII, common2Adar,
+    [-1, 0, 0, 0, "M06-M06 leap-common backwards is -1y"],
+    [0, -12, 0, 0, "M06-M06 leap-common backwards is -12mo"],
+  ],
+  [
+    common1Adar, common2Adar,
+    [-2, 0, 0, 0, "M06-M06 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M06-M06 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Shevat, leapAdarI,
+    [-1, -1, 0, 0, "M05-M05L backwards is -1y -1mo"],
+    [0, -13, 0, 0, "M05-M05L backwards is -13mo"],
+  ],
+  [
+    leapAdarI, common2Shevat,
+    [0, -12, 0, 0, "M05L-M05 backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M05L-M05 backwards is -12mo"],
+  ],
+  [
+    common1Adar, leapAdarI,
+    [0, -12, 0, 0, "M06-M05L backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M06-M05L backwards is -12mo"],
+  ],
+  [
+    leapAdarI, common2Adar,
+    [-1, 0, 0, 0, "M05L-M06 backwards is -1y (exhibits calendar-specific constraining)"],
+    [0, -13, 0, 0, "M05L-M06 backwards is -13mo"],
+  ],
+  [
+    common1Nisan, leapAdarII,
+    [0, -12, 0, 0, "M07-M06 common-leap backwards is -12mo not -11mo"],
+    [0, -12, 0, 0, "M07-M06 common-leap backwards is -12mo not -11mo"],
+  ],
+
+  // Negative
+  [
+    common2Shevat, leapShevat,
+    [1, 0, 0, 0, "M05-M05 common-leap is 1y"],
+    [0, 13, 0, 0, "M05-M05 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapShevat, common1Shevat,
+    [1, 0, 0, 0, "M05-M05 leap-common is 1y"],
+    [0, 12, 0, 0, "M05-M05 leap-common is 12mo not 13mo"],
+  ],
+  [
+    common2Shevat, common1Shevat,
+    [2, 0, 0, 0, "M05-M05 common-common is 2y"],
+    [0, 25, 0, 0, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Adar, leapAdarII,
+    [1, 0, 0, 0, "M06-M06 common-leap is 1y"],
+    [0, 12, 0, 0, "M06-M06 common-leap is 12mo not 13mo"],
+  ],
+  [
+    leapAdarII, common1Adar,
+    [1, 0, 0, 0, "M06-M06 leap-common is 1y"],
+    [0, 13, 0, 0, "M06-M06 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common2Adar, common1Adar,
+    [2, 0, 0, 0, "M06-M06 common-common is 2y"],
+    [0, 25, 0, 0, "M06-M06 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Shevat, leapAdarI,
+    [0, 12, 0, 0, "M05-M05L is 12mo not 1y"],
+    [0, 12, 0, 0, "M05-M05L is 12mo"],
+  ],
+  [
+    leapAdarI, common1Shevat,
+    [1, 1, 0, 0, "M05L-M05 is 1y 1mo (exhibits calendar-specific constraining)"],
+    [0, 13, 0, 0, "M05L-M05 is 13mo"],
+  ],
+  [
+    common2Adar, leapAdarI,
+    [1, 1, 0, 0, "M06-M05L is 1y 1mo"],
+    [0, 13, 0, 0, "M06-M05L is 13mo"],
+  ],
+  [
+    leapAdarI, common1Adar,
+    [0, 12, 0, 0, "M05L-M06 is 12mo not 1y"],
+    [0, 12, 0, 0, "M05L-M06 is 12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, weeks, days, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, weeks, days, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  const oneISO = one.withCalendar("iso8601");
+  const twoISO = two.withCalendar("iso8601");
+
+  const resultWeeks = one.since(two, { largestUnit: "weeks" });
+  const resultWeeksISO = oneISO.since(twoISO, { largestUnit: "weeks" });
+  TemporalHelpers.assertDurationsEqual(resultWeeks, resultWeeksISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit weeks`);
+
+  const resultDays = one.since(two);
+  const resultDaysISO = oneISO.since(twoISO);
+  TemporalHelpers.assertDurationsEqual(resultDays, resultDaysISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit days`);
+}

--- a/test/intl402/Temporal/PlainDate/prototype/until/leap-months-hebrew.js
+++ b/test/intl402/Temporal/PlainDate/prototype/until/leap-months-hebrew.js
@@ -1,0 +1,168 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in hebrew calendar
+esid: sec-temporal.plaindate.prototype.until
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 5784 is a leap year.
+// M05 - Shevat
+// M05L - Adar I
+// M06 - Adar II
+// M07 - Nisan
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+const common1Shevat = Temporal.PlainDate.from({ year: 5783, monthCode: "M05", day: 1, calendar }, options);
+const common1Adar = Temporal.PlainDate.from({ year: 5783, monthCode: "M06", day: 1, calendar }, options);
+const common1Nisan = Temporal.PlainDate.from({ year: 5783, monthCode: "M07", day: 1, calendar }, options);
+const leapShevat = Temporal.PlainDate.from({ year: 5784, monthCode: "M05", day: 1, calendar }, options);
+const leapAdarI = Temporal.PlainDate.from({ year: 5784, monthCode: "M05L", day: 1, calendar }, options);
+const leapAdarII = Temporal.PlainDate.from({ year: 5784, monthCode: "M06", day: 1, calendar }, options);
+const common2Shevat = Temporal.PlainDate.from({ year: 5785, monthCode: "M05", day: 1, calendar }, options);
+const common2Adar = Temporal.PlainDate.from({ year: 5785, monthCode: "M06", day: 1, calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, weeks, days, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+// For largestUnit of days and weeks, the results should be identical to what
+// the ISO calendar gives for the corresponding ISO dates
+const tests = [
+  [
+    common1Shevat, leapShevat,
+    [1, 0, 0, 0, "M05-M05 common-leap is 1y"],
+    [0, 12, 0, 0, "M05-M05 common-leap is 12mo"],
+  ],
+  [
+    leapShevat, common2Shevat,
+    [1, 0, 0, 0, "M05-M05 leap-common is 1y"],
+    [0, 13, 0, 0, "M05-M05 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common1Shevat, common2Shevat,
+    [2, 0, 0, 0, "M05-M05 common-common is 2y"],
+    [0, 25, 0, 0, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Adar, leapAdarII,
+    [1, 0, 0, 0, "M06-M06 common-leap is 1y"],
+    [0, 13, 0, 0, "M06-M06 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapAdarII, common2Adar,
+    [1, 0, 0, 0, "M06-M06 leap-common is 1y"],
+    [0, 12, 0, 0, "M06-M06 leap-common is 12mo"],
+  ],
+  [
+    common1Adar, common2Adar,
+    [2, 0, 0, 0, "M06-M06 common-common is 2y"],
+    [0, 25, 0, 0, "M06-M06 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Shevat, leapAdarI,
+    [1, 1, 0, 0, "M05-M05L is 1y 1mo"],
+    [0, 13, 0, 0, "M05-M05L is 13mo"],
+  ],
+  [
+    leapAdarI, common2Shevat,
+    [0, 12, 0, 0, "M05L-M05 is 12mo not 1y"],
+    [0, 12, 0, 0, "M05L-M05 is 12mo"],
+  ],
+  [
+    common1Adar, leapAdarI,
+    [0, 12, 0, 0, "M06-M05L is 12mo not 1y"],
+    [0, 12, 0, 0, "M06-M05L is 12mo"],
+  ],
+  [
+    leapAdarI, common2Adar,
+    [1, 0, 0, 0, "M05L-M06 is 1y (exhibits calendar-specific constraining)"],
+    [0, 13, 0, 0, "M05L-M06 is 13mo"],
+  ],
+  [
+    common1Nisan, leapAdarII,
+    [0, 12, 0, 0, "M07-M06 common-leap is 12mo not 11mo"],
+    [0, 12, 0, 0, "M07-M06 common-leap is 12mo not 11mo"],
+  ],
+
+  // Negative
+  [
+    common2Shevat, leapShevat,
+    [-1, 0, 0, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -13, 0, 0, "M05-M05 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapShevat, common1Shevat,
+    [-1, 0, 0, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -12, 0, 0, "M05-M05 leap-common backwards is -12mo not -13mo"],
+  ],
+  [
+    common2Shevat, common1Shevat,
+    [-2, 0, 0, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Adar, leapAdarII,
+    [-1, 0, 0, 0, "M06-M06 common-leap backwards is -1y"],
+    [0, -12, 0, 0, "M06-M06 common-leap backwards is -12mo not -13mo"],
+  ],
+  [
+    leapAdarII, common1Adar,
+    [-1, 0, 0, 0, "M06-M06 leap-common backwards is -1y"],
+    [0, -13, 0, 0, "M06-M06 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common2Adar, common1Adar,
+    [-2, 0, 0, 0, "M06-M06 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M06-M06 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Shevat, leapAdarI,
+    [0, -12, 0, 0, "M05-M05L backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M05-M05L backwards is -12mo"],
+  ],
+  [
+    leapAdarI, common1Shevat,
+    [-1, -1, 0, 0, "M05L-M05 backwards is -1y -1mo (exhibits calendar-specific constraining)"],
+    [0, -13, 0, 0, "M05L-M05 backwards is -13mo"],
+  ],
+  [
+    common2Adar, leapAdarI,
+    [-1, -1, 0, 0, "M06-M05L backwards is -1y -1mo"],
+    [0, -13, 0, 0, "M06-M05L backwards is -13mo"],
+  ],
+  [
+    leapAdarI, common1Adar,
+    [0, -12, 0, 0, "M05L-M06 backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M05L-M06 backwards is -12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, weeks, days, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, weeks, days, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  const oneISO = one.withCalendar("iso8601");
+  const twoISO = two.withCalendar("iso8601");
+
+  const resultWeeks = one.until(two, { largestUnit: "weeks" });
+  const resultWeeksISO = oneISO.until(twoISO, { largestUnit: "weeks" });
+  TemporalHelpers.assertDurationsEqual(resultWeeks, resultWeeksISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit weeks`);
+
+  const resultDays = one.until(two);
+  const resultDaysISO = oneISO.until(twoISO);
+  TemporalHelpers.assertDurationsEqual(resultDays, resultDaysISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit days`);
+}

--- a/test/intl402/Temporal/PlainDateTime/prototype/since/leap-months-hebrew.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/since/leap-months-hebrew.js
@@ -1,0 +1,168 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in hebrew calendar
+esid: sec-temporal.plaindatetime.prototype.since
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 5784 is a leap year.
+// M05 - Shevat
+// M05L - Adar I
+// M06 - Adar II
+// M07 - Nisan
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+const common1Shevat = Temporal.PlainDateTime.from({ year: 5783, monthCode: "M05", day: 1, hour: 12, minute: 34, calendar }, options);
+const common1Adar = Temporal.PlainDateTime.from({ year: 5783, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+const common1Nisan = Temporal.PlainDateTime.from({ year: 5783, monthCode: "M07", day: 1, hour: 12, minute: 34, calendar }, options);
+const leapShevat = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M05", day: 1, hour: 12, minute: 34, calendar }, options);
+const leapAdarI = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, calendar }, options);
+const leapAdarII = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+const common2Shevat = Temporal.PlainDateTime.from({ year: 5785, monthCode: "M05", day: 1, hour: 12, minute: 34, calendar }, options);
+const common2Adar = Temporal.PlainDateTime.from({ year: 5785, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, weeks, days, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+// For largestUnit of days and weeks, the results should be identical to what
+// the ISO calendar gives for the corresponding ISO dates
+const tests = [
+  [
+    common1Shevat, leapShevat,
+    [-1, 0, 0, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -12, 0, 0, "M05-M05 common-leap backwards is -12mo"],
+  ],
+  [
+    leapShevat, common2Shevat,
+    [-1, 0, 0, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -13, 0, 0, "M05-M05 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common1Shevat, common2Shevat,
+    [-2, 0, 0, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Adar, leapAdarII,
+    [-1, 0, 0, 0, "M06-M06 common-leap backwards is -1y"],
+    [0, -13, 0, 0, "M06-M06 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapAdarII, common2Adar,
+    [-1, 0, 0, 0, "M06-M06 leap-common backwards is -1y"],
+    [0, -12, 0, 0, "M06-M06 leap-common backwards is -12mo"],
+  ],
+  [
+    common1Adar, common2Adar,
+    [-2, 0, 0, 0, "M06-M06 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M06-M06 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Shevat, leapAdarI,
+    [-1, -1, 0, 0, "M05-M05L backwards is -1y -1mo"],
+    [0, -13, 0, 0, "M05-M05L backwards is -13mo"],
+  ],
+  [
+    leapAdarI, common2Shevat,
+    [0, -12, 0, 0, "M05L-M05 backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M05L-M05 backwards is -12mo"],
+  ],
+  [
+    common1Adar, leapAdarI,
+    [0, -12, 0, 0, "M06-M05L backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M06-M05L backwards is -12mo"],
+  ],
+  [
+    leapAdarI, common2Adar,
+    [-1, 0, 0, 0, "M05L-M06 backwards is -1y (exhibits calendar-specific constraining)"],
+    [0, -13, 0, 0, "M05L-M06 backwards is -13mo"],
+  ],
+  [
+    common1Nisan, leapAdarII,
+    [0, -12, 0, 0, "M07-M06 common-leap backwards is -12mo not -11mo"],
+    [0, -12, 0, 0, "M07-M06 common-leap backwards is -12mo not -11mo"],
+  ],
+
+  // Negative
+  [
+    common2Shevat, leapShevat,
+    [1, 0, 0, 0, "M05-M05 common-leap is 1y"],
+    [0, 13, 0, 0, "M05-M05 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapShevat, common1Shevat,
+    [1, 0, 0, 0, "M05-M05 leap-common is 1y"],
+    [0, 12, 0, 0, "M05-M05 leap-common is 12mo not 13mo"],
+  ],
+  [
+    common2Shevat, common1Shevat,
+    [2, 0, 0, 0, "M05-M05 common-common is 2y"],
+    [0, 25, 0, 0, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Adar, leapAdarII,
+    [1, 0, 0, 0, "M06-M06 common-leap is 1y"],
+    [0, 12, 0, 0, "M06-M06 common-leap is 12mo not 13mo"],
+  ],
+  [
+    leapAdarII, common1Adar,
+    [1, 0, 0, 0, "M06-M06 leap-common is 1y"],
+    [0, 13, 0, 0, "M06-M06 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common2Adar, common1Adar,
+    [2, 0, 0, 0, "M06-M06 common-common is 2y"],
+    [0, 25, 0, 0, "M06-M06 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Shevat, leapAdarI,
+    [0, 12, 0, 0, "M05-M05L is 12mo not 1y"],
+    [0, 12, 0, 0, "M05-M05L is 12mo"],
+  ],
+  [
+    leapAdarI, common1Shevat,
+    [1, 1, 0, 0, "M05L-M05 is 1y 1mo (exhibits calendar-specific constraining)"],
+    [0, 13, 0, 0, "M05L-M05 is 13mo"],
+  ],
+  [
+    common2Adar, leapAdarI,
+    [1, 1, 0, 0, "M06-M05L is 1y 1mo"],
+    [0, 13, 0, 0, "M06-M05L is 13mo"],
+  ],
+  [
+    leapAdarI, common1Adar,
+    [0, 12, 0, 0, "M05L-M06 is 12mo not 1y"],
+    [0, 12, 0, 0, "M05L-M06 is 12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, weeks, days, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, weeks, days, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  const oneISO = one.withCalendar("iso8601");
+  const twoISO = two.withCalendar("iso8601");
+
+  const resultWeeks = one.since(two, { largestUnit: "weeks" });
+  const resultWeeksISO = oneISO.since(twoISO, { largestUnit: "weeks" });
+  TemporalHelpers.assertDurationsEqual(resultWeeks, resultWeeksISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit weeks`);
+
+  const resultDays = one.since(two);
+  const resultDaysISO = oneISO.since(twoISO);
+  TemporalHelpers.assertDurationsEqual(resultDays, resultDaysISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit days`);
+}

--- a/test/intl402/Temporal/PlainDateTime/prototype/until/leap-months-hebrew.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/until/leap-months-hebrew.js
@@ -1,0 +1,168 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in hebrew calendar
+esid: sec-temporal.plaindatetime.prototype.until
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 5784 is a leap year.
+// M05 - Shevat
+// M05L - Adar I
+// M06 - Adar II
+// M07 - Nisan
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+const common1Shevat = Temporal.PlainDateTime.from({ year: 5783, monthCode: "M05", day: 1, hour: 12, minute: 34, calendar }, options);
+const common1Adar = Temporal.PlainDateTime.from({ year: 5783, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+const common1Nisan = Temporal.PlainDateTime.from({ year: 5783, monthCode: "M07", day: 1, hour: 12, minute: 34, calendar }, options);
+const leapShevat = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M05", day: 1, hour: 12, minute: 34, calendar }, options);
+const leapAdarI = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, calendar }, options);
+const leapAdarII = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+const common2Shevat = Temporal.PlainDateTime.from({ year: 5785, monthCode: "M05", day: 1, hour: 12, minute: 34, calendar }, options);
+const common2Adar = Temporal.PlainDateTime.from({ year: 5785, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, weeks, days, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+// For largestUnit of days and weeks, the results should be identical to what
+// the ISO calendar gives for the corresponding ISO dates
+const tests = [
+  [
+    common1Shevat, leapShevat,
+    [1, 0, 0, 0, "M05-M05 common-leap is 1y"],
+    [0, 12, 0, 0, "M05-M05 common-leap is 12mo"],
+  ],
+  [
+    leapShevat, common2Shevat,
+    [1, 0, 0, 0, "M05-M05 leap-common is 1y"],
+    [0, 13, 0, 0, "M05-M05 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common1Shevat, common2Shevat,
+    [2, 0, 0, 0, "M05-M05 common-common is 2y"],
+    [0, 25, 0, 0, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Adar, leapAdarII,
+    [1, 0, 0, 0, "M06-M06 common-leap is 1y"],
+    [0, 13, 0, 0, "M06-M06 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapAdarII, common2Adar,
+    [1, 0, 0, 0, "M06-M06 leap-common is 1y"],
+    [0, 12, 0, 0, "M06-M06 leap-common is 12mo"],
+  ],
+  [
+    common1Adar, common2Adar,
+    [2, 0, 0, 0, "M06-M06 common-common is 2y"],
+    [0, 25, 0, 0, "M06-M06 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Shevat, leapAdarI,
+    [1, 1, 0, 0, "M05-M05L is 1y 1mo"],
+    [0, 13, 0, 0, "M05-M05L is 13mo"],
+  ],
+  [
+    leapAdarI, common2Shevat,
+    [0, 12, 0, 0, "M05L-M05 is 12mo not 1y"],
+    [0, 12, 0, 0, "M05L-M05 is 12mo"],
+  ],
+  [
+    common1Adar, leapAdarI,
+    [0, 12, 0, 0, "M06-M05L is 12mo not 1y"],
+    [0, 12, 0, 0, "M06-M05L is 12mo"],
+  ],
+  [
+    leapAdarI, common2Adar,
+    [1, 0, 0, 0, "M05L-M06 is 1y (exhibits calendar-specific constraining)"],
+    [0, 13, 0, 0, "M05L-M06 is 13mo"],
+  ],
+  [
+    common1Nisan, leapAdarII,
+    [0, 12, 0, 0, "M07-M06 common-leap is 12mo not 11mo"],
+    [0, 12, 0, 0, "M07-M06 common-leap is 12mo not 11mo"],
+  ],
+
+  // Negative
+  [
+    common2Shevat, leapShevat,
+    [-1, 0, 0, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -13, 0, 0, "M05-M05 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapShevat, common1Shevat,
+    [-1, 0, 0, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -12, 0, 0, "M05-M05 leap-common backwards is -12mo not -13mo"],
+  ],
+  [
+    common2Shevat, common1Shevat,
+    [-2, 0, 0, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Adar, leapAdarII,
+    [-1, 0, 0, 0, "M06-M06 common-leap backwards is -1y"],
+    [0, -12, 0, 0, "M06-M06 common-leap backwards is -12mo not -13mo"],
+  ],
+  [
+    leapAdarII, common1Adar,
+    [-1, 0, 0, 0, "M06-M06 leap-common backwards is -1y"],
+    [0, -13, 0, 0, "M06-M06 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common2Adar, common1Adar,
+    [-2, 0, 0, 0, "M06-M06 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M06-M06 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Shevat, leapAdarI,
+    [0, -12, 0, 0, "M05-M05L backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M05-M05L backwards is -12mo"],
+  ],
+  [
+    leapAdarI, common1Shevat,
+    [-1, -1, 0, 0, "M05L-M05 backwards is -1y -1mo (exhibits calendar-specific constraining)"],
+    [0, -13, 0, 0, "M05L-M05 backwards is -13mo"],
+  ],
+  [
+    common2Adar, leapAdarI,
+    [-1, -1, 0, 0, "M06-M05L backwards is -1y -1mo"],
+    [0, -13, 0, 0, "M06-M05L backwards is -13mo"],
+  ],
+  [
+    leapAdarI, common1Adar,
+    [0, -12, 0, 0, "M05L-M06 backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M05L-M06 backwards is -12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, weeks, days, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, weeks, days, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  const oneISO = one.withCalendar("iso8601");
+  const twoISO = two.withCalendar("iso8601");
+
+  const resultWeeks = one.until(two, { largestUnit: "weeks" });
+  const resultWeeksISO = oneISO.until(twoISO, { largestUnit: "weeks" });
+  TemporalHelpers.assertDurationsEqual(resultWeeks, resultWeeksISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit weeks`);
+
+  const resultDays = one.until(two);
+  const resultDaysISO = oneISO.until(twoISO);
+  TemporalHelpers.assertDurationsEqual(resultDays, resultDaysISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit days`);
+}

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/leap-months-hebrew.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/leap-months-hebrew.js
@@ -1,0 +1,168 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in hebrew calendar
+esid: sec-temporal.zoneddatetime.prototype.since
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 5784 is a leap year.
+// M05 - Shevat
+// M05L - Adar I
+// M06 - Adar II
+// M07 - Nisan
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+const common1Shevat = Temporal.ZonedDateTime.from({ year: 5783, monthCode: "M05", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common1Adar = Temporal.ZonedDateTime.from({ year: 5783, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common1Nisan = Temporal.ZonedDateTime.from({ year: 5783, monthCode: "M07", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leapShevat = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M05", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leapAdarI = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leapAdarII = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common2Shevat = Temporal.ZonedDateTime.from({ year: 5785, monthCode: "M05", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common2Adar = Temporal.ZonedDateTime.from({ year: 5785, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, weeks, days, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+// For largestUnit of days and weeks, the results should be identical to what
+// the ISO calendar gives for the corresponding ISO dates
+const tests = [
+  [
+    common1Shevat, leapShevat,
+    [-1, 0, 0, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -12, 0, 0, "M05-M05 common-leap backwards is -12mo"],
+  ],
+  [
+    leapShevat, common2Shevat,
+    [-1, 0, 0, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -13, 0, 0, "M05-M05 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common1Shevat, common2Shevat,
+    [-2, 0, 0, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Adar, leapAdarII,
+    [-1, 0, 0, 0, "M06-M06 common-leap backwards is -1y"],
+    [0, -13, 0, 0, "M06-M06 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapAdarII, common2Adar,
+    [-1, 0, 0, 0, "M06-M06 leap-common backwards is -1y"],
+    [0, -12, 0, 0, "M06-M06 leap-common backwards is -12mo"],
+  ],
+  [
+    common1Adar, common2Adar,
+    [-2, 0, 0, 0, "M06-M06 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M06-M06 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Shevat, leapAdarI,
+    [-1, -1, 0, 0, "M05-M05L backwards is -1y -1mo"],
+    [0, -13, 0, 0, "M05-M05L backwards is -13mo"],
+  ],
+  [
+    leapAdarI, common2Shevat,
+    [0, -12, 0, 0, "M05L-M05 backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M05L-M05 backwards is -12mo"],
+  ],
+  [
+    common1Adar, leapAdarI,
+    [0, -12, 0, 0, "M06-M05L backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M06-M05L backwards is -12mo"],
+  ],
+  [
+    leapAdarI, common2Adar,
+    [-1, 0, 0, 0, "M05L-M06 backwards is -1y (exhibits calendar-specific constraining)"],
+    [0, -13, 0, 0, "M05L-M06 backwards is -13mo"],
+  ],
+  [
+    common1Nisan, leapAdarII,
+    [0, -12, 0, 0, "M07-M06 common-leap backwards is -12mo not -11mo"],
+    [0, -12, 0, 0, "M07-M06 common-leap backwards is -12mo not -11mo"],
+  ],
+
+  // Negative
+  [
+    common2Shevat, leapShevat,
+    [1, 0, 0, 0, "M05-M05 common-leap is 1y"],
+    [0, 13, 0, 0, "M05-M05 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapShevat, common1Shevat,
+    [1, 0, 0, 0, "M05-M05 leap-common is 1y"],
+    [0, 12, 0, 0, "M05-M05 leap-common is 12mo not 13mo"],
+  ],
+  [
+    common2Shevat, common1Shevat,
+    [2, 0, 0, 0, "M05-M05 common-common is 2y"],
+    [0, 25, 0, 0, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Adar, leapAdarII,
+    [1, 0, 0, 0, "M06-M06 common-leap is 1y"],
+    [0, 12, 0, 0, "M06-M06 common-leap is 12mo not 13mo"],
+  ],
+  [
+    leapAdarII, common1Adar,
+    [1, 0, 0, 0, "M06-M06 leap-common is 1y"],
+    [0, 13, 0, 0, "M06-M06 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common2Adar, common1Adar,
+    [2, 0, 0, 0, "M06-M06 common-common is 2y"],
+    [0, 25, 0, 0, "M06-M06 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Shevat, leapAdarI,
+    [0, 12, 0, 0, "M05-M05L is 12mo not 1y"],
+    [0, 12, 0, 0, "M05-M05L is 12mo"],
+  ],
+  [
+    leapAdarI, common1Shevat,
+    [1, 1, 0, 0, "M05L-M05 is 1y 1mo (exhibits calendar-specific constraining)"],
+    [0, 13, 0, 0, "M05L-M05 is 13mo"],
+  ],
+  [
+    common2Adar, leapAdarI,
+    [1, 1, 0, 0, "M06-M05L is 1y 1mo"],
+    [0, 13, 0, 0, "M06-M05L is 13mo"],
+  ],
+  [
+    leapAdarI, common1Adar,
+    [0, 12, 0, 0, "M05L-M06 is 12mo not 1y"],
+    [0, 12, 0, 0, "M05L-M06 is 12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, weeks, days, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, weeks, days, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  const oneISO = one.withCalendar("iso8601");
+  const twoISO = two.withCalendar("iso8601");
+
+  const resultWeeks = one.since(two, { largestUnit: "weeks" });
+  const resultWeeksISO = oneISO.since(twoISO, { largestUnit: "weeks" });
+  TemporalHelpers.assertDurationsEqual(resultWeeks, resultWeeksISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit weeks`);
+
+  const resultDays = one.since(two);
+  const resultDaysISO = oneISO.since(twoISO);
+  TemporalHelpers.assertDurationsEqual(resultDays, resultDaysISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit days`);
+}

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/leap-months-hebrew.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/leap-months-hebrew.js
@@ -1,0 +1,168 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in hebrew calendar
+esid: sec-temporal.zoneddatetime.prototype.until
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 5784 is a leap year.
+// M05 - Shevat
+// M05L - Adar I
+// M06 - Adar II
+// M07 - Nisan
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+const common1Shevat = Temporal.ZonedDateTime.from({ year: 5783, monthCode: "M05", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common1Adar = Temporal.ZonedDateTime.from({ year: 5783, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common1Nisan = Temporal.ZonedDateTime.from({ year: 5783, monthCode: "M07", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leapShevat = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M05", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leapAdarI = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leapAdarII = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common2Shevat = Temporal.ZonedDateTime.from({ year: 5785, monthCode: "M05", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common2Adar = Temporal.ZonedDateTime.from({ year: 5785, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, weeks, days, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+// For largestUnit of days and weeks, the results should be identical to what
+// the ISO calendar gives for the corresponding ISO dates
+const tests = [
+  [
+    common1Shevat, leapShevat,
+    [1, 0, 0, 0, "M05-M05 common-leap is 1y"],
+    [0, 12, 0, 0, "M05-M05 common-leap is 12mo"],
+  ],
+  [
+    leapShevat, common2Shevat,
+    [1, 0, 0, 0, "M05-M05 leap-common is 1y"],
+    [0, 13, 0, 0, "M05-M05 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common1Shevat, common2Shevat,
+    [2, 0, 0, 0, "M05-M05 common-common is 2y"],
+    [0, 25, 0, 0, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Adar, leapAdarII,
+    [1, 0, 0, 0, "M06-M06 common-leap is 1y"],
+    [0, 13, 0, 0, "M06-M06 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapAdarII, common2Adar,
+    [1, 0, 0, 0, "M06-M06 leap-common is 1y"],
+    [0, 12, 0, 0, "M06-M06 leap-common is 12mo"],
+  ],
+  [
+    common1Adar, common2Adar,
+    [2, 0, 0, 0, "M06-M06 common-common is 2y"],
+    [0, 25, 0, 0, "M06-M06 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Shevat, leapAdarI,
+    [1, 1, 0, 0, "M05-M05L is 1y 1mo"],
+    [0, 13, 0, 0, "M05-M05L is 13mo"],
+  ],
+  [
+    leapAdarI, common2Shevat,
+    [0, 12, 0, 0, "M05L-M05 is 12mo not 1y"],
+    [0, 12, 0, 0, "M05L-M05 is 12mo"],
+  ],
+  [
+    common1Adar, leapAdarI,
+    [0, 12, 0, 0, "M06-M05L is 12mo not 1y"],
+    [0, 12, 0, 0, "M06-M05L is 12mo"],
+  ],
+  [
+    leapAdarI, common2Adar,
+    [1, 0, 0, 0, "M05L-M06 is 1y (exhibits calendar-specific constraining)"],
+    [0, 13, 0, 0, "M05L-M06 is 13mo"],
+  ],
+  [
+    common1Nisan, leapAdarII,
+    [0, 12, 0, 0, "M07-M06 common-leap is 12mo not 11mo"],
+    [0, 12, 0, 0, "M07-M06 common-leap is 12mo not 11mo"],
+  ],
+
+  // Negative
+  [
+    common2Shevat, leapShevat,
+    [-1, 0, 0, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -13, 0, 0, "M05-M05 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapShevat, common1Shevat,
+    [-1, 0, 0, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -12, 0, 0, "M05-M05 leap-common backwards is -12mo not -13mo"],
+  ],
+  [
+    common2Shevat, common1Shevat,
+    [-2, 0, 0, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Adar, leapAdarII,
+    [-1, 0, 0, 0, "M06-M06 common-leap backwards is -1y"],
+    [0, -12, 0, 0, "M06-M06 common-leap backwards is -12mo not -13mo"],
+  ],
+  [
+    leapAdarII, common1Adar,
+    [-1, 0, 0, 0, "M06-M06 leap-common backwards is -1y"],
+    [0, -13, 0, 0, "M06-M06 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common2Adar, common1Adar,
+    [-2, 0, 0, 0, "M06-M06 common-common backwards is -2y"],
+    [0, -25, 0, 0, "M06-M06 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Shevat, leapAdarI,
+    [0, -12, 0, 0, "M05-M05L backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M05-M05L backwards is -12mo"],
+  ],
+  [
+    leapAdarI, common1Shevat,
+    [-1, -1, 0, 0, "M05L-M05 backwards is -1y -1mo (exhibits calendar-specific constraining)"],
+    [0, -13, 0, 0, "M05L-M05 backwards is -13mo"],
+  ],
+  [
+    common2Adar, leapAdarI,
+    [-1, -1, 0, 0, "M06-M05L backwards is -1y -1mo"],
+    [0, -13, 0, 0, "M06-M05L backwards is -13mo"],
+  ],
+  [
+    leapAdarI, common1Adar,
+    [0, -12, 0, 0, "M05L-M06 backwards is -12mo not -1y"],
+    [0, -12, 0, 0, "M05L-M06 backwards is -12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, weeks, days, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, weeks, days, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, weeks, days, 0, 0, 0, 0, 0, 0, descr);
+
+  const oneISO = one.withCalendar("iso8601");
+  const twoISO = two.withCalendar("iso8601");
+
+  const resultWeeks = one.until(two, { largestUnit: "weeks" });
+  const resultWeeksISO = oneISO.until(twoISO, { largestUnit: "weeks" });
+  TemporalHelpers.assertDurationsEqual(resultWeeks, resultWeeksISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit weeks`);
+
+  const resultDays = one.until(two);
+  const resultDaysISO = oneISO.until(twoISO);
+  TemporalHelpers.assertDurationsEqual(resultDays, resultDaysISO,
+    `${one.year}-${one.monthCode}-${one.day} : ${two.year}-${two.monthCode}-${two.day} largestUnit days`);
+}


### PR DESCRIPTION
Similar to #4652 - note that the expected results are different for the cases labeled "exhibits calendar-specific constraining"! Covers date difference arithmetic across and including leap months in the Hebrew calendar, for PlainDate, PlainDateTime, and ZonedDateTime.

Like #4652, these test files are all very similar. I'd recommend reviewing just one of them, e.g. [PlainDate.prototype.until](https://github.com/tc39/test262/compare/main...ptomato:test262:hebrew-calendar-difference?expand=1#diff-f7b06d40d8a08c77b92f84b064a94c9b457b55da302d7862eef2f2a93918e7aa).