### PR TITLE
Intl Era Monthcode: Fix Hebrew daysInYear tests

### DIFF
--- a/test/intl402/Temporal/PlainDate/prototype/daysInYear/basic-hebrew.js
+++ b/test/intl402/Temporal/PlainDate/prototype/daysInYear/basic-hebrew.js
@@ -4,6 +4,9 @@
 /*---
 esid: sec-temporal.plaindate.prototype.daysinyear
 description: Days in year in the Hebrew calendar
+info: |
+  There are discrepancies in these data between ICU4C 77.1 and ICU4C 78.1,
+  which will affect implementations relying on ICU4C.
 features: [Temporal, Intl.Era-monthcode]
 ---*/
 
@@ -87,8 +90,8 @@ const sampleData = {
   5803: 385,
   5804: 353,
   5805: 355,
-  5806: 385,
-  5807: 354,
+  5806: 384,
+  5807: 355,
   5808: 353,
   5809: 384,
 }
@@ -99,5 +102,5 @@ for (var [year, days] of Object.entries(sampleData)) {
         month: 1,
         calendar, day: 1
     });
-    assert.sameValue(date.daysInYear, days);
+    assert.sameValue(date.daysInYear, days, `days in year ${year}`);
 }

--- a/test/intl402/Temporal/PlainDateTime/prototype/daysInYear/basic-hebrew.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/daysInYear/basic-hebrew.js
@@ -4,6 +4,9 @@
 /*---
 esid: sec-temporal.plaindatetime.prototype.daysinyear
 description: Days in year in the Hebrew calendar
+info: |
+  There are discrepancies in these data between ICU4C 77.1 and ICU4C 78.1,
+  which will affect implementations relying on ICU4C.
 features: [Temporal, Intl.Era-monthcode]
 ---*/
 
@@ -87,8 +90,8 @@ const sampleData = {
   5803: 385,
   5804: 353,
   5805: 355,
-  5806: 385,
-  5807: 354,
+  5806: 384,
+  5807: 355,
   5808: 353,
   5809: 384,
 }
@@ -99,5 +102,5 @@ for (var [year, days] of Object.entries(sampleData)) {
         month: 1,
         calendar, day: 1, hour: 12, minute: 34
     });
-    assert.sameValue(date.daysInYear, days);
+    assert.sameValue(date.daysInYear, days, `days in year ${year}`);
 }

--- a/test/intl402/Temporal/PlainYearMonth/prototype/daysInYear/basic-hebrew.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/daysInYear/basic-hebrew.js
@@ -4,6 +4,9 @@
 /*---
 esid: sec-temporal.plainyearmonth.prototype.daysinyear
 description: Days in year in the Hebrew calendar
+info: |
+  There are discrepancies in these data between ICU4C 77.1 and ICU4C 78.1,
+  which will affect implementations relying on ICU4C.
 features: [Temporal, Intl.Era-monthcode]
 ---*/
 
@@ -87,8 +90,8 @@ const sampleData = {
   5803: 385,
   5804: 353,
   5805: 355,
-  5806: 385,
-  5807: 354,
+  5806: 384,
+  5807: 355,
   5808: 353,
   5809: 384,
 }
@@ -99,5 +102,5 @@ for (var [year, days] of Object.entries(sampleData)) {
         month: 1,
         calendar
     });
-    assert.sameValue(date.daysInYear, days);
+    assert.sameValue(date.daysInYear, days, `days in year ${year}`);
 }

--- a/test/intl402/Temporal/ZonedDateTime/prototype/daysInYear/basic-hebrew.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/daysInYear/basic-hebrew.js
@@ -4,6 +4,9 @@
 /*---
 esid: sec-temporal.zoneddatetime.prototype.daysinyear
 description: Days in year in the Hebrew calendar
+info: |
+  There are discrepancies in these data between ICU4C 77.1 and ICU4C 78.1,
+  which will affect implementations relying on ICU4C.
 features: [Temporal, Intl.Era-monthcode]
 ---*/
 
@@ -87,8 +90,8 @@ const sampleData = {
   5803: 385,
   5804: 353,
   5805: 355,
-  5806: 385,
-  5807: 354,
+  5806: 384,
+  5807: 355,
   5808: 353,
   5809: 384,
 }
@@ -99,5 +102,5 @@ for (var [year, days] of Object.entries(sampleData)) {
         month: 1,
         calendar, day: 1, hour: 12, minute: 34, timeZone: "UTC"
     });
-    assert.sameValue(date.daysInYear, days);
+    assert.sameValue(date.daysInYear, days, `days in year ${year}`);
 }


### PR DESCRIPTION
I am pretty sure these are just typos. Confirmed informally with two online Hebrew calendar converter apps
(https://www.torahcalc.com/tools/date-converter and https://webspace.science.uu.nl/~gent0113/hebrew/hebrewyear.htm) and the algorithms in SpiderMonkey and V8 also agree.

Also add a debug message to make it possible to see which year failed.