### PR TITLE
harness: Remove typeCoercion.js BigInt/Symbol dependencies

### DIFF
--- a/harness/features.yml
+++ b/harness/features.yml
@@ -1,5 +1,4 @@
 atomicsHelper: [Atomics]
-typeCoercion.js: [Symbol.toPrimitive, BigInt]
 testAtomics.js: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 testBigIntTypedArray.js: [BigInt, TypedArray]
 testTypedArray.js: [TypedArray]


### PR DESCRIPTION
Rather than constraining tests that just need to check type coercion (e.g., `JSON.rawJSON(value)` as in test/built-ins/JSON/rawJSON/text-not-stringable.js from #4682, typeCoercion.js should take advantage of symbol and/or bigint only when support for each respective type is indicated by its corresponding global function.