### PR TITLE
Don't expect era part when formatting MonthDay

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-format-with-era.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-format-with-era.js
@@ -22,7 +22,7 @@ function checkEra(parts) {
 
 assert(checkEra(formatter.formatRangeToParts(new Temporal.PlainDate(2025, 11, 4 , "gregory"), new Temporal.PlainDate(2025, 11, 5, "gregory"))), "formatting a PlainDate should work");
 assert(checkEra(formatter.formatRangeToParts(new Temporal.PlainYearMonth(2025, 11, "gregory"), new Temporal.PlainYearMonth(2025, 12, "gregory"))), "formatting a PlainYearMonth should work");
-assert(checkEra(formatter.formatRangeToParts(new Temporal.PlainMonthDay(11, 4, "gregory"), new Temporal.PlainMonthDay(11, 14, "gregory"))), "formatting a PlainMonthDay should work");
+assert(!checkEra(formatter.formatRangeToParts(new Temporal.PlainMonthDay(11, 4, "gregory"), new Temporal.PlainMonthDay(11, 14, "gregory"))), "formatting a PlainMonthDay should work");
 assert(!checkEra(formatter.formatRangeToParts(new Temporal.PlainTime(14, 46), new Temporal.PlainTime(17, 46))), "formatting a PlainTime should work");
 assert(checkEra(formatter.formatRangeToParts(new Temporal.PlainDateTime(2025, 11, 4, 14, 16, 0, 0, 0, 0, "gregory"), new Temporal.PlainDateTime(2025, 11, 15, 14, 47, 0, 0, 0, 0, "gregory"))), "formatting a PlainDateTime should work");
 assert(checkEra(formatter.formatRangeToParts(new Temporal.Instant(0n), new Temporal.Instant(1000000000n))), "formatting an Instant should work");

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-format-with-era.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-format-with-era.js
@@ -22,7 +22,7 @@ function checkEra(parts) {
 
 assert(checkEra(formatter.formatToParts(new Temporal.PlainDate(2025, 11, 4))), "formatting a PlainDate should work");
 assert(checkEra(formatter.formatToParts(new Temporal.PlainYearMonth(2025, 11, "gregory"))), "formatting a PlainYearMonth should work");
-assert(checkEra(formatter.formatToParts(new Temporal.PlainMonthDay(11, 4, "gregory"))), "formatting a PlainMonthDay should work");
+assert(!checkEra(formatter.formatToParts(new Temporal.PlainMonthDay(11, 4, "gregory"))), "formatting a PlainMonthDay should work");
 assert(!checkEra(formatter.formatToParts(new Temporal.PlainTime(14, 46))), "formatting a PlainTime should work");
 assert(checkEra(formatter.formatToParts(new Temporal.PlainDateTime(2025, 11, 4, 14, 46))), "formatting a PlainDateTime should work");
 assert(checkEra(formatter.formatToParts(new Temporal.Instant(0n))), "formatting an Instant should work");


### PR DESCRIPTION
`era` options are ignored when formatting `Temporal.PlainMonthDay` objects. See GetDateTimeFormat, step 12.b.