### PR TITLE
Test that resolved MonthDay can have a different ordinal month

### DIFF
--- a/test/intl402/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering-chinese.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering-chinese.js
@@ -51,3 +51,10 @@ assert.throws(
   () => Temporal.PlainMonthDay.from({ calendar: "chinese", year: 2020, monthCode: "M01", day: 32 }, { overflow: "reject" }),
   "Out-of-range day throws RangeError when all required fields present"
 );
+
+// No RangeError if month is present and reference date has a different ordinal month.
+var pmd = Temporal.PlainMonthDay.from({ calendar: "chinese", year: 2004, monthCode: "M04", month: 5, day: 1 });
+var pd = Temporal.PlainDate.from(pmd.toString());
+assert.sameValue(pmd.monthCode, "M04", "Temporal.PlainMonthDay monthCode");
+assert.sameValue(pd.monthCode, "M04", "Temporal.PlainDate monthCode");
+assert.sameValue(pd.month, 4, "Temporal.PlainDate ordinal month");

--- a/test/intl402/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering-hebrew.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/calendarresolvefields-error-ordering-hebrew.js
@@ -50,3 +50,10 @@ assert.throws(
   () => Temporal.PlainMonthDay.from({ calendar: "hebrew", year: 5784, monthCode: "M01", day: 32 }, { overflow: "reject" }),
   "Out-of-range day throws RangeError when all required fields present"
 );
+
+// No RangeError if month is present and reference date has a different ordinal month.
+var pmd = Temporal.PlainMonthDay.from({ calendar: "hebrew", year: 5784, monthCode: "M06", month: 7, day: 1 });
+var pd = Temporal.PlainDate.from(pmd.toString());
+assert.sameValue(pmd.monthCode, "M06", "Temporal.PlainMonthDay monthCode");
+assert.sameValue(pd.monthCode, "M06", "Temporal.PlainDate monthCode");
+assert.sameValue(pd.month, 6, "Temporal.PlainDate ordinal month");


### PR DESCRIPTION
PR #4708 covered the second issue reported in
<https://bugzilla.mozilla.org/show_bug.cgi?id=1999918>. Extend the test cases to also cover the first issue reported there.