### PR TITLE
Intl Era Monthcode: Fix Persian leap year discrepancy

### DIFF
--- a/test/intl402/Temporal/PlainDate/from/roundtrip-from-string.js
+++ b/test/intl402/Temporal/PlainDate/from/roundtrip-from-string.js
@@ -72,7 +72,7 @@ const additionalCases = [
   ["2004-03-21[u-ca=indian]", 1926, 1, "M01", 1, "shaka", 1926, "first day of leap year"],
   ["2005-03-22[u-ca=indian]", 1927, 1, "M01", 1, "shaka", 1927, "first day of common year"],
   ["2006-07-25[u-ca=islamic-umalqura]", 1427, 6, "M06", 29, "ah", 1427, "ICU4C/ICU4X discrepancy"],
-  ["2025-04-19[u-ca=persian]", 1404, 1, "M01", 31, "ap", 1404, "ICU4C/ICU4X discrepancy"],
+  ["2025-04-19[u-ca=persian]", 1404, 1, "M01", 30, "ap", 1404, "ICU4C/ICU4X discrepancy"],
   ["2046-10-30[u-ca=hebrew]", 5807, 1, "M01", 30, "am", 5807, "ICU4C/ICU4X discrepancy"],
 ];
 

--- a/test/intl402/Temporal/PlainDateTime/from/roundtrip-from-string.js
+++ b/test/intl402/Temporal/PlainDateTime/from/roundtrip-from-string.js
@@ -72,7 +72,7 @@ const additionalCases = [
   ["2004-03-21T12:34[u-ca=indian]", 1926, 1, "M01", 1, "shaka", 1926, "first day of leap year"],
   ["2005-03-22T12:34[u-ca=indian]", 1927, 1, "M01", 1, "shaka", 1927, "first day of common year"],
   ["2006-07-25T12:34[u-ca=islamic-umalqura]", 1427, 6, "M06", 29, "ah", 1427, "ICU4C/ICU4X discrepancy"],
-  ["2025-04-19T12:34[u-ca=persian]", 1404, 1, "M01", 31, "ap", 1404, "ICU4C/ICU4X discrepancy"],
+  ["2025-04-19T12:34[u-ca=persian]", 1404, 1, "M01", 30, "ap", 1404, "ICU4C/ICU4X discrepancy"],
   ["2046-10-30T12:34[u-ca=hebrew]", 5807, 1, "M01", 30, "am", 5807, "ICU4C/ICU4X discrepancy"],
 ];
 

--- a/test/intl402/Temporal/ZonedDateTime/from/roundtrip-from-string.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/roundtrip-from-string.js
@@ -72,7 +72,7 @@ const additionalCases = [
   ["2004-03-21T12:34Z[UTC][u-ca=indian]", 1926, 1, "M01", 1, "shaka", 1926, "first day of leap year"],
   ["2005-03-22T12:34Z[UTC][u-ca=indian]", 1927, 1, "M01", 1, "shaka", 1927, "first day of common year"],
   ["2006-07-25T12:34Z[UTC][u-ca=islamic-umalqura]", 1427, 6, "M06", 29, "ah", 1427, "ICU4C/ICU4X discrepancy"],
-  ["2025-04-19T12:34Z[UTC][u-ca=persian]", 1404, 1, "M01", 31, "ap", 1404, "ICU4C/ICU4X discrepancy"],
+  ["2025-04-19T12:34Z[UTC][u-ca=persian]", 1404, 1, "M01", 30, "ap", 1404, "ICU4C/ICU4X discrepancy"],
   ["2046-10-30T12:34Z[UTC][u-ca=hebrew]", 5807, 1, "M01", 30, "am", 5807, "ICU4C/ICU4X discrepancy"],
 ];
 


### PR DESCRIPTION
I moved this test in from staging, but after doing more of a deep dive on it I believe it is incorrect. There are two popular algorithms for calculating leap years in the Persian calendar: a 33-year cycle and a 2820-year cycle. The 2820-year cycle happens to be incorrect in the spring equinox of ISO year 2025. (ref: https://www.tondering.dk/claus/cal/persian.php#leap)

The correct dates are provided by the Iranian calendar authority: https://calendar.ut.ac.ir/documents/2139738/7092644/Kabise+Shamsi+1206-1498.pdf
Unofficial English translation: https://github.com/roozbehp/persiancalendar/blob/main/kabise.txt
AP 1403 is a leap year, ending on 2025-03-20, so 2025-04-19 falls on 30 Farvardin of AP 1404, not 31 Farvardin.

At the time Anba wrote the staging test, ICU4X used the 2820-year cycle and has now switched to the 33-year cycle, which ICU4C already used. (See discussion in https://github.com/unicode-org/icu4x/issues/4713).