### PR TITLE
Add PlainMonthDay month code tests for non-ISO calendars

### DIFF
--- a/test/intl402/Temporal/PlainMonthDay/from/buddhist-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/buddhist-invalid-month-code-m13.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Buddhist calendar (12-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Buddhist calendar is a 12-month calendar and should not accept M13
+
+const calendar = "buddhist";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/buddhist-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/buddhist-month-codes.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M12) in Buddhist calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+// Test that all month codes M01-M12 are valid for the Buddhist calendar
+// The Buddhist calendar follows the Gregorian calendar structure
+
+const calendar = "buddhist";
+
+for (const { monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
+  // Test creation with monthCode and day 1
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  TemporalHelpers.assertPlainMonthDay(pmd, monthCode, 1, `monthCode ${monthCode} should be preserved`);
+
+  // Test with maximum day value for this month (minimum for PlainMonthDay)
+  const pmdMax = Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth });
+  TemporalHelpers.assertPlainMonthDay(pmdMax, monthCode, daysInMonth, `${monthCode} with day ${daysInMonth} should be valid`);
+
+  // Test constrain overflow
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: daysInMonth + 1 },
+    { overflow: "constrain" }
+  );
+  TemporalHelpers.assertPlainMonthDay(constrained, monthCode, daysInMonth, `day ${daysInMonth + 1} should be constrained to ${daysInMonth} for ${monthCode}`);
+
+  // Test reject overflow
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth + 1 }, { overflow: "reject" });
+  }, `${monthCode} with day ${daysInMonth + 1} should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/chinese-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/chinese-invalid-month-code-m13.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Chinese calendar (12-month calendar with leap months)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Chinese calendar is a 12-month lunisolar calendar with leap months (M01L-M12L)
+// but does not have a thirteenth month (M13)
+
+const calendar = "chinese";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/chinese-leap-month-codes-common.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/chinese-leap-month-codes-common.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for common leap month codes in Chinese calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test common leap months in the Chinese calendar
+// The Chinese calendar is a lunisolar calendar where leap months are inserted
+// to keep the lunar year synchronized with the solar year.
+// Common leap months (occurring more frequently in the astronomical cycle):
+// M02L, M03L, M04L, M05L, M06L, M07L, M08L
+//
+// The distribution of leap months follows astronomical calculations.
+//
+// Note: M01L, M02L and M08L through M12L are temporarily omitted from this
+// test because while any leap month can have 30 days, there isn't a year in the
+// supported range where these months do, and it's not yet well-defined what
+// reference ISO year should be used.
+// See https://github.com/tc39/proposal-intl-era-monthcode/issues/60
+
+const calendar = "chinese";
+
+// Test leap months M03L-M07L with day 30
+// These are well-established leap months that can have 30 days
+const leapMonthsWith30Days = ["M03L", "M04L", "M05L", "M06L", "M07L"];
+
+for (const monthCode of leapMonthsWith30Days) {
+  // Test creation with monthCode
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `leap monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  // These leap months can have up to 30 days (minimum for PlainMonthDay)
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  // Test constrain overflow - day 31 should be constrained to 30
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  // Test reject overflow - day 31 should throw
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/chinese-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/chinese-month-codes.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all regular month codes (M01-M12) in Chinese calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all regular month codes M01-M12 are valid for the Chinese calendar
+// The Chinese calendar is a lunisolar calendar, so months vary in length
+// Leap months (M01L-M12L) are tested elsewhere
+
+const calendar = "chinese";
+const monthCodes = [
+  "M01", "M02", "M03", "M04", "M05", "M06",
+  "M07", "M08", "M09", "M10", "M11", "M12"
+];
+
+for (const monthCode of monthCodes) {
+  // Test creation with monthCode
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, "day should be 1");
+
+  // Test with day 30 (months can have 29 or 30 days)
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  // Test constrain overflow - Chinese months vary from 29-30 days
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  // Test reject overflow for day 31
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/coptic-invalid-month-code-m14.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/coptic-invalid-month-code-m14.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M14 month code is invalid for Coptic calendar (13-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Coptic calendar has 13 months (M01-M13) and should not accept M14
+
+const calendar = "coptic";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M14", day: 1 });
+}, `M14 should not be a valid month code for ${calendar} calendar`);
+
+// M14 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M14", day: 1 }, { overflow: "constrain" });
+}, `M14 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M14 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M14", day: 1 }, { overflow: "reject" });
+}, `M14 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/coptic-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/coptic-month-codes.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M13) in Coptic calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all month codes M01-M13 are valid for the Coptic calendar
+// The Coptic calendar has 12 months of 30 days each, plus a 13th month (Epagomenal days)
+// of 5 or 6 days
+
+const calendar = "coptic";
+
+// M01-M12: Regular months with 30 days each
+const regularMonthCodes = [
+  "M01", "M02", "M03", "M04", "M05", "M06",
+  "M07", "M08", "M09", "M10", "M11", "M12"
+];
+
+for (const monthCode of regularMonthCodes) {
+  // Test creation with monthCode
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, "day should be 1");
+
+  // Test with day 30 (all regular months have 30 days)
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  // Test overflow: constrain to 30
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  // Test overflow: reject should throw for day 31
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}
+
+// M13: Short month (Epagomenal days) with 5 or 6 days
+
+// Test M13 with day 6 (maximum, valid in leap years)
+const pmdM13Day6 = Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 6 });
+assert.sameValue(pmdM13Day6.monthCode, "M13", "M13 should be valid with day 6");
+assert.sameValue(pmdM13Day6.day, 6, "day should be 6 for M13");
+
+// Test M13 overflow: constrain to maximum
+const constrained = Temporal.PlainMonthDay.from(
+  { calendar, monthCode: "M13", day: 7 },
+  { overflow: "constrain" }
+);
+assert.sameValue(constrained.monthCode, "M13", "M13 should be preserved with constrain");
+assert.sameValue(constrained.day, 6, "day 7 should be constrained to 6 for M13");
+
+// Test M13 overflow: reject should throw for day 7
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 7 }, { overflow: "reject" });
+}, "M13 with day 7 should throw with reject overflow");

--- a/test/intl402/Temporal/PlainMonthDay/from/dangi-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/dangi-invalid-month-code-m13.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Dangi calendar (12-month calendar with leap months)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Dangi calendar is a 12-month lunisolar calendar with leap months (M01L-M12L)
+// but does not have a thirteenth month (M13)
+
+const calendar = "dangi";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/dangi-leap-month-codes-common.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/dangi-leap-month-codes-common.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for common leap month codes in Dangi calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test common leap months in the Dangi calendar
+// Dangi is a lunisolar calendar where leap months follow the same distribution as Chinese
+// Common leap months (occurring more frequently in the astronomical cycle):
+// M02L, M03L, M04L, M05L, M06L, M07L, M08L
+//
+// Like the Chinese calendar, the Dangi calendar inserts leap months to keep the
+// lunar year synchronized with the solar year. The distribution of leap months
+// follows astronomical calculations.
+//
+// Note: M01L, M02L and M08L through M12L are temporarily omitted from this
+// test because while any leap month can have 30 days, there isn't a year in the
+// supported range where these months do, and it's not yet well-defined what
+// reference ISO year should be used.
+// See https://github.com/tc39/proposal-intl-era-monthcode/issues/60
+
+const calendar = "dangi";
+
+// Test leap months M03L-M07L with day 30
+// These are well-established leap months that can have 30 days
+const leapMonthsWith30Days = ["M03L", "M04L", "M05L", "M06L", "M07L"];
+
+for (const monthCode of leapMonthsWith30Days) {
+  // Test creation with monthCode
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `leap monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  // These leap months can have up to 30 days (minimum for PlainMonthDay)
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  // Test constrain overflow - day 31 should be constrained to 30
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  // Test reject overflow - day 31 should throw
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/dangi-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/dangi-month-codes.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all regular month codes in Dangi calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all regular month codes M01-M12 are valid for the Dangi calendar
+// Dangi is a lunisolar calendar used in Korea, structurally identical to Chinese
+
+const calendar = "dangi";
+const monthCodes = [
+  "M01", "M02", "M03", "M04", "M05", "M06",
+  "M07", "M08", "M09", "M10", "M11", "M12"
+];
+
+for (const monthCode of monthCodes) {
+  // Test creation with monthCode
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, "day should be 1");
+
+  // Test with a larger day value (months can have 29 or 30 days)
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `monthCode ${monthCode} with day 30 should be valid`);
+
+  // Test overflow: constrain to maximum valid day in the month
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `monthCode ${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  // Test overflow: reject should throw for invalid day
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `monthCode ${monthCode} with day 31 should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/ethioaa-invalid-month-code-m14.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/ethioaa-invalid-month-code-m14.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M14 month code is invalid for Ethioaa calendar (13-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Ethioaa calendar has 13 months (M01-M13) and should not accept M14
+
+const calendar = "ethioaa";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M14", day: 1 });
+}, `M14 should not be a valid month code for ${calendar} calendar`);
+
+// M14 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M14", day: 1 }, { overflow: "constrain" });
+}, `M14 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M14 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M14", day: 1 }, { overflow: "reject" });
+}, `M14 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/ethioaa-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/ethioaa-month-codes.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M13) in Ethioaa calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all month codes M01-M13 are valid for the Ethioaa calendar
+// Ethioaa (also known as ethiopic-amete-alem) has the same structure as Ethiopic:
+// 12 months of 30 days each, plus a 13th month (Pagumen) of 5 or 6 days
+
+const calendar = "ethioaa";
+
+// M01-M12: Regular months with 30 days each
+const regularMonthCodes = [
+  "M01", "M02", "M03", "M04", "M05", "M06",
+  "M07", "M08", "M09", "M10", "M11", "M12"
+];
+
+for (const monthCode of regularMonthCodes) {
+  // Test creation with monthCode
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, "day should be 1");
+
+  // Test with day 30 (all regular months have 30 days)
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  // Test overflow: constrain to 30
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  // Test overflow: reject should throw for day 31
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}
+
+// M13: Short month (Pagumen) with 5 or 6 days
+
+// Test M13 with day 6 (maximum, valid in leap years)
+const pmdM13Day6 = Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 6 });
+assert.sameValue(pmdM13Day6.monthCode, "M13", "M13 should be valid with day 6");
+assert.sameValue(pmdM13Day6.day, 6, "day should be 6 for M13");
+
+// Test M13 overflow: constrain to maximum
+const constrained = Temporal.PlainMonthDay.from(
+  { calendar, monthCode: "M13", day: 7 },
+  { overflow: "constrain" }
+);
+assert.sameValue(constrained.monthCode, "M13", "M13 should be preserved with constrain");
+assert.sameValue(constrained.day, 6, "day 7 should be constrained to 6 for M13");
+
+// Test M13 overflow: reject should throw for day 7
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 7 }, { overflow: "reject" });
+}, "M13 with day 7 should throw with reject overflow");

--- a/test/intl402/Temporal/PlainMonthDay/from/ethiopic-invalid-month-code-m14.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/ethiopic-invalid-month-code-m14.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M14 month code is invalid for Ethiopic calendar (13-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Ethiopic calendar has 13 months (M01-M13) and should not accept M14
+
+const calendar = "ethiopic";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M14", day: 1 });
+}, `M14 should not be a valid month code for ${calendar} calendar`);
+
+// M14 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M14", day: 1 }, { overflow: "constrain" });
+}, `M14 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M14 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M14", day: 1 }, { overflow: "reject" });
+}, `M14 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/ethiopic-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/ethiopic-month-codes.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M13) in Ethiopic calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all month codes M01-M13 are valid for the Ethiopic calendar
+// The Ethiopic calendar has 12 months of 30 days each, plus a 13th month (Pagumen)
+// of 5 or 6 days
+
+const calendar = "ethiopic";
+
+// M01-M12: Regular months with 30 days each
+const regularMonthCodes = [
+  "M01", "M02", "M03", "M04", "M05", "M06",
+  "M07", "M08", "M09", "M10", "M11", "M12"
+];
+
+for (const monthCode of regularMonthCodes) {
+  // Test creation with monthCode
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, "day should be 1");
+
+  // Test with day 30 (all regular months have 30 days)
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  // Test overflow: constrain to 30
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  // Test overflow: reject should throw for day 31
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}
+
+// M13: Short month (Pagumen) with 5 or 6 days
+
+// Test M13 with day 6 (maximum, valid in leap years)
+const pmdM13Day6 = Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 6 });
+assert.sameValue(pmdM13Day6.monthCode, "M13", "M13 should be valid with day 6");
+assert.sameValue(pmdM13Day6.day, 6, "day should be 6 for M13");
+
+// Test M13 overflow: constrain to maximum
+const constrained = Temporal.PlainMonthDay.from(
+  { calendar, monthCode: "M13", day: 7 },
+  { overflow: "constrain" }
+);
+assert.sameValue(constrained.monthCode, "M13", "M13 should be preserved with constrain");
+assert.sameValue(constrained.day, 6, "day 7 should be constrained to 6 for M13");
+
+// Test M13 overflow: reject should throw for day 7
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 7 }, { overflow: "reject" });
+}, "M13 with day 7 should throw with reject overflow");

--- a/test/intl402/Temporal/PlainMonthDay/from/gregory-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/gregory-invalid-month-code-m13.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Gregorian calendar (12-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Gregorian calendar is a 12-month calendar and should not accept M13
+
+const calendar = "gregory";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/gregory-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/gregory-month-codes.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M12) in Gregorian calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+// Test that all month codes M01-M12 are valid for the Gregorian calendar
+
+const calendar = "gregory";
+
+for (const { monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
+  // Test creation with monthCode and day 1
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  TemporalHelpers.assertPlainMonthDay(pmd, monthCode, 1, `monthCode ${monthCode} should be preserved`);
+
+  // Test with maximum day value for this month (minimum for PlainMonthDay)
+  const pmdMax = Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth });
+  TemporalHelpers.assertPlainMonthDay(pmdMax, monthCode, daysInMonth, `${monthCode} with day ${daysInMonth} should be valid`);
+
+  // Test constrain overflow
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: daysInMonth + 1 },
+    { overflow: "constrain" }
+  );
+  TemporalHelpers.assertPlainMonthDay(constrained, monthCode, daysInMonth, `day ${daysInMonth + 1} should be constrained to ${daysInMonth} for ${monthCode}`);
+
+  // Test reject overflow
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth + 1 }, { overflow: "reject" });
+  }, `${monthCode} with day ${daysInMonth + 1} should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/hebrew-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/hebrew-invalid-month-code-m13.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Hebrew calendar (12-month calendar with leap month M05L)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Hebrew calendar is a 12-month lunisolar calendar with leap month M05L (Adar I)
+// but does not have a thirteenth month (M13)
+
+const calendar = "hebrew";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/hebrew-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/hebrew-month-codes.js
@@ -1,0 +1,61 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all regular month codes and leap month in Hebrew calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all regular month codes M01-M12 and leap month M05L are valid for the Hebrew calendar
+
+const calendar = "hebrew";
+
+// Months with 30 days maximum
+// M05L is the leap month (Adar I); in leap years M05L is Adar I and M06 is Adar II
+const monthsWith30Days = ["M01", "M02", "M03", "M05", "M05L", "M07", "M09", "M11"];
+
+for (const monthCode of monthsWith30Days) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, "day should be 1");
+
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}
+
+// Months with 29 days maximum
+const monthsWith29Days = ["M04", "M06", "M08", "M10", "M12"];
+
+for (const monthCode of monthsWith29Days) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, "day should be 1");
+
+  const pmd29 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 29 });
+  assert.sameValue(pmd29.monthCode, monthCode, `${monthCode} with day 29 should be valid`);
+  assert.sameValue(pmd29.day, 29, `day should be 29 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 30 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 29, `day 30 should be constrained to 29 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 }, { overflow: "reject" });
+  }, `${monthCode} with day 30 should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/indian-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/indian-invalid-month-code-m13.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Indian calendar (12-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Indian calendar is a 12-month calendar and should not accept M13
+
+const calendar = "indian";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/indian-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/indian-month-codes.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M12) in Indian calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all month codes M01-M12 are valid for the Indian calendar
+// Indian calendar month lengths:
+// - M01-M06: 31 days
+// - M07-M12: 30 days
+
+const calendar = "indian";
+
+// Months with 31 days
+const monthsWith31Days = ["M01", "M02", "M03", "M04", "M05", "M06"];
+
+for (const monthCode of monthsWith31Days) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  const pmd31 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 });
+  assert.sameValue(pmd31.monthCode, monthCode, `${monthCode} with day 31 should be valid`);
+  assert.sameValue(pmd31.day, 31, `day should be 31 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 32 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 31, `day 32 should be constrained to 31 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 32 }, { overflow: "reject" });
+  }, `${monthCode} with day 32 should throw with reject overflow`);
+}
+
+// Months with 30 days
+const monthsWith30Days = ["M07", "M08", "M09", "M10", "M11", "M12"];
+
+for (const monthCode of monthsWith30Days) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/islamic-civil-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/islamic-civil-invalid-month-code-m13.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Islamic-civil calendar (12-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Islamic-civil calendar is a 12-month calendar and should not accept M13
+
+const calendar = "islamic-civil";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/islamic-civil-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/islamic-civil-month-codes.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M12) in Islamic-civil calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all month codes M01-M12 are valid for the Islamic-civil calendar
+// Islamic calendar month lengths:
+// - 30 days: M01, M03, M05, M07, M09, M11, M12
+// - 29 days: M02, M04, M06, M08, M10
+
+const calendar = "islamic-civil";
+
+// Months with 30 days
+const monthsWith30Days = ["M01", "M03", "M05", "M07", "M09", "M11", "M12"];
+
+for (const monthCode of monthsWith30Days) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}
+
+// Months with 29 days
+const monthsWith29Days = ["M02", "M04", "M06", "M08", "M10"];
+
+for (const monthCode of monthsWith29Days) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  const pmd29 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 29 });
+  assert.sameValue(pmd29.monthCode, monthCode, `${monthCode} with day 29 should be valid`);
+  assert.sameValue(pmd29.day, 29, `day should be 29 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 30 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 29, `day 30 should be constrained to 29 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 }, { overflow: "reject" });
+  }, `${monthCode} with day 30 should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/islamic-tbla-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/islamic-tbla-invalid-month-code-m13.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Islamic-tbla calendar (12-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Islamic-tbla calendar is a 12-month calendar and should not accept M13
+
+const calendar = "islamic-tbla";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/islamic-tbla-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/islamic-tbla-month-codes.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M12) in Islamic-tbla calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all month codes M01-M12 are valid for the Islamic-tbla calendar
+// Islamic calendar month lengths:
+// - 30 days: M01, M03, M05, M07, M09, M11, M12
+// - 29 days: M02, M04, M06, M08, M10
+
+const calendar = "islamic-tbla";
+
+// Months with 30 days
+const monthsWith30Days = ["M01", "M03", "M05", "M07", "M09", "M11", "M12"];
+
+for (const monthCode of monthsWith30Days) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}
+
+// Months with 29 days
+const monthsWith29Days = ["M02", "M04", "M06", "M08", "M10"];
+
+for (const monthCode of monthsWith29Days) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  const pmd29 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 29 });
+  assert.sameValue(pmd29.monthCode, monthCode, `${monthCode} with day 29 should be valid`);
+  assert.sameValue(pmd29.day, 29, `day should be 29 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 30 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 29, `day 30 should be constrained to 29 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 }, { overflow: "reject" });
+  }, `${monthCode} with day 30 should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/islamic-umalqura-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/islamic-umalqura-invalid-month-code-m13.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Islamic-umalqura calendar (12-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Islamic-umalqura calendar is a 12-month calendar and should not accept M13
+
+const calendar = "islamic-umalqura";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/islamic-umalqura-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/islamic-umalqura-month-codes.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M12) in Islamic-umalqura calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all month codes M01-M12 are valid for the Islamic-umalqura calendar
+// Unlike the tabular islamic-civil and islamic-tbla calendars, islamic-umalqura
+// is an observational calendar where any month can have either 29 or 30 days
+// depending on the year. Therefore, all months support up to 30 days for PlainMonthDay.
+
+const calendar = "islamic-umalqura";
+
+const allMonths = ["M01", "M02", "M03", "M04", "M05", "M06", "M07", "M08", "M09", "M10", "M11", "M12"];
+
+for (const monthCode of allMonths) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/japanese-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/japanese-invalid-month-code-m13.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Japanese calendar (12-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Japanese calendar is a 12-month calendar and should not accept M13
+
+const calendar = "japanese";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/japanese-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/japanese-month-codes.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M12) in Japanese calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+// Test that all month codes M01-M12 are valid for the Japanese calendar
+
+const calendar = "japanese";
+
+for (const { monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
+  // Test creation with monthCode and day 1
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  TemporalHelpers.assertPlainMonthDay(pmd, monthCode, 1, `monthCode ${monthCode} should be preserved`);
+
+  // Test with maximum day value for this month (minimum for PlainMonthDay)
+  const pmdMax = Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth });
+  TemporalHelpers.assertPlainMonthDay(pmdMax, monthCode, daysInMonth, `${monthCode} with day ${daysInMonth} should be valid`);
+
+  // Test constrain overflow
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: daysInMonth + 1 },
+    { overflow: "constrain" }
+  );
+  TemporalHelpers.assertPlainMonthDay(constrained, monthCode, daysInMonth, `day ${daysInMonth + 1} should be constrained to ${daysInMonth} for ${monthCode}`);
+
+  // Test reject overflow
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth + 1 }, { overflow: "reject" });
+  }, `${monthCode} with day ${daysInMonth + 1} should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/persian-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/persian-invalid-month-code-m13.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for Persian calendar (12-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The Persian calendar is a 12-month calendar and should not accept M13
+
+const calendar = "persian";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/persian-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/persian-month-codes.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M12) in Persian calendar
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Test that all month codes M01-M12 are valid for the Persian calendar
+// Persian calendar month lengths:
+// - M01-M06: 31 days
+// - M07-M12: 30 days
+
+const calendar = "persian";
+
+// Months with 31 days
+const monthsWith31Days = ["M01", "M02", "M03", "M04", "M05", "M06"];
+
+for (const monthCode of monthsWith31Days) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  const pmd31 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 });
+  assert.sameValue(pmd31.monthCode, monthCode, `${monthCode} with day 31 should be valid`);
+  assert.sameValue(pmd31.day, 31, `day should be 31 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 32 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 31, `day 32 should be constrained to 31 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 32 }, { overflow: "reject" });
+  }, `${monthCode} with day 32 should throw with reject overflow`);
+}
+
+// Months with 30 days
+const monthsWith30Days = ["M07", "M08", "M09", "M10", "M11", "M12"];
+
+for (const monthCode of monthsWith30Days) {
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  assert.sameValue(pmd.monthCode, monthCode, `monthCode ${monthCode} should be preserved`);
+  assert.sameValue(pmd.day, 1, `day should be 1 for ${monthCode}`);
+
+  const pmd30 = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 30 });
+  assert.sameValue(pmd30.monthCode, monthCode, `${monthCode} with day 30 should be valid`);
+  assert.sameValue(pmd30.day, 30, `day should be 30 for ${monthCode}`);
+
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: 31 },
+    { overflow: "constrain" }
+  );
+  assert.sameValue(constrained.monthCode, monthCode, `${monthCode} should be preserved with constrain`);
+  assert.sameValue(constrained.day, 30, `day 31 should be constrained to 30 for ${monthCode}`);
+
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: 31 }, { overflow: "reject" });
+  }, `${monthCode} with day 31 should throw with reject overflow`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/roc-invalid-month-code-m13.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/roc-invalid-month-code-m13.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: M13 month code is invalid for ROC calendar (12-month calendar)
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// The ROC calendar is a 12-month calendar and should not accept M13
+
+const calendar = "roc";
+
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 });
+}, `M13 should not be a valid month code for ${calendar} calendar`);
+
+// M13 should throw even with overflow: "constrain"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "constrain" });
+}, `M13 should not be valid for ${calendar} calendar even with constrain overflow`);
+
+// M13 should throw with overflow: "reject"
+assert.throws(RangeError, () => {
+  Temporal.PlainMonthDay.from({ calendar, monthCode: "M13", day: 1 }, { overflow: "reject" });
+}, `M13 should not be valid for ${calendar} calendar with reject overflow`);

--- a/test/intl402/Temporal/PlainMonthDay/from/roc-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/roc-month-codes.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: PlainMonthDay can be created for all month codes (M01-M12) in ROC calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+// Test that all month codes M01-M12 are valid for the ROC calendar
+
+const calendar = "roc";
+
+for (const { monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
+  // Test creation with monthCode and day 1
+  const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+  TemporalHelpers.assertPlainMonthDay(pmd, monthCode, 1, `monthCode ${monthCode} should be preserved`);
+
+  // Test with maximum day value for this month (minimum for PlainMonthDay)
+  const pmdMax = Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth });
+  TemporalHelpers.assertPlainMonthDay(pmdMax, monthCode, daysInMonth, `${monthCode} with day ${daysInMonth} should be valid`);
+
+  // Test constrain overflow
+  const constrained = Temporal.PlainMonthDay.from(
+    { calendar, monthCode, day: daysInMonth + 1 },
+    { overflow: "constrain" }
+  );
+  TemporalHelpers.assertPlainMonthDay(constrained, monthCode, daysInMonth, `day ${daysInMonth + 1} should be constrained to ${daysInMonth} for ${monthCode}`);
+
+  // Test reject overflow
+  assert.throws(RangeError, () => {
+    Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth + 1 }, { overflow: "reject" });
+  }, `${monthCode} with day ${daysInMonth + 1} should throw with reject overflow`);
+}


### PR DESCRIPTION
Tests for `Temporal.PlainMonthDay.from()` verifying that all valid month codes are accepted for various calendar systems.