### PR TITLE
fix: unify and clarify language around undefined timeout arg in DoWait

### DIFF
--- a/test/built-ins/Atomics/waitAsync/bigint/undefined-for-timeout-agent.js
+++ b/test/built-ins/Atomics/waitAsync/bigint/undefined-for-timeout-agent.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-atomics.waitasync
 description: >
-  Undefined timeout arg is coerced to zero
+  Undefined timeout arg should result in an infinite timeout
 info: |
   Atomics.waitAsync( typedArray, index, value, timeout )
 

--- a/test/built-ins/Atomics/waitAsync/bigint/undefined-for-timeout.js
+++ b/test/built-ins/Atomics/waitAsync/bigint/undefined-for-timeout.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-atomics.waitasync
 description: >
-  Undefined timeout arg is coerced to zero
+  Undefined timeout arg should result in an infinite timeout
 info: |
   Atomics.waitAsync( typedArray, index, value, timeout )
 

--- a/test/built-ins/Atomics/waitAsync/implicit-infinity-for-timeout.js
+++ b/test/built-ins/Atomics/waitAsync/implicit-infinity-for-timeout.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-atomics.waitasync
 description: >
-  Undefined timeout arg is coerced to zero
+  Undefined timeout arg should result in an infinite timeout
 info: |
   Atomics.waitAsync( typedArray, index, value, timeout )
 

--- a/test/built-ins/Atomics/waitAsync/undefined-for-timeout-agent.js
+++ b/test/built-ins/Atomics/waitAsync/undefined-for-timeout-agent.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-atomics.waitasync
 description: >
-  Undefined timeout arg is coerced to zero
+  Undefined timeout arg should result in an infinite timeout
 info: |
   Atomics.waitAsync( typedArray, index, value, timeout )
 

--- a/test/built-ins/Atomics/waitAsync/undefined-for-timeout.js
+++ b/test/built-ins/Atomics/waitAsync/undefined-for-timeout.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-atomics.waitasync
 description: >
-  Undefined timeout arg is coerced to zero
+  Undefined timeout arg should result in an infinite timeout
 info: |
   Atomics.waitAsync( typedArray, index, value, timeout )
 


### PR DESCRIPTION
A timeout of 0 does not mean "never timeout" or "infinite timeout", so the text here is just plain wrong.

Tests themselves are correct.