### PR TITLE
Temporal: Add tests for order of operations on property bag reads

### DIFF
--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/order-of-operations.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.toplaindatetime
+description: Properties on an object passed to toPlainDateTime() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get fields.hour",
+  "get fields.hour.valueOf",
+  "call fields.hour.valueOf",
+  "get fields.microsecond",
+  "get fields.microsecond.valueOf",
+  "call fields.microsecond.valueOf",
+  "get fields.millisecond",
+  "get fields.millisecond.valueOf",
+  "call fields.millisecond.valueOf",
+  "get fields.minute",
+  "get fields.minute.valueOf",
+  "call fields.minute.valueOf",
+  "get fields.nanosecond",
+  "get fields.nanosecond.valueOf",
+  "call fields.nanosecond.valueOf",
+  "get fields.second",
+  "get fields.second.valueOf",
+  "call fields.second.valueOf",
+];
+const actual = [];
+
+const fields = TemporalHelpers.propertyBagObserver(actual, {
+  year: 1.7,
+  month: 1.7,
+  monthCode: "M01",
+  day: 1.7,
+  hour: 1,
+  microsecond: 2,
+  millisecond: 3,
+  minute: 4,
+  nanosecond: 5,
+  second: 6,
+  calendar: "iso8601",
+}, "fields", ["calendar"]);
+
+const date = new Temporal.PlainDate(2025, 5, 2);
+
+date.toPlainDateTime(fields);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/order-of-operations.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.withplaintime
+description: Properties on an object passed to withPlainTime() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get fields.hour",
+  "get fields.hour.valueOf",
+  "call fields.hour.valueOf",
+  "get fields.microsecond",
+  "get fields.microsecond.valueOf",
+  "call fields.microsecond.valueOf",
+  "get fields.millisecond",
+  "get fields.millisecond.valueOf",
+  "call fields.millisecond.valueOf",
+  "get fields.minute",
+  "get fields.minute.valueOf",
+  "call fields.minute.valueOf",
+  "get fields.nanosecond",
+  "get fields.nanosecond.valueOf",
+  "call fields.nanosecond.valueOf",
+  "get fields.second",
+  "get fields.second.valueOf",
+  "call fields.second.valueOf",
+];
+const actual = [];
+
+const fields = TemporalHelpers.propertyBagObserver(actual, {
+  year: 1.7,
+  month: 1.7,
+  monthCode: "M01",
+  day: 1.7,
+  hour: 1,
+  microsecond: 2,
+  millisecond: 3,
+  minute: 4,
+  nanosecond: 5,
+  second: 6,
+  calendar: "iso8601",
+}, "fields", ["calendar"]);
+
+const pdt = new Temporal.PlainDateTime(2025, 5, 2, 0, 0, 0, 0, 0, 0);
+
+pdt.withPlainTime(fields);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/getTimeZoneTransition/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/getTimeZoneTransition/order-of-operations.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.gettimezonetransition
+description: Properties on an object passed to getTimeZoneTransition() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get fields.direction",
+  "get fields.direction.toString",
+  "call fields.direction.toString"
+];
+const actual = [];
+
+const fields = TemporalHelpers.propertyBagObserver(actual, {
+  year: 1.7,
+  month: 1.7,
+  monthCode: "M01",
+  day: 1.7,
+  hour: 1,
+  microsecond: 2,
+  millisecond: 3,
+  minute: 4,
+  nanosecond: 5,
+  second: 6,
+  overflow: "constrain",
+  largestUnit: "years",
+  smallestUnit: "months",
+  direction: "next",
+  calendar: "iso8601",
+}, "fields", ["calendar"]);
+
+const zdt = new Temporal.ZonedDateTime(0n, "UTC");
+
+zdt.getTimeZoneTransition(fields);
+assert.compareArray(actual, expected, "order of operations");


### PR DESCRIPTION
Add tests for order of operations on property bag reads for the following methods:

* PlainDate.prototype.toPlainDateTime
* PlainDateTime.prototype.withPlainTime
* ZonedDateTime.prototype.getTimeZoneTransition

Closes https://github.com/tc39/proposal-temporal/issues/3189