### PR TITLE
Move tests for Gregorian PlainMonthDay month codes out of staging

### DIFF
--- a/test/intl402/Temporal/PlainMonthDay/from/buddhist-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/buddhist-month-codes.js
@@ -13,10 +13,14 @@ includes: [temporalHelpers.js]
 
 const calendar = "buddhist";
 
-for (const { monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
+for (const { month, monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
   // Test creation with monthCode and day 1
   const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
   TemporalHelpers.assertPlainMonthDay(pmd, monthCode, 1, `monthCode ${monthCode} should be preserved`);
+
+  // Test creation with month and day 1
+  const pmdMonth = Temporal.PlainMonthDay.from({ calendar, year: 2515, month, day: 1 });
+  TemporalHelpers.assertPlainMonthDay(pmdMonth, monthCode, 1, `Equivalent monthCode ${monthCode} and month ${month} are resolved to the same PlainMonthDay`);
 
   // Test with maximum day value for this month (minimum for PlainMonthDay)
   const pmdMax = Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth });

--- a/test/intl402/Temporal/PlainMonthDay/from/fields-overspecified.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/fields-overspecified.js
@@ -2,31 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-features:
-  - Temporal
-description: |
-  pending
-esid: pending
+esid: sec-temporal.plainmonthday.from
+description: Throw a RangeError if fields conflict with each other
+features: [Temporal, Intl.Era-monthcode]
 ---*/
-
-// Equivalent monthCode and month are resolved to the same PlainMonthDay.
-{
-  let withMonthCode = Temporal.PlainMonthDay.from({
-    calendar: "gregory",
-    year: 2023,
-    monthCode: "M02",
-    day: 30,
-  });
-
-  let withMonth = Temporal.PlainMonthDay.from({
-    calendar: "gregory",
-    year: 2023,
-    month: 2,
-    day: 30,
-  });
-
-  assert.sameValue(withMonthCode.equals(withMonth), true);
-}
 
 // eraYear and year must be consistent when monthCode is present.
 {

--- a/test/intl402/Temporal/PlainMonthDay/from/gregory-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/gregory-month-codes.js
@@ -12,10 +12,14 @@ includes: [temporalHelpers.js]
 
 const calendar = "gregory";
 
-for (const { monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
+for (const { month, monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
   // Test creation with monthCode and day 1
   const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
   TemporalHelpers.assertPlainMonthDay(pmd, monthCode, 1, `monthCode ${monthCode} should be preserved`);
+
+  // Test creation with month and day 1
+  const pmdMonth = Temporal.PlainMonthDay.from({ calendar, year: 1972, month, day: 1 });
+  TemporalHelpers.assertPlainMonthDay(pmdMonth, monthCode, 1, `Equivalent monthCode ${monthCode} and month ${month} are resolved to the same PlainMonthDay`);
 
   // Test with maximum day value for this month (minimum for PlainMonthDay)
   const pmdMax = Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth });

--- a/test/intl402/Temporal/PlainMonthDay/from/japanese-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/japanese-month-codes.js
@@ -12,10 +12,14 @@ includes: [temporalHelpers.js]
 
 const calendar = "japanese";
 
-for (const { monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
+for (const { month, monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
   // Test creation with monthCode and day 1
   const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
   TemporalHelpers.assertPlainMonthDay(pmd, monthCode, 1, `monthCode ${monthCode} should be preserved`);
+
+  // Test creation with month and day 1
+  const pmdMonth = Temporal.PlainMonthDay.from({ calendar, year: 1972, month, day: 1 });
+  TemporalHelpers.assertPlainMonthDay(pmdMonth, monthCode, 1, `Equivalent monthCode ${monthCode} and month ${month} are resolved to the same PlainMonthDay`);
 
   // Test with maximum day value for this month (minimum for PlainMonthDay)
   const pmdMax = Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth });

--- a/test/intl402/Temporal/PlainMonthDay/from/roc-month-codes.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/roc-month-codes.js
@@ -12,10 +12,14 @@ includes: [temporalHelpers.js]
 
 const calendar = "roc";
 
-for (const { monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
+for (const { month, monthCode, daysInMonth } of TemporalHelpers.ISOMonths) {
   // Test creation with monthCode and day 1
   const pmd = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
   TemporalHelpers.assertPlainMonthDay(pmd, monthCode, 1, `monthCode ${monthCode} should be preserved`);
+
+  // Test creation with month and day 1
+  const pmdMonth = Temporal.PlainMonthDay.from({ calendar, year: 61, month, day: 1 });
+  TemporalHelpers.assertPlainMonthDay(pmdMonth, monthCode, 1, `Equivalent monthCode ${monthCode} and month ${month} are resolved to the same PlainMonthDay`);
 
   // Test with maximum day value for this month (minimum for PlainMonthDay)
   const pmdMax = Temporal.PlainMonthDay.from({ calendar, monthCode, day: daysInMonth });


### PR DESCRIPTION
Add tests for creating from ordinal month number to the ISO8601-like `*-month-codes.js` files. Move the remaining tests from the staging file to a new `fields-overspecified.js` to parallel the existing `fields-underspecified.js` test.