### PR TITLE
Intl Era Monthcode: Era code updates for CLDR 48

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatToParts/era.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/era.js
@@ -12,6 +12,9 @@ features: [Intl.Era-monthcode]
 
 const multipleEraTests = [
   ["gregory", [-100, 2025]],
+  ["islamic-civil", [600, 2025]],
+  ["islamic-tbla", [600, 2025]],
+  ["islamic-umalqura", [600, 2025]],
   ["japanese", [-100, 1850, 1880, 1920, 1930, 1990, 2025]],
   ["roc", [1900, 2025]],
 ];
@@ -45,10 +48,44 @@ for (const [calendar, isoYears] of multipleEraTests) {
   assert.sameValue(new Set(eras).size, eras.length, `${calendar} eras (${eras.join(",")}) should be unique`);
 }
 
+// Test that ethopic has two distinct eras and the first one encompasses both
+// negative and positive years
+{
+  const formatter = new Intl.DateTimeFormat("en", {
+    calendar: "ethiopic",
+    era: "long",
+    year: "numeric",
+  });
+
+  const eras = [];
+
+  for (const isoYear of [-6000, 0, 2025]) {
+    const date = new Date(isoYear, 5, 15);
+    const parts = formatter.formatToParts(date);
+
+    const eraPart = parts.find(({ type }) => type === "era");
+    assert.notSameValue(eraPart, undefined, `Format of ethiopic ISO ${isoYear} should have era part`);
+    assert.sameValue(typeof eraPart.value, "string", `Era format of ethiopic ISO ${isoYear} should be a string`);
+    assert(eraPart.value.length > 0, `Era format of ethiopic ISO ${isoYear} should not be empty`);
+    eras.push(eraPart.value);
+
+    const format = formatter.format(date);
+    assert(format.includes(eraPart.value), `${format} should include ${eraPart.value} era`);
+
+    const yearPart = parts.find(({ type }) => type === "year");
+    assert.notSameValue(yearPart, undefined, `Format of ethiopic ISO ${isoYear} should have year part`);
+  }
+
+  assert.sameValue(eras[0], eras[1], "Ethiopic AA era for both positive and negative years");
+  assert.notSameValue(eras[0], eras[2], "Ethopic AA and AM eras are distinct");
+}
+
+
 // Calendars with a single era: test one year occurring before and one after the
 // single era's epoch
 const singleEraTests = [
   ["buddhist", [-600, 2025]],
+  ["coptic", [250, 2025]],
   ["ethioaa", [-5550, 2025]],
   ["hebrew", [-3800, 2025]],
   ["indian", [70, 2025]],


### PR DESCRIPTION
Coptic, Ethiopic, and Hijri calendars got era code changes in CLDR 48.

As per the maintainers policy on the other CLDR 48 changes, this should be merged about a month after CLDR 48 released, so in late November, to give implementations a chance to catch up.