### PR TITLE
Add CalendarResolveFields error ordering tests

### DIFF
--- a/test/built-ins/Temporal/PlainDate/from/calendarresolvefields-error-ordering.js
+++ b/test/built-ins/Temporal/PlainDate/from/calendarresolvefields-error-ordering.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: CalendarResolveFields throws TypeError before RangeError
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal]
+---*/
+
+// Missing required property (year) should throw TypeError even with invalid monthCode
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ monthCode: "M99L", day: 1 }),
+  "Missing year throws TypeError before invalid monthCode throws RangeError"
+);
+
+// Missing required property (month/monthCode) should throw TypeError even with out-of-range day
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ year: 2021, day: 32 }, { overflow: "reject" }),
+  "Missing month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing required property (day) should throw TypeError even with invalid monthCode
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ year: 2021, monthCode: "M99L" }),
+  "Missing day throws TypeError before invalid monthCode throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.from({ year: 2021, monthCode: "M99L", day: 1 }),
+  "Invalid monthCode throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.from({ year: 2021, month: 11, monthCode: "M12", day: 18 }),
+  "Conflicting month/monthCode throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.from({ year: 2021, month: 1, day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/built-ins/Temporal/PlainDateTime/from/calendarresolvefields-error-ordering.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/calendarresolvefields-error-ordering.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: CalendarResolveFields throws TypeError before RangeError
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal]
+---*/
+
+// Missing required property (year) should throw TypeError even with invalid monthCode
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDateTime.from({ monthCode: "M99L", day: 1, hour: 12 }),
+  "Missing year throws TypeError before invalid monthCode throws RangeError"
+);
+
+// Missing required property (month/monthCode) should throw TypeError even with out-of-range day
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDateTime.from({ year: 2021, day: 32, hour: 12 }, { overflow: "reject" }),
+  "Missing month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing required property (day) should throw TypeError even with invalid monthCode
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDateTime.from({ year: 2021, monthCode: "M99L", hour: 12 }),
+  "Missing day throws TypeError before invalid monthCode throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDateTime.from({ year: 2021, monthCode: "M99L", day: 1, hour: 12 }),
+  "Invalid monthCode throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDateTime.from({ year: 2021, month: 11, monthCode: "M12", day: 18, hour: 12 }),
+  "Conflicting month/monthCode throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDateTime.from({ year: 2021, month: 1, day: 32, hour: 12 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/built-ins/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: CalendarResolveFields throws TypeError before RangeError
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal]
+---*/
+
+// Missing required property (monthCode/month) should throw TypeError even with out-of-range day
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ day: 32 }, { overflow: "reject" }),
+  "Missing monthCode/month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing required property (day) should throw TypeError even with invalid monthCode
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ monthCode: "M99L" }),
+  "Missing day throws TypeError before invalid monthCode throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ monthCode: "M99L", day: 1 }),
+  "Invalid monthCode throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ month: 11, monthCode: "M12", day: 18 }),
+  "Conflicting month/monthCode throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ monthCode: "M01", day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ monthCode: "M00", day: 1 }),
+  "Invalid monthCode M00 throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ month: 13, day: 1 }, { overflow: "reject" }),
+  "Out-of-range month throws RangeError when all types are valid"
+);

--- a/test/built-ins/Temporal/PlainYearMonth/from/calendarresolvefields-error-ordering.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/calendarresolvefields-error-ordering.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: CalendarResolveFields throws TypeError before RangeError
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal]
+---*/
+
+// Missing required property (year) should throw TypeError even with invalid monthCode
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ monthCode: "M99L" }),
+  "Missing year throws TypeError before invalid monthCode throws RangeError"
+);
+
+// Missing required property (month/monthCode) should throw TypeError even with valid year
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ year: 2021 }),
+  "Missing month/monthCode throws TypeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M99L" }),
+  "Invalid monthCode throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.from({ year: 2021, month: 11, monthCode: "M12" }),
+  "Conflicting month/monthCode throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.from({ year: 2021, month: 13 }, { overflow: "reject" }),
+  "Out-of-range month throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M00" }),
+  "Invalid monthCode M00 throws RangeError when all types are valid"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/from/calendarresolvefields-error-ordering.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/calendarresolvefields-error-ordering.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: CalendarResolveFields throws TypeError before RangeError
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal]
+---*/
+
+// Missing required property (year) should throw TypeError even with invalid monthCode
+assert.throws(
+  TypeError,
+  () => Temporal.ZonedDateTime.from({ monthCode: "M99L", day: 1, timeZone: "UTC" }),
+  "Missing year throws TypeError before invalid monthCode throws RangeError"
+);
+
+// Missing required property (month/monthCode) should throw TypeError even with out-of-range day
+assert.throws(
+  TypeError,
+  () => Temporal.ZonedDateTime.from({ year: 2021, day: 32, timeZone: "UTC" }, { overflow: "reject" }),
+  "Missing month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing required property (day) should throw TypeError even with invalid monthCode
+assert.throws(
+  TypeError,
+  () => Temporal.ZonedDateTime.from({ year: 2021, monthCode: "M99L", timeZone: "UTC" }),
+  "Missing day throws TypeError before invalid monthCode throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.ZonedDateTime.from({ year: 2021, monthCode: "M99L", day: 1, timeZone: "UTC" }),
+  "Invalid monthCode throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.ZonedDateTime.from({ year: 2021, month: 11, monthCode: "M12", day: 18, timeZone: "UTC" }),
+  "Conflicting month/monthCode throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.ZonedDateTime.from({ year: 2021, month: 1, day: 32, timeZone: "UTC" }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainDate/from/calendarresolvefields-error-ordering-chinese.js
+++ b/test/intl402/Temporal/PlainDate/from/calendarresolvefields-error-ordering-chinese.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: CalendarResolveFields throws TypeError before RangeError (chinese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Missing year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "chinese", monthCode: "M05", month: 6, day: 1 }),
+  "Missing year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing month/monthCode should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "chinese", year: 2020, day: 32 }, { overflow: "reject" }),
+  "Missing month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing day should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "chinese", year: 2020, monthCode: "M05", month: 6 }),
+  "Missing day throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "chinese", year: undefined, monthCode: "M05", month: 6, day: 1 }),
+  "undefined year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.from({ calendar: "chinese", year: 2020, monthCode: "M05", month: 12, day: 1 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.from({ calendar: "chinese", year: 2020, month: 1, day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainDate/from/calendarresolvefields-error-ordering-gregory.js
+++ b/test/intl402/Temporal/PlainDate/from/calendarresolvefields-error-ordering-gregory.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: CalendarResolveFields throws TypeError before RangeError (gregory calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Missing year (and no era/eraYear) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "gregory", monthCode: "M05", month: 6, day: 1 }),
+  "Missing year/era throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing month/monthCode should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "gregory", year: 2020, day: 32 }),
+  "Missing month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing day should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "gregory", year: 2020, monthCode: "M05", month: 6 }),
+  "Missing day throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "gregory", year: undefined, monthCode: "M05", month: 6, day: 1 }),
+  "undefined year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.from({ calendar: "gregory", year: 2020, monthCode: "M05", month: 6, day: 1 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.from({ calendar: "gregory", year: 2020, month: 1, day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainDate/from/calendarresolvefields-error-ordering-japanese.js
+++ b/test/intl402/Temporal/PlainDate/from/calendarresolvefields-error-ordering-japanese.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: CalendarResolveFields throws TypeError before RangeError (japanese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Missing year (and no era/eraYear) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "japanese", monthCode: "M05", month: 6, day: 1 }),
+  "Missing year/era throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing month/monthCode should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "japanese", year: 2020, day: 32 }),
+  "Missing month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing day should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "japanese", year: 2020, monthCode: "M05", month: 6 }),
+  "Missing day throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDate.from({ calendar: "japanese", year: undefined, monthCode: "M05", month: 6, day: 1 }),
+  "undefined year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.from({ calendar: "japanese", year: 2020, monthCode: "M05", month: 6, day: 1 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDate.from({ calendar: "japanese", year: 2020, month: 1, day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainDate/prototype/with/calendarresolvefields-error-ordering-gregory.js
+++ b/test/intl402/Temporal/PlainDate/prototype/with/calendarresolvefields-error-ordering-gregory.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.with
+description: CalendarResolveFields throws TypeError before RangeError (gregory calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const plainDate = Temporal.PlainDate.from({ calendar: "gregory", year: 2020, month: 5, day: 15 });
+
+// Missing required property (eraYear when era is present) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainDate.with({ era: "ce", monthCode: "M05", month: 6 }),
+  "Missing eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing required property (eraYear when era is present) should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => plainDate.with({ era: "ce", day: 32 }),
+  "Missing eraYear throws TypeError before out-of-range day throws RangeError"
+);
+
+// undefined eraYear should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainDate.with({ era: "ce", eraYear: undefined, monthCode: "M05", month: 6 }),
+  "undefined eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => plainDate.with({ monthCode: "M05", month: 6 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => plainDate.with({ day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainDate/prototype/with/calendarresolvefields-error-ordering-japanese.js
+++ b/test/intl402/Temporal/PlainDate/prototype/with/calendarresolvefields-error-ordering-japanese.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.with
+description: CalendarResolveFields throws TypeError before RangeError (japanese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const plainDate = Temporal.PlainDate.from({ calendar: "japanese", year: 2020, month: 5, day: 15 });
+
+// Missing required property (eraYear when era is present) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainDate.with({ era: "heisei", monthCode: "M05", month: 6 }),
+  "Missing eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing required property (eraYear when era is present) should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => plainDate.with({ era: "heisei", day: 32 }),
+  "Missing eraYear throws TypeError before out-of-range day throws RangeError"
+);
+
+// undefined eraYear should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainDate.with({ era: "heisei", eraYear: undefined, monthCode: "M05", month: 6 }),
+  "undefined eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => plainDate.with({ monthCode: "M05", month: 6 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => plainDate.with({ day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainDateTime/from/calendarresolvefields-error-ordering-chinese.js
+++ b/test/intl402/Temporal/PlainDateTime/from/calendarresolvefields-error-ordering-chinese.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: CalendarResolveFields throws TypeError before RangeError (chinese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Missing year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDateTime.from({ calendar: "chinese", monthCode: "M05", month: 6, day: 1, hour: 12 }),
+  "Missing year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing month/monthCode should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDateTime.from({ calendar: "chinese", year: 2020, day: 32, hour: 12 }, { overflow: "reject" }),
+  "Missing month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing day should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDateTime.from({ calendar: "chinese", year: 2020, monthCode: "M05", month: 6, hour: 12 }),
+  "Missing day throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainDateTime.from({ calendar: "chinese", year: undefined, monthCode: "M05", month: 6, day: 1, hour: 12 }),
+  "undefined year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDateTime.from({ calendar: "chinese", year: 2020, monthCode: "M05", month: 12, day: 1, hour: 12 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainDateTime.from({ calendar: "chinese", year: 2020, month: 1, day: 32, hour: 12 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainDateTime/prototype/with/calendarresolvefields-error-ordering-gregory.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/with/calendarresolvefields-error-ordering-gregory.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.with
+description: CalendarResolveFields throws TypeError before RangeError (gregory calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const plainDateTime = Temporal.PlainDateTime.from({ calendar: "gregory", year: 2020, month: 5, day: 15, hour: 12 });
+
+// Missing required property (eraYear when era is present) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainDateTime.with({ era: "ce", monthCode: "M05", month: 6 }),
+  "Missing eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing required property (eraYear when era is present) should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => plainDateTime.with({ era: "ce", day: 32 }),
+  "Missing eraYear throws TypeError before out-of-range day throws RangeError"
+);
+
+// undefined eraYear should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainDateTime.with({ era: "ce", eraYear: undefined, monthCode: "M05", month: 6 }),
+  "undefined eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => plainDateTime.with({ monthCode: "M05", month: 6 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => plainDateTime.with({ day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainDateTime/prototype/with/calendarresolvefields-error-ordering-japanese.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/with/calendarresolvefields-error-ordering-japanese.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.with
+description: CalendarResolveFields throws TypeError before RangeError (japanese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const plainDateTime = Temporal.PlainDateTime.from({ calendar: "japanese", year: 2020, month: 5, day: 15, hour: 12 });
+
+// Missing required property (eraYear when era is present) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainDateTime.with({ era: "heisei", monthCode: "M05", month: 6 }),
+  "Missing eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing required property (eraYear when era is present) should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => plainDateTime.with({ era: "heisei", day: 32 }),
+  "Missing eraYear throws TypeError before out-of-range day throws RangeError"
+);
+
+// undefined eraYear should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainDateTime.with({ era: "heisei", eraYear: undefined, monthCode: "M05", month: 6 }),
+  "undefined eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => plainDateTime.with({ monthCode: "M05", month: 6 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => plainDateTime.with({ day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering-chinese.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering-chinese.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: CalendarResolveFields throws TypeError before RangeError (chinese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Missing year (required for month) should throw TypeError even with month/monthCode conflict
+// This is the example from https://github.com/tc39/proposal-intl-era-monthcode/issues/90#issuecomment-3518215482
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "chinese", monthCode: "M04", month: 5, day: 1 }),
+  "Missing year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing monthCode/month should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "chinese", year: 2020, day: 32 }, { overflow: "reject" }),
+  "Missing monthCode/month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing day should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "chinese", year: 2020, monthCode: "M04", month: 5 }),
+  "Missing day throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "chinese", year: undefined, monthCode: "M04", month: 5, day: 1 }),
+  "undefined year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "chinese", year: 2020, monthCode: "M04", month: 5, day: 1 }),
+  "month/monthCode conflict throws RangeError when all required fields present"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "chinese", year: 2020, monthCode: "M01", day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all required fields present"
+);

--- a/test/intl402/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering-hebrew.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering-hebrew.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: CalendarResolveFields throws TypeError before RangeError (hebrew calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Missing year (required for month) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "hebrew", monthCode: "M04", month: 5, day: 1 }),
+  "Missing year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing monthCode/month should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "hebrew", year: 5784, day: 32 }, { overflow: "reject" }),
+  "Missing monthCode/month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing day should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "hebrew", year: 5784, monthCode: "M04", month: 5 }),
+  "Missing day throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "hebrew", year: undefined, monthCode: "M04", month: 5, day: 1 }),
+  "undefined year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "hebrew", year: 5784, monthCode: "M04", month: 5, day: 1 }),
+  "month/monthCode conflict throws RangeError when all required fields present"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "hebrew", year: 5784, monthCode: "M01", day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all required fields present"
+);

--- a/test/intl402/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering-islamic.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering-islamic.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: CalendarResolveFields throws TypeError before RangeError (islamic calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Missing year (required for month) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "islamic-civil", monthCode: "M04", month: 5, day: 1 }),
+  "Missing year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing monthCode/month should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "islamic-civil", year: 1445, day: 32 }, { overflow: "reject" }),
+  "Missing monthCode/month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing day should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "islamic-civil", year: 1445, monthCode: "M04", month: 5 }),
+  "Missing day throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "islamic-civil", year: undefined, monthCode: "M04", month: 5, day: 1 }),
+  "undefined year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "islamic-civil", year: 1445, monthCode: "M04", month: 5, day: 1 }),
+  "month/monthCode conflict throws RangeError when all required fields present"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainMonthDay.from({ calendar: "islamic-civil", year: 1445, monthCode: "M01", day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all required fields present"
+);

--- a/test/intl402/Temporal/PlainYearMonth/from/calendarresolvefields-error-ordering-chinese.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/calendarresolvefields-error-ordering-chinese.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: CalendarResolveFields throws TypeError before RangeError (chinese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Missing year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "chinese", monthCode: "M05", month: 12 }),
+  "Missing year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing month/monthCode should throw TypeError even with valid year
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "chinese", year: 2020 }),
+  "Missing month/monthCode throws TypeError"
+);
+
+// undefined year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "chinese", year: undefined, monthCode: "M05", month: 12 }),
+  "undefined year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined month should throw TypeError even with valid year
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "chinese", year: 2020, month: undefined }),
+  "undefined month throws TypeError"
+);
+
+// undefined monthCode (when month is also missing) should throw TypeError
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "chinese", year: 2020, monthCode: undefined }),
+  "undefined monthCode throws TypeError when month is missing"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "chinese", year: 2020, monthCode: "M05", month: 12 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "chinese", year: 2020, month: 14 }, { overflow: "reject" }),
+  "Out-of-range month throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainYearMonth/from/calendarresolvefields-error-ordering-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/calendarresolvefields-error-ordering-japanese.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: CalendarResolveFields throws TypeError before RangeError (japanese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Missing year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "japanese", monthCode: "M05", month: 12 }),
+  "Missing year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing month/monthCode should throw TypeError even with valid year
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "japanese", year: 2020 }),
+  "Missing month/monthCode throws TypeError"
+);
+
+// undefined year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "japanese", year: undefined, monthCode: "M05", month: 12 }),
+  "undefined year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined month should throw TypeError even with valid year
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "japanese", year: 2020, month: undefined }),
+  "undefined month throws TypeError"
+);
+
+// undefined monthCode (when month is also missing) should throw TypeError
+assert.throws(
+  TypeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "japanese", year: 2020, monthCode: undefined }),
+  "undefined monthCode throws TypeError when month is missing"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "japanese", year: 2020, monthCode: "M05", month: 12 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.from({ calendar: "japanese", year: 2020, month: 13 }, { overflow: "reject" }),
+  "Out-of-range month throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/with/calendarresolvefields-error-ordering-gregory.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/with/calendarresolvefields-error-ordering-gregory.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.with
+description: CalendarResolveFields throws TypeError before RangeError (gregory calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const plainYearMonth = Temporal.PlainYearMonth.from({ calendar: "gregory", year: 2020, month: 5 });
+
+// Missing required property (eraYear when era is present) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainYearMonth.with({ era: "ce", monthCode: "M05", month: 6 }),
+  "Missing eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined eraYear should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainYearMonth.with({ era: "ce", eraYear: undefined, monthCode: "M05", month: 6 }),
+  "undefined eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => plainYearMonth.with({ monthCode: "M05", month: 6 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => plainYearMonth.with({ month: 13 }, { overflow: "reject" }),
+  "Out-of-range month throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/with/calendarresolvefields-error-ordering-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/with/calendarresolvefields-error-ordering-japanese.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.with
+description: CalendarResolveFields throws TypeError before RangeError (japanese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const plainYearMonth = Temporal.PlainYearMonth.from({ calendar: "japanese", year: 2020, month: 5 });
+
+// Missing required property (eraYear when era is present) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainYearMonth.with({ era: "heisei", monthCode: "M05", month: 6 }),
+  "Missing eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined eraYear should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => plainYearMonth.with({ era: "heisei", eraYear: undefined, monthCode: "M05", month: 6 }),
+  "undefined eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => plainYearMonth.with({ monthCode: "M05", month: 6 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => plainYearMonth.with({ month: 13 }, { overflow: "reject" }),
+  "Out-of-range month throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/ZonedDateTime/from/calendarresolvefields-error-ordering-chinese.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/calendarresolvefields-error-ordering-chinese.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: CalendarResolveFields throws TypeError before RangeError (chinese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Missing year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.ZonedDateTime.from({ calendar: "chinese", monthCode: "M05", month: 6, day: 1, timeZone: "UTC" }),
+  "Missing year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing month/monthCode should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => Temporal.ZonedDateTime.from({ calendar: "chinese", year: 2020, day: 32, timeZone: "UTC" }, { overflow: "reject" }),
+  "Missing month throws TypeError before out-of-range day throws RangeError"
+);
+
+// Missing day should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.ZonedDateTime.from({ calendar: "chinese", year: 2020, monthCode: "M05", month: 6, timeZone: "UTC" }),
+  "Missing day throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// undefined year should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => Temporal.ZonedDateTime.from({ calendar: "chinese", year: undefined, monthCode: "M05", month: 6, day: 1, timeZone: "UTC" }),
+  "undefined year throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => Temporal.ZonedDateTime.from({ calendar: "chinese", year: 2020, monthCode: "M05", month: 12, day: 1, timeZone: "UTC" }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.ZonedDateTime.from({ calendar: "chinese", year: 2020, month: 1, day: 32, timeZone: "UTC" }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/with/calendarresolvefields-error-ordering-gregory.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/with/calendarresolvefields-error-ordering-gregory.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.with
+description: CalendarResolveFields throws TypeError before RangeError (gregory calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const zonedDateTime = Temporal.ZonedDateTime.from({ calendar: "gregory", timeZone: "UTC", year: 2020, month: 5, day: 15, hour: 12 });
+
+// Missing required property (eraYear when era is present) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => zonedDateTime.with({ era: "ce", monthCode: "M05", month: 6 }),
+  "Missing eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing required property (eraYear when era is present) should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => zonedDateTime.with({ era: "ce", day: 32 }),
+  "Missing eraYear throws TypeError before out-of-range day throws RangeError"
+);
+
+// undefined eraYear should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => zonedDateTime.with({ era: "ce", eraYear: undefined, monthCode: "M05", month: 6 }),
+  "undefined eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => zonedDateTime.with({ monthCode: "M05", month: 6 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => zonedDateTime.with({ day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/with/calendarresolvefields-error-ordering-japanese.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/with/calendarresolvefields-error-ordering-japanese.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.with
+description: CalendarResolveFields throws TypeError before RangeError (japanese calendar)
+info: |
+  CalendarResolveFields validates field types before validating field ranges,
+  ensuring TypeError is thrown before RangeError when both conditions exist.
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const zonedDateTime = Temporal.ZonedDateTime.from({ calendar: "japanese", timeZone: "Asia/Tokyo", year: 2020, month: 5, day: 15, hour: 12 });
+
+// Missing required property (eraYear when era is present) should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => zonedDateTime.with({ era: "heisei", monthCode: "M05", month: 6 }),
+  "Missing eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// Missing required property (eraYear when era is present) should throw TypeError even with invalid day
+assert.throws(
+  TypeError,
+  () => zonedDateTime.with({ era: "heisei", day: 32 }),
+  "Missing eraYear throws TypeError before out-of-range day throws RangeError"
+);
+
+// undefined eraYear should throw TypeError even with month/monthCode conflict
+assert.throws(
+  TypeError,
+  () => zonedDateTime.with({ era: "heisei", eraYear: undefined, monthCode: "M05", month: 6 }),
+  "undefined eraYear throws TypeError before month/monthCode conflict throws RangeError"
+);
+
+// After type validation passes, range validation should throw RangeError
+assert.throws(
+  RangeError,
+  () => zonedDateTime.with({ monthCode: "M05", month: 6 }),
+  "month/monthCode conflict throws RangeError when all types are valid"
+);
+
+assert.throws(
+  RangeError,
+  () => zonedDateTime.with({ day: 32 }, { overflow: "reject" }),
+  "Out-of-range day throws RangeError when all types are valid"
+);


### PR DESCRIPTION
Verify that CalendarResolveFields throws TypeError for missing required fields before throwing RangeError for invalid field values.

Covers:
- `from()` methods for PlainDate, PlainDateTime, PlainMonthDay, PlainYearMonth, ZonedDateTime (ISO and non-ISO calendars)
- `with()` methods for Japanese calendar (PlainDate, PlainDateTime, PlainYearMonth, ZonedDateTime)