### PR TITLE
Update old Temporal tests for CLDR 48

### DIFF
--- a/test/staging/Intl402/Temporal/old/non-iso-calendars-coptic.js
+++ b/test/staging/Intl402/Temporal/old/non-iso-calendars-coptic.js
@@ -26,14 +26,14 @@ function compareFormatToPartsSnapshot(isoString, expectedComponents) {
 
 compareFormatToPartsSnapshot("2000-01-01T00:00Z", {
   year: 1716,
-  era: "ERA1",
+  era: "AM",
   month: 4,
   day: 22,
 });
 
 compareFormatToPartsSnapshot("0001-01-01T00:00Z", {
-  year: 284,
-  era: "ERA0",
+  year: -283,
+  era: "AM",
   month: 5,
   day: 8,
 });

--- a/test/staging/Intl402/Temporal/old/non-iso-calendars-ethioaa.js
+++ b/test/staging/Intl402/Temporal/old/non-iso-calendars-ethioaa.js
@@ -26,14 +26,14 @@ function compareFormatToPartsSnapshot(isoString, expectedComponents) {
 
 compareFormatToPartsSnapshot("2000-01-01T00:00Z", {
   year: 7492,
-  era: "ERA0",
+  era: "AA",
   month: 4,
   day: 22,
 });
 
 compareFormatToPartsSnapshot("0001-01-01T00:00Z", {
   year: 5493,
-  era: "ERA0",
+  era: "AA",
   month: 5,
   day: 8,
 });

--- a/test/staging/Intl402/Temporal/old/non-iso-calendars-ethiopic.js
+++ b/test/staging/Intl402/Temporal/old/non-iso-calendars-ethiopic.js
@@ -26,7 +26,7 @@ function compareFormatToPartsSnapshot(isoString, expectedComponents) {
 
 compareFormatToPartsSnapshot("2000-01-01T00:00Z", {
   year: 1992,
-  era: "ERA1",
+  era: "AM",
   month: 4,
   day: 22,
 });

--- a/test/staging/Intl402/Temporal/old/non-iso-calendars-indian.js
+++ b/test/staging/Intl402/Temporal/old/non-iso-calendars-indian.js
@@ -26,14 +26,14 @@ function compareFormatToPartsSnapshot(isoString, expectedComponents) {
 
 compareFormatToPartsSnapshot("2000-01-01T00:00Z", {
   year: 1921,
-  era: "Saka",
+  era: "Śaka",
   month: 10,
   day: 11,
 });
 
 compareFormatToPartsSnapshot("0001-01-01T00:00Z", {
   year: -78,
-  era: "Saka",
+  era: "Śaka",
   month: 10,
   day: 11,
 });


### PR DESCRIPTION
CLDR 48 changed some era names, update the tests accordingly.