### PR TITLE
Remove "iso8601" from  intl-era-monthcode test

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatToParts/era.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/era.js
@@ -87,7 +87,6 @@ for (const [calendar, isoYears] of singleEraTests) {
 const noEraTests = [
   "chinese",
   "dangi",
-  "iso8601",
 ];
 
 for (const calendar of noEraTests) {


### PR DESCRIPTION
"iso8601" is not part of intl-era-monthcode proposal and should not be part of this test