### PR TITLE
CI: Don't fail the esmeta job due to lack of support

### DIFF
--- a/.github/workflows/esmeta-test262.yml
+++ b/.github/workflows/esmeta-test262.yml
@@ -44,4 +44,8 @@ jobs:
           for file in ${{ steps.changed_tests.outputs.all_changed_files }}; do
             echo $file
           done | tee "$HOME/changed.txt"
-          cat "$HOME/changed.txt" | xargs "${ESMETA_HOME}"/bin/esmeta test262-test -status -test262dir=$(pwd)
+          ESMETA_RESULT=0
+          cat "$HOME/changed.txt" | xargs "${ESMETA_HOME}"/bin/esmeta test262-test -status -test262dir=$(pwd) >"$HOME/esmeta.out" 2>&1 || ESMETA_RESULT=$?
+          cat "$HOME/esmeta.out"
+          # Still exit successfully if we hit an error but it was from lack of support.
+          [ $ESMETA_RESULT = 0 ] || tail -n 1 "$HOME/esmeta.out" | grep -q '^[[]NotSupported[]]' || exit $ESMETA_RESULT


### PR DESCRIPTION
See https://github.com/tc39/test262/pull/4623#issuecomment-3523487990 and https://github.com/tc39/test262/actions/runs/18957730032/job/54138279811?pr=4623

> ```
> Run echo 'New or modified test files:'
> New or modified test files:
> test/built-ins/ThrowTypeError/distinct-cross-realm.js
> ========================================
>  extract phase
> ----------------------------------------
> ========================================
>  compile phase
> ----------------------------------------
> ========================================
>  build-cfg phase
> ----------------------------------------
> ========================================
>  test262-test phase
> ----------------------------------------
> [NotSupported] feature/$262
> Error: Process completed with exit code 123.
> ```