### PR TITLE
Remove check for old nodejs versions

### DIFF
--- a/test/staging/Intl402/Temporal/old/indian-calendar.js
+++ b/test/staging/Intl402/Temporal/old/indian-calendar.js
@@ -8,12 +8,6 @@ features: [Temporal]
 ---*/
 
 
-// throws in Node 12 & 14 before 1 CE
-var vulnerableToBceBug = new Date("0000-01-01T00:00Z").toLocaleDateString("en-US-u-ca-indian", { timeZone: "UTC" }) !== "10/11/-79 Saka";
-if (vulnerableToBceBug) {
-  assert.throws(RangeError, () => Temporal.PlainDate.from("0000-01-01").withCalendar("indian").day);
-}
-
 // handles leap days
 var leapYearFirstDay = Temporal.PlainDate.from("2004-03-21[u-ca=indian]");
 assert.sameValue(leapYearFirstDay.year, 2004 - 78);


### PR DESCRIPTION
CLDR 48 changed the era name, so the output is now `"10/11/-79 Śaka"`. This leads to taking the `vulnerableToBceBug == true` code path, which then fails because no `RangeError` is thrown. Rather than adding the new output, simply remove the lines to handle old nodejs versions.