### PR TITLE
Intl Era Monthcode: Update Chinese calendar reference day test

### DIFF
--- a/test/intl402/Temporal/PlainYearMonth/from/reference-day-chinese.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/reference-day-chinese.js
@@ -27,37 +27,14 @@ const months2022TestData = [
   ["M12", 12, 23],
 ];
 for (let [nonLeapMonthCode, month, referenceISODay] of months2022TestData) {
-  // Allow implementation-defined "epoch year" for the Chinese calendar.
-  const year = new Temporal.PlainDate(2022, 3, 1).withCalendar("chinese").year;
   const leapMonthCode = nonLeapMonthCode + "L";
-  const fields = { year, monthCode: leapMonthCode, calendar: "chinese" };
+  const fields = { year: 2022, monthCode: leapMonthCode, calendar: "chinese" };
 
   const result = Temporal.PlainYearMonth.from(fields, { overflow: "constrain" });
-
-  // CalendarDateToISO ( calendar, fields, overflow )
-  //
-  // > If the month is a leap month that doesn't exist in the year, pick another
-  // > date according to the cultural conventions of that calendar's users.
-  // > Usually this will result in the same day in the month before or after
-  // > where that month would normally fall in a leap year.
-  //
-  // Without clear information in which direction the month has to be adjusted,
-  // we have to allow two possible implementations:
-  // 1. The previous month is used, i.e. "M01L" is constrained to "M01".
-  // 2. The next month is used, i.e. "M01L" is constrained to "M02".
-  if (result.month !== month) {
-    assert.sameValue(result.month, month + 1);
-
-    // Adjust nonLeapMonthCode, month, referenceISODay using the data from the
-    // next month.
-    const nextMonth = months2022TestData.find(e => e[1] === month + 1);
-    [nonLeapMonthCode, month, referenceISODay] = nextMonth;
-  }
-
   TemporalHelpers.assertPlainYearMonth(
     result,
     year, month, nonLeapMonthCode,
-    `Chinese intercalary month ${leapMonthCode} does not exist in year 2022 (overflow constrain)`,
+    `Chinese intercalary month ${leapMonthCode} is constrained to ${nonLeapMonthCode} in year 2022 (overflow constrain)`,
     /* era = */ undefined, /* era year = */ undefined, referenceISODay
   );
 
@@ -83,9 +60,7 @@ const leapMonthsTestData = [
   ["M10L", 1984, 11, 23],
   ["M11L", 2033, 12, 22],
 ];
-for (const [monthCode, relatedYear, month, referenceISODay, isoYear = relatedYear, isoMonth = month] of leapMonthsTestData) {
-  // Allow implementation-defined "epoch year" for the Chinese calendar.
-  const year = new Temporal.PlainDate(relatedYear, 3, 1).withCalendar("chinese").year;
+for (const [monthCode, year, month, referenceISODay, isoYear = year, isoMonth = month] of leapMonthsTestData) {
   const result = Temporal.PlainYearMonth.from({ year, monthCode, calendar: "chinese" });
   TemporalHelpers.assertPlainYearMonth(
     result,


### PR DESCRIPTION
This removes some workarounds for things that are no longer implementation-defined as of the Intl Era Monthcode proposal.