### PR TITLE
Fix constructor-options-calendar-islamic-fallback.js

### DIFF
--- a/test/intl402/DateTimeFormat/constructor-options-calendar-islamic-fallback.js
+++ b/test/intl402/DateTimeFormat/constructor-options-calendar-islamic-fallback.js
@@ -19,24 +19,7 @@ locale: [en]
 features: [Intl.Era-monthcode]
 ---*/
 
-const availableCalendars = [
-  "buddhist",
-	"chinese",
-	"coptic",
-	"dangi",
-	"ethioaa",
-	"ethiopic",
-	"gregory",
-	"hebrew",
-	"indian",
-	"islamic-civil",
-	"islamic-tbla",
-	"islamic-umalqura",
-	"iso8601",
-	"japanese",
-	"persian",
-	"roc",
-];
+const availableCalendars = Intl.supportedValuesOf("calendar");
 
 const islamic = new Intl.DateTimeFormat("en", { calendar: "islamic" });
 assert.sameValue(availableCalendars.includes(islamic.resolvedOptions().calendar), true, "no valid fallback for 'islamic' calendar option");


### PR DESCRIPTION
The defintion of AvailableCalendars in https://tc39.es/proposal-intl-era-monthcode/#sup-availablecalendars is "The List must include the Calendar Type value of every row of Table 1, except the header row." It does said it ONLY include those listed in that Table. so the return list may also include "islamic" and "islamic-rgsa" and therefore the test is incorrect.

so we should get availableCalendars from calling Intl.supportedValuesOf("calendar") instead

@ben-allen @sffc 