### PR TITLE
Remove non-canonical values from Intl.supportedValuesOf("calendar") test

### DIFF
--- a/test/intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js
+++ b/test/intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js
@@ -37,7 +37,6 @@ const requiredCalendars = [
   "islamic-civil",
   "islamic-tbla",
   "islamic-umalqura",
-  "islamicc",
   "iso8601",
   "japanese",
   "persian",


### PR DESCRIPTION
Fixes #4639.