### PR TITLE
Add tests for two-digit date when day is over 31

### DIFF
--- a/test/staging/sm/Date/two-digit-years.js
+++ b/test/staging/sm/Date/two-digit-years.js
@@ -64,3 +64,16 @@ for (let year of Array(1000).keys()) {
 
 assert.sameValue(new Date("may 1999 1999").getTime(), new Date(NaN).getTime());
 assert.sameValue(new Date("may 0 0").getTime(), new Date(NaN).getTime());
+
+for (let year = 50; year <= 99; ++year) {
+  for (let month = 0; month < 12; ++month) {
+    for (let day = 1; day <= 100; ++day) {
+        const date = `${year}/${month + 1}/${day}`;
+        if (day <= 31) {
+            assert.sameValue((new Date(year, month, day)).getTime(), (new Date(date).getTime()))
+        } else {
+            assert.sameValue(Number.isNaN(new Date(date).getTime()), true)
+        }
+    }
+  }
+}


### PR DESCRIPTION
The `Date` object allows two-digit years, but Chrome and Firefox currently return `NaN` when the year is between `50` and `99` and the day exceeds `31`. WebKit also has an open [PR](https://github.com/WebKit/WebKit/pull/47652)  to adopt the same behavior.
This patch adds test cases to confirm that two-digit dates return NaN for the compatibility across browsers.