### PR TITLE
Temporal: Change leap month for 1987 in Chinese calendar tests

### DIFF
--- a/test/intl402/Temporal/PlainDate/prototype/monthCode/chinese-calendar-dates.js
+++ b/test/intl402/Temporal/PlainDate/prototype/monthCode/chinese-calendar-dates.js
@@ -17,7 +17,7 @@ const leapMonthCases = [
   { year: 1979, month: 7, monthCode: "M06L", day: 1, referenceYear: 1960, referenceDay: 24 },
   { year: 1982, month: 5, monthCode: "M04L", day: 1, referenceYear: 1963, referenceDay: 23 },
   { year: 1984, month: 11, monthCode: "M10L", day: 1, referenceYear: 1870, referenceDay: 23 },
-  { year: 1987, month: 8, monthCode: "M07L", day: 1, referenceYear: 1968, referenceDay: 24 },
+  { year: 1987, month: 7, monthCode: "M06L", day: 1, referenceYear: 1960, referenceDay: 24 },
   { year: 1990, month: 6, monthCode: "M05L", day: 1, referenceYear: 1971, referenceDay: 23 },
   { year: 1993, month: 4, monthCode: "M03L", day: 1, referenceYear: 1966, referenceDay: 22 },
   { year: 1995, month: 9, monthCode: "M08L", day: 1, referenceYear: 1957, referenceDay: 25 },

--- a/test/intl402/Temporal/PlainDateTime/prototype/monthCode/chinese-calendar-dates.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/monthCode/chinese-calendar-dates.js
@@ -17,7 +17,7 @@ const leapMonthCases = [
   { year: 1979, month: 7, monthCode: "M06L", day: 1, referenceYear: 1960, referenceDay: 24 },
   { year: 1982, month: 5, monthCode: "M04L", day: 1, referenceYear: 1963, referenceDay: 23 },
   { year: 1984, month: 11, monthCode: "M10L", day: 1, referenceYear: 1870, referenceDay: 23 },
-  { year: 1987, month: 8, monthCode: "M07L", day: 1, referenceYear: 1968, referenceDay: 24 },
+  { year: 1987, month: 7, monthCode: "M06L", day: 1, referenceYear: 1960, referenceDay: 24 },
   { year: 1990, month: 6, monthCode: "M05L", day: 1, referenceYear: 1971, referenceDay: 23 },
   { year: 1993, month: 4, monthCode: "M03L", day: 1, referenceYear: 1966, referenceDay: 22 },
   { year: 1995, month: 9, monthCode: "M08L", day: 1, referenceYear: 1957, referenceDay: 25 },

--- a/test/intl402/Temporal/PlainMonthDay/prototype/monthCode/chinese-calendar-dates.js
+++ b/test/intl402/Temporal/PlainMonthDay/prototype/monthCode/chinese-calendar-dates.js
@@ -18,7 +18,7 @@ const leapMonthCases = [
   { year: 1982, month: 5, monthCode: "M04L", day: 1, referenceYear: 1963 },
   // See https://github.com/tc39/proposal-intl-era-monthcode/issues/60
   // { year: 1984, month: 11, monthCode: "M10L", day: 1, referenceYear: 1870 },
-  { year: 1987, month: 8, monthCode: "M07L", day: 1, referenceYear: 1968 },
+  { year: 1987, month: 7, monthCode: "M06L", day: 1, referenceYear: 1960 },
   { year: 1990, month: 6, monthCode: "M05L", day: 1, referenceYear: 1971 },
   { year: 1993, month: 4, monthCode: "M03L", day: 1, referenceYear: 1966 },
   { year: 1995, month: 9, monthCode: "M08L", day: 1, referenceYear: 1957 },

--- a/test/intl402/Temporal/ZonedDateTime/prototype/monthCode/chinese-calendar-dates.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/monthCode/chinese-calendar-dates.js
@@ -17,7 +17,7 @@ const leapMonthCases = [
   { year: 1979, month: 7, monthCode: "M06L", day: 1, referenceYear: 1960, referenceDay: 24 },
   { year: 1982, month: 5, monthCode: "M04L", day: 1, referenceYear: 1963, referenceDay: 23 },
   { year: 1984, month: 11, monthCode: "M10L", day: 1, referenceYear: 1870, referenceDay: 23 },
-  { year: 1987, month: 8, monthCode: "M07L", day: 1, referenceYear: 1968, referenceDay: 24 },
+  { year: 1987, month: 7, monthCode: "M06L", day: 1, referenceYear: 1960, referenceDay: 24 },
   { year: 1990, month: 6, monthCode: "M05L", day: 1, referenceYear: 1971, referenceDay: 23 },
   { year: 1993, month: 4, monthCode: "M03L", day: 1, referenceYear: 1966, referenceDay: 22 },
   { year: 1995, month: 9, monthCode: "M08L", day: 1, referenceYear: 1957, referenceDay: 25 },


### PR DESCRIPTION
The test data included a case for year 1987, monthCode M07L. This was incorrect; the leap month for 1987 was M06L. This is due to a bug in ICU4C. These tests will have to be expected-to-fail in ICU4C-based implementations until the underlying bug is fixed. See https://github.com/tc39/test262/issues/4704

Closes #4704 