### PR TITLE
Temporal: Test both "use" and "ignore" offsets

### DIFF
--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-string-limits.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-string-limits.js
@@ -24,7 +24,7 @@ const validStringsForOffsetUseIgnore = [
 
 for (const offset of ["use", "ignore"]) {
   for (const arg of validStringsForOffsetUseIgnore) {
-    Temporal.ZonedDateTime.from(arg, { offset: "use" });
+    Temporal.ZonedDateTime.from(arg, { offset });
   }
 }
 


### PR DESCRIPTION
This test was previously only testing the "use" offset option when testing valid strings.