### PR TITLE
Intl Era Monthcode: Complete Hebrew leap month addition tests

### DIFF
--- a/test/intl402/Temporal/PlainDate/prototype/add/leap-months-hebrew.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/leap-months-hebrew.js
@@ -13,14 +13,114 @@ const options = { overflow: "reject" };
 
 // Years
 
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years2 = new Temporal.Duration(2);
+const years2n = new Temporal.Duration(-2);
+
+const leap1AdarI = Temporal.PlainDate.from({ year: 5782, monthCode: "M05L", day: 1, calendar }, options);
+const leap1AdarII = Temporal.PlainDate.from({ year: 5782, monthCode: "M06", day: 1, calendar }, options);
+const common1Adar = Temporal.PlainDate.from({ year: 5783, monthCode: "M06", day: 1, calendar }, options);
+const leap2AdarI = Temporal.PlainDate.from({ year: 5784, monthCode: "M05L", day: 1, calendar }, options);
+const leap2AdarII = Temporal.PlainDate.from({ year: 5784, monthCode: "M06", day: 1, calendar }, options);
+const common2Adar = Temporal.PlainDate.from({ year: 5785, monthCode: "M06", day: 1, calendar }, options);
+
+TemporalHelpers.assertPlainDate(
+  common1Adar.add(years1, options),
+  5784, 7, "M06", 1, "Adding 1 year to common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  common1Adar.add(years2, options),
+  5785, 6, "M06", 1, "Adding 2 years to common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.add(years1),
+  5785, 6, "M06", 1, "Adding 1 year to Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5785
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.add(years1, options);
+}, "Adding 1 year to Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.add(years1, options),
+  5785, 6, "M06", 1, "Adding 1 year to Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  leap1AdarI.add(years2, options),
+  5784, 6, "M05L", 1, "Adding 2 years to leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  leap1AdarII.add(years2, options),
+  5784, 7, "M06", 1, "Adding 2 years to leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  common2Adar.add(years1n, options),
+  5784, 7, "M06", 1, "Subtracting 1 year from common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  common2Adar.add(years2n, options),
+  5783, 6, "M06", 1, "Subtracting 2 years from common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.add(years1n),
+  5783, 6, "M06", 1, "Subtracting 1 year from Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5783
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.add(years1n, options);
+}, "Subtracting 1 year from Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.add(years1n, options),
+  5783, 6, "M06", 1, "Subtracting 1 year from Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.add(years2n, options),
+  5782, 6, "M05L", 1, "Subtracting 2 years from leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.add(years2n, options),
+  5782, 7, "M06", 1, "Subtracting 2 years from leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5782
+);
+
 // Months
 
 const months1 = new Temporal.Duration(0, 1);
 const months1n = new Temporal.Duration(0, -1);
 const months2 = new Temporal.Duration(0, 2);
 const months2n = new Temporal.Duration(0, -2);
+const months12 = new Temporal.Duration(0, 12);
+const months12n = new Temporal.Duration(0, -12);
+const months13 = new Temporal.Duration(0, 13);
+const months13n = new Temporal.Duration(0, -13);
+const months24 = new Temporal.Duration(0, 24);
+const months24n = new Temporal.Duration(0, -24);
 
 const date1 = Temporal.PlainDate.from({ year: 5784, monthCode: "M04", day: 1, calendar }, options);
+const date3 = Temporal.PlainDate.from({ year: 5784, monthCode: "M07", day: 1, calendar }, options);
+
 TemporalHelpers.assertPlainDate(
   date1.add(months1),
   5784, 5, "M05", 1, "Adding 1 month to M04 in leap year lands in M05 (Shevat)",
@@ -39,9 +139,8 @@ TemporalHelpers.assertPlainDate(
   "am", 5784
 );
 
-const date2 = Temporal.PlainDate.from({ year: 5784, monthCode: "M05L", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(
-  date2.add(months1),
+  leap2AdarI.add(months1),
   5784, 7, "M06", 1, "Adding 1 month to M05L (Adar I) lands in M06 (Adar II)",
   "am", 5784
 );
@@ -52,7 +151,60 @@ TemporalHelpers.assertPlainDate(
   "am", 5783
 );
 
-const date3 = Temporal.PlainDate.from({ year: 5784, monthCode: "M07", day: 1, calendar }, options);
+TemporalHelpers.assertPlainDate(
+  common1Adar.add(months12),
+  5784, 6, "M05L", 1, "Adding 12 months to common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  common1Adar.add(months13),
+  5784, 7, "M06", 1, "Adding 13 months to common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.add(months12),
+  5785, 5, "M05", 1, "Adding 12 months to leap-year Adar I lands in Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.add(months13),
+  5785, 6, "M06", 1, "Adding 13 months to leap-year Adar I lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.add(months12),
+  5785, 6, "M06", 1, "Adding 12 months to leap-year Adar II lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  common1Adar.add(months24),
+  5785, 5, "M05", 1, "Adding 24 months to common-year Adar crossing a leap year lands in common-year Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  common1Adar.add(new Temporal.Duration(0, 25)),
+  5785, 6, "M06", 1, "Adding 25 months to common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  leap1AdarI.add(months24),
+  5784, 5, "M05", 1, "Adding 24 months to leap-year Adar I lands in leap-year Shevat (M05)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  leap1AdarII.add(months24),
+  5784, 6, "M05L", 1, "Adding 24 months to leap-year Adar II lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
 TemporalHelpers.assertPlainDate(
   date3.add(months1n),
   5784, 7, "M06", 1, "Subtracting 1 month from M07 in leap year lands in M06 (Adar II)",
@@ -72,13 +224,13 @@ TemporalHelpers.assertPlainDate(
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 5784, monthCode: "M06", day: 1, calendar }).add(months1n),
+  leap2AdarII.add(months1n),
   5784, 6, "M05L", 1, "Subtracting 1 month from M06 (Adar II) in leap year lands in M05L (Adar I)",
   "am", 5784
 );
 
 TemporalHelpers.assertPlainDate(
-  date2.add(months1n),
+  leap2AdarI.add(months1n),
   5784, 5, "M05", 1, "Subtracting 1 month from M05L (Adar I) lands in M05 (Shevat)",
   "am", 5784
 );
@@ -89,13 +241,56 @@ TemporalHelpers.assertPlainDate(
   "am", 5783
 );
 
-// Weeks
-
-// Days
-
-const days10 = new Temporal.Duration(0, 0, 0, /* days = */ 10);
+TemporalHelpers.assertPlainDate(
+  common2Adar.add(months12n),
+  5784, 7, "M06", 1, "Subtracting 12 months from common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 5784, monthCode: "M05L", day: 30, calendar }, options).add(days10),
-  5784, 7, "M06", 10, "add 10 days to leap day", "am", 5784
+  common2Adar.add(months13n),
+  5784, 6, "M05L", 1, "Subtracting 13 months from common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.add(months12n),
+  5783, 6, "M06", 1, "Subtracting 12 months from leap-year Adar I lands in Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.add(months13n),
+  5783, 5, "M05", 1, "Subtracting 13 months from leap-year Adar I lands in Shevat (M05)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.add(months12n),
+  5783, 7, "M07", 1, "Subtracting 12 months from leap-year Adar II lands in Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  common2Adar.add(months24n),
+  5783, 7, "M07", 1, "Subtracting 24 months from common-year Adar crossing a leap year lands in common-year Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  common2Adar.add(new Temporal.Duration(0, -25)),
+  5783, 6, "M06", 1, "Subtracting 25 months from common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.add(months24n),
+  5782, 7, "M06", 1, "Subtracting 24 months from leap-year Adar I lands in leap-year Adar (M06)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.add(months24n),
+  5782, 8, "M07", 1, "Subtracting 24 months from leap-year Adar II lands in leap-year Nisan (M07)",
+  "am", 5782
 );

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/leap-months-hebrew.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/leap-months-hebrew.js
@@ -13,14 +13,114 @@ const options = { overflow: "reject" };
 
 // Years
 
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years2 = new Temporal.Duration(-2);
+const years2n = new Temporal.Duration(2);
+
+const leap1AdarI = Temporal.PlainDate.from({ year: 5782, monthCode: "M05L", day: 1, calendar }, options);
+const leap1AdarII = Temporal.PlainDate.from({ year: 5782, monthCode: "M06", day: 1, calendar }, options);
+const common1Adar = Temporal.PlainDate.from({ year: 5783, monthCode: "M06", day: 1, calendar }, options);
+const leap2AdarI = Temporal.PlainDate.from({ year: 5784, monthCode: "M05L", day: 1, calendar }, options);
+const leap2AdarII = Temporal.PlainDate.from({ year: 5784, monthCode: "M06", day: 1, calendar }, options);
+const common2Adar = Temporal.PlainDate.from({ year: 5785, monthCode: "M06", day: 1, calendar }, options);
+
+TemporalHelpers.assertPlainDate(
+  common1Adar.subtract(years1, options),
+  5784, 7, "M06", 1, "Adding 1 year to common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  common1Adar.subtract(years2, options),
+  5785, 6, "M06", 1, "Adding 2 years to common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.subtract(years1),
+  5785, 6, "M06", 1, "Adding 1 year to Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5785
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.subtract(years1, options);
+}, "Adding 1 year to Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.subtract(years1, options),
+  5785, 6, "M06", 1, "Adding 1 year to Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  leap1AdarI.subtract(years2, options),
+  5784, 6, "M05L", 1, "Adding 2 years to leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  leap1AdarII.subtract(years2, options),
+  5784, 7, "M06", 1, "Adding 2 years to leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  common2Adar.subtract(years1n, options),
+  5784, 7, "M06", 1, "Subtracting 1 year from common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  common2Adar.subtract(years2n, options),
+  5783, 6, "M06", 1, "Subtracting 2 years from common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.subtract(years1n),
+  5783, 6, "M06", 1, "Subtracting 1 year from Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5783
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.subtract(years1n, options);
+}, "Subtracting 1 year from Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.subtract(years1n, options),
+  5783, 6, "M06", 1, "Subtracting 1 year from Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.subtract(years2n, options),
+  5782, 6, "M05L", 1, "Subtracting 2 years from leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.subtract(years2n, options),
+  5782, 7, "M06", 1, "Subtracting 2 years from leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5782
+);
+
 // Months
 
 const months1 = new Temporal.Duration(0, -1);
 const months1n = new Temporal.Duration(0, 1);
 const months2 = new Temporal.Duration(0, -2);
 const months2n = new Temporal.Duration(0, 2);
+const months12 = new Temporal.Duration(0, -12);
+const months12n = new Temporal.Duration(0, 12);
+const months13 = new Temporal.Duration(0, -13);
+const months13n = new Temporal.Duration(0, 13);
+const months24 = new Temporal.Duration(0, -24);
+const months24n = new Temporal.Duration(0, 24);
 
 const date1 = Temporal.PlainDate.from({ year: 5784, monthCode: "M04", day: 1, calendar }, options);
+const date3 = Temporal.PlainDate.from({ year: 5784, monthCode: "M07", day: 1, calendar }, options);
+
 TemporalHelpers.assertPlainDate(
   date1.subtract(months1),
   5784, 5, "M05", 1, "Adding 1 month to M04 in leap year lands in M05 (Shevat)",
@@ -39,9 +139,8 @@ TemporalHelpers.assertPlainDate(
   "am", 5784
 );
 
-const date2 = Temporal.PlainDate.from({ year: 5784, monthCode: "M05L", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(
-  date2.subtract(months1),
+  leap2AdarI.subtract(months1),
   5784, 7, "M06", 1, "Adding 1 month to M05L (Adar I) lands in M06 (Adar II)",
   "am", 5784
 );
@@ -52,7 +151,60 @@ TemporalHelpers.assertPlainDate(
   "am", 5783
 );
 
-const date3 = Temporal.PlainDate.from({ year: 5784, monthCode: "M07", day: 1, calendar }, options);
+TemporalHelpers.assertPlainDate(
+  common1Adar.subtract(months12),
+  5784, 6, "M05L", 1, "Adding 12 months to common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  common1Adar.subtract(months13),
+  5784, 7, "M06", 1, "Adding 13 months to common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.subtract(months12),
+  5785, 5, "M05", 1, "Adding 12 months to leap-year Adar I lands in Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.subtract(months13),
+  5785, 6, "M06", 1, "Adding 13 months to leap-year Adar I lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.subtract(months12),
+  5785, 6, "M06", 1, "Adding 12 months to leap-year Adar II lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  common1Adar.subtract(months24),
+  5785, 5, "M05", 1, "Adding 24 months to common-year Adar crossing a leap year lands in common-year Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  common1Adar.subtract(new Temporal.Duration(0, -25)),
+  5785, 6, "M06", 1, "Adding 25 months to common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDate(
+  leap1AdarI.subtract(months24),
+  5784, 5, "M05", 1, "Adding 24 months to leap-year Adar I lands in leap-year Shevat (M05)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  leap1AdarII.subtract(months24),
+  5784, 6, "M05L", 1, "Adding 24 months to leap-year Adar II lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
 TemporalHelpers.assertPlainDate(
   date3.subtract(months1n),
   5784, 7, "M06", 1, "Subtracting 1 month from M07 in leap year lands in M06 (Adar II)",
@@ -72,13 +224,13 @@ TemporalHelpers.assertPlainDate(
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 5784, monthCode: "M06", day: 1, calendar }).subtract(months1n),
+  leap2AdarII.subtract(months1n),
   5784, 6, "M05L", 1, "Subtracting 1 month from M06 (Adar II) in leap year lands in M05L (Adar I)",
   "am", 5784
 );
 
 TemporalHelpers.assertPlainDate(
-  date2.subtract(months1n),
+  leap2AdarI.subtract(months1n),
   5784, 5, "M05", 1, "Subtracting 1 month from M05L (Adar I) lands in M05 (Shevat)",
   "am", 5784
 );
@@ -89,13 +241,56 @@ TemporalHelpers.assertPlainDate(
   "am", 5783
 );
 
-// Weeks
-
-// Days
-
-const days10 = new Temporal.Duration(0, 0, 0, /* days = */ -10);
+TemporalHelpers.assertPlainDate(
+  common2Adar.subtract(months12n),
+  5784, 7, "M06", 1, "Subtracting 12 months from common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 5784, monthCode: "M05L", day: 30, calendar }, options).subtract(days10),
-  5784, 7, "M06", 10, "add 10 days to leap day", "am", 5784
+  common2Adar.subtract(months13n),
+  5784, 6, "M05L", 1, "Subtracting 13 months from common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.subtract(months12n),
+  5783, 6, "M06", 1, "Subtracting 12 months from leap-year Adar I lands in Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.subtract(months13n),
+  5783, 5, "M05", 1, "Subtracting 13 months from leap-year Adar I lands in Shevat (M05)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.subtract(months12n),
+  5783, 7, "M07", 1, "Subtracting 12 months from leap-year Adar II lands in Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  common2Adar.subtract(months24n),
+  5783, 7, "M07", 1, "Subtracting 24 months from common-year Adar crossing a leap year lands in common-year Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  common2Adar.subtract(new Temporal.Duration(0, 25)),
+  5783, 6, "M06", 1, "Subtracting 25 months from common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarI.subtract(months24n),
+  5782, 7, "M06", 1, "Subtracting 24 months from leap-year Adar I lands in leap-year Adar (M06)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDate(
+  leap2AdarII.subtract(months24n),
+  5782, 8, "M07", 1, "Subtracting 24 months from leap-year Adar II lands in leap-year Nisan (M07)",
+  "am", 5782
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/leap-months-hebrew.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/leap-months-hebrew.js
@@ -13,14 +13,114 @@ const options = { overflow: "reject" };
 
 // Years
 
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years2 = new Temporal.Duration(2);
+const years2n = new Temporal.Duration(-2);
+
+const leap1AdarI = Temporal.PlainDateTime.from({ year: 5782, monthCode: "M05L", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap1AdarII = Temporal.PlainDateTime.from({ year: 5782, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+const common1Adar = Temporal.PlainDateTime.from({ year: 5783, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap2AdarI = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap2AdarII = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+const common2Adar = Temporal.PlainDateTime.from({ year: 5785, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(years1, options),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(years2, options),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(years1),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5785
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.add(years1, options);
+}, "Adding 1 year to Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(years1, options),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarI.add(years2, options),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarII.add(years2, options),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.add(years1n, options),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.add(years2n, options),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(years1n),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5783
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.add(years1n, options);
+}, "Subtracting 1 year from Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(years1n, options),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(years2n, options),
+  5782, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(years2n, options),
+  5782, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5782
+);
+
 // Months
 
 const months1 = new Temporal.Duration(0, 1);
 const months1n = new Temporal.Duration(0, -1);
 const months2 = new Temporal.Duration(0, 2);
 const months2n = new Temporal.Duration(0, -2);
+const months12 = new Temporal.Duration(0, 12);
+const months12n = new Temporal.Duration(0, -12);
+const months13 = new Temporal.Duration(0, 13);
+const months13n = new Temporal.Duration(0, -13);
+const months24 = new Temporal.Duration(0, 24);
+const months24n = new Temporal.Duration(0, -24);
 
 const date1 = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
+const date3 = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M07", day: 1, hour: 12, minute: 34, calendar }, options);
+
 TemporalHelpers.assertPlainDateTime(
   date1.add(months1),
   5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 1 month to M04 in leap year lands in M05 (Shevat)",
@@ -39,9 +139,8 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5784
 );
 
-const date2 = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.add(months1),
+  leap2AdarI.add(months1),
   5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 month to M05L (Adar I) lands in M06 (Adar II)",
   "am", 5784
 );
@@ -52,7 +151,60 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5783
 );
 
-const date3 = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M07", day: 1, hour: 12, minute: 34, calendar }, options);
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(months12),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(months13),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(months12),
+  5785, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year Adar I lands in Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(months13),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year Adar I lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(months12),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year Adar II lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(months24),
+  5785, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year Adar crossing a leap year lands in common-year Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(new Temporal.Duration(0, 25)),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarI.add(months24),
+  5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to leap-year Adar I lands in leap-year Shevat (M05)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarII.add(months24),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to leap-year Adar II lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
 TemporalHelpers.assertPlainDateTime(
   date3.add(months1n),
   5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M07 in leap year lands in M06 (Adar II)",
@@ -72,13 +224,13 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }).add(months1n),
+  leap2AdarII.add(months1n),
   5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 (Adar II) in leap year lands in M05L (Adar I)",
   "am", 5784
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.add(months1n),
+  leap2AdarI.add(months1n),
   5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M05L (Adar I) lands in M05 (Shevat)",
   "am", 5784
 );
@@ -89,13 +241,56 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5783
 );
 
-// Weeks
-
-// Days
-
-const days10 = new Temporal.Duration(0, 0, 0, /* days = */ 10);
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.add(months12n),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 5784, monthCode: "M05L", day: 30, hour: 12, minute: 34, calendar }, options).add(days10),
-  5784, 7, "M06", 10, 12, 34, 0, 0, 0, 0, "add 10 days to leap day", "am", 5784
+  common2Adar.add(months13n),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(months12n),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year Adar I lands in Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(months13n),
+  5783, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from leap-year Adar I lands in Shevat (M05)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(months12n),
+  5783, 7, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year Adar II lands in Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.add(months24n),
+  5783, 7, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year Adar crossing a leap year lands in common-year Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.add(new Temporal.Duration(0, -25)),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(months24n),
+  5782, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from leap-year Adar I lands in leap-year Adar (M06)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(months24n),
+  5782, 8, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from leap-year Adar II lands in leap-year Nisan (M07)",
+  "am", 5782
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/leap-months-hebrew.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/leap-months-hebrew.js
@@ -13,14 +13,114 @@ const options = { overflow: "reject" };
 
 // Years
 
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years2 = new Temporal.Duration(-2);
+const years2n = new Temporal.Duration(2);
+
+const leap1AdarI = Temporal.PlainDateTime.from({ year: 5782, monthCode: "M05L", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap1AdarII = Temporal.PlainDateTime.from({ year: 5782, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+const common1Adar = Temporal.PlainDateTime.from({ year: 5783, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap2AdarI = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap2AdarII = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+const common2Adar = Temporal.PlainDateTime.from({ year: 5785, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(years1, options),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(years2, options),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(years1),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5785
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.subtract(years1, options);
+}, "Adding 1 year to Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(years1, options),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarI.subtract(years2, options),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarII.subtract(years2, options),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.subtract(years1n, options),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.subtract(years2n, options),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(years1n),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5783
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.subtract(years1n, options);
+}, "Subtracting 1 year from Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(years1n, options),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(years2n, options),
+  5782, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(years2n, options),
+  5782, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5782
+);
+
 // Months
 
 const months1 = new Temporal.Duration(0, -1);
 const months1n = new Temporal.Duration(0, 1);
 const months2 = new Temporal.Duration(0, -2);
 const months2n = new Temporal.Duration(0, 2);
+const months12 = new Temporal.Duration(0, -12);
+const months12n = new Temporal.Duration(0, 12);
+const months13 = new Temporal.Duration(0, -13);
+const months13n = new Temporal.Duration(0, 13);
+const months24 = new Temporal.Duration(0, -24);
+const months24n = new Temporal.Duration(0, 24);
 
 const date1 = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
+const date3 = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M07", day: 1, hour: 12, minute: 34, calendar }, options);
+
 TemporalHelpers.assertPlainDateTime(
   date1.subtract(months1),
   5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 1 month to M04 in leap year lands in M05 (Shevat)",
@@ -39,9 +139,8 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5784
 );
 
-const date2 = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(months1),
+  leap2AdarI.subtract(months1),
   5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 month to M05L (Adar I) lands in M06 (Adar II)",
   "am", 5784
 );
@@ -52,7 +151,60 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5783
 );
 
-const date3 = Temporal.PlainDateTime.from({ year: 5784, monthCode: "M07", day: 1, hour: 12, minute: 34, calendar }, options);
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(months12),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(months13),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(months12),
+  5785, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year Adar I lands in Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(months13),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year Adar I lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(months12),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year Adar II lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(months24),
+  5785, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year Adar crossing a leap year lands in common-year Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(new Temporal.Duration(0, -25)),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarI.subtract(months24),
+  5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to leap-year Adar I lands in leap-year Shevat (M05)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarII.subtract(months24),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to leap-year Adar II lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
 TemporalHelpers.assertPlainDateTime(
   date3.subtract(months1n),
   5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M07 in leap year lands in M06 (Adar II)",
@@ -72,13 +224,13 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }).subtract(months1n),
+  leap2AdarII.subtract(months1n),
   5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 (Adar II) in leap year lands in M05L (Adar I)",
   "am", 5784
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(months1n),
+  leap2AdarI.subtract(months1n),
   5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M05L (Adar I) lands in M05 (Shevat)",
   "am", 5784
 );
@@ -89,13 +241,56 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5783
 );
 
-// Weeks
-
-// Days
-
-const days10 = new Temporal.Duration(0, 0, 0, /* days = */ -10);
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.subtract(months12n),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 5784, monthCode: "M05L", day: 30, hour: 12, minute: 34, calendar }, options).subtract(days10),
-  5784, 7, "M06", 10, 12, 34, 0, 0, 0, 0, "add 10 days to leap day", "am", 5784
+  common2Adar.subtract(months13n),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(months12n),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year Adar I lands in Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(months13n),
+  5783, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from leap-year Adar I lands in Shevat (M05)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(months12n),
+  5783, 7, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year Adar II lands in Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.subtract(months24n),
+  5783, 7, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year Adar crossing a leap year lands in common-year Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.subtract(new Temporal.Duration(0, 25)),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(months24n),
+  5782, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from leap-year Adar I lands in leap-year Adar (M06)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(months24n),
+  5782, 8, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from leap-year Adar II lands in leap-year Nisan (M07)",
+  "am", 5782
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/leap-months-hebrew.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/leap-months-hebrew.js
@@ -13,14 +13,114 @@ const options = { overflow: "reject" };
 
 // Years
 
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years2 = new Temporal.Duration(2);
+const years2n = new Temporal.Duration(-2);
+
+const leap1AdarI = Temporal.ZonedDateTime.from({ year: 5782, monthCode: "M05L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap1AdarII = Temporal.ZonedDateTime.from({ year: 5782, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common1Adar = Temporal.ZonedDateTime.from({ year: 5783, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap2AdarI = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap2AdarII = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common2Adar = Temporal.ZonedDateTime.from({ year: 5785, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(years1, options).toPlainDateTime(),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(years2, options).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(years1).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5785
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.add(years1, options);
+}, "Adding 1 year to Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(years1, options).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarI.add(years2, options).toPlainDateTime(),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarII.add(years2, options).toPlainDateTime(),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.add(years1n, options).toPlainDateTime(),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.add(years2n, options).toPlainDateTime(),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(years1n).toPlainDateTime(),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5783
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.add(years1n, options);
+}, "Subtracting 1 year from Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(years1n, options).toPlainDateTime(),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(years2n, options).toPlainDateTime(),
+  5782, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(years2n, options).toPlainDateTime(),
+  5782, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5782
+);
+
 // Months
 
 const months1 = new Temporal.Duration(0, 1);
 const months1n = new Temporal.Duration(0, -1);
 const months2 = new Temporal.Duration(0, 2);
 const months2n = new Temporal.Duration(0, -2);
+const months12 = new Temporal.Duration(0, 12);
+const months12n = new Temporal.Duration(0, -12);
+const months13 = new Temporal.Duration(0, 13);
+const months13n = new Temporal.Duration(0, -13);
+const months24 = new Temporal.Duration(0, 24);
+const months24n = new Temporal.Duration(0, -24);
 
 const date1 = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const date3 = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M07", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+
 TemporalHelpers.assertPlainDateTime(
   date1.add(months1).toPlainDateTime(),
   5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 1 month to M04 in leap year lands in M05 (Shevat)",
@@ -39,9 +139,8 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5784
 );
 
-const date2 = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.add(months1).toPlainDateTime(),
+  leap2AdarI.add(months1).toPlainDateTime(),
   5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 month to M05L (Adar I) lands in M06 (Adar II)",
   "am", 5784
 );
@@ -52,7 +151,60 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5783
 );
 
-const date3 = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M07", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(months12).toPlainDateTime(),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(months13).toPlainDateTime(),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(months12).toPlainDateTime(),
+  5785, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year Adar I lands in Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(months13).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year Adar I lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(months12).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year Adar II lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(months24).toPlainDateTime(),
+  5785, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year Adar crossing a leap year lands in common-year Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.add(new Temporal.Duration(0, 25)).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarI.add(months24).toPlainDateTime(),
+  5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to leap-year Adar I lands in leap-year Shevat (M05)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarII.add(months24).toPlainDateTime(),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to leap-year Adar II lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
 TemporalHelpers.assertPlainDateTime(
   date3.add(months1n).toPlainDateTime(),
   5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M07 in leap year lands in M06 (Adar II)",
@@ -72,13 +224,13 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }).add(months1n).toPlainDateTime(),
+  leap2AdarII.add(months1n).toPlainDateTime(),
   5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 (Adar II) in leap year lands in M05L (Adar I)",
   "am", 5784
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.add(months1n).toPlainDateTime(),
+  leap2AdarI.add(months1n).toPlainDateTime(),
   5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M05L (Adar I) lands in M05 (Shevat)",
   "am", 5784
 );
@@ -89,13 +241,56 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5783
 );
 
-// Weeks
-
-// Days
-
-const days10 = new Temporal.Duration(0, 0, 0, /* days = */ 10);
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.add(months12n).toPlainDateTime(),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M05L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(days10).toPlainDateTime(),
-  5784, 7, "M06", 10, 12, 34, 0, 0, 0, 0, "add 10 days to leap day", "am", 5784
+  common2Adar.add(months13n).toPlainDateTime(),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(months12n).toPlainDateTime(),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year Adar I lands in Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(months13n).toPlainDateTime(),
+  5783, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from leap-year Adar I lands in Shevat (M05)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(months12n).toPlainDateTime(),
+  5783, 7, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year Adar II lands in Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.add(months24n).toPlainDateTime(),
+  5783, 7, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year Adar crossing a leap year lands in common-year Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.add(new Temporal.Duration(0, -25)).toPlainDateTime(),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.add(months24n).toPlainDateTime(),
+  5782, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from leap-year Adar I lands in leap-year Adar (M06)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.add(months24n).toPlainDateTime(),
+  5782, 8, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from leap-year Adar II lands in leap-year Nisan (M07)",
+  "am", 5782
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/leap-months-hebrew.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/leap-months-hebrew.js
@@ -13,14 +13,114 @@ const options = { overflow: "reject" };
 
 // Years
 
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years2 = new Temporal.Duration(-2);
+const years2n = new Temporal.Duration(2);
+
+const leap1AdarI = Temporal.ZonedDateTime.from({ year: 5782, monthCode: "M05L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap1AdarII = Temporal.ZonedDateTime.from({ year: 5782, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common1Adar = Temporal.ZonedDateTime.from({ year: 5783, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap2AdarI = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap2AdarII = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common2Adar = Temporal.ZonedDateTime.from({ year: 5785, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(years1, options).toPlainDateTime(),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(years2, options).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(years1).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5785
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.subtract(years1, options);
+}, "Adding 1 year to Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(years1, options).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarI.subtract(years2, options).toPlainDateTime(),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarII.subtract(years2, options).toPlainDateTime(),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.subtract(years1n, options).toPlainDateTime(),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year Adar (M06) lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.subtract(years2n, options).toPlainDateTime(),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year Adar (M06) crossing leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(years1n).toPlainDateTime(),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from Adar I (M05L) lands in common-year Adar (M06) with constrain",
+  "am", 5783
+);
+
+assert.throws(RangeError, function () {
+  leap2AdarI.subtract(years1n, options);
+}, "Subtracting 1 year from Adar I (M05L) rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(years1n, options).toPlainDateTime(),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from Adar II (M06) lands in common-year Adar (M06) even with reject",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(years2n, options).toPlainDateTime(),
+  5782, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from leap-year Adar I (M05L) lands in leap-year Adar I (M05L)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(years2n, options).toPlainDateTime(),
+  5782, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from leap-year Adar II (M06) lands in leap-year Adar II (M06)",
+  "am", 5782
+);
+
 // Months
 
 const months1 = new Temporal.Duration(0, -1);
 const months1n = new Temporal.Duration(0, 1);
 const months2 = new Temporal.Duration(0, -2);
 const months2n = new Temporal.Duration(0, 2);
+const months12 = new Temporal.Duration(0, -12);
+const months12n = new Temporal.Duration(0, 12);
+const months13 = new Temporal.Duration(0, -13);
+const months13n = new Temporal.Duration(0, 13);
+const months24 = new Temporal.Duration(0, -24);
+const months24n = new Temporal.Duration(0, 24);
 
 const date1 = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const date3 = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M07", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+
 TemporalHelpers.assertPlainDateTime(
   date1.subtract(months1).toPlainDateTime(),
   5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 1 month to M04 in leap year lands in M05 (Shevat)",
@@ -39,9 +139,8 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5784
 );
 
-const date2 = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M05L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(months1).toPlainDateTime(),
+  leap2AdarI.subtract(months1).toPlainDateTime(),
   5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 1 month to M05L (Adar I) lands in M06 (Adar II)",
   "am", 5784
 );
@@ -52,7 +151,60 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5783
 );
 
-const date3 = Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M07", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(months12).toPlainDateTime(),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(months13).toPlainDateTime(),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(months12).toPlainDateTime(),
+  5785, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year Adar I lands in Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(months13).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year Adar I lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(months12).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year Adar II lands in Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(months24).toPlainDateTime(),
+  5785, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year Adar crossing a leap year lands in common-year Shevat (M05)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common1Adar.subtract(new Temporal.Duration(0, -25)).toPlainDateTime(),
+  5785, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5785
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarI.subtract(months24).toPlainDateTime(),
+  5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to leap-year Adar I lands in leap-year Shevat (M05)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap1AdarII.subtract(months24).toPlainDateTime(),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to leap-year Adar II lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
 TemporalHelpers.assertPlainDateTime(
   date3.subtract(months1n).toPlainDateTime(),
   5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M07 in leap year lands in M06 (Adar II)",
@@ -72,13 +224,13 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }).subtract(months1n).toPlainDateTime(),
+  leap2AdarII.subtract(months1n).toPlainDateTime(),
   5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 (Adar II) in leap year lands in M05L (Adar I)",
   "am", 5784
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(months1n).toPlainDateTime(),
+  leap2AdarI.subtract(months1n).toPlainDateTime(),
   5784, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M05L (Adar I) lands in M05 (Shevat)",
   "am", 5784
 );
@@ -89,13 +241,56 @@ TemporalHelpers.assertPlainDateTime(
   "am", 5783
 );
 
-// Weeks
-
-// Days
-
-const days10 = new Temporal.Duration(0, 0, 0, /* days = */ -10);
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.subtract(months12n).toPlainDateTime(),
+  5784, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year Adar lands in leap-year Adar II (M06)",
+  "am", 5784
+);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 5784, monthCode: "M05L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(days10).toPlainDateTime(),
-  5784, 7, "M06", 10, 12, 34, 0, 0, 0, 0, "add 10 days to leap day", "am", 5784
+  common2Adar.subtract(months13n).toPlainDateTime(),
+  5784, 6, "M05L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year Adar lands in leap-year Adar I (M05L)",
+  "am", 5784
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(months12n).toPlainDateTime(),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year Adar I lands in Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(months13n).toPlainDateTime(),
+  5783, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from leap-year Adar I lands in Shevat (M05)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(months12n).toPlainDateTime(),
+  5783, 7, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year Adar II lands in Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.subtract(months24n).toPlainDateTime(),
+  5783, 7, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year Adar crossing a leap year lands in common-year Nisan (M07)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common2Adar.subtract(new Temporal.Duration(0, 25)).toPlainDateTime(),
+  5783, 6, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year Adar crossing a leap year lands in common-year Adar (M06)",
+  "am", 5783
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarI.subtract(months24n).toPlainDateTime(),
+  5782, 7, "M06", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from leap-year Adar I lands in leap-year Adar (M06)",
+  "am", 5782
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap2AdarII.subtract(months24n).toPlainDateTime(),
+  5782, 8, "M07", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from leap-year Adar II lands in leap-year Nisan (M07)",
+  "am", 5782
 );


### PR DESCRIPTION
This adds tests for overflow constrain/reject with years, expands the coverage with months to test edge cases using 12, 13, 24, and 25 months, and cleans up a bit.

I started to add weeks and days tests for this in the previous PR, but on reflection I don't think those are that useful.