### PR TITLE
Temporal: Pre-1582 tests for Gregorian-like calendars

### DIFF
--- a/test/intl402/Temporal/PlainDate/prototype/add/proleptic-buddhist.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.add
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date21251004 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 4, calendar });
+const date21251015 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertPlainDate(
+  date21251004.add(days3),
+  2125, 10, "M10", 7, "add 3 days to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDate(
+  date21251015.add(days3n),
+  2125, 10, "M10", 12, "subtract 3 days from 2125-10-15",
+  "be", 2125);
+TemporalHelpers.assertPlainDate(
+  date21251004.add(weeks1),
+  2125, 10, "M10", 11, "add 1 week to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDate(
+  date21251015.add(weeks1n),
+  2125, 10, "M10", 8, "subtract 1 week from 2125-10-15",
+  "be", 2125);
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const months2 = new Temporal.Duration(0, 2);
+const months2n = new Temporal.Duration(0, -2);
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.PlainDate.from({ year: 2483, monthCode: "M03", day: 1, calendar });
+const date24831201 = Temporal.PlainDate.from({ year: 2483, monthCode: "M12", day: 1, calendar });
+const date24840301 = Temporal.PlainDate.from({ year: 2484, monthCode: "M03", day: 1, calendar });
+const date24840416 = Temporal.PlainDate.from({ year: 2484, monthCode: "M04", day: 16, calendar });
+
+TemporalHelpers.assertPlainDate(
+  date24831201.add(months2),
+  2484, 2, "M02", 1, "add 2 months to 2484-02-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDate(
+  date24840416.add(months2n),
+  2484, 2, "M02", 16, "subtract 2 months from 2484-04-16",
+  "be", 2484);
+TemporalHelpers.assertPlainDate(
+  date24830301.add(years1),
+  2484, 3, "M03", 1, "add 1 years to 2483-03-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDate(
+  date24840301.add(years1n),
+  2483, 3, "M03", 1, "subtract 1 year from to 2484-03-01",
+  "be", 2483);

--- a/test/intl402/Temporal/PlainDate/prototype/add/proleptic-gregory.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/proleptic-gregory.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.add
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date15821004 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 4, calendar });
+const date15821015 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertPlainDate(
+  date15821004.add(days3),
+  1582, 10, "M10", 7, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821015.add(days3n),
+  1582, 10, "M10", 12, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821004.add(weeks1),
+  1582, 10, "M10", 11, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821015.add(weeks1n),
+  1582, 10, "M10", 8, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/PlainDate/prototype/add/proleptic-japanese.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/proleptic-japanese.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.add
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date15821004 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 4, calendar });
+const date15821015 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertPlainDate(
+  date15821004.add(days3),
+  1582, 10, "M10", 7, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821015.add(days3n),
+  1582, 10, "M10", 12, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821004.add(weeks1),
+  1582, 10, "M10", 11, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821015.add(weeks1n),
+  1582, 10, "M10", 8, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/PlainDate/prototype/add/proleptic-roc.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/proleptic-roc.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.add
+description: >
+  Check that roc calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date329n1004 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 4, calendar });
+const date329n1015 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertPlainDate(
+  date329n1004.add(days3),
+  -329, 10, "M10", 7, "add 3 days to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDate(
+  date329n1015.add(days3n),
+  -329, 10, "M10", 12, "subtract 3 days from -329-10-15",
+  "broc", 330);
+TemporalHelpers.assertPlainDate(
+  date329n1004.add(weeks1),
+  -329, 10, "M10", 11, "add 1 week to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDate(
+  date329n1015.add(weeks1n),
+  -329, 10, "M10", 8, "subtract 1 week from -329-10-15",
+  "broc", 330);

--- a/test/intl402/Temporal/PlainDate/prototype/since/proleptic-buddhist.js
+++ b/test/intl402/Temporal/PlainDate/prototype/since/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const date21251004 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 4, calendar });
+const date21251007 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 7, calendar });
+const date21251011 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 11, calendar });
+const date21251012 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 12, calendar });
+const date21251015 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertDuration(
+  date21251004.since(date21251007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-07");
+TemporalHelpers.assertDuration(
+  date21251015.since(date21251012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "2125-10-15 and 2125-10-12");
+TemporalHelpers.assertDuration(
+  date21251004.since(date21251011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-11")
+TemporalHelpers.assertDuration(
+  date21251011.since(date21251004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-11 and 2125-10-04")
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.PlainDate.from({ year: 2483, monthCode: "M03", day: 1, calendar });
+const date24831201 = Temporal.PlainDate.from({ year: 2483, monthCode: "M12", day: 1, calendar });
+const date24840201 = Temporal.PlainDate.from({ year: 2484, monthCode: "M03", day: 1, calendar });
+const date24840216 = Temporal.PlainDate.from({ year: 2484, monthCode: "M02", day: 16, calendar });
+const date24840301 = Temporal.PlainDate.from({ year: 2484, monthCode: "M03", day: 1, calendar });
+const date24840416 = Temporal.PlainDate.from({ year: 2484, monthCode: "M04", day: 16, calendar });
+
+// 2483 is a leap year => 3 months
+TemporalHelpers.assertDuration(
+  date24831201.since(date24840201, { largestUnit: "months" }),
+  0, -3, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-12-01 and 2484-02-01"
+);
+TemporalHelpers.assertDuration(
+  date24840416.since(date24840216, { largestUnit: "months" }),
+  0, 2, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-04-16 and 2484-02-16"
+);
+TemporalHelpers.assertDuration(
+  date24830301.since(date24840301, { largestUnit: "years" }),
+  -1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-03-01 and 2484-03-01"
+);
+TemporalHelpers.assertDuration(
+  date24830301.since(date24840301, { largestUnit: "years" }),
+  -1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-03-01 and 2483-03-01"
+);

--- a/test/intl402/Temporal/PlainDate/prototype/since/proleptic-gregory.js
+++ b/test/intl402/Temporal/PlainDate/prototype/since/proleptic-gregory.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const date15821004 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 4, calendar });
+const date15821007 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 7, calendar });
+const date15821011 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 11, calendar });
+const date15821012 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 12, calendar });
+const date15821015 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.since(date15821012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.since(date15821004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/PlainDate/prototype/since/proleptic-japanese.js
+++ b/test/intl402/Temporal/PlainDate/prototype/since/proleptic-japanese.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const date15821004 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 4, calendar });
+const date15821007 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 7, calendar });
+const date15821011 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 11, calendar });
+const date15821012 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 12, calendar });
+const date15821015 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.since(date15821012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.since(date15821004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/PlainDate/prototype/since/proleptic-roc.js
+++ b/test/intl402/Temporal/PlainDate/prototype/since/proleptic-roc.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+  Check that ROC calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const date329n1004 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 4, calendar });
+const date329n1007 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 7, calendar });
+const date329n1011 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 11, calendar });
+const date329n1012 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 12, calendar });
+const date329n1015 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertDuration(
+  date329n1004.since(date329n1007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-07");
+TemporalHelpers.assertDuration(
+  date329n1015.since(date329n1012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "-329-10-15 and -329-10-12");
+TemporalHelpers.assertDuration(
+  date329n1004.since(date329n1011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-11")
+TemporalHelpers.assertDuration(
+  date329n1011.since(date329n1004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-11 and -329-10-04")

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/proleptic-buddhist.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.subtract
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date21251004 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 4, calendar });
+const date21251015 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertPlainDate(
+  date21251004.subtract(days3),
+  2125, 10, "M10", 7, "add 3 days to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDate(
+  date21251015.subtract(days3n),
+  2125, 10, "M10", 12, "subtract 3 days from 2125-10-15",
+  "be", 2125);
+TemporalHelpers.assertPlainDate(
+  date21251004.subtract(weeks1),
+  2125, 10, "M10", 11, "add 1 week to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDate(
+  date21251015.subtract(weeks1n),
+  2125, 10, "M10", 8, "subtract 1 week from 2125-10-15",
+  "be", 2125);
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const months2 = new Temporal.Duration(0, -2);
+const months2n = new Temporal.Duration(0, 2);
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.PlainDate.from({ year: 2483, monthCode: "M03", day: 1, calendar });
+const date24831201 = Temporal.PlainDate.from({ year: 2483, monthCode: "M12", day: 1, calendar });
+const date24840301 = Temporal.PlainDate.from({ year: 2484, monthCode: "M03", day: 1, calendar });
+const date24840416 = Temporal.PlainDate.from({ year: 2484, monthCode: "M04", day: 16, calendar });
+
+TemporalHelpers.assertPlainDate(
+  date24831201.subtract(months2),
+  2484, 2, "M02", 1, "add 2 months to 2484-02-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDate(
+  date24840416.subtract(months2n),
+  2484, 2, "M02", 16, "subtract 2 months from 2484-04-16",
+  "be", 2484);
+TemporalHelpers.assertPlainDate(
+  date24830301.subtract(years1),
+  2484, 3, "M03", 1, "add 1 years to 2483-03-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDate(
+  date24840301.subtract(years1n),
+  2483, 3, "M03", 1, "subtract 1 year from to 2484-03-01",
+  "be", 2483);

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/proleptic-gregory.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/proleptic-gregory.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.subtract
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date15821004 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 4, calendar });
+const date15821015 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertPlainDate(
+  date15821004.subtract(days3),
+  1582, 10, "M10", 7, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821015.subtract(days3n),
+  1582, 10, "M10", 12, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821004.subtract(weeks1),
+  1582, 10, "M10", 11, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821015.subtract(weeks1n),
+  1582, 10, "M10", 8, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/proleptic-japanese.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/proleptic-japanese.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.subtract
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date15821004 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 4, calendar });
+const date15821015 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertPlainDate(
+  date15821004.subtract(days3),
+  1582, 10, "M10", 7, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821015.subtract(days3n),
+  1582, 10, "M10", 12, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821004.subtract(weeks1),
+  1582, 10, "M10", 11, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDate(
+  date15821015.subtract(weeks1n),
+  1582, 10, "M10", 8, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/proleptic-roc.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/proleptic-roc.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.subtract
+description: >
+  Check that roc calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date329n1004 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 4, calendar });
+const date329n1015 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertPlainDate(
+  date329n1004.subtract(days3),
+  -329, 10, "M10", 7, "add 3 days to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDate(
+  date329n1015.subtract(days3n),
+  -329, 10, "M10", 12, "subtract 3 days from -329-10-15",
+  "broc", 330);
+TemporalHelpers.assertPlainDate(
+  date329n1004.subtract(weeks1),
+  -329, 10, "M10", 11, "add 1 week to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDate(
+  date329n1015.subtract(weeks1n),
+  -329, 10, "M10", 8, "subtract 1 week from -329-10-15",
+  "broc", 330);

--- a/test/intl402/Temporal/PlainDate/prototype/until/proleptic-buddhist.js
+++ b/test/intl402/Temporal/PlainDate/prototype/until/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const date21251004 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 4, calendar });
+const date21251007 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 7, calendar });
+const date21251011 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 11, calendar });
+const date21251012 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 12, calendar });
+const date21251015 = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertDuration(
+  date21251004.until(date21251007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-07");
+TemporalHelpers.assertDuration(
+  date21251015.until(date21251012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "2125-10-15 and 2125-10-12");
+TemporalHelpers.assertDuration(
+  date21251004.until(date21251011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-11")
+TemporalHelpers.assertDuration(
+  date21251011.until(date21251004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-11 and 2125-10-04")
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.PlainDate.from({ year: 2483, monthCode: "M03", day: 1, calendar });
+const date24831201 = Temporal.PlainDate.from({ year: 2483, monthCode: "M12", day: 1, calendar });
+const date24840201 = Temporal.PlainDate.from({ year: 2484, monthCode: "M03", day: 1, calendar });
+const date24840216 = Temporal.PlainDate.from({ year: 2484, monthCode: "M02", day: 16, calendar });
+const date24840301 = Temporal.PlainDate.from({ year: 2484, monthCode: "M03", day: 1, calendar });
+const date24840416 = Temporal.PlainDate.from({ year: 2484, monthCode: "M04", day: 16, calendar });
+
+// 2483 is a leap year => 3 months
+TemporalHelpers.assertDuration(
+  date24831201.until(date24840201, { largestUnit: "months" }),
+  0, 3, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-12-01 and 2484-02-01"
+);
+TemporalHelpers.assertDuration(
+  date24840416.until(date24840216, { largestUnit: "months" }),
+  0, -2, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-04-16 and 2484-02-16"
+);
+TemporalHelpers.assertDuration(
+  date24830301.until(date24840301, { largestUnit: "years" }),
+  1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-03-01 and 2484-03-01"
+);
+TemporalHelpers.assertDuration(
+  date24830301.until(date24840301, { largestUnit: "years" }),
+  1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-03-01 and 2483-03-01"
+);

--- a/test/intl402/Temporal/PlainDate/prototype/until/proleptic-gregory.js
+++ b/test/intl402/Temporal/PlainDate/prototype/until/proleptic-gregory.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const date15821004 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 4, calendar });
+const date15821007 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 7, calendar });
+const date15821011 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 11, calendar });
+const date15821012 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 12, calendar });
+const date15821015 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.until(date15821012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.until(date15821004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/PlainDate/prototype/until/proleptic-japanese.js
+++ b/test/intl402/Temporal/PlainDate/prototype/until/proleptic-japanese.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const date15821004 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 4, calendar });
+const date15821007 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 7, calendar });
+const date15821011 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 11, calendar });
+const date15821012 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 12, calendar });
+const date15821015 = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.until(date15821012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.until(date15821004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/PlainDate/prototype/until/proleptic-roc.js
+++ b/test/intl402/Temporal/PlainDate/prototype/until/proleptic-roc.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+  Check that ROC calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const date329n1004 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 4, calendar });
+const date329n1007 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 7, calendar });
+const date329n1011 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 11, calendar });
+const date329n1012 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 12, calendar });
+const date329n1015 = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 15, calendar });
+TemporalHelpers.assertDuration(
+  date329n1004.until(date329n1007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-07");
+TemporalHelpers.assertDuration(
+  date329n1015.until(date329n1012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "-329-10-15 and -329-10-12");
+TemporalHelpers.assertDuration(
+  date329n1004.until(date329n1011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-11")
+TemporalHelpers.assertDuration(
+  date329n1011.until(date329n1004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-11 and -329-10-04")

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/proleptic-buddhist.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date21251004 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date21251015 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertPlainDateTime(
+  date21251004.add(days3),
+  2125, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251015.add(days3n),
+  2125, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 2125-10-15",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251004.add(weeks1),
+  2125, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251015.add(weeks1n),
+  2125, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 2125-10-15",
+  "be", 2125);
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const months2 = new Temporal.Duration(0, 2);
+const months2n = new Temporal.Duration(0, -2);
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.PlainDateTime.from({ year: 2483, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar });
+const date24831201 = Temporal.PlainDateTime.from({ year: 2483, monthCode: "M12", day: 1, hour: 12, minute: 34, calendar });
+const date24840301 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar });
+const date24840416 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M04", day: 16, hour: 12, minute: 34, calendar });
+
+TemporalHelpers.assertPlainDateTime(
+  date24831201.add(months2),
+  2484, 2, "M02", 1, 12, 34, 0, 0, 0, 0, "add 2 months to 2484-02-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24840416.add(months2n),
+  2484, 2, "M02", 16, 12, 34, 0, 0, 0, 0, "subtract 2 months from 2484-04-16",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24830301.add(years1),
+  2484, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 years to 2483-03-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24840301.add(years1n),
+  2483, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "subtract 1 year from to 2484-03-01",
+  "be", 2483);

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/proleptic-gregory.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/proleptic-gregory.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date15821004 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date15821015 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertPlainDateTime(
+  date15821004.add(days3),
+  1582, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.add(days3n),
+  1582, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821004.add(weeks1),
+  1582, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.add(weeks1n),
+  1582, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/proleptic-japanese.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/proleptic-japanese.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date15821004 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date15821015 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertPlainDateTime(
+  date15821004.add(days3),
+  1582, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.add(days3n),
+  1582, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821004.add(weeks1),
+  1582, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.add(weeks1n),
+  1582, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/proleptic-roc.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/proleptic-roc.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: >
+  Check that roc calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date329n1004 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date329n1015 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertPlainDateTime(
+  date329n1004.add(days3),
+  -329, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1015.add(days3n),
+  -329, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from -329-10-15",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1004.add(weeks1),
+  -329, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1015.add(weeks1n),
+  -329, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from -329-10-15",
+  "broc", 330);

--- a/test/intl402/Temporal/PlainDateTime/prototype/since/proleptic-buddhist.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/since/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const date21251004 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date21251007 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 7, hour: 12, minute: 34, calendar });
+const date21251011 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 11, hour: 12, minute: 34, calendar });
+const date21251012 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 12, hour: 12, minute: 34, calendar });
+const date21251015 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertDuration(
+  date21251004.since(date21251007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-07");
+TemporalHelpers.assertDuration(
+  date21251015.since(date21251012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "2125-10-15 and 2125-10-12");
+TemporalHelpers.assertDuration(
+  date21251004.since(date21251011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-11")
+TemporalHelpers.assertDuration(
+  date21251011.since(date21251004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-11 and 2125-10-04")
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.PlainDateTime.from({ year: 2483, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar });
+const date24831201 = Temporal.PlainDateTime.from({ year: 2483, monthCode: "M12", day: 1, hour: 12, minute: 34, calendar });
+const date24840201 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar });
+const date24840216 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M02", day: 16, hour: 12, minute: 34, calendar });
+const date24840301 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar });
+const date24840416 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M04", day: 16, hour: 12, minute: 34, calendar });
+
+// 2483 is a leap year => 3 months
+TemporalHelpers.assertDuration(
+  date24831201.since(date24840201, { largestUnit: "months" }),
+  0, -3, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-12-01 and 2484-02-01"
+);
+TemporalHelpers.assertDuration(
+  date24840416.since(date24840216, { largestUnit: "months" }),
+  0, 2, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-04-16 and 2484-02-16"
+);
+TemporalHelpers.assertDuration(
+  date24830301.since(date24840301, { largestUnit: "years" }),
+  -1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-03-01 and 2484-03-01"
+);
+TemporalHelpers.assertDuration(
+  date24830301.since(date24840301, { largestUnit: "years" }),
+  -1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-03-01 and 2483-03-01"
+);

--- a/test/intl402/Temporal/PlainDateTime/prototype/since/proleptic-gregory.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/since/proleptic-gregory.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const date15821004 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date15821007 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 7, hour: 12, minute: 34, calendar });
+const date15821011 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 11, hour: 12, minute: 34, calendar });
+const date15821012 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 12, hour: 12, minute: 34, calendar });
+const date15821015 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.since(date15821012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.since(date15821004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/PlainDateTime/prototype/since/proleptic-japanese.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/since/proleptic-japanese.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const date15821004 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date15821007 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 7, hour: 12, minute: 34, calendar });
+const date15821011 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 11, hour: 12, minute: 34, calendar });
+const date15821012 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 12, hour: 12, minute: 34, calendar });
+const date15821015 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.since(date15821012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.since(date15821004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/PlainDateTime/prototype/since/proleptic-roc.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/since/proleptic-roc.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  Check that ROC calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const date329n1004 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date329n1007 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 7, hour: 12, minute: 34, calendar });
+const date329n1011 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 11, hour: 12, minute: 34, calendar });
+const date329n1012 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 12, hour: 12, minute: 34, calendar });
+const date329n1015 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertDuration(
+  date329n1004.since(date329n1007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-07");
+TemporalHelpers.assertDuration(
+  date329n1015.since(date329n1012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "-329-10-15 and -329-10-12");
+TemporalHelpers.assertDuration(
+  date329n1004.since(date329n1011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-11")
+TemporalHelpers.assertDuration(
+  date329n1011.since(date329n1004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-11 and -329-10-04")

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/proleptic-buddhist.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date21251004 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date21251015 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertPlainDateTime(
+  date21251004.subtract(days3),
+  2125, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251015.subtract(days3n),
+  2125, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 2125-10-15",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251004.subtract(weeks1),
+  2125, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251015.subtract(weeks1n),
+  2125, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 2125-10-15",
+  "be", 2125);
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const months2 = new Temporal.Duration(0, -2);
+const months2n = new Temporal.Duration(0, 2);
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.PlainDateTime.from({ year: 2483, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar });
+const date24831201 = Temporal.PlainDateTime.from({ year: 2483, monthCode: "M12", day: 1, hour: 12, minute: 34, calendar });
+const date24840301 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar });
+const date24840416 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M04", day: 16, hour: 12, minute: 34, calendar });
+
+TemporalHelpers.assertPlainDateTime(
+  date24831201.subtract(months2),
+  2484, 2, "M02", 1, 12, 34, 0, 0, 0, 0, "add 2 months to 2484-02-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24840416.subtract(months2n),
+  2484, 2, "M02", 16, 12, 34, 0, 0, 0, 0, "subtract 2 months from 2484-04-16",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24830301.subtract(years1),
+  2484, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 years to 2483-03-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24840301.subtract(years1n),
+  2483, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "subtract 1 year from to 2484-03-01",
+  "be", 2483);

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/proleptic-gregory.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/proleptic-gregory.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date15821004 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date15821015 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertPlainDateTime(
+  date15821004.subtract(days3),
+  1582, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.subtract(days3n),
+  1582, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821004.subtract(weeks1),
+  1582, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.subtract(weeks1n),
+  1582, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/proleptic-japanese.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/proleptic-japanese.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date15821004 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date15821015 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertPlainDateTime(
+  date15821004.subtract(days3),
+  1582, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.subtract(days3n),
+  1582, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821004.subtract(weeks1),
+  1582, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.subtract(weeks1n),
+  1582, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/proleptic-roc.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/proleptic-roc.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: >
+  Check that roc calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date329n1004 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date329n1015 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertPlainDateTime(
+  date329n1004.subtract(days3),
+  -329, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1015.subtract(days3n),
+  -329, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from -329-10-15",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1004.subtract(weeks1),
+  -329, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1015.subtract(weeks1n),
+  -329, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from -329-10-15",
+  "broc", 330);

--- a/test/intl402/Temporal/PlainDateTime/prototype/until/proleptic-buddhist.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/until/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const date21251004 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date21251007 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 7, hour: 12, minute: 34, calendar });
+const date21251011 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 11, hour: 12, minute: 34, calendar });
+const date21251012 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 12, hour: 12, minute: 34, calendar });
+const date21251015 = Temporal.PlainDateTime.from({ year: 2125, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertDuration(
+  date21251004.until(date21251007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-07");
+TemporalHelpers.assertDuration(
+  date21251015.until(date21251012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "2125-10-15 and 2125-10-12");
+TemporalHelpers.assertDuration(
+  date21251004.until(date21251011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-11")
+TemporalHelpers.assertDuration(
+  date21251011.until(date21251004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-11 and 2125-10-04")
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.PlainDateTime.from({ year: 2483, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar });
+const date24831201 = Temporal.PlainDateTime.from({ year: 2483, monthCode: "M12", day: 1, hour: 12, minute: 34, calendar });
+const date24840201 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar });
+const date24840216 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M02", day: 16, hour: 12, minute: 34, calendar });
+const date24840301 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, calendar });
+const date24840416 = Temporal.PlainDateTime.from({ year: 2484, monthCode: "M04", day: 16, hour: 12, minute: 34, calendar });
+
+// 2483 is a leap year => 3 months
+TemporalHelpers.assertDuration(
+  date24831201.until(date24840201, { largestUnit: "months" }),
+  0, 3, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-12-01 and 2484-02-01"
+);
+TemporalHelpers.assertDuration(
+  date24840416.until(date24840216, { largestUnit: "months" }),
+  0, -2, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-04-16 and 2484-02-16"
+);
+TemporalHelpers.assertDuration(
+  date24830301.until(date24840301, { largestUnit: "years" }),
+  1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-03-01 and 2484-03-01"
+);
+TemporalHelpers.assertDuration(
+  date24830301.until(date24840301, { largestUnit: "years" }),
+  1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-03-01 and 2483-03-01"
+);

--- a/test/intl402/Temporal/PlainDateTime/prototype/until/proleptic-gregory.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/until/proleptic-gregory.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const date15821004 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date15821007 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 7, hour: 12, minute: 34, calendar });
+const date15821011 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 11, hour: 12, minute: 34, calendar });
+const date15821012 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 12, hour: 12, minute: 34, calendar });
+const date15821015 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.until(date15821012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.until(date15821004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/PlainDateTime/prototype/until/proleptic-japanese.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/until/proleptic-japanese.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const date15821004 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date15821007 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 7, hour: 12, minute: 34, calendar });
+const date15821011 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 11, hour: 12, minute: 34, calendar });
+const date15821012 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 12, hour: 12, minute: 34, calendar });
+const date15821015 = Temporal.PlainDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.until(date15821012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.until(date15821004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/PlainDateTime/prototype/until/proleptic-roc.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/until/proleptic-roc.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  Check that ROC calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const date329n1004 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 4, hour: 12, minute: 34, calendar });
+const date329n1007 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 7, hour: 12, minute: 34, calendar });
+const date329n1011 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 11, hour: 12, minute: 34, calendar });
+const date329n1012 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 12, hour: 12, minute: 34, calendar });
+const date329n1015 = Temporal.PlainDateTime.from({ year: -329, monthCode: "M10", day: 15, hour: 12, minute: 34, calendar });
+TemporalHelpers.assertDuration(
+  date329n1004.until(date329n1007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-07");
+TemporalHelpers.assertDuration(
+  date329n1015.until(date329n1012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "-329-10-15 and -329-10-12");
+TemporalHelpers.assertDuration(
+  date329n1004.until(date329n1011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-11")
+TemporalHelpers.assertDuration(
+  date329n1011.until(date329n1004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-11 and -329-10-04")

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/proleptic-buddhist.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date21251004 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date21251015 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertPlainDateTime(
+  date21251004.add(days3).toPlainDateTime(),
+  2125, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251015.add(days3n).toPlainDateTime(),
+  2125, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 2125-10-15",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251004.add(weeks1).toPlainDateTime(),
+  2125, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251015.add(weeks1n).toPlainDateTime(),
+  2125, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 2125-10-15",
+  "be", 2125);
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const months2 = new Temporal.Duration(0, 2);
+const months2n = new Temporal.Duration(0, -2);
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.ZonedDateTime.from({ year: 2483, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24831201 = Temporal.ZonedDateTime.from({ year: 2483, monthCode: "M12", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840301 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840416 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M04", day: 16, hour: 12, minute: 34, timeZone: "UTC", calendar });
+
+TemporalHelpers.assertPlainDateTime(
+  date24831201.add(months2).toPlainDateTime(),
+  2484, 2, "M02", 1, 12, 34, 0, 0, 0, 0, "add 2 months to 2484-02-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24840416.add(months2n).toPlainDateTime(),
+  2484, 2, "M02", 16, 12, 34, 0, 0, 0, 0, "subtract 2 months from 2484-04-16",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24830301.add(years1).toPlainDateTime(),
+  2484, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 years to 2483-03-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24840301.add(years1n).toPlainDateTime(),
+  2483, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "subtract 1 year from to 2484-03-01",
+  "be", 2483);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/proleptic-gregory.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/proleptic-gregory.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date15821004 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821015 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertPlainDateTime(
+  date15821004.add(days3).toPlainDateTime(),
+  1582, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.add(days3n).toPlainDateTime(),
+  1582, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821004.add(weeks1).toPlainDateTime(),
+  1582, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.add(weeks1n).toPlainDateTime(),
+  1582, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/proleptic-japanese.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/proleptic-japanese.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date15821004 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821015 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertPlainDateTime(
+  date15821004.add(days3).toPlainDateTime(),
+  1582, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.add(days3n).toPlainDateTime(),
+  1582, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821004.add(weeks1).toPlainDateTime(),
+  1582, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.add(weeks1n).toPlainDateTime(),
+  1582, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/proleptic-roc.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/proleptic-roc.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: >
+  Check that roc calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const days3 = new Temporal.Duration(0, 0, 0, 3);
+const days3n = new Temporal.Duration(0, 0, 0, -3);
+const weeks1 = new Temporal.Duration(0, 0, 1);
+const weeks1n = new Temporal.Duration(0, 0, -1);
+
+const date329n1004 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date329n1015 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertPlainDateTime(
+  date329n1004.add(days3).toPlainDateTime(),
+  -329, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1015.add(days3n).toPlainDateTime(),
+  -329, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from -329-10-15",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1004.add(weeks1).toPlainDateTime(),
+  -329, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1015.add(weeks1n).toPlainDateTime(),
+  -329, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from -329-10-15",
+  "broc", 330);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/proleptic-buddhist.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const date21251004 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date21251007 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 7, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date21251011 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 11, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date21251012 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 12, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date21251015 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertDuration(
+  date21251004.since(date21251007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-07");
+TemporalHelpers.assertDuration(
+  date21251015.since(date21251012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "2125-10-15 and 2125-10-12");
+TemporalHelpers.assertDuration(
+  date21251004.since(date21251011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-11")
+TemporalHelpers.assertDuration(
+  date21251011.since(date21251004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-11 and 2125-10-04")
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.ZonedDateTime.from({ year: 2483, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24831201 = Temporal.ZonedDateTime.from({ year: 2483, monthCode: "M12", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840201 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840216 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M02", day: 16, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840301 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840416 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M04", day: 16, hour: 12, minute: 34, timeZone: "UTC", calendar });
+
+// 2483 is a leap year => 3 months
+TemporalHelpers.assertDuration(
+  date24831201.since(date24840201, { largestUnit: "months" }),
+  0, -3, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-12-01 and 2484-02-01"
+);
+TemporalHelpers.assertDuration(
+  date24840416.since(date24840216, { largestUnit: "months" }),
+  0, 2, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-04-16 and 2484-02-16"
+);
+TemporalHelpers.assertDuration(
+  date24830301.since(date24840301, { largestUnit: "years" }),
+  -1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-03-01 and 2484-03-01"
+);
+TemporalHelpers.assertDuration(
+  date24830301.since(date24840301, { largestUnit: "years" }),
+  -1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-03-01 and 2483-03-01"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/proleptic-gregory.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/proleptic-gregory.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const date15821004 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821007 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 7, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821011 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 11, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821012 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 12, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821015 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.since(date15821012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.since(date15821004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/proleptic-japanese.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/proleptic-japanese.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const date15821004 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821007 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 7, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821011 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 11, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821012 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 12, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821015 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.since(date15821012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.since(date15821011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.since(date15821004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/proleptic-roc.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/proleptic-roc.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  Check that ROC calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const date329n1004 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date329n1007 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 7, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date329n1011 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 11, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date329n1012 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 12, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date329n1015 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertDuration(
+  date329n1004.since(date329n1007, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-07");
+TemporalHelpers.assertDuration(
+  date329n1015.since(date329n1012, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "-329-10-15 and -329-10-12");
+TemporalHelpers.assertDuration(
+  date329n1004.since(date329n1011, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-11")
+TemporalHelpers.assertDuration(
+  date329n1011.since(date329n1004, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-11 and -329-10-04")

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/proleptic-buddhist.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date21251004 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date21251015 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertPlainDateTime(
+  date21251004.subtract(days3).toPlainDateTime(),
+  2125, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251015.subtract(days3n).toPlainDateTime(),
+  2125, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 2125-10-15",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251004.subtract(weeks1).toPlainDateTime(),
+  2125, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 2125-10-04",
+  "be", 2125);
+TemporalHelpers.assertPlainDateTime(
+  date21251015.subtract(weeks1n).toPlainDateTime(),
+  2125, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 2125-10-15",
+  "be", 2125);
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const months2 = new Temporal.Duration(0, -2);
+const months2n = new Temporal.Duration(0, 2);
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.ZonedDateTime.from({ year: 2483, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24831201 = Temporal.ZonedDateTime.from({ year: 2483, monthCode: "M12", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840301 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840416 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M04", day: 16, hour: 12, minute: 34, timeZone: "UTC", calendar });
+
+TemporalHelpers.assertPlainDateTime(
+  date24831201.subtract(months2).toPlainDateTime(),
+  2484, 2, "M02", 1, 12, 34, 0, 0, 0, 0, "add 2 months to 2484-02-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24840416.subtract(months2n).toPlainDateTime(),
+  2484, 2, "M02", 16, 12, 34, 0, 0, 0, 0, "subtract 2 months from 2484-04-16",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24830301.subtract(years1).toPlainDateTime(),
+  2484, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "add 1 years to 2483-03-01",
+  "be", 2484);
+TemporalHelpers.assertPlainDateTime(
+  date24840301.subtract(years1n).toPlainDateTime(),
+  2483, 3, "M03", 1, 12, 34, 0, 0, 0, 0, "subtract 1 year from to 2484-03-01",
+  "be", 2483);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/proleptic-gregory.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/proleptic-gregory.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date15821004 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821015 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertPlainDateTime(
+  date15821004.subtract(days3).toPlainDateTime(),
+  1582, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.subtract(days3n).toPlainDateTime(),
+  1582, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821004.subtract(weeks1).toPlainDateTime(),
+  1582, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.subtract(weeks1n).toPlainDateTime(),
+  1582, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/proleptic-japanese.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/proleptic-japanese.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date15821004 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821015 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertPlainDateTime(
+  date15821004.subtract(days3).toPlainDateTime(),
+  1582, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.subtract(days3n).toPlainDateTime(),
+  1582, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from 1582-10-15",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821004.subtract(weeks1).toPlainDateTime(),
+  1582, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to 1582-10-04",
+  "ce", 1582);
+TemporalHelpers.assertPlainDateTime(
+  date15821015.subtract(weeks1n).toPlainDateTime(),
+  1582, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from 1582-10-15",
+  "ce", 1582);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/proleptic-roc.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/proleptic-roc.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: >
+  Check that roc calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const days3 = new Temporal.Duration(0, 0, 0, -3);
+const days3n = new Temporal.Duration(0, 0, 0, 3);
+const weeks1 = new Temporal.Duration(0, 0, -1);
+const weeks1n = new Temporal.Duration(0, 0, 1);
+
+const date329n1004 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date329n1015 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertPlainDateTime(
+  date329n1004.subtract(days3).toPlainDateTime(),
+  -329, 10, "M10", 7, 12, 34, 0, 0, 0, 0, "add 3 days to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1015.subtract(days3n).toPlainDateTime(),
+  -329, 10, "M10", 12, 12, 34, 0, 0, 0, 0, "subtract 3 days from -329-10-15",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1004.subtract(weeks1).toPlainDateTime(),
+  -329, 10, "M10", 11, 12, 34, 0, 0, 0, 0, "add 1 week to -329-10-04",
+  "broc", 330);
+TemporalHelpers.assertPlainDateTime(
+  date329n1015.subtract(weeks1n).toPlainDateTime(),
+  -329, 10, "M10", 8, 12, 34, 0, 0, 0, 0, "subtract 1 week from -329-10-15",
+  "broc", 330);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/proleptic-buddhist.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/proleptic-buddhist.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  Check that Buddhist calendar is implemented as proleptic
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const date21251004 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date21251007 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 7, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date21251011 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 11, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date21251012 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 12, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date21251015 = Temporal.ZonedDateTime.from({ year: 2125, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertDuration(
+  date21251004.until(date21251007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-07");
+TemporalHelpers.assertDuration(
+  date21251015.until(date21251012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "2125-10-15 and 2125-10-12");
+TemporalHelpers.assertDuration(
+  date21251004.until(date21251011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-04 and 2125-10-11")
+TemporalHelpers.assertDuration(
+  date21251011.until(date21251004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "2125-10-11 and 2125-10-04")
+
+// Test that skipped months in ISO year 1941 are disregarded because the calendar is proleptic
+
+// 2483 BE = Gregorian year 1940
+const date24830301 = Temporal.ZonedDateTime.from({ year: 2483, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24831201 = Temporal.ZonedDateTime.from({ year: 2483, monthCode: "M12", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840201 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840216 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M02", day: 16, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840301 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M03", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date24840416 = Temporal.ZonedDateTime.from({ year: 2484, monthCode: "M04", day: 16, hour: 12, minute: 34, timeZone: "UTC", calendar });
+
+// 2483 is a leap year => 3 months
+TemporalHelpers.assertDuration(
+  date24831201.until(date24840201, { largestUnit: "months" }),
+  0, 3, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-12-01 and 2484-02-01"
+);
+TemporalHelpers.assertDuration(
+  date24840416.until(date24840216, { largestUnit: "months" }),
+  0, -2, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-04-16 and 2484-02-16"
+);
+TemporalHelpers.assertDuration(
+  date24830301.until(date24840301, { largestUnit: "years" }),
+  1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2483-03-01 and 2484-03-01"
+);
+TemporalHelpers.assertDuration(
+  date24830301.until(date24840301, { largestUnit: "years" }),
+  1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "2484-03-01 and 2483-03-01"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/proleptic-gregory.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/proleptic-gregory.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  Check that Gregorian calendar is implemented as proleptic
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const date15821004 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821007 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 7, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821011 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 11, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821012 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 12, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821015 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.until(date15821012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.until(date15821004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/proleptic-japanese.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/proleptic-japanese.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  Check that Japanese calendar is implemented as proleptic
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const date15821004 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821007 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 7, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821011 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 11, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821012 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 12, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date15821015 = Temporal.ZonedDateTime.from({ year: 1582, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-07");
+TemporalHelpers.assertDuration(
+  date15821015.until(date15821012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "1582-10-15 and 1582-10-12");
+TemporalHelpers.assertDuration(
+  date15821004.until(date15821011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-04 and 1582-10-11")
+TemporalHelpers.assertDuration(
+  date15821011.until(date15821004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "1582-10-11 and 1582-10-04")

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/proleptic-roc.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/proleptic-roc.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  Check that ROC calendar is implemented as proleptic
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const date329n1004 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 4, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date329n1007 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 7, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date329n1011 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 11, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date329n1012 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 12, hour: 12, minute: 34, timeZone: "UTC", calendar });
+const date329n1015 = Temporal.ZonedDateTime.from({ year: -329, monthCode: "M10", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar });
+TemporalHelpers.assertDuration(
+  date329n1004.until(date329n1007, { largestUnit: "days" }),
+  0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-07");
+TemporalHelpers.assertDuration(
+  date329n1015.until(date329n1012, { largestUnit: "days" }),
+  0, 0, 0, -3, 0, 0, 0, 0, 0, 0,
+  "-329-10-15 and -329-10-12");
+TemporalHelpers.assertDuration(
+  date329n1004.until(date329n1011, { largestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-04 and -329-10-11")
+TemporalHelpers.assertDuration(
+  date329n1011.until(date329n1004, { largestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "-329-10-11 and -329-10-04")


### PR DESCRIPTION
These tests check that the calendar does not skip days from Gregorian dates 1582-10-04 to 1582-10-14; for the Buddhist calendar, the tests also check that the calendar does not skip months in Gregorian year 1941.