### PR TITLE
Intl Era Monthcode: Complete Chinese and Dangi leap month addition tests

### DIFF
--- a/test/intl402/Temporal/PlainDate/prototype/add/leap-months-chinese.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/leap-months-chinese.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+
+const leap193807L = Temporal.PlainDate.from({ year: 1938, monthCode: "M07L", day: 30, calendar }, options);
+const leap195205L = Temporal.PlainDate.from({ year: 1952, monthCode: "M05L", day: 30, calendar }, options);
+const leap196603L = Temporal.PlainDate.from({ year: 1966, monthCode: "M03L", day: 1, calendar }, options);
+const common201901 = Temporal.PlainDate.from({ year: 2019, monthCode: "M01", day: 1, calendar }, options);
+const common201904 = Temporal.PlainDate.from({ year: 2019, monthCode: "M04", day: 1, calendar }, options);
+const leap202004 = Temporal.PlainDate.from({ year: 2020, monthCode: "M04", day: 1, calendar }, options);
+const leap202004L = Temporal.PlainDate.from({ year: 2020, monthCode: "M04L", day: 1, calendar }, options);
+const common202104 = Temporal.PlainDate.from({ year: 2021, monthCode: "M04", day: 1, calendar }, options);
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 2019, monthCode: "M01", day: 1, calendar }, options).add(years1),
+  common201901.add(years1),
   2020, 1, "M01", 1, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 1966, monthCode: "M03L", day: 1, calendar }, options).add(years1),
-  1967, 3, "M03", 1, "add 1 year from leap month"
+  leap196603L.add(years1),
+  1967, 3, "M03", 1, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap193807L.add(years1),
+  1939, 7, "M07", 29, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.add(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDate(
+  common201904.add(years1, options),
+  2020, 4, "M04", 1, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 1938, monthCode: "M07L", day: 30, calendar }, options).add(years1),
-  1939, 7, "M07", 29, "add 1 year from leap day in leap month"
+  leap202004.add(years1, options),
+  2021, 4, "M04", 1, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  Temporal.PlainDate.from({ year: 2012, monthCode: "M04L", day: 1, calendar }, options).add(new Temporal.Duration(8), options),
+  2020, 5, "M04L", 1, "Adding years to go from one M04L to the next M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.add(new Temporal.Duration(2), options),
+  2021, 4, "M04", 1, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201901.add(years1n),
+  2018, 1, "M01", 1, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap196603L.add(years1n),
+  1965, 3, "M03", 1, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap195205L.add(years1n),
+  1951, 5, "M05", 29, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.add(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(years1n, options),
+  2020, 4, "M04", 1, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.add(years1n, options),
+  2019, 4, "M04", 1, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.add(new Temporal.Duration(-8), options),
+  2012, 5, "M04L", 1, "Subtracting years to go from one M04L to the previous M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(new Temporal.Duration(-2), options),
+  2019, 4, "M04", 1, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, 1);
 const months1n = new Temporal.Duration(0, -1);
+const months12 = new Temporal.Duration(0, 12);
+const months12n = new Temporal.Duration(0, -12);
+const months13 = new Temporal.Duration(0, 13);
+const months13n = new Temporal.Duration(0, -13);
+
+const leap202003 = Temporal.PlainDate.from({ year: 2020, monthCode: "M03", day: 1, calendar }, options);
+const leap202006 = Temporal.PlainDate.from({ year: 2020, monthCode: "M06", day: 1, calendar }, options);
 
 TemporalHelpers.assertPlainDate(
   Temporal.PlainDate.from({ year: 1947, monthCode: "M02L", day: 1, calendar }, options).add(months1),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDate(
   1955, 5, "M04", 1, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.PlainDate.from({ year: 2020, monthCode: "M03", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(
-  date1.add(months1),
+  leap202003.add(months1),
   2020, 4, "M04", 1, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date1.add(new Temporal.Duration(0, 2)),
+  leap202003.add(new Temporal.Duration(0, 2)),
   2020, 5, "M04L", 1, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date1.add(new Temporal.Duration(0, 3)),
+  leap202003.add(new Temporal.Duration(0, 3)),
   2020, 6, "M05", 1, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.PlainDate.from({ year: 2020, monthCode: "M06", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(
-  date2.add(months1n),
+  common201904.add(months12),
+  2020, 4, "M04", 1, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.add(months13),
+  2020, 5, "M04L", 1, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.add(months12),
+  2021, 3, "M03", 1, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.add(months13),
+  2021, 4, "M04", 1, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.add(months12),
+  2021, 4, "M04", 1, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.add(new Temporal.Duration(0, 24)),
+  2021, 3, "M03", 1, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.add(new Temporal.Duration(0, 25)),
+  2021, 4, "M04", 1, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202006.add(months1n),
   2020, 6, "M05", 1, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDate(
-  date2.add(new Temporal.Duration(0, -2)),
+  leap202006.add(new Temporal.Duration(0, -2)),
   2020, 5, "M04L", 1, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date2.add(new Temporal.Duration(0, -3)),
+  leap202006.add(new Temporal.Duration(0, -3)),
   2020, 4, "M04", 1, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDate(
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 2020, monthCode: "M04L", day: 1, calendar }, options).add(months1n),
+  leap202004L.add(months1n),
   2020, 4, "M04", 1, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(months12n),
+  2020, 5, "M04L", 1, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(months13n),
+  2020, 4, "M04", 1, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.add(months12n),
+  2019, 4, "M04", 1, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.add(months12n),
+  2019, 5, "M05", 1, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.add(months13n),
+  2019, 4, "M04", 1, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(new Temporal.Duration(0, -24)),
+  2019, 5, "M05", 1, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(new Temporal.Duration(0, -25)),
+  2019, 4, "M04", 1, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/PlainDate/prototype/add/leap-months-dangi.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/leap-months-dangi.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+
+const leap193807L = Temporal.PlainDate.from({ year: 1938, monthCode: "M07L", day: 30, calendar }, options);
+const leap195205L = Temporal.PlainDate.from({ year: 1952, monthCode: "M05L", day: 30, calendar }, options);
+const leap196603L = Temporal.PlainDate.from({ year: 1966, monthCode: "M03L", day: 1, calendar }, options);
+const common201901 = Temporal.PlainDate.from({ year: 2019, monthCode: "M01", day: 1, calendar }, options);
+const common201904 = Temporal.PlainDate.from({ year: 2019, monthCode: "M04", day: 1, calendar }, options);
+const leap202004 = Temporal.PlainDate.from({ year: 2020, monthCode: "M04", day: 1, calendar }, options);
+const leap202004L = Temporal.PlainDate.from({ year: 2020, monthCode: "M04L", day: 1, calendar }, options);
+const common202104 = Temporal.PlainDate.from({ year: 2021, monthCode: "M04", day: 1, calendar }, options);
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 2019, monthCode: "M01", day: 1, calendar }, options).add(years1),
+  common201901.add(years1),
   2020, 1, "M01", 1, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 1966, monthCode: "M03L", day: 1, calendar }, options).add(years1),
-  1967, 3, "M03", 1, "add 1 year from leap month"
+  leap196603L.add(years1),
+  1967, 3, "M03", 1, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap193807L.add(years1),
+  1939, 7, "M07", 29, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.add(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDate(
+  common201904.add(years1, options),
+  2020, 4, "M04", 1, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 1938, monthCode: "M07L", day: 30, calendar }, options).add(years1),
-  1939, 7, "M07", 29, "add 1 year from leap day in leap month"
+  leap202004.add(years1, options),
+  2021, 4, "M04", 1, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  Temporal.PlainDate.from({ year: 2012, monthCode: "M03L", day: 1, calendar }, options).add(new Temporal.Duration(-19), options),
+  1993, 4, "M03L", 1, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.add(new Temporal.Duration(2), options),
+  2021, 4, "M04", 1, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201901.add(years1n),
+  2018, 1, "M01", 1, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap196603L.add(years1n),
+  1965, 3, "M03", 1, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap195205L.add(years1n),
+  1951, 5, "M05", 29, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.add(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(years1n, options),
+  2020, 4, "M04", 1, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.add(years1n, options),
+  2019, 4, "M04", 1, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  Temporal.PlainDate.from({ year: 2012, monthCode: "M03L", day: 1, calendar }, options).add(new Temporal.Duration(-19), options),
+  1993, 4, "M03L", 1, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(new Temporal.Duration(-2), options),
+  2019, 4, "M04", 1, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, 1);
 const months1n = new Temporal.Duration(0, -1);
+const months12 = new Temporal.Duration(0, 12);
+const months12n = new Temporal.Duration(0, -12);
+const months13 = new Temporal.Duration(0, 13);
+const months13n = new Temporal.Duration(0, -13);
+
+const leap202003 = Temporal.PlainDate.from({ year: 2020, monthCode: "M03", day: 1, calendar }, options);
+const leap202006 = Temporal.PlainDate.from({ year: 2020, monthCode: "M06", day: 1, calendar }, options);
 
 TemporalHelpers.assertPlainDate(
   Temporal.PlainDate.from({ year: 1947, monthCode: "M02L", day: 1, calendar }, options).add(months1),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDate(
   1955, 5, "M04", 1, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.PlainDate.from({ year: 2020, monthCode: "M03", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(
-  date1.add(months1),
+  leap202003.add(months1),
   2020, 4, "M04", 1, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date1.add(new Temporal.Duration(0, 2)),
+  leap202003.add(new Temporal.Duration(0, 2)),
   2020, 5, "M04L", 1, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date1.add(new Temporal.Duration(0, 3)),
+  leap202003.add(new Temporal.Duration(0, 3)),
   2020, 6, "M05", 1, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.PlainDate.from({ year: 2020, monthCode: "M06", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(
-  date2.add(months1n),
+  common201904.add(months12),
+  2020, 4, "M04", 1, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.add(months13),
+  2020, 5, "M04L", 1, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.add(months12),
+  2021, 3, "M03", 1, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.add(months13),
+  2021, 4, "M04", 1, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.add(months12),
+  2021, 4, "M04", 1, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.add(new Temporal.Duration(0, 24)),
+  2021, 3, "M03", 1, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.add(new Temporal.Duration(0, 25)),
+  2021, 4, "M04", 1, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202006.add(months1n),
   2020, 6, "M05", 1, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDate(
-  date2.add(new Temporal.Duration(0, -2)),
+  leap202006.add(new Temporal.Duration(0, -2)),
   2020, 5, "M04L", 1, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date2.add(new Temporal.Duration(0, -3)),
+  leap202006.add(new Temporal.Duration(0, -3)),
   2020, 4, "M04", 1, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDate(
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 2020, monthCode: "M04L", day: 1, calendar }, options).add(months1n),
+  leap202004L.add(months1n),
   2020, 4, "M04", 1, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(months12n),
+  2020, 5, "M04L", 1, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(months13n),
+  2020, 4, "M04", 1, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.add(months12n),
+  2019, 4, "M04", 1, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.add(months12n),
+  2019, 5, "M05", 1, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.add(months13n),
+  2019, 4, "M04", 1, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(new Temporal.Duration(0, -24)),
+  2019, 5, "M05", 1, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.add(new Temporal.Duration(0, -25)),
+  2019, 4, "M04", 1, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/leap-months-chinese.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/leap-months-chinese.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+
+const leap193807L = Temporal.PlainDate.from({ year: 1938, monthCode: "M07L", day: 30, calendar }, options);
+const leap195205L = Temporal.PlainDate.from({ year: 1952, monthCode: "M05L", day: 30, calendar }, options);
+const leap196603L = Temporal.PlainDate.from({ year: 1966, monthCode: "M03L", day: 1, calendar }, options);
+const common201901 = Temporal.PlainDate.from({ year: 2019, monthCode: "M01", day: 1, calendar }, options);
+const common201904 = Temporal.PlainDate.from({ year: 2019, monthCode: "M04", day: 1, calendar }, options);
+const leap202004 = Temporal.PlainDate.from({ year: 2020, monthCode: "M04", day: 1, calendar }, options);
+const leap202004L = Temporal.PlainDate.from({ year: 2020, monthCode: "M04L", day: 1, calendar }, options);
+const common202104 = Temporal.PlainDate.from({ year: 2021, monthCode: "M04", day: 1, calendar }, options);
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 2019, monthCode: "M01", day: 1, calendar }, options).subtract(years1),
+  common201901.subtract(years1),
   2020, 1, "M01", 1, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 1966, monthCode: "M03L", day: 1, calendar }, options).subtract(years1),
-  1967, 3, "M03", 1, "add 1 year from leap month"
+  leap196603L.subtract(years1),
+  1967, 3, "M03", 1, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap193807L.subtract(years1),
+  1939, 7, "M07", 29, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.subtract(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDate(
+  common201904.subtract(years1, options),
+  2020, 4, "M04", 1, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 1938, monthCode: "M07L", day: 30, calendar }, options).subtract(years1),
-  1939, 7, "M07", 29, "add 1 year from leap day in leap month"
+  leap202004.subtract(years1, options),
+  2021, 4, "M04", 1, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  Temporal.PlainDate.from({ year: 2012, monthCode: "M04L", day: 1, calendar }, options).subtract(new Temporal.Duration(-8), options),
+  2020, 5, "M04L", 1, "Adding years to go from one M04L to the next M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.subtract(new Temporal.Duration(-2), options),
+  2021, 4, "M04", 1, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201901.subtract(years1n),
+  2018, 1, "M01", 1, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap196603L.subtract(years1n),
+  1965, 3, "M03", 1, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap195205L.subtract(years1n),
+  1951, 5, "M05", 29, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(years1n, options),
+  2020, 4, "M04", 1, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.subtract(years1n, options),
+  2019, 4, "M04", 1, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.subtract(new Temporal.Duration(8), options),
+  2012, 5, "M04L", 1, "Subtracting years to go from one M04L to the previous M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(new Temporal.Duration(2), options),
+  2019, 4, "M04", 1, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, -1);
 const months1n = new Temporal.Duration(0, 1);
+const months12 = new Temporal.Duration(0, -12);
+const months12n = new Temporal.Duration(0, 12);
+const months13 = new Temporal.Duration(0, -13);
+const months13n = new Temporal.Duration(0, 13);
+
+const leap202003 = Temporal.PlainDate.from({ year: 2020, monthCode: "M03", day: 1, calendar }, options);
+const leap202006 = Temporal.PlainDate.from({ year: 2020, monthCode: "M06", day: 1, calendar }, options);
 
 TemporalHelpers.assertPlainDate(
   Temporal.PlainDate.from({ year: 1947, monthCode: "M02L", day: 1, calendar }, options).subtract(months1),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDate(
   1955, 5, "M04", 1, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.PlainDate.from({ year: 2020, monthCode: "M03", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(
-  date1.subtract(months1),
+  leap202003.subtract(months1),
   2020, 4, "M04", 1, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date1.subtract(new Temporal.Duration(0, -2)),
+  leap202003.subtract(new Temporal.Duration(0, -2)),
   2020, 5, "M04L", 1, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date1.subtract(new Temporal.Duration(0, -3)),
+  leap202003.subtract(new Temporal.Duration(0, -3)),
   2020, 6, "M05", 1, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.PlainDate.from({ year: 2020, monthCode: "M06", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(
-  date2.subtract(months1n),
+  common201904.subtract(months12),
+  2020, 4, "M04", 1, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.subtract(months13),
+  2020, 5, "M04L", 1, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.subtract(months12),
+  2021, 3, "M03", 1, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.subtract(months13),
+  2021, 4, "M04", 1, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.subtract(months12),
+  2021, 4, "M04", 1, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.subtract(new Temporal.Duration(0, -24)),
+  2021, 3, "M03", 1, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.subtract(new Temporal.Duration(0, -25)),
+  2021, 4, "M04", 1, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202006.subtract(months1n),
   2020, 6, "M05", 1, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDate(
-  date2.subtract(new Temporal.Duration(0, 2)),
+  leap202006.subtract(new Temporal.Duration(0, 2)),
   2020, 5, "M04L", 1, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date2.subtract(new Temporal.Duration(0, 3)),
+  leap202006.subtract(new Temporal.Duration(0, 3)),
   2020, 4, "M04", 1, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDate(
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 2020, monthCode: "M04L", day: 1, calendar }, options).subtract(months1n),
+  leap202004L.subtract(months1n),
   2020, 4, "M04", 1, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(months12n),
+  2020, 5, "M04L", 1, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(months13n),
+  2020, 4, "M04", 1, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.subtract(months12n),
+  2019, 4, "M04", 1, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.subtract(months12n),
+  2019, 5, "M05", 1, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.subtract(months13n),
+  2019, 4, "M04", 1, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(new Temporal.Duration(0, 24)),
+  2019, 5, "M05", 1, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(new Temporal.Duration(0, 25)),
+  2019, 4, "M04", 1, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/leap-months-dangi.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/leap-months-dangi.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+
+const leap193807L = Temporal.PlainDate.from({ year: 1938, monthCode: "M07L", day: 30, calendar }, options);
+const leap195205L = Temporal.PlainDate.from({ year: 1952, monthCode: "M05L", day: 30, calendar }, options);
+const leap196603L = Temporal.PlainDate.from({ year: 1966, monthCode: "M03L", day: 1, calendar }, options);
+const common201901 = Temporal.PlainDate.from({ year: 2019, monthCode: "M01", day: 1, calendar }, options);
+const common201904 = Temporal.PlainDate.from({ year: 2019, monthCode: "M04", day: 1, calendar }, options);
+const leap202004 = Temporal.PlainDate.from({ year: 2020, monthCode: "M04", day: 1, calendar }, options);
+const leap202004L = Temporal.PlainDate.from({ year: 2020, monthCode: "M04L", day: 1, calendar }, options);
+const common202104 = Temporal.PlainDate.from({ year: 2021, monthCode: "M04", day: 1, calendar }, options);
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 2019, monthCode: "M01", day: 1, calendar }, options).subtract(years1),
+  common201901.subtract(years1),
   2020, 1, "M01", 1, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 1966, monthCode: "M03L", day: 1, calendar }, options).subtract(years1),
-  1967, 3, "M03", 1, "add 1 year from leap month"
+  leap196603L.subtract(years1),
+  1967, 3, "M03", 1, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap193807L.subtract(years1),
+  1939, 7, "M07", 29, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.subtract(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDate(
+  common201904.subtract(years1, options),
+  2020, 4, "M04", 1, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 1938, monthCode: "M07L", day: 30, calendar }, options).subtract(years1),
-  1939, 7, "M07", 29, "add 1 year from leap day in leap month"
+  leap202004.subtract(years1, options),
+  2021, 4, "M04", 1, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  Temporal.PlainDate.from({ year: 2012, monthCode: "M03L", day: 1, calendar }, options).subtract(new Temporal.Duration(19), options),
+  1993, 4, "M03L", 1, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.subtract(new Temporal.Duration(-2), options),
+  2021, 4, "M04", 1, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201901.subtract(years1n),
+  2018, 1, "M01", 1, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap196603L.subtract(years1n),
+  1965, 3, "M03", 1, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDate(
+  leap195205L.subtract(years1n),
+  1951, 5, "M05", 29, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(years1n, options),
+  2020, 4, "M04", 1, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.subtract(years1n, options),
+  2019, 4, "M04", 1, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  Temporal.PlainDate.from({ year: 2012, monthCode: "M03L", day: 1, calendar }, options).subtract(new Temporal.Duration(19), options),
+  1993, 4, "M03L", 1, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(new Temporal.Duration(2), options),
+  2019, 4, "M04", 1, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, -1);
 const months1n = new Temporal.Duration(0, 1);
+const months12 = new Temporal.Duration(0, -12);
+const months12n = new Temporal.Duration(0, 12);
+const months13 = new Temporal.Duration(0, -13);
+const months13n = new Temporal.Duration(0, 13);
+
+const leap202003 = Temporal.PlainDate.from({ year: 2020, monthCode: "M03", day: 1, calendar }, options);
+const leap202006 = Temporal.PlainDate.from({ year: 2020, monthCode: "M06", day: 1, calendar }, options);
 
 TemporalHelpers.assertPlainDate(
   Temporal.PlainDate.from({ year: 1947, monthCode: "M02L", day: 1, calendar }, options).subtract(months1),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDate(
   1955, 5, "M04", 1, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.PlainDate.from({ year: 2020, monthCode: "M03", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(
-  date1.subtract(months1),
+  leap202003.subtract(months1),
   2020, 4, "M04", 1, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date1.subtract(new Temporal.Duration(0, -2)),
+  leap202003.subtract(new Temporal.Duration(0, -2)),
   2020, 5, "M04L", 1, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date1.subtract(new Temporal.Duration(0, -3)),
+  leap202003.subtract(new Temporal.Duration(0, -3)),
   2020, 6, "M05", 1, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.PlainDate.from({ year: 2020, monthCode: "M06", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(
-  date2.subtract(months1n),
+  common201904.subtract(months12),
+  2020, 4, "M04", 1, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.subtract(months13),
+  2020, 5, "M04L", 1, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.subtract(months12),
+  2021, 3, "M03", 1, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.subtract(months13),
+  2021, 4, "M04", 1, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.subtract(months12),
+  2021, 4, "M04", 1, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.subtract(new Temporal.Duration(0, -24)),
+  2021, 3, "M03", 1, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDate(
+  common201904.subtract(new Temporal.Duration(0, -25)),
+  2021, 4, "M04", 1, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202006.subtract(months1n),
   2020, 6, "M05", 1, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDate(
-  date2.subtract(new Temporal.Duration(0, 2)),
+  leap202006.subtract(new Temporal.Duration(0, 2)),
   2020, 5, "M04L", 1, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDate(
-  date2.subtract(new Temporal.Duration(0, 3)),
+  leap202006.subtract(new Temporal.Duration(0, 3)),
   2020, 4, "M04", 1, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDate(
 );
 
 TemporalHelpers.assertPlainDate(
-  Temporal.PlainDate.from({ year: 2020, monthCode: "M04L", day: 1, calendar }, options).subtract(months1n),
+  leap202004L.subtract(months1n),
   2020, 4, "M04", 1, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(months12n),
+  2020, 5, "M04L", 1, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(months13n),
+  2020, 4, "M04", 1, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004.subtract(months12n),
+  2019, 4, "M04", 1, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.subtract(months12n),
+  2019, 5, "M05", 1, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDate(
+  leap202004L.subtract(months13n),
+  2019, 4, "M04", 1, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(new Temporal.Duration(0, 24)),
+  2019, 5, "M05", 1, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDate(
+  common202104.subtract(new Temporal.Duration(0, 25)),
+  2019, 4, "M04", 1, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/leap-months-chinese.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/leap-months-chinese.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+
+const leap193807L = Temporal.PlainDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, calendar }, options);
+const leap195205L = Temporal.PlainDateTime.from({ year: 1952, monthCode: "M05L", day: 30, hour: 12, minute: 34, calendar }, options);
+const leap196603L = Temporal.PlainDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options);
+const common201901 = Temporal.PlainDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar }, options);
+const common201904 = Temporal.PlainDateTime.from({ year: 2019, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202004 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202004L = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, calendar }, options);
+const common202104 = Temporal.PlainDateTime.from({ year: 2021, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar }, options).add(years1),
+  common201901.add(years1),
   2020, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options).add(years1),
-  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 year from leap month"
+  leap196603L.add(years1),
+  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap193807L.add(years1),
+  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.add(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(years1, options),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, calendar }, options).add(years1),
-  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "add 1 year from leap day in leap month"
+  leap202004.add(years1, options),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.PlainDateTime.from({ year: 2012, monthCode: "M04L", day: 1, hour: 12, minute: 34, calendar }, options).add(new Temporal.Duration(8), options),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding years to go from one M04L to the next M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(2), options),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201901.add(years1n),
+  2018, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap196603L.add(years1n),
+  1965, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap195205L.add(years1n),
+  1951, 5, "M05", 29, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.add(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(years1n, options),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(years1n, options),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(new Temporal.Duration(-8), options),
+  2012, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M04L to the previous M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(-2), options),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, 1);
 const months1n = new Temporal.Duration(0, -1);
+const months12 = new Temporal.Duration(0, 12);
+const months12n = new Temporal.Duration(0, -12);
+const months13 = new Temporal.Duration(0, 13);
+const months13n = new Temporal.Duration(0, -13);
+
+const leap202003 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202006 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
   Temporal.PlainDateTime.from({ year: 1947, monthCode: "M02L", day: 1, hour: 12, minute: 34, calendar }, options).add(months1),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDateTime(
   1955, 5, "M04", 1, 12, 34, 0, 0, 0, 0, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date1.add(months1),
+  leap202003.add(months1),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.add(new Temporal.Duration(0, 2)),
+  leap202003.add(new Temporal.Duration(0, 2)),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.add(new Temporal.Duration(0, 3)),
+  leap202003.add(new Temporal.Duration(0, 3)),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.add(months1n),
+  common201904.add(months12),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(months13),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months12),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months13),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months12),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(0, 24)),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(0, 25)),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202006.add(months1n),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.add(new Temporal.Duration(0, -2)),
+  leap202006.add(new Temporal.Duration(0, -2)),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.add(new Temporal.Duration(0, -3)),
+  leap202006.add(new Temporal.Duration(0, -3)),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, calendar }, options).add(months1n),
+  leap202004L.add(months1n),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(months12n),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(months13n),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months12n),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months12n),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months13n),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(0, -24)),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(0, -25)),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/leap-months-dangi.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/leap-months-dangi.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+
+const leap193807L = Temporal.PlainDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, calendar }, options);
+const leap195205L = Temporal.PlainDateTime.from({ year: 1952, monthCode: "M05L", day: 30, hour: 12, minute: 34, calendar }, options);
+const leap196603L = Temporal.PlainDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options);
+const common201901 = Temporal.PlainDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar }, options);
+const common201904 = Temporal.PlainDateTime.from({ year: 2019, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202004 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202004L = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, calendar }, options);
+const common202104 = Temporal.PlainDateTime.from({ year: 2021, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar }, options).add(years1),
+  common201901.add(years1),
   2020, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options).add(years1),
-  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 year from leap month"
+  leap196603L.add(years1),
+  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap193807L.add(years1),
+  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.add(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(years1, options),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, calendar }, options).add(years1),
-  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "add 1 year from leap day in leap month"
+  leap202004.add(years1, options),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.PlainDateTime.from({ year: 2012, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options).add(new Temporal.Duration(-19), options),
+  1993, 4, "M03L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(2), options),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201901.add(years1n),
+  2018, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap196603L.add(years1n),
+  1965, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap195205L.add(years1n),
+  1951, 5, "M05", 29, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.add(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(years1n, options),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(years1n, options),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.PlainDateTime.from({ year: 2012, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options).add(new Temporal.Duration(-19), options),
+  1993, 4, "M03L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(-2), options),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, 1);
 const months1n = new Temporal.Duration(0, -1);
+const months12 = new Temporal.Duration(0, 12);
+const months12n = new Temporal.Duration(0, -12);
+const months13 = new Temporal.Duration(0, 13);
+const months13n = new Temporal.Duration(0, -13);
+
+const leap202003 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202006 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
   Temporal.PlainDateTime.from({ year: 1947, monthCode: "M02L", day: 1, hour: 12, minute: 34, calendar }, options).add(months1),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDateTime(
   1955, 5, "M04", 1, 12, 34, 0, 0, 0, 0, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date1.add(months1),
+  leap202003.add(months1),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.add(new Temporal.Duration(0, 2)),
+  leap202003.add(new Temporal.Duration(0, 2)),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.add(new Temporal.Duration(0, 3)),
+  leap202003.add(new Temporal.Duration(0, 3)),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.add(months1n),
+  common201904.add(months12),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(months13),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months12),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months13),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months12),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(0, 24)),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(0, 25)),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202006.add(months1n),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.add(new Temporal.Duration(0, -2)),
+  leap202006.add(new Temporal.Duration(0, -2)),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.add(new Temporal.Duration(0, -3)),
+  leap202006.add(new Temporal.Duration(0, -3)),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, calendar }, options).add(months1n),
+  leap202004L.add(months1n),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(months12n),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(months13n),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months12n),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months12n),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months13n),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(0, -24)),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(0, -25)),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/leap-months-chinese.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/leap-months-chinese.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+
+const leap193807L = Temporal.PlainDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, calendar }, options);
+const leap195205L = Temporal.PlainDateTime.from({ year: 1952, monthCode: "M05L", day: 30, hour: 12, minute: 34, calendar }, options);
+const leap196603L = Temporal.PlainDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options);
+const common201901 = Temporal.PlainDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar }, options);
+const common201904 = Temporal.PlainDateTime.from({ year: 2019, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202004 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202004L = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, calendar }, options);
+const common202104 = Temporal.PlainDateTime.from({ year: 2021, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar }, options).subtract(years1),
+  common201901.subtract(years1),
   2020, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options).subtract(years1),
-  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 year from leap month"
+  leap196603L.subtract(years1),
+  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap193807L.subtract(years1),
+  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.subtract(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(years1, options),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, calendar }, options).subtract(years1),
-  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "add 1 year from leap day in leap month"
+  leap202004.subtract(years1, options),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.PlainDateTime.from({ year: 2012, monthCode: "M04L", day: 1, hour: 12, minute: 34, calendar }, options).subtract(new Temporal.Duration(-8), options),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding years to go from one M04L to the next M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(-2), options),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201901.subtract(years1n),
+  2018, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap196603L.subtract(years1n),
+  1965, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap195205L.subtract(years1n),
+  1951, 5, "M05", 29, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(years1n, options),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(years1n, options),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(new Temporal.Duration(8), options),
+  2012, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M04L to the previous M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(2), options),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, -1);
 const months1n = new Temporal.Duration(0, 1);
+const months12 = new Temporal.Duration(0, -12);
+const months12n = new Temporal.Duration(0, 12);
+const months13 = new Temporal.Duration(0, -13);
+const months13n = new Temporal.Duration(0, 13);
+
+const leap202003 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202006 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
   Temporal.PlainDateTime.from({ year: 1947, monthCode: "M02L", day: 1, hour: 12, minute: 34, calendar }, options).subtract(months1),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDateTime(
   1955, 5, "M04", 1, 12, 34, 0, 0, 0, 0, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(months1),
+  leap202003.subtract(months1),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(new Temporal.Duration(0, -2)),
+  leap202003.subtract(new Temporal.Duration(0, -2)),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(new Temporal.Duration(0, -3)),
+  leap202003.subtract(new Temporal.Duration(0, -3)),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(months1n),
+  common201904.subtract(months12),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(months13),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months12),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months13),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months12),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(0, -24)),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(0, -25)),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202006.subtract(months1n),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(new Temporal.Duration(0, 2)),
+  leap202006.subtract(new Temporal.Duration(0, 2)),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(new Temporal.Duration(0, 3)),
+  leap202006.subtract(new Temporal.Duration(0, 3)),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, calendar }, options).subtract(months1n),
+  leap202004L.subtract(months1n),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(months12n),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(months13n),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months12n),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months12n),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months13n),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(0, 24)),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(0, 25)),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/leap-months-dangi.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/leap-months-dangi.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+
+const leap193807L = Temporal.PlainDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, calendar }, options);
+const leap195205L = Temporal.PlainDateTime.from({ year: 1952, monthCode: "M05L", day: 30, hour: 12, minute: 34, calendar }, options);
+const leap196603L = Temporal.PlainDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options);
+const common201901 = Temporal.PlainDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar }, options);
+const common201904 = Temporal.PlainDateTime.from({ year: 2019, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202004 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202004L = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, calendar }, options);
+const common202104 = Temporal.PlainDateTime.from({ year: 2021, monthCode: "M04", day: 1, hour: 12, minute: 34, calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar }, options).subtract(years1),
+  common201901.subtract(years1),
   2020, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options).subtract(years1),
-  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 year from leap month"
+  leap196603L.subtract(years1),
+  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap193807L.subtract(years1),
+  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.subtract(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(years1, options),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, calendar }, options).subtract(years1),
-  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "add 1 year from leap day in leap month"
+  leap202004.subtract(years1, options),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.PlainDateTime.from({ year: 2012, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options).subtract(new Temporal.Duration(19), options),
+  1993, 4, "M03L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(-2), options),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201901.subtract(years1n),
+  2018, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap196603L.subtract(years1n),
+  1965, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap195205L.subtract(years1n),
+  1951, 5, "M05", 29, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(years1n, options),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(years1n, options),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.PlainDateTime.from({ year: 2012, monthCode: "M03L", day: 1, hour: 12, minute: 34, calendar }, options).subtract(new Temporal.Duration(19), options),
+  1993, 4, "M03L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(2), options),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, -1);
 const months1n = new Temporal.Duration(0, 1);
+const months12 = new Temporal.Duration(0, -12);
+const months12n = new Temporal.Duration(0, 12);
+const months13 = new Temporal.Duration(0, -13);
+const months13n = new Temporal.Duration(0, 13);
+
+const leap202003 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar }, options);
+const leap202006 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
   Temporal.PlainDateTime.from({ year: 1947, monthCode: "M02L", day: 1, hour: 12, minute: 34, calendar }, options).subtract(months1),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDateTime(
   1955, 5, "M04", 1, 12, 34, 0, 0, 0, 0, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(months1),
+  leap202003.subtract(months1),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(new Temporal.Duration(0, -2)),
+  leap202003.subtract(new Temporal.Duration(0, -2)),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(new Temporal.Duration(0, -3)),
+  leap202003.subtract(new Temporal.Duration(0, -3)),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.PlainDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(months1n),
+  common201904.subtract(months12),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(months13),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months12),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months13),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months12),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(0, -24)),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(0, -25)),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202006.subtract(months1n),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(new Temporal.Duration(0, 2)),
+  leap202006.subtract(new Temporal.Duration(0, 2)),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(new Temporal.Duration(0, 3)),
+  leap202006.subtract(new Temporal.Duration(0, 3)),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.PlainDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, calendar }, options).subtract(months1n),
+  leap202004L.subtract(months1n),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(months12n),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(months13n),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months12n),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months12n),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months13n),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(0, 24)),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(0, 25)),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/leap-months-chinese.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/leap-months-chinese.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+
+const leap193807L = Temporal.ZonedDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap195205L = Temporal.ZonedDateTime.from({ year: 1952, monthCode: "M05L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap196603L = Temporal.ZonedDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common201901 = Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common201904 = Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202004 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202004L = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common202104 = Temporal.ZonedDateTime.from({ year: 2021, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(years1).toPlainDateTime(),
+  common201901.add(years1).toPlainDateTime(),
   2020, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(years1).toPlainDateTime(),
-  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 year from leap month"
+  leap196603L.add(years1).toPlainDateTime(),
+  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap193807L.add(years1).toPlainDateTime(),
+  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.add(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(years1, options).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(years1).toPlainDateTime(),
-  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "add 1 year from leap day in leap month"
+  leap202004.add(years1, options).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.ZonedDateTime.from({ year: 2012, monthCode: "M04L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(new Temporal.Duration(8), options).toPlainDateTime(),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding years to go from one M04L to the next M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(2), options).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201901.add(years1n).toPlainDateTime(),
+  2018, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap196603L.add(years1n).toPlainDateTime(),
+  1965, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap195205L.add(years1n).toPlainDateTime(),
+  1951, 5, "M05", 29, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.add(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(years1n, options).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(years1n, options).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(new Temporal.Duration(-8), options).toPlainDateTime(),
+  2012, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M04L to the previous M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(-2), options).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, 1);
 const months1n = new Temporal.Duration(0, -1);
+const months12 = new Temporal.Duration(0, 12);
+const months12n = new Temporal.Duration(0, -12);
+const months13 = new Temporal.Duration(0, 13);
+const months13n = new Temporal.Duration(0, -13);
+
+const leap202003 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202006 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
   Temporal.ZonedDateTime.from({ year: 1947, monthCode: "M02L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(months1).toPlainDateTime(),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDateTime(
   1955, 5, "M04", 1, 12, 34, 0, 0, 0, 0, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date1.add(months1).toPlainDateTime(),
+  leap202003.add(months1).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.add(new Temporal.Duration(0, 2)).toPlainDateTime(),
+  leap202003.add(new Temporal.Duration(0, 2)).toPlainDateTime(),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.add(new Temporal.Duration(0, 3)).toPlainDateTime(),
+  leap202003.add(new Temporal.Duration(0, 3)).toPlainDateTime(),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.add(months1n).toPlainDateTime(),
+  common201904.add(months12).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(months13).toPlainDateTime(),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months12).toPlainDateTime(),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months13).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months12).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(0, 24)).toPlainDateTime(),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(0, 25)).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202006.add(months1n).toPlainDateTime(),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.add(new Temporal.Duration(0, -2)).toPlainDateTime(),
+  leap202006.add(new Temporal.Duration(0, -2)).toPlainDateTime(),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.add(new Temporal.Duration(0, -3)).toPlainDateTime(),
+  leap202006.add(new Temporal.Duration(0, -3)).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(months1n).toPlainDateTime(),
+  leap202004L.add(months1n).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(months12n).toPlainDateTime(),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(months13n).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months12n).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months12n).toPlainDateTime(),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months13n).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(0, -24)).toPlainDateTime(),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(0, -25)).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/leap-months-dangi.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/leap-months-dangi.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+
+const leap193807L = Temporal.ZonedDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap195205L = Temporal.ZonedDateTime.from({ year: 1952, monthCode: "M05L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap196603L = Temporal.ZonedDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common201901 = Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common201904 = Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202004 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202004L = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common202104 = Temporal.ZonedDateTime.from({ year: 2021, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(years1).toPlainDateTime(),
+  common201901.add(years1).toPlainDateTime(),
   2020, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(years1).toPlainDateTime(),
-  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 year from leap month"
+  leap196603L.add(years1).toPlainDateTime(),
+  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap193807L.add(years1).toPlainDateTime(),
+  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.add(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(years1, options).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(years1).toPlainDateTime(),
-  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "add 1 year from leap day in leap month"
+  leap202004.add(years1, options).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.ZonedDateTime.from({ year: 2012, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(new Temporal.Duration(-19), options).toPlainDateTime(),
+  1993, 4, "M03L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(2), options).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201901.add(years1n).toPlainDateTime(),
+  2018, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap196603L.add(years1n).toPlainDateTime(),
+  1965, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.add(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap195205L.add(years1n).toPlainDateTime(),
+  1951, 5, "M05", 29, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.add(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(years1n, options).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(years1n, options).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.ZonedDateTime.from({ year: 2012, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(new Temporal.Duration(-19), options).toPlainDateTime(),
+  1993, 4, "M03L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(-2), options).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, 1);
 const months1n = new Temporal.Duration(0, -1);
+const months12 = new Temporal.Duration(0, 12);
+const months12n = new Temporal.Duration(0, -12);
+const months13 = new Temporal.Duration(0, 13);
+const months13n = new Temporal.Duration(0, -13);
+
+const leap202003 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202006 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
   Temporal.ZonedDateTime.from({ year: 1947, monthCode: "M02L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(months1).toPlainDateTime(),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDateTime(
   1955, 5, "M04", 1, 12, 34, 0, 0, 0, 0, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date1.add(months1).toPlainDateTime(),
+  leap202003.add(months1).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.add(new Temporal.Duration(0, 2)).toPlainDateTime(),
+  leap202003.add(new Temporal.Duration(0, 2)).toPlainDateTime(),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.add(new Temporal.Duration(0, 3)).toPlainDateTime(),
+  leap202003.add(new Temporal.Duration(0, 3)).toPlainDateTime(),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.add(months1n).toPlainDateTime(),
+  common201904.add(months12).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(months13).toPlainDateTime(),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months12).toPlainDateTime(),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months13).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months12).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(0, 24)).toPlainDateTime(),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.add(new Temporal.Duration(0, 25)).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202006.add(months1n).toPlainDateTime(),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.add(new Temporal.Duration(0, -2)).toPlainDateTime(),
+  leap202006.add(new Temporal.Duration(0, -2)).toPlainDateTime(),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.add(new Temporal.Duration(0, -3)).toPlainDateTime(),
+  leap202006.add(new Temporal.Duration(0, -3)).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).add(months1n).toPlainDateTime(),
+  leap202004L.add(months1n).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(months12n).toPlainDateTime(),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(months13n).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.add(months12n).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months12n).toPlainDateTime(),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.add(months13n).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(0, -24)).toPlainDateTime(),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.add(new Temporal.Duration(0, -25)).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/leap-months-chinese.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/leap-months-chinese.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+
+const leap193807L = Temporal.ZonedDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap195205L = Temporal.ZonedDateTime.from({ year: 1952, monthCode: "M05L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap196603L = Temporal.ZonedDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common201901 = Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common201904 = Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202004 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202004L = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common202104 = Temporal.ZonedDateTime.from({ year: 2021, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(years1).toPlainDateTime(),
+  common201901.subtract(years1).toPlainDateTime(),
   2020, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(years1).toPlainDateTime(),
-  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 year from leap month"
+  leap196603L.subtract(years1).toPlainDateTime(),
+  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap193807L.subtract(years1).toPlainDateTime(),
+  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.subtract(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(years1, options).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(years1).toPlainDateTime(),
-  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "add 1 year from leap day in leap month"
+  leap202004.subtract(years1, options).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.ZonedDateTime.from({ year: 2012, monthCode: "M04L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(new Temporal.Duration(-8), options).toPlainDateTime(),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding years to go from one M04L to the next M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(-2), options).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201901.subtract(years1n).toPlainDateTime(),
+  2018, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap196603L.subtract(years1n).toPlainDateTime(),
+  1965, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap195205L.subtract(years1n).toPlainDateTime(),
+  1951, 5, "M05", 29, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(years1n, options).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(years1n, options).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(new Temporal.Duration(8), options).toPlainDateTime(),
+  2012, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M04L to the previous M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(2), options).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, -1);
 const months1n = new Temporal.Duration(0, 1);
+const months12 = new Temporal.Duration(0, -12);
+const months12n = new Temporal.Duration(0, 12);
+const months13 = new Temporal.Duration(0, -13);
+const months13n = new Temporal.Duration(0, 13);
+
+const leap202003 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202006 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
   Temporal.ZonedDateTime.from({ year: 1947, monthCode: "M02L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(months1).toPlainDateTime(),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDateTime(
   1955, 5, "M04", 1, 12, 34, 0, 0, 0, 0, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(months1).toPlainDateTime(),
+  leap202003.subtract(months1).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(new Temporal.Duration(0, -2)).toPlainDateTime(),
+  leap202003.subtract(new Temporal.Duration(0, -2)).toPlainDateTime(),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(new Temporal.Duration(0, -3)).toPlainDateTime(),
+  leap202003.subtract(new Temporal.Duration(0, -3)).toPlainDateTime(),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(months1n).toPlainDateTime(),
+  common201904.subtract(months12).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(months13).toPlainDateTime(),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months12).toPlainDateTime(),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months13).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months12).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(0, -24)).toPlainDateTime(),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(0, -25)).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202006.subtract(months1n).toPlainDateTime(),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(new Temporal.Duration(0, 2)).toPlainDateTime(),
+  leap202006.subtract(new Temporal.Duration(0, 2)).toPlainDateTime(),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(new Temporal.Duration(0, 3)).toPlainDateTime(),
+  leap202006.subtract(new Temporal.Duration(0, 3)).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(months1n).toPlainDateTime(),
+  leap202004L.subtract(months1n).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(months12n).toPlainDateTime(),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(months13n).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months12n).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months12n).toPlainDateTime(),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months13n).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(0, 24)).toPlainDateTime(),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(0, 25)).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/leap-months-dangi.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/leap-months-dangi.js
@@ -14,26 +14,114 @@ const options = { overflow: "reject" };
 // Years
 
 const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+
+const leap193807L = Temporal.ZonedDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap195205L = Temporal.ZonedDateTime.from({ year: 1952, monthCode: "M05L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap196603L = Temporal.ZonedDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common201901 = Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common201904 = Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202004 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202004L = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const common202104 = Temporal.ZonedDateTime.from({ year: 2021, monthCode: "M04", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 2019, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(years1).toPlainDateTime(),
+  common201901.subtract(years1).toPlainDateTime(),
   2020, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "add 1 year from non-leap day"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 1966, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(years1).toPlainDateTime(),
-  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 year from leap month"
+  leap196603L.subtract(years1).toPlainDateTime(),
+  1967, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1, options);
+}, "Adding 1 year to leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap193807L.subtract(years1).toPlainDateTime(),
+  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap month M07L on day 30 constrains to M07 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap193807L.subtract(years1, options);
+}, "Adding 1 year to leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(years1, options).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to common-year M04 lands in leap-year M04"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 1938, monthCode: "M07L", day: 30, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(years1).toPlainDateTime(),
-  1939, 7, "M07", 29, 12, 34, 0, 0, 0, 0, "add 1 year from leap day in leap month"
+  leap202004.subtract(years1, options).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 1 year to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.ZonedDateTime.from({ year: 2012, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(new Temporal.Duration(19), options).toPlainDateTime(),
+  1993, 4, "M03L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(-2), options).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 2 years to common-year M04 crossing leap year lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201901.subtract(years1n).toPlainDateTime(),
+  2018, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from non-leap day"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap196603L.subtract(years1n).toPlainDateTime(),
+  1965, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M03L lands in common-year M03 with overflow constrain"
+);
+
+assert.throws(RangeError, function () {
+  leap196603L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  leap195205L.subtract(years1n).toPlainDateTime(),
+  1951, 5, "M05", 29, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap month M05L on day 30 constrains to M05 day 29"
+);
+
+assert.throws(RangeError, function () {
+  leap195205L.subtract(years1n, options);
+}, "Subtracting 1 year from leap month day 30 rejects");
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(years1n, options).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(years1n, options).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 year from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  Temporal.ZonedDateTime.from({ year: 2012, monthCode: "M03L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(new Temporal.Duration(19), options).toPlainDateTime(),
+  1993, 4, "M03L", 1, 12, 34, 0, 0, 0, 0, "Subtracting years to go from one M03L to the previous M03L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(2), options).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 years from common-year M04 crossing leap year lands in common-year M04"
 );
 
 // Months
 
 const months1 = new Temporal.Duration(0, -1);
 const months1n = new Temporal.Duration(0, 1);
+const months12 = new Temporal.Duration(0, -12);
+const months12n = new Temporal.Duration(0, 12);
+const months13 = new Temporal.Duration(0, -13);
+const months13n = new Temporal.Duration(0, 13);
+
+const leap202003 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const leap202006 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 
 TemporalHelpers.assertPlainDateTime(
   Temporal.ZonedDateTime.from({ year: 1947, monthCode: "M02L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(months1).toPlainDateTime(),
@@ -45,35 +133,68 @@ TemporalHelpers.assertPlainDateTime(
   1955, 5, "M04", 1, 12, 34, 0, 0, 0, 0, "add 1 month, starting at start of leap month with 30 days"
 );
 
-const date1 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(months1).toPlainDateTime(),
+  leap202003.subtract(months1).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "adding 1 month to M03 in leap year lands in M04 (not M04L)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(new Temporal.Duration(0, -2)).toPlainDateTime(),
+  leap202003.subtract(new Temporal.Duration(0, -2)).toPlainDateTime(),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "adding 2 months to M03 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date1.subtract(new Temporal.Duration(0, -3)).toPlainDateTime(),
+  leap202003.subtract(new Temporal.Duration(0, -3)).toPlainDateTime(),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "adding 3 months to M03 in leap year lands in M05 (not M06)"
 );
 
-const date2 = Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(months1n).toPlainDateTime(),
+  common201904.subtract(months12).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(months13).toPlainDateTime(),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months12).toPlainDateTime(),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to leap-year M04 lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months13).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 13 months to leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months12).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 12 months to M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(0, -24)).toPlainDateTime(),
+  2021, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "Adding 24 months to common-year M04 crossing leap year with M04L, lands in common-year M03"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common201904.subtract(new Temporal.Duration(0, -25)).toPlainDateTime(),
+  2021, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Adding 25 months to common-year M04 crossing leap year with M04L, lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202006.subtract(months1n).toPlainDateTime(),
   2020, 6, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M06 in leap year lands in M05"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(new Temporal.Duration(0, 2)).toPlainDateTime(),
+  leap202006.subtract(new Temporal.Duration(0, 2)).toPlainDateTime(),
   2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 2 months from M06 in leap year lands in M04L (leap month)"
 );
 
 TemporalHelpers.assertPlainDateTime(
-  date2.subtract(new Temporal.Duration(0, 3)).toPlainDateTime(),
+  leap202006.subtract(new Temporal.Duration(0, 3)).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 3 months from M06 in leap year lands in M04 (not M03)"
 );
 
@@ -83,8 +204,43 @@ TemporalHelpers.assertPlainDateTime(
 );
 
 TemporalHelpers.assertPlainDateTime(
-  Temporal.ZonedDateTime.from({ year: 2020, monthCode: "M04L", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options).subtract(months1n).toPlainDateTime(),
+  leap202004L.subtract(months1n).toPlainDateTime(),
   2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 1 month from M04L in calendar lands in M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(months12n).toPlainDateTime(),
+  2020, 5, "M04L", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from common-year M04 lands in leap-year M04L"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(months13n).toPlainDateTime(),
+  2020, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from common-year M04 lands in leap-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004.subtract(months12n).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from leap-year M04 lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months12n).toPlainDateTime(),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 12 months from M04L lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  leap202004L.subtract(months13n).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 13 months from M04L lands in common-year M04"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(0, 24)).toPlainDateTime(),
+  2019, 5, "M05", 1, 12, 34, 0, 0, 0, 0, "Subtracting 24 months from common-year M04 crossing leap year with M04L, lands in common-year M05"
+);
+
+TemporalHelpers.assertPlainDateTime(
+  common202104.subtract(new Temporal.Duration(0, 25)).toPlainDateTime(),
+  2019, 4, "M04", 1, 12, 34, 0, 0, 0, 0, "Subtracting 25 months from common-year M04 crossing leap year with M04L, lands in common-year M04"
 );
 
 // Weeks


### PR DESCRIPTION
This adds tests for overflow constrain/reject with years, expands the coverage with months to test edge cases using 12, 13, 24, and 25 months, and cleans up a bit.

Note the tests adding a number of years to get from a leap month in one year to the same leap month in another year! 2012 has M04L in the Chinese calendar and M03L in the Dangi calendar, so these are different between the two calendars.