### PR TITLE
[Temporal] Fix strict mode errors in recently-added tests

### DIFF
--- a/test/intl402/Temporal/PlainDate/prototype/add/basic-coptic.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/basic-coptic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date171601.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  1716, 01, "M01", 1, "Subtracting 40 weeks, with result in same year", "am", 1716
+  1716, 1, "M01", 1, "Subtracting 40 weeks, with result in same year", "am", 1716
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date171601.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  1716, 01, "M01", 1, "Subtracting 280 days, with result in same year", "am", 1716
+  1716, 1, "M01", 1, "Subtracting 280 days, with result in same year", "am", 1716
 );

--- a/test/intl402/Temporal/PlainDate/prototype/add/basic-ethioaa.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/basic-ethioaa.js
@@ -177,7 +177,7 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date749201.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  7492, 01, "M01", 1, "Subtracting 40 weeks, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, "Subtracting 40 weeks, with result in same year", "aa", 7492
 );
 
 // Days
@@ -226,5 +226,5 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date749201.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  7492, 01, "M01", 1, "Subtracting 280 days, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, "Subtracting 280 days, with result in same year", "aa", 7492
 );

--- a/test/intl402/Temporal/PlainDate/prototype/add/basic-ethiopic.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/basic-ethiopic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date200001.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  2000, 01, "M01", 1, "Subtracting 40 weeks, with result in same year", "am", 2000
+  2000, 1, "M01", 1, "Subtracting 40 weeks, with result in same year", "am", 2000
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date200001.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  2000, 01, "M01", 1, "Subtracting 280 days, with result in same year", "am", 2000
+  2000, 1, "M01", 1, "Subtracting 280 days, with result in same year", "am", 2000
 );

--- a/test/intl402/Temporal/PlainDate/prototype/add/basic-gregory.js
+++ b/test/intl402/Temporal/PlainDate/prototype/add/basic-gregory.js
@@ -257,7 +257,7 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date20000101.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  2000, 01, "M01", 1, "Subtracting 40 weeks, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, "Subtracting 40 weeks, with result in same year", "ce", 2000
 );
 
 // Days
@@ -348,5 +348,5 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date20000101.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  2000, 01, "M01", 1, "Subtracting 280 days, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, "Subtracting 280 days, with result in same year", "ce", 2000
 );

--- a/test/intl402/Temporal/PlainDate/prototype/daysInMonth/basic-islamic-civil.js
+++ b/test/intl402/Temporal/PlainDate/prototype/daysInMonth/basic-islamic-civil.js
@@ -48,7 +48,7 @@ const daysInMonth = {};
 daysInMonth[leapYear] = leapYearDaysInMonth;
 daysInMonth[commonYear] = commonYearDaysInMonth;
 
-for (year of [leapYear, commonYear]) {
+for (var year of [leapYear, commonYear]) {
   for (var month = 1; month < 13; month++) {
     const date = Temporal.PlainDate.from({
       year,

--- a/test/intl402/Temporal/PlainDate/prototype/daysInMonth/basic-islamic-tbla.js
+++ b/test/intl402/Temporal/PlainDate/prototype/daysInMonth/basic-islamic-tbla.js
@@ -48,7 +48,7 @@ const daysInMonth = {};
 daysInMonth[leapYear] = leapYearDaysInMonth;
 daysInMonth[commonYear] = commonYearDaysInMonth;
 
-for (year of [leapYear, commonYear]) {
+for (var year of [leapYear, commonYear]) {
   for (var month = 1; month < 13; month++) {
     const date = Temporal.PlainDate.from({
       year,

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/basic-coptic.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/basic-coptic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date171601.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  1716, 01, "M01", 1, "Subtracting 40 weeks, with result in same year", "am", 1716
+  1716, 1, "M01", 1, "Subtracting 40 weeks, with result in same year", "am", 1716
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date171601.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  1716, 01, "M01", 1, "Subtracting 280 days, with result in same year", "am", 1716
+  1716, 1, "M01", 1, "Subtracting 280 days, with result in same year", "am", 1716
 );

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/basic-ethioaa.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/basic-ethioaa.js
@@ -177,7 +177,7 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date749201.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  7492, 01, "M01", 1, "Subtracting 40 weeks, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, "Subtracting 40 weeks, with result in same year", "aa", 7492
 );
 
 // Days
@@ -226,5 +226,5 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date749201.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  7492, 01, "M01", 1, "Subtracting 280 days, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, "Subtracting 280 days, with result in same year", "aa", 7492
 );

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/basic-ethiopic.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/basic-ethiopic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date200001.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  2000, 01, "M01", 1, "Subtracting 40 weeks, with result in same year", "am", 2000
+  2000, 1, "M01", 1, "Subtracting 40 weeks, with result in same year", "am", 2000
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date200001.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  2000, 01, "M01", 1, "Subtracting 280 days, with result in same year", "am", 2000
+  2000, 1, "M01", 1, "Subtracting 280 days, with result in same year", "am", 2000
 );

--- a/test/intl402/Temporal/PlainDate/prototype/subtract/basic-gregory.js
+++ b/test/intl402/Temporal/PlainDate/prototype/subtract/basic-gregory.js
@@ -257,7 +257,7 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date20000101.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  2000, 01, "M01", 1, "Subtracting 40 weeks, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, "Subtracting 40 weeks, with result in same year", "ce", 2000
 );
 
 // Days
@@ -348,5 +348,5 @@ TemporalHelpers.assertPlainDate(
 calculatedStart = date20000101.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDate(
   calculatedStart,
-  2000, 01, "M01", 1, "Subtracting 280 days, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, "Subtracting 280 days, with result in same year", "ce", 2000
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/basic-coptic.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/basic-coptic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date171601.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  1716, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 1716
+  1716, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 1716
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date171601.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  1716, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 1716
+  1716, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 1716
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/basic-ethioaa.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/basic-ethioaa.js
@@ -177,7 +177,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date749201.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  7492, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "aa", 7492
 );
 
 // Days
@@ -226,5 +226,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date749201.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  7492, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "aa", 7492
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/basic-ethiopic.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/basic-ethiopic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date200001.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 2000
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date200001.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 2000
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/add/basic-gregory.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/add/basic-gregory.js
@@ -257,7 +257,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date20000101.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "ce", 2000
 );
 
 // Days
@@ -348,5 +348,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date20000101.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "ce", 2000
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/daysInMonth/basic-islamic-civil.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/daysInMonth/basic-islamic-civil.js
@@ -48,7 +48,7 @@ const daysInMonth = {};
 daysInMonth[leapYear] = leapYearDaysInMonth;
 daysInMonth[commonYear] = commonYearDaysInMonth;
 
-for (year of [leapYear, commonYear]) {
+for (var year of [leapYear, commonYear]) {
   for (var month = 1; month < 13; month++) {
     const date = Temporal.PlainDateTime.from({
       year,

--- a/test/intl402/Temporal/PlainDateTime/prototype/daysInMonth/basic-islamic-tbla.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/daysInMonth/basic-islamic-tbla.js
@@ -48,7 +48,7 @@ const daysInMonth = {};
 daysInMonth[leapYear] = leapYearDaysInMonth;
 daysInMonth[commonYear] = commonYearDaysInMonth;
 
-for (year of [leapYear, commonYear]) {
+for (var year of [leapYear, commonYear]) {
   for (var month = 1; month < 13; month++) {
     const date = Temporal.PlainDateTime.from({
       year,

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/basic-coptic.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/basic-coptic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date171601.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  1716, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 1716
+  1716, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 1716
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date171601.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  1716, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 1716
+  1716, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 1716
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/basic-ethioaa.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/basic-ethioaa.js
@@ -177,7 +177,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date749201.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  7492, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "aa", 7492
 );
 
 // Days
@@ -226,5 +226,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date749201.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  7492, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "aa", 7492
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/basic-ethiopic.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/basic-ethiopic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date200001.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 2000
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date200001.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 2000
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/subtract/basic-gregory.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/subtract/basic-gregory.js
@@ -257,7 +257,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date20000101.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "ce", 2000
 );
 
 // Days
@@ -348,5 +348,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date20000101.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart,
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "ce", 2000
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/basic-coptic.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/basic-coptic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date171601.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  1716, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 1716
+  1716, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 1716
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date171601.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  1716, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 1716
+  1716, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 1716
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/basic-ethioaa.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/basic-ethioaa.js
@@ -177,7 +177,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date749201.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  7492, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "aa", 7492
 );
 
 // Days
@@ -226,5 +226,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date749201.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  7492, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "aa", 7492
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/basic-ethiopic.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/basic-ethiopic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date200001.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 2000
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date200001.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 2000
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/basic-gregory.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/basic-gregory.js
@@ -257,7 +257,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date20000101.add(weeks40).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "ce", 2000
 );
 
 // Days
@@ -348,5 +348,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date20000101.add(days280).add(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "ce", 2000
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/daysInMonth/basic-islamic-civil.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/daysInMonth/basic-islamic-civil.js
@@ -48,7 +48,7 @@ const daysInMonth = {};
 daysInMonth[leapYear] = leapYearDaysInMonth;
 daysInMonth[commonYear] = commonYearDaysInMonth;
 
-for (year of [leapYear, commonYear]) {
+for (var year of [leapYear, commonYear]) {
   for (var month = 1; month < 13; month++) {
     const date = Temporal.ZonedDateTime.from({
       year,

--- a/test/intl402/Temporal/ZonedDateTime/prototype/daysInMonth/basic-islamic-tbla.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/daysInMonth/basic-islamic-tbla.js
@@ -48,7 +48,7 @@ const daysInMonth = {};
 daysInMonth[leapYear] = leapYearDaysInMonth;
 daysInMonth[commonYear] = commonYearDaysInMonth;
 
-for (year of [leapYear, commonYear]) {
+for (var year of [leapYear, commonYear]) {
   for (var month = 1; month < 13; month++) {
     const date = Temporal.ZonedDateTime.from({
       year,

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/basic-coptic.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/basic-coptic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date171601.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  1716, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 1716
+  1716, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 1716
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date171601.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  1716, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 1716
+  1716, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 1716
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/basic-ethioaa.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/basic-ethioaa.js
@@ -177,7 +177,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date749201.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  7492, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "aa", 7492
 );
 
 // Days
@@ -226,5 +226,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date749201.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  7492, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "aa", 7492
+  7492, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "aa", 7492
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/basic-ethiopic.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/basic-ethiopic.js
@@ -176,7 +176,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date200001.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "am", 2000
 );
 
 // Days
@@ -225,5 +225,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date200001.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "am", 2000
 );

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/basic-gregory.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/basic-gregory.js
@@ -257,7 +257,7 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date20000101.subtract(weeks40).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 40 weeks, with result in same year", "ce", 2000
 );
 
 // Days
@@ -348,5 +348,5 @@ TemporalHelpers.assertPlainDateTime(
 calculatedStart = date20000101.subtract(days280).subtract(weeks40n);
 TemporalHelpers.assertPlainDateTime(
   calculatedStart.toPlainDateTime(),
-  2000, 01, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "ce", 2000
+  2000, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "Subtracting 280 days, with result in same year", "ce", 2000
 );


### PR DESCRIPTION
Remove accidental octal literals and add variable declarations.