### PR TITLE
Intl Era Monthcode: PlainYearMonth tests, part 2

### DIFF
--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-buddhist.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-buddhist.js
@@ -1,0 +1,203 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (buddhist calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "buddhist";
+
+const date250302 = Temporal.PlainYearMonth.from({ year: 2503, monthCode: "M02", calendar });
+const date250303 = Temporal.PlainYearMonth.from({ year: 2503, monthCode: "M03", calendar });
+const date251207 = Temporal.PlainYearMonth.from({ year: 2512, monthCode: "M07", calendar });
+const date254007 = Temporal.PlainYearMonth.from({ year: 2540, monthCode: "M07", calendar });
+const date254012 = Temporal.PlainYearMonth.from({ year: 2540, monthCode: "M12", calendar });
+const date255512 = Temporal.PlainYearMonth.from({ year: 2555, monthCode: "M12", calendar });
+const date255606 = Temporal.PlainYearMonth.from({ year: 2556, monthCode: "M06", calendar });
+const date255906 = Temporal.PlainYearMonth.from({ year: 2559, monthCode: "M06", calendar });
+const date256207 = Temporal.PlainYearMonth.from({ year: 2562, monthCode: "M07", calendar });
+const date256212 = Temporal.PlainYearMonth.from({ year: 2562, monthCode: "M12", calendar });
+const date256303 = Temporal.PlainYearMonth.from({ year: 2563, monthCode: "M03", calendar });
+const date256312 = Temporal.PlainYearMonth.from({ year: 2563, monthCode: "M12", calendar });
+const date256401 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M01", calendar });
+const date256403 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M03", calendar });
+const date256407 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M07", calendar });
+const date256408 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M08", calendar });
+const date256409 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M09", calendar });
+const date256507 = Temporal.PlainYearMonth.from({ year: 2565, monthCode: "M07", calendar });
+const date256509 = Temporal.PlainYearMonth.from({ year: 2565, monthCode: "M09", calendar });
+const date257407 = Temporal.PlainYearMonth.from({ year: 2574, monthCode: "M07", calendar });
+const date257412 = Temporal.PlainYearMonth.from({ year: 2574, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date256407, date256407, "same month",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date256407, date256408, "1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date256312, date256401, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date256407, date256409, "2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date256407, date256507, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date256407, date257407, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date256407, date256509, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date256407, date257412, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date254012, date256407, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date254007, date256407, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date250302, date256303, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date256403, date256407, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date256303, date256407, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date250303, date256407, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date256212, date256407, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date255512, date255606, "6 months",
+    ["months", 0, -6],
+  ],
+  [
+    date256212, date256403, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date255512, date255906, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date251207, date256207, "crossing epoch",
+    ["years", -50, 0],
+  ],
+  [
+    date256408, date256407, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date256401, date256312, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date256409, date256407, "negative 2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date256507, date256407, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date257407, date256407, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date256509, date256407, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date257412, date256407, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date256407, date254012, "negative 23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date256407, date254007, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date256303, date250302, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date256407, date256403, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date256407, date256303, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date256407, date250303, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date256407, date256212, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date256407, date256312, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date256407, date254012, "negative 23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date256207, date251207, "crossing epoch",
+    ["years", 50, 0],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-chinese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-chinese.js
@@ -1,0 +1,214 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (chinese calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "chinese";
+
+const date196002 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M02", calendar });
+const date196003 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M03", calendar });
+const date196103 = Temporal.PlainYearMonth.from({ year: 1961, monthCode: "M03", calendar });
+const date199707 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M07", calendar });
+const date199712 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M12", calendar });
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar });
+const date202003 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M03", calendar });
+const date202012 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M12", calendar });
+const date202101 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar });
+const date202102 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M02", calendar });
+const date202103 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar });
+const date202104 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M04", calendar });
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+const date202108 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar });
+const date202109 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M09", calendar });
+const date202112 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M12", calendar });
+const date202207 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M07", calendar });
+const date202209 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M09", calendar });
+const date202307 = Temporal.PlainYearMonth.from({ year: 2023, monthCode: "M07", calendar });
+const date203107 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M07", calendar });
+const date203112 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date202107, date202107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date202107, date202108, "1 month in same year (30-day month to 29-day month)",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202012, date202101, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202101, date202102, "1 month in same year (29-day month to 30-day month)",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202102, date202103, "1 month in a month with 30 days",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202107, date202109, "2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date202107, date202207, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date202107, date203107, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -124],
+  ],
+  [
+    date202107, date202209, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date202107, date203112, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date199712, date202107, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date199707, date202107, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date196002, date202003, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date202103, date202107, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date202003, date202107, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date196003, date202107, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date201912, date202107, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date202012, date202107, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date199712, date202107, "23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date201912, date202103, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date202108, date202107, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202101, date202012, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202103, date202102, "negative 1 month in a month with 30 days",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202104, date202102, "negative 2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date202207, date202107, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date203107, date202107, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 124],
+  ],
+  [
+    date202209, date202107, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date203112, date202107, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date202107, date199712, "negative 23 years and 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date202107, date199707, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date202003, date196002, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date202107, date202103, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date202207, date202103, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date202207, date196103, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date202307, date202112, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date202107, date202012, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date202107, date199712, "negative 23 years, 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date202103, date201912, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      `${descr} (largestUnit = ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-coptic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-coptic.js
@@ -1,0 +1,219 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (coptic calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "coptic";
+
+// Years
+
+const date171002 = Temporal.PlainYearMonth.from({ year: 1710, monthCode: "M02", calendar });
+const date171003 = Temporal.PlainYearMonth.from({ year: 1710, monthCode: "M03", calendar });
+const date171103 = Temporal.PlainYearMonth.from({ year: 1711, monthCode: "M03", calendar });
+const date171312 = Temporal.PlainYearMonth.from({ year: 1713, monthCode: "M12", calendar });
+const date171612 = Temporal.PlainYearMonth.from({ year: 1716, monthCode: "M12", calendar });
+const date171705 = Temporal.PlainYearMonth.from({ year: 1717, monthCode: "M05", calendar });
+const date174707 = Temporal.PlainYearMonth.from({ year: 1747, monthCode: "M07", calendar });
+const date174712 = Temporal.PlainYearMonth.from({ year: 1747, monthCode: "M12", calendar });
+const date174713 = Temporal.PlainYearMonth.from({ year: 1747, monthCode: "M13", calendar });
+const date176912 = Temporal.PlainYearMonth.from({ year: 1769, monthCode: "M12", calendar });
+const date176913 = Temporal.PlainYearMonth.from({ year: 1769, monthCode: "M13", calendar });
+const date177003 = Temporal.PlainYearMonth.from({ year: 1770, monthCode: "M03", calendar });
+const date177012 = Temporal.PlainYearMonth.from({ year: 1770, monthCode: "M12", calendar });
+const date177013 = Temporal.PlainYearMonth.from({ year: 1770, monthCode: "M13", calendar });
+const date177101 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M01", calendar });
+const date177102 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M02", calendar });
+const date177103 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M03", calendar });
+const date177104 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M04", calendar });
+const date177106 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M06", calendar });
+const date177107 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M07", calendar });
+const date177108 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M08", calendar });
+const date177112 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M12", calendar });
+const date177207 = Temporal.PlainYearMonth.from({ year: 1772, monthCode: "M07", calendar });
+const date177209 = Temporal.PlainYearMonth.from({ year: 1772, monthCode: "M09", calendar });
+const date177307 = Temporal.PlainYearMonth.from({ year: 1773, monthCode: "M07", calendar });
+const date178107 = Temporal.PlainYearMonth.from({ year: 1781, monthCode: "M07", calendar });
+const date178112 = Temporal.PlainYearMonth.from({ year: 1781, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date177107, date177107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date177107, date177108, "1 month in same year (30-day month to 29-day month)",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date177013, date177101, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date177101, date177102, "1 month in same year (29-day month to 30-day month)",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date171612, date171705, "6 months in different year",
+    ["months", 0, -6],
+  ],
+  [
+    date177207, date177307, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    date177107, date178107, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -130],
+  ],
+  [
+    date177107, date177209, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date171312, date171705, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date177107, date178112, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date174712, date177106, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date174707, date177107, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date174707, date177106, "23 years, 12 months",
+    ["years", -23, -12],
+  ],
+  [
+    date171002, date177003, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date177103, date177107, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date177003, date177107, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date171003, date177107, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date176912, date177107, "1 year, 8 months",
+    ["years", -1, -8],
+  ],
+  [
+    date177013, date177106, "6 months",
+    ["years", 0, -6],
+  ],
+  [
+    date174713, date177106, "23 years, 6 months",
+    ["years", -23, -6],
+  ],
+  [
+    date176913, date177102, "1 year, 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date177108, date177107, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date177101, date177013, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date177104, date177102, "negative 2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date177307, date177207, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    date178107, date177107, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 130],
+  ],
+  [
+    date177209, date177107, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date178112, date177107, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date177107, date174712, "negative 23 years and 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date177107, date174707, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date177003, date171002, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date177107, date177103, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date177207, date177103, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date177207, date171103, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date177307, date177112, "negative 1 year, 8 months",
+    ["years", 1, 8],
+  ],
+  [
+    date177107, date177012, "negative 8 months",
+    ["years", 0, 8],
+  ],
+  [
+    date177107, date174712, "negative 23 years, 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date177103, date176912, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      `${descr} (largestUnit = ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-dangi.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-dangi.js
@@ -1,0 +1,197 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (dangi calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "dangi";
+
+// Years
+
+const date196002 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M02", calendar });
+const date196003 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M03", calendar });
+const date196103 = Temporal.PlainYearMonth.from({ year: 1961, monthCode: "M03", calendar });
+const date199707 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M07", calendar });
+const date199712 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M12", calendar });
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar });
+const date202003 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M03", calendar });
+const date202012 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M12", calendar });
+const date202101 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar });
+const date202102 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M02", calendar });
+const date202103 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar });
+const date202104 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M04", calendar });
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+const date202108 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar });
+const date202109 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M09", calendar });
+const date202112 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M12", calendar });
+const date202207 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M07", calendar });
+const date202209 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M09", calendar });
+const date202307 = Temporal.PlainYearMonth.from({ year: 2023, monthCode: "M07", calendar });
+const date203107 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M07", calendar });
+const date203112 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date202107, date202107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date202107, date202108, "1 month in same year (30-day month to 29-day month)",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202012, date202101, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202101, date202102, "1 month in same year (29-day month to 30-day month)",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202107, date202109, "2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date202107, date203107, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -124],
+  ],
+  [
+    date202107, date202209, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date202107, date203112, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date199712, date202107, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date199707, date202107, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date196002, date202003, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date202103, date202107, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date202003, date202107, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date196003, date202107, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date201912, date202107, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date202012, date202107, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date199712, date202107, "23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date202108, date202107, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202101, date202012, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202104, date202102, "negative 2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date202207, date202107, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date203107, date202107, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 124],
+  ],
+  [
+    date202209, date202107, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date203112, date202107, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date202107, date199712, "negative 23 years and 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date202107, date199707, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date202003, date196002, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date202107, date202103, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date202207, date202103, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date202207, date196103, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date202307, date202112, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date202107, date202012, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date202107, date199712, "negative 23 years, 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date202103, date201912, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      `${descr} (largestUnit = ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-ethioaa.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-ethioaa.js
@@ -1,0 +1,213 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (ethioaa calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "ethioaa";
+
+// Years
+
+const date745302 = Temporal.PlainYearMonth.from({ year: 7453, monthCode: "M02", calendar });
+const date745303 = Temporal.PlainYearMonth.from({ year: 7453, monthCode: "M03", calendar });
+const date745403 = Temporal.PlainYearMonth.from({ year: 7454, monthCode: "M03", calendar });
+const date748912 = Temporal.PlainYearMonth.from({ year: 7489, monthCode: "M12", calendar });
+const date749007 = Temporal.PlainYearMonth.from({ year: 7490, monthCode: "M07", calendar });
+const date749012 = Temporal.PlainYearMonth.from({ year: 7490, monthCode: "M12", calendar });
+const date749013 = Temporal.PlainYearMonth.from({ year: 7490, monthCode: "M13", calendar });
+const date749305 = Temporal.PlainYearMonth.from({ year: 7493, monthCode: "M05", calendar });
+const date751212 = Temporal.PlainYearMonth.from({ year: 7512, monthCode: "M12", calendar });
+const date751213 = Temporal.PlainYearMonth.from({ year: 7512, monthCode: "M13", calendar });
+const date751303 = Temporal.PlainYearMonth.from({ year: 7513, monthCode: "M03", calendar });
+const date751313 = Temporal.PlainYearMonth.from({ year: 7513, monthCode: "M13", calendar });
+const date751401 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M01", calendar });
+const date751402 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M02", calendar });
+const date751403 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M03", calendar });
+const date751404 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M04", calendar });
+const date751406 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M06", calendar });
+const date751407 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M07", calendar });
+const date751408 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M08", calendar });
+const date751412 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M12", calendar });
+const date751507 = Temporal.PlainYearMonth.from({ year: 7515, monthCode: "M07", calendar });
+const date751509 = Temporal.PlainYearMonth.from({ year: 7515, monthCode: "M09", calendar });
+const date751607 = Temporal.PlainYearMonth.from({ year: 7516, monthCode: "M07", calendar });
+const date752407 = Temporal.PlainYearMonth.from({ year: 7524, monthCode: "M07", calendar });
+const date752412 = Temporal.PlainYearMonth.from({ year: 7524, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date751407, date751407, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date751407, date751408, "1 month in same year (30-day month to 29-day month)",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date751313, date751401, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date751401, date751402, "1 month in same year (29-day month to 30-day month)",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date751407, date751507, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    date751407, date752407, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -130],
+  ],
+  [
+    date751407, date751509, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date751407, date752412, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date749012, date751406, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date749007, date751407, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date749007, date751406, "23 years, 12 months",
+    ["years", -23, -12],
+  ],
+  [
+    date745302, date751303, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date751403, date751407, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date751303, date751407, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date748912, date749305, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date745303, date751407, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date751212, date751407, "1 year, 8 months",
+    ["years", -1, -8],
+  ],
+  [
+    date751313, date751406, "6 months",
+    ["years", 0, -6],
+  ],
+  [
+    date749013, date751406, "23 years, 6 months",
+    ["years", -23, -6],
+  ],
+  [
+    date751213, date751402, "1 year, 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date751408, date751407, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date751401, date751313, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date751404, date751402, "negative 2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date751507, date751407, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    date752407, date751407, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 130],
+  ],
+  [
+    date751509, date751407, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date752412, date751407, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date751407, date749012, "negative 23 years and 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date751407, date749007, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date751303, date745302, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date751407, date751403, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date751507, date751403, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date751507, date745403, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date751607, date751412, "negative 1 year, 8 months",
+    ["years", 1, 8],
+  ],
+  [
+    date751507, date751412, "negative 8 months",
+    ["years", 0, 8],
+  ],
+  [
+    date751407, date749012, "negative 23 years, 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date751403, date751212, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      `${descr} (largestUnit = ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-ethiopic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-ethiopic.js
@@ -1,0 +1,209 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (ethiopic calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "ethiopic";
+
+// Years
+
+const date196002 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M02", calendar });
+const date196003 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M03", calendar });
+const date196103 = Temporal.PlainYearMonth.from({ year: 1961, monthCode: "M03", calendar });
+const date199707 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M07", calendar });
+const date199712 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M12", calendar });
+const date199713 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M13", calendar });
+const date200105 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M05", calendar });
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar });
+const date201913 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M13", calendar });
+const date202003 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M03", calendar });
+const date202012 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M12", calendar });
+const date202013 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M13", calendar });
+const date202101 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar });
+const date202102 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M02", calendar });
+const date202103 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar });
+const date202104 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M04", calendar });
+const date202106 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M06", calendar });
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+const date202108 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar });
+const date202112 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M12", calendar });
+const date202207 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M07", calendar });
+const date202209 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M09", calendar });
+const date202307 = Temporal.PlainYearMonth.from({ year: 2023, monthCode: "M07", calendar });
+const date203107 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M07", calendar });
+const date203112 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date202107, date202107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date202107, date202108, "1 month in same year (30-day month to 29-day month)",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202013, date202101, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202101, date202102, "1 month in same year (29-day month to 30-day month)",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202207, date202307, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    date202107, date203107, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -130],
+  ],
+  [
+    date202107, date202209, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date202107, date203112, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date199712, date202106, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date199707, date202107, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date199707, date202106, "23 years, 12 months",
+    ["years", -23, -12],
+  ],
+  [
+    date196002, date202003, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date202103, date202107, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date202003, date202107, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date199712, date200105, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date196003, date202107, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date201912, date202107, "1 year, 8 months",
+    ["years", -1, -8],
+  ],
+  [
+    date202013, date202106, "6 months",
+    ["years", 0, -6],
+  ],
+  [
+    date199713, date202106, "23 years, 6 months",
+    ["years", -23, -6],
+  ],
+  [
+    date201913, date202102, "1 year, 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date202108, date202107, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202101, date202013, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202104, date202102, "negative 2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date202307, date202207, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    date203107, date202107, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 130],
+  ],
+  [
+    date202209, date202107, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date203112, date202107, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date202107, date199712, "negative 23 years and 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date202107, date199707, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date202003, date196002, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date202107, date202103, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date202207, date202103, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date202207, date196103, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date202307, date202112, "negative 1 year, 8 months",
+    ["years", 1, 8],
+  ],
+  [
+    date202107, date202012, "negative 8 months",
+    ["years", 0, 8],
+  ],
+  [
+    date202107, date199712, "negative 23 years, 8 months",
+    ["years", 23, 8],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      `${descr} (largestUnit = ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-gregory.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-gregory.js
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (gregory calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "gregory";
+
+// Years
+
+const date196002 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M02", calendar });
+const date196003 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M03", calendar });
+const date196907 = Temporal.PlainYearMonth.from({ year: 1969, monthCode: "M07", calendar });
+const date199707 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M07", calendar });
+const date199712 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M12", calendar });
+const date200106 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M06", calendar });
+const date201907 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M07", calendar });
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar });
+const date202003 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M03", calendar });
+const date202012 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M12", calendar });
+const date202101 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar });
+const date202103 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar });
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+const date202108 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar });
+const date202109 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M09", calendar });
+const date202207 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M07", calendar });
+const date202209 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M09", calendar });
+const date203107 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M07", calendar });
+const date203112 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date202107, date202107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date202107, date202108, "1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202012, date202101, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202107, date202109, "2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date202107, date202207, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date202107, date203107, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date202107, date202209, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date202107, date203112, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date199712, date202107, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date199707, date202107, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date196002, date202003, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date202103, date202107, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date202003, date202107, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date199712, date200106, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date196003, date202107, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date201912, date202107, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date202012, date202107, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date199712, date202107, "23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date201912, date202103, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date196907, date201907, "crossing epoch",
+    ["years", -50, 0],
+  ],
+  [
+    date202108, date202107, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202101, date202012, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202109, date202107, "negative 2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date202207, date202107, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date203107, date202107, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date202209, date202107, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date203112, date202107, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date202107, date199712, "negative 23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date202107, date199707, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date202003, date196002, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date202107, date202103, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date202107, date202003, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date202107, date196003, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date202107, date201912, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date202107, date202012, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date202107, date199712, "negative 23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date202103, date201912, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date201907, date196907, "crossing epoch",
+    ["years", 50, 0],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-hebrew.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-hebrew.js
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (hebrew calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "hebrew";
+
+// Years
+
+const date572202 = Temporal.PlainYearMonth.from({ year: 5722, monthCode: "M02", calendar });
+const date572203 = Temporal.PlainYearMonth.from({ year: 5722, monthCode: "M03", calendar });
+const date572302 = Temporal.PlainYearMonth.from({ year: 5723, monthCode: "M02", calendar });
+const date572303 = Temporal.PlainYearMonth.from({ year: 5723, monthCode: "M03", calendar });
+const date575901 = Temporal.PlainYearMonth.from({ year: 5759, monthCode: "M01", calendar });
+const date575910 = Temporal.PlainYearMonth.from({ year: 5759, monthCode: "M10", calendar });
+const date575912 = Temporal.PlainYearMonth.from({ year: 5759, monthCode: "M12", calendar });
+const date576001 = Temporal.PlainYearMonth.from({ year: 5760, monthCode: "M01", calendar });
+const date576007 = Temporal.PlainYearMonth.from({ year: 5760, monthCode: "M07", calendar });
+const date576012 = Temporal.PlainYearMonth.from({ year: 5760, monthCode: "M12", calendar });
+const date576206 = Temporal.PlainYearMonth.from({ year: 5762, monthCode: "M06", calendar });
+const date578112 = Temporal.PlainYearMonth.from({ year: 5781, monthCode: "M12", calendar });
+const date578203 = Temporal.PlainYearMonth.from({ year: 5782, monthCode: "M03", calendar });
+const date578207 = Temporal.PlainYearMonth.from({ year: 5782, monthCode: "M07", calendar });
+const date578212 = Temporal.PlainYearMonth.from({ year: 5782, monthCode: "M12", calendar });
+const date578301 = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M01", calendar });
+const date578303 = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M03", calendar });
+const date578307 = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M07", calendar });
+const date578308 = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M08", calendar });
+const date578309 = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M09", calendar });
+const date578407 = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M07", calendar });
+const date578409 = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M09", calendar });
+const date579307 = Temporal.PlainYearMonth.from({ year: 5793, monthCode: "M07", calendar });
+const date579312 = Temporal.PlainYearMonth.from({ year: 5793, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date578307, date578307, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date578307, date578308, "1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date578212, date578301, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date578307, date578309, "2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date578207, date578307, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date578307, date579307, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -124],
+  ],
+  [
+    date578307, date578409, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date575912, date576206, "2 years 6 months",
+    ["years", -2, -6],
+  ],
+  [
+    date578307, date579312, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date576012, date578407, "23 years and 8 months",
+    ["years", -23, -8],
+  ],
+  [
+    date576007, date578407, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date572302, date578303, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date578303, date578307, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date578203, date578307, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date572303, date578407, "61 years, 5 months",
+    ["years", -61, -5],
+  ],
+  [
+    date578112, date578307, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date578212, date578307, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date575901, date575910, "40 weeks",
+  ],
+  [
+    date576001, date578307, "23 years, 6 months",
+    ["years", -23, -6],
+  ],
+  [
+    date578112, date578303, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date578308, date578307, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date578301, date578212, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date578309, date578307, "negative 2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date578307, date578207, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date579307, date578307, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 124],
+  ],
+  [
+    date578409, date578307, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date579312, date578307, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date578407, date576012, "negative 23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date578407, date576007, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date578203, date572202, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date578307, date578303, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date578307, date578203, "negative 1 year, 5 months",
+    ["years", 1, 5],
+  ],
+  [
+    date578307, date572203, "negative 61 years, 5 months",
+    ["years", 61, 5],
+  ],
+  [
+    date578307, date578112, "negative 1 year, 8 months",
+    ["years", 1, 8],
+  ],
+  [
+    date578307, date578212, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date578307, date575912, "negative 23 years, 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date578303, date578112, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-indian.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-indian.js
@@ -1,0 +1,205 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (indian calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "indian";
+
+// Years
+
+const date188102 = Temporal.PlainYearMonth.from({ year: 1881, monthCode: "M02", calendar });
+const date188202 = Temporal.PlainYearMonth.from({ year: 1882, monthCode: "M02", calendar });
+const date188203 = Temporal.PlainYearMonth.from({ year: 1882, monthCode: "M03", calendar });
+const date191907 = Temporal.PlainYearMonth.from({ year: 1919, monthCode: "M07", calendar });
+const date191912 = Temporal.PlainYearMonth.from({ year: 1919, monthCode: "M12", calendar });
+const date192306 = Temporal.PlainYearMonth.from({ year: 1923, monthCode: "M06", calendar });
+const date194103 = Temporal.PlainYearMonth.from({ year: 1941, monthCode: "M03", calendar });
+const date194112 = Temporal.PlainYearMonth.from({ year: 1941, monthCode: "M12", calendar });
+const date194203 = Temporal.PlainYearMonth.from({ year: 1942, monthCode: "M03", calendar });
+const date194212 = Temporal.PlainYearMonth.from({ year: 1942, monthCode: "M12", calendar });
+const date194301 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M01", calendar });
+const date194302 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M02", calendar });
+const date194303 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M03", calendar });;
+const date194304 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M04", calendar });
+const date194306 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M06", calendar });
+const date194307 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M07", calendar });
+const date194308 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M08", calendar });
+const date194407 = Temporal.PlainYearMonth.from({ year: 1944, monthCode: "M07", calendar });
+const date194409 = Temporal.PlainYearMonth.from({ year: 1944, monthCode: "M09", calendar });
+const date195307 = Temporal.PlainYearMonth.from({ year: 1953, monthCode: "M07", calendar });
+const date195312 = Temporal.PlainYearMonth.from({ year: 1953, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date194307, date194307, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date194307, date194308, "1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date194212, date194301, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date194302, date194304, "2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date194307, date194407, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date194307, date195307, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date194307, date194409, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date194307, date195312, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date191912, date194307, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date191907, date194307, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date188202, date194203, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date194303, date194307, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date194203, date194307, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date191912, date192306, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date188203, date194307, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date194112, date194307, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date194212, date194307, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date191912, date194307, "23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date194112, date194303, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date194308, date194307, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date194301, date194212, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date194306, date194304, "negative 2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date194407, date194307, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date195307, date194307, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date194409, date194307, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date195312, date194307, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date194307, date191912, "negative 23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date194307, date191907, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date194103, date188102, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date194307, date194303, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date194307, date194203, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date194307, date188203, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date194307, date194112, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date194307, date194212, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date194307, date191912, "negative 23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date194303, date194112, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-islamic-civil.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-islamic-civil.js
@@ -1,0 +1,204 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (Islamic civil calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-civil";
+
+// Years
+
+const date137702 = Temporal.PlainYearMonth.from({ year: 1377, monthCode: "M02", calendar });
+const date137802 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M02", calendar });
+const date137803 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M03", calendar });
+const date141507 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M07", calendar });
+const date141512 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M12", calendar });
+const date141712 = Temporal.PlainYearMonth.from({ year: 1417, monthCode: "M12", calendar });
+const date142106 = Temporal.PlainYearMonth.from({ year: 1421, monthCode: "M06", calendar });
+const date143703 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M03", calendar });
+const date143712 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M12", calendar });
+const date143803 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M03", calendar });
+const date143812 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M12", calendar });
+const date143901 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M01", calendar });
+const date143903 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M03", calendar });
+const date143905 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M05", calendar });
+const date143907 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M07", calendar });
+const date143908 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M08", calendar });
+const date144007 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M07", calendar });
+const date144009 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M09", calendar });
+const date144907 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M07", calendar });
+const date144912 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date143907, date143907, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date143907, date143908, "1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143812, date143901, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143903, date143905, "2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date143907, date144007, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date143907, date144907, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date143907, date144009, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date143907, date144912, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date141512, date143907, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date141507, date143907, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date137802, date143803, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date143903, date143907, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date143803, date143907, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date141712, date142106, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date137803, date143907, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date143712, date143907, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date143812, date143907, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date141512, date143907, "23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date143712, date143903, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date143908, date143907, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143901, date143812, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143907, date143905, "negative 2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date144007, date143907, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date144907, date143907, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date144009, date143907, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date144912, date143907, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date143907, date141512, "negative 23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date143907, date141507, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date143703, date137702, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date143907, date143903, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date143907, date143803, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date143907, date137803, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date143907, date143712, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date143907, date143812, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date143907, date141512, "negative 23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date143903, date143712, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-islamic-tbla.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-islamic-tbla.js
@@ -1,0 +1,209 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (Islamic tbla calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-tbla";
+
+// Years
+
+const date137702 = Temporal.PlainYearMonth.from({ year: 1377, monthCode: "M02", calendar });
+const date137802 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M02", calendar });
+const date137803 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M03", calendar });
+const date141507 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M07", calendar });
+const date141512 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M12", calendar });
+const date141712 = Temporal.PlainYearMonth.from({ year: 1417, monthCode: "M12", calendar });
+const date142001 = Temporal.PlainYearMonth.from({ year: 1420, monthCode: "M01", calendar });
+const date142010 = Temporal.PlainYearMonth.from({ year: 1420, monthCode: "M10", calendar });
+const date142106 = Temporal.PlainYearMonth.from({ year: 1421, monthCode: "M06", calendar });
+const date143703 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M03", calendar });
+const date143712 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M12", calendar });
+const date143803 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M03", calendar });
+const date143812 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M12", calendar });
+const date143901 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M01", calendar });
+const date143903 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M03", calendar });;
+const date143905 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M05", calendar });
+const date143907 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M07", calendar });
+const date143908 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M08", calendar });
+const date144007 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M07", calendar });
+const date144009 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M09", calendar });
+const date144907 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M07", calendar });
+const date144912 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date143907, date143907, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date143907, date143908, "1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143812, date143901, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143903, date143905, "2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date143907, date144007, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date143907, date144907, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date143907, date144009, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date143907, date144912, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date141512, date143907, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date141507, date143907, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date137802, date143803, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date143903, date143907, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date143803, date143907, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date141712, date142106, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date137803, date143907, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date143712, date143907, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date143812, date143907, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date142001, date142010, "40 weeks",
+  ],
+  [
+    date141512, date143907, "23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date143712, date143903, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date143908, date143907, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143901, date143812, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143907, date143905, "negative 2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date144007, date143907, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date144907, date143907, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date144009, date143907, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date144912, date143907, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date143907, date141512, "negative 23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date143907, date141507, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date143703, date137702, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date143907, date143903, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date143907, date143803, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date143907, date137803, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date143907, date143712, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date143907, date143812, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date143907, date141512, "negative 23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date143903, date143712, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-islamic-umalqura.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-islamic-umalqura.js
@@ -1,0 +1,204 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (Islamic umalqura calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-umalqura";
+
+// Years
+
+const date137702 = Temporal.PlainYearMonth.from({ year: 1377, monthCode: "M02", calendar });
+const date137802 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M02", calendar });
+const date137803 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M03", calendar });
+const date141507 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M07", calendar });
+const date141512 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M12", calendar });
+const date141712 = Temporal.PlainYearMonth.from({ year: 1417, monthCode: "M12", calendar });
+const date142106 = Temporal.PlainYearMonth.from({ year: 1421, monthCode: "M06", calendar });
+const date143703 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M03", calendar });
+const date143712 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M12", calendar });
+const date143803 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M03", calendar });
+const date143812 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M12", calendar });
+const date143901 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M01", calendar });
+const date143903 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M03", calendar });
+const date143905 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M05", calendar });
+const date143907 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M07", calendar });
+const date143908 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M08", calendar });
+const date144007 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M07", calendar });
+const date144009 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M09", calendar });
+const date144907 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M07", calendar });
+const date144912 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date143907, date143907, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date143907, date143908, "1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143812, date143901, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143903, date143905, "2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date143907, date144007, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date143907, date144907, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date143907, date144009, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date143907, date144912, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date141512, date143907, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date141507, date143907, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date137802, date143803, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date143903, date143907, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date143803, date143907, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date141712, date142106, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date137803, date143907, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date143712, date143907, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date143812, date143907, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date141512, date143907, "23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date143712, date143903, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date143908, date143907, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143901, date143812, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143907, date143905, "negative 2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date144007, date143907, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date144907, date143907, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date144009, date143907, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date144912, date143907, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date143907, date141512, "negative 23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date143907, date141507, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date143703, date137702, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date143907, date143903, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date143907, date143803, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date143907, date137803, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date143907, date143712, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date143907, date143812, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date143907, date141512, "negative 23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date143903, date143712, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-japanese.js
@@ -1,0 +1,216 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (japanese calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "japanese";
+
+// Years
+
+const date196002 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M02", calendar });
+const date196003 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M03", calendar });
+const date196907 = Temporal.PlainYearMonth.from({ year: 1969, monthCode: "M07", calendar });
+const date199707 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M07", calendar });
+const date199712 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M12", calendar });
+const date200001 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M01", calendar });
+const date200010 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M10", calendar });
+const date200106 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M06", calendar });
+const date201907 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M07", calendar });
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar });
+const date202003 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M03", calendar });
+const date202012 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M12", calendar });
+const date202101 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar });
+const date202103 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar });
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+const date202108 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar });
+const date202109 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M09", calendar });
+const date202207 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M07", calendar });
+const date202209 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M09", calendar });
+const date203107 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M07", calendar });
+const date203112 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date202107, date202107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date202107, date202108, "1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202012, date202101, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202107, date202109, "2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date202107, date202207, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date202107, date203107, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date202107, date202209, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date202107, date203112, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date199712, date202107, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date199707, date202107, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date196002, date202003, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date202103, date202107, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date202003, date202107, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date199712, date200106, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date196003, date202107, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date201912, date202107, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date202012, date202107, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date200001, date200010, "40 weeks",
+  ],
+  [
+    date199712, date202107, "23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date201912, date202103, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date196907, date201907, "crossing epoch",
+    ["years", -50, 0],
+  ],
+  [
+    date202108, date202107, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202101, date202012, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202109, date202107, "negative 2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date202207, date202107, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date203107, date202107, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date202209, date202107, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date203112, date202107, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date202107, date199712, "negative 23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date202107, date199707, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date202003, date196002, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date202107, date202103, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date202107, date202003, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date202107, date196003, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date202107, date201912, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date202107, date202012, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date202107, date199712, "negative 23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date202103, date201912, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date201907, date196907, "crossing epoch",
+    ["years", 50, 0],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-persian.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-persian.js
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (Persian calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "persian";
+
+// Years
+
+const date137512 = Temporal.PlainYearMonth.from({ year: 1375, monthCode: "M12", calendar });
+const date137906 = Temporal.PlainYearMonth.from({ year: 1379, monthCode: "M06", calendar });
+const date134202 = Temporal.PlainYearMonth.from({ year: 1342, monthCode: "M02", calendar });
+const date134302 = Temporal.PlainYearMonth.from({ year: 1343, monthCode: "M02", calendar });
+const date134303 = Temporal.PlainYearMonth.from({ year: 1343, monthCode: "M03", calendar });
+const date138007 = Temporal.PlainYearMonth.from({ year: 1380, monthCode: "M07", calendar });
+const date138012 = Temporal.PlainYearMonth.from({ year: 1380, monthCode: "M12", calendar });
+const date140203 = Temporal.PlainYearMonth.from({ year: 1402, monthCode: "M03", calendar });
+const date140212 = Temporal.PlainYearMonth.from({ year: 1402, monthCode: "M12", calendar });
+const date140303 = Temporal.PlainYearMonth.from({ year: 1403, monthCode: "M03", calendar });
+const date140312 = Temporal.PlainYearMonth.from({ year: 1403, monthCode: "M12", calendar });
+const date140401 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M01", calendar });
+const date140403 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M03", calendar });
+const date140404 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M04", calendar });
+const date140406 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M06", calendar });
+const date140407 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M07", calendar });
+const date140408 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M08", calendar });
+const date140409 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M09", calendar });
+const date140507 = Temporal.PlainYearMonth.from({ year: 1405, monthCode: "M07", calendar });
+const date140509 = Temporal.PlainYearMonth.from({ year: 1405, monthCode: "M09", calendar });
+const date141407 = Temporal.PlainYearMonth.from({ year: 1414, monthCode: "M07", calendar });
+const date141412 = Temporal.PlainYearMonth.from({ year: 1414, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date140407, date140407, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date140407, date140408, "1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date140312, date140401, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date140407, date140409, "2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date140404, date140406, "2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date140407, date140507, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date140407, date141407, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date140407, date140509, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date137512, date137906, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date140407, date141412, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date138012, date140407, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date138007, date140407, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date134302, date140303, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date140403, date140407, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date140303, date140407, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date134303, date140407, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date140212, date140407, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date140312, date140407, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date138012, date140407, "23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date140212, date140403, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date140408, date140407, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date140401, date140312, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date140409, date140407, "negative 2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date140507, date140407, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date141407, date140407, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date140509, date140407, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date141412, date140407, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date140407, date138012, "negative 23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date140407, date138007, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date140203, date134202, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date140407, date140403, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date140407, date140303, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date140407, date134303, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date140407, date140212, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date140407, date140312, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date140407, date138012, "negative 23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date140403, date140212, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-roc.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/basic-roc.js
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (roc calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "roc";
+
+// Years
+
+const date04902 = Temporal.PlainYearMonth.from({ year: 49, monthCode: "M02", calendar });
+const date04903 = Temporal.PlainYearMonth.from({ year: 49, monthCode: "M03", calendar });
+const date05807 = Temporal.PlainYearMonth.from({ year: 58, monthCode: "M07", calendar });
+const date08607 = Temporal.PlainYearMonth.from({ year: 86, monthCode: "M07", calendar });
+const date08612 = Temporal.PlainYearMonth.from({ year: 86, monthCode: "M12", calendar });
+const date09006 = Temporal.PlainYearMonth.from({ year: 90, monthCode: "M06", calendar });
+const date10807 = Temporal.PlainYearMonth.from({ year: 108, monthCode: "M07", calendar });
+const date10812 = Temporal.PlainYearMonth.from({ year: 108, monthCode: "M12", calendar });
+const date10903 = Temporal.PlainYearMonth.from({ year: 109, monthCode: "M03", calendar });
+const date10912 = Temporal.PlainYearMonth.from({ year: 109, monthCode: "M12", calendar });
+const date11001 = Temporal.PlainYearMonth.from({ year: 110, monthCode: "M01", calendar });
+const date11003 = Temporal.PlainYearMonth.from({ year: 110, monthCode: "M03", calendar });
+const date11007 = Temporal.PlainYearMonth.from({ year: 110, monthCode: "M07", calendar });
+const date11008 = Temporal.PlainYearMonth.from({ year: 110, monthCode: "M08", calendar });
+const date11009 = Temporal.PlainYearMonth.from({ year: 110, monthCode: "M09", calendar });
+const date11107 = Temporal.PlainYearMonth.from({ year: 111, monthCode: "M07", calendar });
+const date11109 = Temporal.PlainYearMonth.from({ year: 111, monthCode: "M09", calendar });
+const date12007 = Temporal.PlainYearMonth.from({ year: 120, monthCode: "M07", calendar });
+const date12012 = Temporal.PlainYearMonth.from({ year: 120, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date11007, date11007, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date11007, date11008, "1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date10912, date11001, "1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date11007, date11009, "2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date11007, date11107, "1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date11007, date12007, "10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date11007, date11109, "1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date11007, date12012, "10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date08612, date11007, "23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date08607, date11007, "24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date04902, date10903, "60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date11003, date11007, "4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date10903, date11007, "1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date04903, date11007, "61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date10812, date11007, "1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date08612, date09006, "3 years, 6 months",
+    ["years", -3, -6],
+  ],
+  [
+    date10912, date11007, "7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date08612, date11007, "23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date10812, date11003, "1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date05807, date10807, "crossing epoch",
+    ["years", -50, 0],
+  ],
+  [
+    date11008, date11007, "negative 1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date11001, date10912, "negative 1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date11009, date11007, "negative 2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date11107, date11007, "negative 1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date12007, date11007, "negative 10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date11109, date11007, "negative 1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date12012, date11007, "negative 10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date11007, date08612, "negative 23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date11007, date08607, "negative 24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date10903, date04902, "negative 60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date11007, date11003, "negative 4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date11007, date10903, "negative 1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date11007, date04903, "negative 61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date11007, date10812, "negative 1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date11007, date10912, "negative 7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date11007, date08612, "negative 23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date11003, date10812, "negative 1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date10807, date05807, "crossing epoch",
+    ["years", 50, 0],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/calendar-mismatch.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/calendar-mismatch.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: RangeError thrown if calendars' IDs do not match
+features: [Temporal]
+---*/
+
+const plainYearMonth1 = new Temporal.PlainYearMonth(2000, 1, "gregory", 1);
+const plainYearMonth2 = new Temporal.PlainYearMonth(2000, 1, "japanese", 1);
+assert.throws(RangeError, () => plainYearMonth1.since(plainYearMonth2));

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-ethiopic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-ethiopic.js
@@ -1,0 +1,77 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "ethiopic";
+const options = { overflow: "reject" };
+
+const aa5500 = Temporal.PlainYearMonth.from({ era: "aa", eraYear: 5500, monthCode: "M01", calendar }, options);
+const am1 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 1, monthCode: "M01", calendar }, options);
+const am2000 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 2000, monthCode: "M06", calendar }, options);
+const am2005 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 2005, monthCode: "M06", calendar }, options);
+const aa5450 = Temporal.PlainYearMonth.from({ era: "aa", eraYear: 5450, monthCode: "M07", calendar }, options);
+const aa5455 = Temporal.PlainYearMonth.from({ era: "aa", eraYear: 5455, monthCode: "M07", calendar }, options);
+const am5 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 5, monthCode: "M01", calendar }, options);
+
+const tests = [
+  // From 5500 AA to 1 AM
+  [
+    aa5500, am1,
+    [-1, 0, "-1y backwards  from 5500 AA to 1 AM"],
+    [0, -13, "-13mo backwards  from 5500 AA to 1 AM"],
+  ],
+  [
+    am1, aa5500,
+    [1, 0, "1y  from 5500 AA to 1 AM"],
+    [0, 13, "13mo  from 1 AM to 5500 AA"],
+  ],
+  // From 2000 AM to 2005 AM
+  [
+    am2000, am2005,
+    [-5, 0, "-5y backwards from 2000 AM to 2005 AM"],
+    [0, -65, "-65mo backwards from 2000 AM to 2005 AM"],
+  ],
+  [
+    am2005, am2000,
+    [5, 0, "5y from 2000 AM to 2005 AM"],
+    [0, 65, "65mo from 2000 AM to 2005 AM"],
+  ],
+  // From 5450 AA to 5455 AA
+  [
+    aa5450, aa5455,
+    [-5, 0, "-5y backwards from 5450 AA to 5455 AA"],
+    [0, -65, "-65mo backwards from 5450 AA to 5455 AA"],
+  ],
+  [
+    aa5455, aa5450,
+    [5, 0, "5y  from 5450 AA to 5455 AA"],
+    [0, 65, "65mo from 5450 AA to 5455 AA"],
+  ],
+  // From 5 AM to 5500 AA
+  [
+    aa5500, am5,
+    [-5, 0, "-5y backwards from 5 AM to 5500 AA"],
+    [0, -65, "-65mo backwards from 5 AM to 5500 AA"],
+  ],
+  [
+    am5, aa5500,
+    [5, 0, "5y from 5 AM to 5500 AA"],
+    [0, 65, "65mo from 5 AM to 5500 AA"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-gregory.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-gregory.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "gregory";
+const options = { overflow: "reject" };
+
+const bce5 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 5, monthCode: "M06", calendar }, options);
+const bce2 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 2, monthCode: "M12", calendar }, options);
+const bce1 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 1, monthCode: "M06", calendar }, options);
+const ce1 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1, monthCode: "M06", calendar }, options);
+const ce2 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 2, monthCode: "M01", calendar }, options);
+const ce5 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 5, monthCode: "M06", calendar }, options);
+
+const tests = [
+  // From 5 BCE to 5 CE
+  [
+    bce5, ce5,
+    [-9, 0, "-9y backwards  from 5 BCE to 5 CE (no year 0)"],
+    [0, -108, "-108mo backwards  from 5 BCE to 5 CE (no year 0)"],
+  ],
+  [
+    ce5, bce5,
+    [9, 0, "9y  from 5 BCE to 5 CE (no year 0)"],
+    [0, 108, "108mo  from 5 BCE to 5 CE (no year 0)"],
+  ],
+  // CE-BCE boundary
+  [
+    bce1, ce1,
+    [-1, 0, "-1y backwards from 1 BCE to 1 CE"],
+    [0, -12, "-12mo backwards from 1 BCE to 1 CE"],
+  ],
+  [
+    ce1, bce1,
+    [1, 0, "1y from 1 BCE to 1 CE"],
+    [0, 12, "12mo from 1 BCE to 1 CE"],
+  ],
+  [
+    bce2, ce2,
+    [-2, -1, "-2y -1mo backwards from 2 BCE Dec to 2 CE Jan"],
+    [0, -25, "-25mo backwards from 2 BCE Dec to 2 CE Jan"],
+  ],
+  [
+    ce2, bce2,
+    [2, 1, "2y 1mo from 2 BCE Dec to 2 CE Jan"],
+    [0, 25, "25mo from 2 BCE Dec to 2 CE Jan"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-islamic-civil.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-islamic-civil.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-civil";
+const options = { overflow: "reject" };
+
+const bh5 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M06", calendar }, options);
+const bh2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M12", calendar }, options);
+const bh1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah1 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah2 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M01", calendar }, options);
+const ah5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M06", calendar }, options);
+
+const tests = [
+  // From 5 BH to 5 AH
+  [
+    bh5, ah5,
+    [-9, 0, "-9y backwards  from 5 BH to 5 AH (no year 0)"],
+    [0, -108, "-108mo backwards  from 5 BH to 5 AH (no year 0)"],
+  ],
+  [
+    ah5, bh5,
+    [9, 0, "9y  from 5 BH to 5 AH (no year 0)"],
+    [0, 108, "108mo  from 5 BH to 5 AH (no year 0)"],
+  ],
+  // AH-BH boundary
+  [
+    bh1, ah1,
+    [-1, 0, "-1y backwards from 1 BH to 1 AH"],
+    [0, -12, "-12mo backwards from 1 BH to 1 AH"],
+  ],
+  [
+    ah1, bh1,
+    [1, 0, "1y from 1 BH to 1 AH"],
+    [0, 12, "12mo from 1 BH to 1 AH"],
+  ],
+  [
+    bh2, ah2,
+    [-2, -1, "-2y -1mo backwards from 2 BH Dec to 2 AH Jan"],
+    [0, -25, "-25mo backwards from 2 BH Dec to 2 AH Jan"],
+  ],
+  [
+    ah2, bh2,
+    [2, 1, "2y 1mo from 2 BH Dec to 2 AH Jan"],
+    [0, 25, "25mo from 2 BH Dec to 2 AH Jan"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-islamic-tbla.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-islamic-tbla.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-tbla";
+const options = { overflow: "reject" };
+
+const bh5 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M06", calendar }, options);
+const bh2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M12", calendar }, options);
+const bh1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah1 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah2 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M01", calendar }, options);
+const ah5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M06", calendar }, options);
+
+const tests = [
+  // From 5 BH to 5 AH
+  [
+    bh5, ah5,
+    [-9, 0, "-9y backwards  from 5 BH to 5 AH (no year 0)"],
+    [0, -108, "-108mo backwards  from 5 BH to 5 AH (no year 0)"],
+  ],
+  [
+    ah5, bh5,
+    [9, 0, "9y  from 5 BH to 5 AH (no year 0)"],
+    [0, 108, "108mo  from 5 BH to 5 AH (no year 0)"],
+  ],
+  // AH-BH boundary
+  [
+    bh1, ah1,
+    [-1, 0, "-1y backwards from 1 BH to 1 AH"],
+    [0, -12, "-12mo backwards from 1 BH to 1 AH"],
+  ],
+  [
+    ah1, bh1,
+    [1, 0, "1y from 1 BH to 1 AH"],
+    [0, 12, "12mo from 1 BH to 1 AH"],
+  ],
+  [
+    bh2, ah2,
+    [-2, -1, "-2y -1mo backwards from 2 BH Dec to 2 AH Jan"],
+    [0, -25, "-25mo backwards from 2 BH Dec to 2 AH Jan"],
+  ],
+  [
+    ah2, bh2,
+    [2, 1, "2y 1mo from 2 BH Dec to 2 AH Jan"],
+    [0, 25, "25mo from 2 BH Dec to 2 AH Jan"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-islamic-umalqura.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-islamic-umalqura.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-umalqura";
+const options = { overflow: "reject" };
+
+const bh5 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M06", calendar }, options);
+const bh2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M12", calendar }, options);
+const bh1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah1 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah2 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M01", calendar }, options);
+const ah5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M06", calendar }, options);
+
+const tests = [
+  // From 5 BH to 5 AH
+  [
+    bh5, ah5,
+    [-9, 0, "-9y backwards  from 5 BH to 5 AH (no year 0)"],
+    [0, -108, "-108mo backwards  from 5 BH to 5 AH (no year 0)"],
+  ],
+  [
+    ah5, bh5,
+    [9, 0, "9y  from 5 BH to 5 AH (no year 0)"],
+    [0, 108, "108mo  from 5 BH to 5 AH (no year 0)"],
+  ],
+  // AH-BH boundary
+  [
+    bh1, ah1,
+    [-1, 0, "-1y backwards from 1 BH to 1 AH"],
+    [0, -12, "-12mo backwards from 1 BH to 1 AH"],
+  ],
+  [
+    ah1, bh1,
+    [1, 0, "1y from 1 BH to 1 AH"],
+    [0, 12, "12mo from 1 BH to 1 AH"],
+  ],
+  [
+    bh2, ah2,
+    [-2, -1, "-2y -1mo backwards from 2 BH Dec to 2 AH Jan"],
+    [0, -25, "-25mo backwards from 2 BH Dec to 2 AH Jan"],
+  ],
+  [
+    ah2, bh2,
+    [2, 1, "2y 1mo from 2 BH Dec to 2 AH Jan"],
+    [0, 25, "25mo from 2 BH Dec to 2 AH Jan"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-japanese.js
@@ -1,0 +1,127 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "japanese";
+const options = { overflow: "reject" };
+
+const bce1 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 1, monthCode: "M06", calendar }, options);
+const ce1 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1, monthCode: "M06", calendar }, options);
+const meiji5 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 5, monthCode: "M01", calendar }, options);
+const meiji45 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 45, monthCode: "M05", calendar }, options);
+const taisho1 = Temporal.PlainYearMonth.from({ era: "taisho", eraYear: 1, monthCode: "M08", calendar }, options);
+const taisho6 = Temporal.PlainYearMonth.from({ era: "taisho", eraYear: 6, monthCode: "M03", calendar }, options);
+const showa55 = Temporal.PlainYearMonth.from({ era: "showa", eraYear: 55, monthCode: "M03", calendar }, options);
+const showa64 = Temporal.PlainYearMonth.from({ era: "showa", eraYear: 64, monthCode: "M01", calendar }, options);
+const heisei1 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 1, monthCode: "M02", calendar }, options);
+const heisei30 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 30, monthCode: "M03", calendar }, options);
+const heisei31 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 31, monthCode: "M04", calendar }, options);
+const reiwa1 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 1, monthCode: "M06", calendar }, options);
+const reiwa2 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 2, monthCode: "M03", calendar }, options);
+
+const tests = [
+  // From Heisei 30 (2018) to Reiwa 2 (2020) - crossing era boundary
+  [
+    heisei30, reiwa2,
+    [-2, 0, "-2y backwards from Heisei 30 March to Reiwa 2 March"],
+    [0, -24, "-24mo backwards from Heisei 30 March to Reiwa 2 March"],
+  ],
+  [
+    reiwa2, heisei30,
+    [2, 0, "2y from Heisei 30 March to Reiwa 2 March"],
+    [0, 24, "24mo from Heisei 30 March to Reiwa 2 March"],
+  ],
+  // Within same year but different eras
+  [
+    heisei31, reiwa1,
+    [0, -2, "-2mo backwards from Heisei 31 April to Reiwa 1 June"],
+    [0, -2, "-2mo backwards from Heisei 31 April to Reiwa 1 June"],
+  ],
+  [
+    reiwa1, heisei31,
+    [0, 2, "2mo from Heisei 31 April to Reiwa 1 June"],
+    [0, 2, "2mo from Heisei 31 April to Reiwa 1 June"],
+  ],
+  // From Showa 55 (1980) to Heisei 30 (2018) - crossing era boundary
+  [
+    showa55, heisei30,
+    [-38, 0, "-38y backwards from Showa 55 March to Heisei 30 March"],
+    [0, -456, "-456mo backwards from Showa 55 March to Heisei 30 March"],
+  ],
+  [
+    heisei30, showa55,
+    [38, 0, "38y from Showa 55 March to Heisei 30 March"],
+    [0, 456, "456mo from Showa 55 March to Heisei 30 March"],
+  ],
+  // Within same year but different eras
+  [
+    showa64, heisei1,
+    [0, -1, "-1mo from Showa 64 January to Heisei 1 February"],
+    [0, -1, "-1mo from Showa 64 January to Heisei 1 February"],
+  ],
+  [
+    heisei1, showa64,
+    [0, 1, "1mo from Showa 64 January to Heisei 1 February"],
+    [0, 1, "1mo from Showa 64 January to Heisei 1 February"],
+  ],
+  // From Taisho 6 (1917) to Showa 55 (1980) - crossing era boundary
+  [
+    taisho6, showa55,
+    [-63, 0, "-63y backwards from Taisho 6 March to Showa 55 March"],
+    [0, -756, "-756mo backwards from Taisho 6 March to Showa 55 March"],
+  ],
+  [
+    showa55, taisho6,
+    [63, 0, "63y from Taisho 6 March to Showa 55 March"],
+    [0, 756, "756mo from Taisho 6 March to Showa 55 March"],
+  ],
+  // From Meiji 5 (1872) to Taisho 6 (1917) - crossing era boundary
+  [
+    meiji5, taisho6,
+    [-45, -2, "-45y -2mo backwards from Meiji 5 January to Taisho 6 March"],
+    [0, -542, "-542mo backwards from Meiji 5 January to Taisho 6 March"],
+  ],
+  [
+    taisho6, meiji5,
+    [45, 2, "45y 2mo from Meiji 5 January to Taisho 6 March"],
+    [0, 542, "542mo from Meiji 5 January to Taisho 6 March"],
+  ],
+  // Within same year but different eras
+  [
+    meiji45, taisho1,
+    [0, -3, "-3mo backwards from Meiji 45 May to Taisho 1 August"],
+    [0, -3, "-3mo backwards from Meiji 45 May to Taisho 1 August"],
+  ],
+  [
+    taisho1, meiji45,
+    [0, 3, "3mo from Meiji 45 May to Taisho 1 August"],
+    [0, 3, "3mo from Meiji 45 May to Taisho 1 August"],
+  ],
+  // CE-BCE boundary
+  [
+    bce1, ce1,
+    [-1, 0, "-1y backwards from 1 BCE to 1 CE"],
+    [0, -12, "-12mo backwards from 1 BCE to 1 CE"],
+  ],
+  [
+    ce1, bce1,
+    [1, 0, "1y from 1 BCE to 1 CE"],
+    [0, 12, "12mo from 1 BCE to 1 CE"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-roc.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-roc.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "roc";
+const options = { overflow: "reject" };
+
+const broc5 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 5, monthCode: "M03", calendar }, options);
+const broc3 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 3, monthCode: "M01", calendar }, options);
+const broc1 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 1, monthCode: "M06", calendar }, options);
+const roc1 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 1, monthCode: "M06", calendar }, options);
+const roc5 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 5, monthCode: "M03", calendar }, options);
+const roc10 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 10, monthCode: "M01", calendar }, options);
+
+const tests = [
+  // From BROC 5 to ROC 5
+  [
+    broc5, roc5,
+    [-9, 0, "-9y backwards  from BROC 5 to ROC 5 (no year 0)"],
+    [0, -108, "-108mo backwards  from BROC 5 to ROC 5 (no year 0)"],
+  ],
+  [
+    roc5, broc5,
+    [9, 0, "9y  from BROC 5 to ROC 5 (no year 0)"],
+    [0, 108, "108mo  from BROC 5 to ROC 5 (no year 0)"],
+  ],
+  // Era boundary
+  [
+    broc1, roc1,
+    [-1, 0, "-1y backwards from BROC 1 to ROC 1"],
+    [0, -12, "-12mo backwards from BROC 1 to ROC 1"],
+  ],
+  [
+    roc1, broc1,
+    [1, 0, "1y from BROC 1 to ROC 1"],
+    [0, 12, "12mo from BROC 1 to ROC 1"],
+  ],
+  [
+    broc3, roc10,
+    [-12, 0, "-12y backwards from BROC 3 to ROC 10"],
+    [0, -144, "-144mo backwards from BROC 3 to ROC 10"],
+  ],
+  [
+    roc10, broc3,
+    [12, 0, "12y from BROC 3 to ROC 10"],
+    [0, 144, "144mo from BROC 3 to ROC 10"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/intercalary-month-coptic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/intercalary-month-coptic.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations involving the intercalary month (coptic
+  calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "coptic";
+const options = { overflow: "reject" };
+
+const commonM12 = Temporal.PlainYearMonth.from({ year: 1738, monthCode: "M12", calendar}, options);
+const commonIntercalary = Temporal.PlainYearMonth.from({ year: 1738, monthCode: "M13", calendar}, options);
+const leapFirst = Temporal.PlainYearMonth.from({ year: 1739, monthCode: "M01", calendar}, options);
+const leapM12 = Temporal.PlainYearMonth.from({ year: 1739, monthCode: "M12", calendar}, options);
+const leapIntercalary = Temporal.PlainYearMonth.from({ year: 1739, monthCode: "M13", calendar}, options);
+const common2First = Temporal.PlainYearMonth.from({ year: 1740, monthCode: "M01", calendar }, options);
+const common2Intercalary = Temporal.PlainYearMonth.from({ year: 1740, monthCode: "M13", calendar }, options);
+
+const tests = [
+  [
+    commonIntercalary, leapIntercalary, "backwards last month of common year to last month of leap year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    leapIntercalary, common2Intercalary, "backwards last month of leap year to last month of common year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    commonM12, leapFirst, "backwards 2mo passing through intercalary month in common year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    leapM12, common2First, "backwards 2mo passing through intercalary month in leap year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    common2Intercalary, leapIntercalary, "last month of common year to last month of leap year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    leapIntercalary, commonIntercalary, "last month of leap year to last month of common year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    leapFirst, commonM12, "2mo passing through intercalary month in common year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    common2First, leapM12, "2mo passing through intercalary month in leap year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr + ` (largest unit ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/intercalary-month-ethioaa.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/intercalary-month-ethioaa.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations involving the intercalary month (ethioaa
+  calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "ethioaa";
+const options = { overflow: "reject" };
+
+const commonM12 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M12", calendar}, options);
+const commonIntercalary = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M13", calendar}, options);
+const leapFirst = Temporal.PlainYearMonth.from({ year: 7515, monthCode: "M01", calendar}, options);
+const leapM12 = Temporal.PlainYearMonth.from({ year: 7515, monthCode: "M12", calendar}, options);
+const leapIntercalary = Temporal.PlainYearMonth.from({ year: 7515, monthCode: "M13", calendar}, options);
+const common2First = Temporal.PlainYearMonth.from({ year: 7516, monthCode: "M01", calendar }, options);
+const common2Intercalary = Temporal.PlainYearMonth.from({ year: 7516, monthCode: "M13", calendar }, options);
+
+const tests = [
+  [
+    commonIntercalary, leapIntercalary, "backwards last month of common year to last month of leap year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    leapIntercalary, common2Intercalary, "backwards last month of leap year to last month of common year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    commonM12, leapFirst, "backwards 2mo passing through intercalary month in common year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    leapM12, common2First, "backwards 2mo passing through intercalary month in leap year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    common2Intercalary, leapIntercalary, "last month of common year to last month of leap year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    leapIntercalary, commonIntercalary, "last month of leap year to last month of common year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    leapFirst, commonM12, "2mo passing through intercalary month in common year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    common2First, leapM12, "2mo passing through intercalary month in leap year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr + ` (largest unit ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/intercalary-month-ethiopic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/intercalary-month-ethiopic.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Check various basic calculations involving the intercalary month (ethiopic
+  calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "ethiopic";
+const options = { overflow: "reject" };
+
+const commonM12 = Temporal.PlainYearMonth.from({ year: 2014, monthCode: "M12", calendar}, options);
+const commonIntercalary = Temporal.PlainYearMonth.from({ year: 2014, monthCode: "M13", calendar}, options);
+const leapFirst = Temporal.PlainYearMonth.from({ year: 2015, monthCode: "M01", calendar}, options);
+const leapM12 = Temporal.PlainYearMonth.from({ year: 2015, monthCode: "M12", calendar}, options);
+const leapIntercalary = Temporal.PlainYearMonth.from({ year: 2015, monthCode: "M13", calendar}, options);
+const common2First = Temporal.PlainYearMonth.from({ year: 2016, monthCode: "M01", calendar }, options);
+const common2Intercalary = Temporal.PlainYearMonth.from({ year: 2016, monthCode: "M13", calendar }, options);
+
+const tests = [
+  [
+    commonIntercalary, leapIntercalary, "backwards last month of common year to last month of leap year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    leapIntercalary, common2Intercalary, "backwards last month of leap year to last month of common year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    commonM12, leapFirst, "backwards 2mo passing through intercalary month in common year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    leapM12, common2First, "backwards 2mo passing through intercalary month in leap year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    common2Intercalary, leapIntercalary, "last month of common year to last month of leap year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    leapIntercalary, commonIntercalary, "last month of leap year to last month of common year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    leapFirst, commonM12, "2mo passing through intercalary month in common year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    common2First, leapM12, "2mo passing through intercalary month in leap year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.since(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr + ` (largest unit ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/leap-months-chinese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/leap-months-chinese.js
@@ -1,0 +1,149 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in chinese calendar
+esid: sec-temporal.plainyearmonth.prototype.since
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 2001 is a leap year with a M04L leap month.
+
+const calendar = "chinese";
+const options = { overflow: "reject" };
+
+const common1Month4 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M04", calendar }, options);
+const common1Month5 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M05", calendar }, options);
+const common1Month6 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M06", calendar }, options);
+const leapMonth4 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M04", calendar }, options);
+const leapMonth4L = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M04L", calendar }, options);
+const leapMonth5 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M05", calendar }, options);
+const common2Month4 = Temporal.PlainYearMonth.from({ year: 2002, monthCode: "M04", calendar }, options);
+const common2Month5 = Temporal.PlainYearMonth.from({ year: 2002, monthCode: "M05", calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+const tests = [
+  [
+    common1Month4, leapMonth4,
+    [-1, 0, "M04-M04 common-leap backwards is -1y"],
+    [0, -12, "M04-M04 common-leap backwards is -12mo"],
+  ],
+  [
+    leapMonth4, common2Month4,
+    [-1, 0, "M04-M04 leap-common backwards is -1y"],
+    [0, -13, "M04-M04 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common1Month4, common2Month4,
+    [-2, 0, "M04-M04 common-common backwards is -2y"],
+    [0, -25, "M04-M04 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Month5, leapMonth5,
+    [-1, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -13, "M05-M05 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapMonth5, common2Month5,
+    [-1, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -12, "M05-M05 leap-common backwards is -12mo"],
+  ],
+  [
+    common1Month5, common2Month5,
+    [-2, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Month4, leapMonth4L,
+    [-1, -1, "M04-M04L backwards is -1y -1mo"],
+    [0, -13, "M04-M04L backwards is -13mo"],
+  ],
+  [
+    leapMonth4L, common2Month4,
+    [0, -12, "M04L-M04 backwards is -12mo not -1y"],
+    [0, -12, "M04L-M04 backwards is -12mo"],
+  ],
+  [
+    common1Month5, leapMonth4L,
+    [0, -12, "M05-M04L backwards is -12mo not -1y"],
+    [0, -12, "M05-M04L backwards is -12mo"],
+  ],
+  [
+    leapMonth4L, common2Month5,
+    [-1, -1, "M04L-M05 backwards is -1y -1mo (exhibits calendar-specific constraining)"],
+    [0, -13, "M04L-M05 backwards is -13mo"],
+  ],
+  [
+    common1Month6, leapMonth5,
+    [0, -12, "M06-M05 common-leap backwards is -12mo not -11mo"],
+    [0, -12, "M06-M05 common-leap backwards is -12mo not -11mo"],
+  ],
+
+  // Negative
+  [
+    common2Month4, leapMonth4,
+    [1, 0, "M04-M04 common-leap is 1y"],
+    [0, 13, "M04-M04 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapMonth4, common1Month4,
+    [1, 0, "M04-M04 leap-common is 1y"],
+    [0, 12, "M04-M04 leap-common is 12mo not 13mo"],
+  ],
+  [
+    common2Month4, common1Month4,
+    [2, 0, "M04-M04 common-common is 2y"],
+    [0, 25, "M04-M04 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Month5, leapMonth5,
+    [1, 0, "M05-M05 common-leap is 1y"],
+    [0, 12, "M05-M05 common-leap is 12mo not 13mo"],
+  ],
+  [
+    leapMonth5, common1Month5,
+    [1, 0, "M05-M05 leap-common is 1y"],
+    [0, 13, "M05-M05 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common2Month5, common1Month5,
+    [2, 0, "M05-M05 common-common is 2y"],
+    [0, 25, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Month4, leapMonth4L,
+    [0, 12, "M04-M04L is 12mo not 1y"],
+    [0, 12, "M04-M04L is 12mo"],
+  ],
+  [
+    leapMonth4L, common1Month4,
+    [1, 0, "M04L-M04 is 1y not 1y 1mo (exhibits calendar-specific constraining)"],
+    [0, 13, "M04L-M04 is 13mo"],
+  ],
+  [
+    common2Month5, leapMonth4L,
+    [1, 1, "M05-M04L is 1y 1mo"],
+    [0, 13, "M05-M04L is 13mo"],
+  ],
+  [
+    leapMonth4L, common1Month5,
+    [0, 12, "M04L-M05 is 12mo not 1y"],
+    [0, 12, "M04L-M05 is 12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/leap-months-dangi.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/leap-months-dangi.js
@@ -1,0 +1,149 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in dangi calendar
+esid: sec-temporal.plainyearmonth.prototype.since
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 2001 is a leap year with a M04L leap month.
+
+const calendar = "dangi";
+const options = { overflow: "reject" };
+
+const common1Month4 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M04", calendar }, options);
+const common1Month5 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M05", calendar }, options);
+const common1Month6 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M06", calendar }, options);
+const leapMonth4 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M04", calendar }, options);
+const leapMonth4L = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M04L", calendar }, options);
+const leapMonth5 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M05", calendar }, options);
+const common2Month4 = Temporal.PlainYearMonth.from({ year: 2002, monthCode: "M04", calendar }, options);
+const common2Month5 = Temporal.PlainYearMonth.from({ year: 2002, monthCode: "M05", calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+const tests = [
+  [
+    common1Month4, leapMonth4,
+    [-1, 0, "M04-M04 common-leap backwards is -1y"],
+    [0, -12, "M04-M04 common-leap backwards is -12mo"],
+  ],
+  [
+    leapMonth4, common2Month4,
+    [-1, 0, "M04-M04 leap-common backwards is -1y"],
+    [0, -13, "M04-M04 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common1Month4, common2Month4,
+    [-2, 0, "M04-M04 common-common backwards is -2y"],
+    [0, -25, "M04-M04 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Month5, leapMonth5,
+    [-1, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -13, "M05-M05 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapMonth5, common2Month5,
+    [-1, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -12, "M05-M05 leap-common backwards is -12mo"],
+  ],
+  [
+    common1Month5, common2Month5,
+    [-2, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Month4, leapMonth4L,
+    [-1, -1, "M04-M04L backwards is -1y -1mo"],
+    [0, -13, "M04-M04L backwards is -13mo"],
+  ],
+  [
+    leapMonth4L, common2Month4,
+    [0, -12, "M04L-M04 backwards is -12mo not -1y"],
+    [0, -12, "M04L-M04 backwards is -12mo"],
+  ],
+  [
+    common1Month5, leapMonth4L,
+    [0, -12, "M05-M04L backwards is -12mo not -1y"],
+    [0, -12, "M05-M04L backwards is -12mo"],
+  ],
+  [
+    leapMonth4L, common2Month5,
+    [-1, -1, "M04L-M05 backwards is -1y -1mo (exhibits calendar-specific constraining)"],
+    [0, -13, "M04L-M05 backwards is -13mo"],
+  ],
+  [
+    common1Month6, leapMonth5,
+    [0, -12, "M06-M05 common-leap backwards is -12mo not -11mo"],
+    [0, -12, "M06-M05 common-leap backwards is -12mo not -11mo"],
+  ],
+
+  // Negative
+  [
+    common2Month4, leapMonth4,
+    [1, 0, "M04-M04 common-leap is 1y"],
+    [0, 13, "M04-M04 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapMonth4, common1Month4,
+    [1, 0, "M04-M04 leap-common is 1y"],
+    [0, 12, "M04-M04 leap-common is 12mo not 13mo"],
+  ],
+  [
+    common2Month4, common1Month4,
+    [2, 0, "M04-M04 common-common is 2y"],
+    [0, 25, "M04-M04 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Month5, leapMonth5,
+    [1, 0, "M05-M05 common-leap is 1y"],
+    [0, 12, "M05-M05 common-leap is 12mo not 13mo"],
+  ],
+  [
+    leapMonth5, common1Month5,
+    [1, 0, "M05-M05 leap-common is 1y"],
+    [0, 13, "M05-M05 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common2Month5, common1Month5,
+    [2, 0, "M05-M05 common-common is 2y"],
+    [0, 25, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Month4, leapMonth4L,
+    [0, 12, "M04-M04L is 12mo not 1y"],
+    [0, 12, "M04-M04L is 12mo"],
+  ],
+  [
+    leapMonth4L, common1Month4,
+    [1, 0, "M04L-M04 is 1y not 1y 1mo (exhibits calendar-specific constraining)"],
+    [0, 13, "M04L-M04 is 13mo"],
+  ],
+  [
+    common2Month5, leapMonth4L,
+    [1, 1, "M05-M04L is 1y 1mo"],
+    [0, 13, "M05-M04L is 13mo"],
+  ],
+  [
+    leapMonth4L, common1Month5,
+    [0, 12, "M04L-M05 is 12mo not 1y"],
+    [0, 12, "M04L-M05 is 12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/leap-months-hebrew.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/leap-months-hebrew.js
@@ -1,0 +1,153 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in hebrew calendar
+esid: sec-temporal.plainyearmonth.prototype.since
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 5784 is a leap year.
+// M05 - Shevat
+// M05L - Adar I
+// M06 - Adar II
+// M07 - Nisan
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+const common1Shevat = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M05", calendar }, options);
+const common1Adar = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M06", calendar }, options);
+const common1Nisan = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M07", calendar }, options);
+const leapShevat = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M05", calendar }, options);
+const leapAdarI = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M05L", calendar }, options);
+const leapAdarII = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M06", calendar }, options);
+const common2Shevat = Temporal.PlainYearMonth.from({ year: 5785, monthCode: "M05", calendar }, options);
+const common2Adar = Temporal.PlainYearMonth.from({ year: 5785, monthCode: "M06", calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+const tests = [
+  [
+    common1Shevat, leapShevat,
+    [-1, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -12, "M05-M05 common-leap backwards is -12mo"],
+  ],
+  [
+    leapShevat, common2Shevat,
+    [-1, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -13, "M05-M05 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common1Shevat, common2Shevat,
+    [-2, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Adar, leapAdarII,
+    [-1, 0, "M06-M06 common-leap backwards is -1y"],
+    [0, -13, "M06-M06 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapAdarII, common2Adar,
+    [-1, 0, "M06-M06 leap-common backwards is -1y"],
+    [0, -12, "M06-M06 leap-common backwards is -12mo"],
+  ],
+  [
+    common1Adar, common2Adar,
+    [-2, 0, "M06-M06 common-common backwards is -2y"],
+    [0, -25, "M06-M06 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common1Shevat, leapAdarI,
+    [-1, -1, "M05-M05L backwards is -1y -1mo"],
+    [0, -13, "M05-M05L backwards is -13mo"],
+  ],
+  [
+    leapAdarI, common2Shevat,
+    [0, -12, "M05L-M05 backwards is -12mo not -1y"],
+    [0, -12, "M05L-M05 backwards is -12mo"],
+  ],
+  [
+    common1Adar, leapAdarI,
+    [0, -12, "M06-M05L backwards is -12mo not -1y"],
+    [0, -12, "M06-M05L backwards is -12mo"],
+  ],
+  [
+    leapAdarI, common2Adar,
+    [-1, 0, "M05L-M06 backwards is -1y (exhibits calendar-specific constraining)"],
+    [0, -13, "M05L-M06 backwards is -13mo"],
+  ],
+  [
+    common1Nisan, leapAdarII,
+    [0, -12, "M07-M06 common-leap backwards is -12mo not -11mo"],
+    [0, -12, "M07-M06 common-leap backwards is -12mo not -11mo"],
+  ],
+
+  // Negative
+  [
+    common2Shevat, leapShevat,
+    [1, 0, "M05-M05 common-leap is 1y"],
+    [0, 13, "M05-M05 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapShevat, common1Shevat,
+    [1, 0, "M05-M05 leap-common is 1y"],
+    [0, 12, "M05-M05 leap-common is 12mo not 13mo"],
+  ],
+  [
+    common2Shevat, common1Shevat,
+    [2, 0, "M05-M05 common-common is 2y"],
+    [0, 25, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Adar, leapAdarII,
+    [1, 0, "M06-M06 common-leap is 1y"],
+    [0, 12, "M06-M06 common-leap is 12mo not 13mo"],
+  ],
+  [
+    leapAdarII, common1Adar,
+    [1, 0, "M06-M06 leap-common is 1y"],
+    [0, 13, "M06-M06 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common2Adar, common1Adar,
+    [2, 0, "M06-M06 common-common is 2y"],
+    [0, 25, "M06-M06 common-common is 25mo not 24mo"],
+  ],
+  [
+    common2Shevat, leapAdarI,
+    [0, 12, "M05-M05L is 12mo not 1y"],
+    [0, 12, "M05-M05L is 12mo"],
+  ],
+  [
+    leapAdarI, common1Shevat,
+    [1, 1, "M05L-M05 is 1y 1mo (exhibits calendar-specific constraining)"],
+    [0, 13, "M05L-M05 is 13mo"],
+  ],
+  [
+    common2Adar, leapAdarI,
+    [1, 1, "M06-M05L is 1y 1mo"],
+    [0, 13, "M06-M05L is 13mo"],
+  ],
+  [
+    leapAdarI, common1Adar,
+    [0, 12, "M05L-M06 is 12mo not 1y"],
+    [0, 12, "M05L-M06 is 12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.since(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.since(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-buddhist.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-buddhist.js
@@ -1,0 +1,213 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (buddhist calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "buddhist";
+
+// Years
+
+const date250302 = Temporal.PlainYearMonth.from({ year: 2503, monthCode: "M02", calendar });
+const date250303 = Temporal.PlainYearMonth.from({ year: 2503, monthCode: "M03", calendar });
+const date251207 = Temporal.PlainYearMonth.from({ year: 2512, monthCode: "M07", calendar });
+const date254007 = Temporal.PlainYearMonth.from({ year: 2540, monthCode: "M07", calendar });
+const date254012 = Temporal.PlainYearMonth.from({ year: 2540, monthCode: "M12", calendar });
+const date255512 = Temporal.PlainYearMonth.from({ year: 2555, monthCode: "M12", calendar });
+const date255606 = Temporal.PlainYearMonth.from({ year: 2556, monthCode: "M06", calendar });
+const date255906 = Temporal.PlainYearMonth.from({ year: 2559, monthCode: "M06", calendar });
+const date256207 = Temporal.PlainYearMonth.from({ year: 2562, monthCode: "M07", calendar });
+const date256212 = Temporal.PlainYearMonth.from({ year: 2562, monthCode: "M12", calendar });
+const date256303 = Temporal.PlainYearMonth.from({ year: 2563, monthCode: "M03", calendar });
+const date256312 = Temporal.PlainYearMonth.from({ year: 2563, monthCode: "M12", calendar });
+const date256401 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M01", calendar });
+const date256403 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M03", calendar });
+const date256407 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M07", calendar });
+const date256408 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M08", calendar });
+const date256409 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M09", calendar });
+const date256507 = Temporal.PlainYearMonth.from({ year: 2565, monthCode: "M07", calendar });
+const date256509 = Temporal.PlainYearMonth.from({ year: 2565, monthCode: "M09", calendar });
+const date257407 = Temporal.PlainYearMonth.from({ year: 2574, monthCode: "M07", calendar });
+const date257412 = Temporal.PlainYearMonth.from({ year: 2574, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date256407, date256407, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date256407, date256408, "1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date256312, date256401, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date256407, date256409, "2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date256407, date256507, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date256407, date257407, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date256407, date256509, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date256407, date257412, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date254012, date256407, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date254007, date256407, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date250302, date256303, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date256403, date256407, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date256303, date256407, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date250303, date256407, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date256212, date256407, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date255512, date255606, "6 months",
+    ["months", 0, 6],
+  ],
+  [
+    date254012, date256407, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date256212, date256403, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date255512, date255906, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date251207, date256207, "crossing epoch",
+    ["years", 50, 0],
+  ],
+  [
+    date256408, date256407, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date256401, date256312, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date256409, date256407, "negative 2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date256507, date256407, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date257407, date256407, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date256509, date256407, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date257412, date256407, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date256407, date254012, "negative 23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date256407, date254007, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date256303, date250302, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date256407, date256403, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date256407, date256303, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date256407, date250303, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date256407, date256212, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date256407, date256312, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date256407, date254012, "negative 23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date256403, date256212, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date256207, date251207, "crossing epoch",
+    ["years", -50, 0],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-chinese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-chinese.js
@@ -1,0 +1,206 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (chinese calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "chinese";
+
+// Years
+
+const date196002 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M02", calendar });
+const date196003 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M03", calendar });
+const date196103 = Temporal.PlainYearMonth.from({ year: 1961, monthCode: "M03", calendar });
+const date199707 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M07", calendar });
+const date199712 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M12", calendar });
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar });
+const date202003 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M03", calendar });
+const date202012 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M12", calendar });
+const date202101 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar });
+const date202102 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M02", calendar });
+const date202103 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar });
+const date202104 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M04", calendar });
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+const date202108 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar });
+const date202109 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M09", calendar });
+const date202112 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M12", calendar });
+const date202207 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M07", calendar });
+const date202209 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M09", calendar });
+const date202307 = Temporal.PlainYearMonth.from({ year: 2023, monthCode: "M07", calendar });
+const date203107 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M07", calendar });
+const date203112 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date202107, date202107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date202107, date202108, "1 month in same year (30-day month to 29-day month)",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202012, date202101, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202101, date202102, "1 month in same year (29-day month to 30-day month)",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202107, date202109, "2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date202107, date202207, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date202107, date203107, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 124],
+  ],
+  [
+    date202107, date202209, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date202107, date203112, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date199712, date202107, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date199707, date202107, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date196002, date202003, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date202103, date202107, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date202003, date202107, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date196003, date202107, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date201912, date202107, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date202012, date202107, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date199712, date202107, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date201912, date202103, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date202108, date202107, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202101, date202012, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202104, date202102, "negative 2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date202207, date202107, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date203107, date202107, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -124],
+  ],
+  [
+    date202209, date202107, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date203112, date202107, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date202107, date199712, "negative 23 years and 8 months",
+    ["years", -23, -8],
+  ],
+  [
+    date202107, date199707, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date202003, date196002, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date202107, date202103, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date202207, date202103, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date202207, date196103, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date202307, date202112, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date202107, date202012, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date202107, date199712, "negative 23 years, 8 months",
+    ["years", -23, -8],
+  ],
+  [
+    date202103, date201912, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      `${descr} (largestUnit = ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-coptic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-coptic.js
@@ -1,0 +1,215 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (coptic calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "coptic";
+
+// Years
+
+const date171002 = Temporal.PlainYearMonth.from({ year: 1710, monthCode: "M02", calendar });
+const date171003 = Temporal.PlainYearMonth.from({ year: 1710, monthCode: "M03", calendar });
+const date171103 = Temporal.PlainYearMonth.from({ year: 1711, monthCode: "M03", calendar });
+const date171312 = Temporal.PlainYearMonth.from({ year: 1713, monthCode: "M12", calendar });
+const date171612 = Temporal.PlainYearMonth.from({ year: 1716, monthCode: "M12", calendar });
+const date171705 = Temporal.PlainYearMonth.from({ year: 1717, monthCode: "M05", calendar });
+const date174707 = Temporal.PlainYearMonth.from({ year: 1747, monthCode: "M07", calendar });
+const date174712 = Temporal.PlainYearMonth.from({ year: 1747, monthCode: "M12", calendar });
+const date174713 = Temporal.PlainYearMonth.from({ year: 1747, monthCode: "M13", calendar });
+const date176912 = Temporal.PlainYearMonth.from({ year: 1769, monthCode: "M12", calendar });
+const date176913 = Temporal.PlainYearMonth.from({ year: 1769, monthCode: "M13", calendar });
+const date177003 = Temporal.PlainYearMonth.from({ year: 1770, monthCode: "M03", calendar });
+const date177012 = Temporal.PlainYearMonth.from({ year: 1770, monthCode: "M12", calendar });
+const date177013 = Temporal.PlainYearMonth.from({ year: 1770, monthCode: "M13", calendar });
+const date177101 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M01", calendar });
+const date177102 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M02", calendar });
+const date177103 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M03", calendar });;
+const date177104 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M04", calendar });
+const date177106 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M06", calendar });
+const date177107 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M07", calendar });
+const date177108 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M08", calendar });
+const date177112 = Temporal.PlainYearMonth.from({ year: 1771, monthCode: "M12", calendar });
+const date177207 = Temporal.PlainYearMonth.from({ year: 1772, monthCode: "M07", calendar });
+const date177209 = Temporal.PlainYearMonth.from({ year: 1772, monthCode: "M09", calendar });
+const date177307 = Temporal.PlainYearMonth.from({ year: 1773, monthCode: "M07", calendar });
+const date178107 = Temporal.PlainYearMonth.from({ year: 1781, monthCode: "M07", calendar });
+const date178112 = Temporal.PlainYearMonth.from({ year: 1781, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date177107, date177107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date177107, date177108, "1 month in same year (30-day month to 29-day month)",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date177013, date177101, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date177101, date177102, "1 month in same year (29-day month to 30-day month)",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date171612, date171705, "6 months in different year",
+    ["months", 0, 6],
+  ],
+  [
+    date177207, date177307, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    date177107, date178107, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 130],
+  ],
+  [
+    date177107, date177209, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date171312, date171705, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date177107, date178112, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date174712, date177106, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date174707, date177107, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date174707, date177106, "23 years, 12 months",
+    ["years", 23, 12],
+  ],
+  [
+    date171002, date177003, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date177103, date177107, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date177003, date177107, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date171003, date177107, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date176912, date177107, "1 year, 8 months",
+    ["years", 1, 8],
+  ],
+  [
+    date177013, date177106, "6 months",
+    ["years", 0, 6],
+  ],
+  [
+    date174713, date177106, "23 years, 6 months",
+    ["years", 23, 6],
+  ],
+  [
+    date176913, date177102, "1 year, 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date177108, date177107, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date177101, date177013, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date177104, date177102, "negative 2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date177307, date177207, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    date178107, date177107, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -130],
+  ],
+  [
+    date177209, date177107, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date178112, date177107, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date177107, date174712, "negative 23 years and 8 months",
+    ["years", -23, -8],
+  ],
+  [
+    date177107, date174707, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date177003, date171002, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date177107, date177103, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date177207, date177103, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date177207, date171103, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date177307, date177112, "negative 1 year, 8 months",
+    ["years", -1, -8],
+  ],
+  [
+    date177107, date177012, "negative 8 months",
+    ["years", 0, -8],
+  ],
+  [
+    date177107, date174712, "negative 23 years, 8 months",
+    ["years", -23, -8],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      `${descr} (largestUnit = ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-dangi.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-dangi.js
@@ -1,0 +1,206 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (dangi calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "dangi";
+
+// Years
+
+const date196002 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M02", calendar });
+const date196003 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M03", calendar });
+const date196103 = Temporal.PlainYearMonth.from({ year: 1961, monthCode: "M03", calendar });
+const date199707 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M07", calendar });
+const date199712 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M12", calendar });
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar });
+const date202003 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M03", calendar });
+const date202012 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M12", calendar });
+const date202101 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar });
+const date202102 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M02", calendar });
+const date202103 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar });;
+const date202104 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M04", calendar });
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+const date202108 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar });
+const date202109 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M09", calendar });
+const date202112 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M12", calendar });
+const date202207 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M07", calendar });
+const date202209 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M09", calendar });
+const date202307 = Temporal.PlainYearMonth.from({ year: 2023, monthCode: "M07", calendar });
+const date203107 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M07", calendar });
+const date203112 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date202107, date202107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date202107, date202108, "1 month in same year (30-day month to 29-day month)",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202012, date202101, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202101, date202102, "1 month in same year (29-day month to 30-day month)",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202107, date202109, "2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date202107, date202207, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date202107, date203107, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 124],
+  ],
+  [
+    date202107, date202209, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date202107, date203112, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date199712, date202107, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date199707, date202107, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date196002, date202003, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date202103, date202107, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date202003, date202107, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date196003, date202107, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date201912, date202107, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date202012, date202107, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date199712, date202107, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date201912, date202103, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date202108, date202107, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202101, date202012, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202104, date202102, "negative 2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date202207, date202107, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date203107, date202107, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -124],
+  ],
+  [
+    date202209, date202107, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date203112, date202107, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date202107, date199712, "negative 23 years and 8 months",
+    ["years", -23, -8],
+  ],
+  [
+    date202107, date199707, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date202003, date196002, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date202107, date202103, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date202207, date202103, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date202207, date196103, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date202307, date202112, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date202107, date202012, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date202107, date199712, "negative 23 years, 8 months",
+    ["years", -23, -8],
+  ],
+  [
+    date202103, date201912, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      `${descr} (largestUnit = ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-ethioaa.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-ethioaa.js
@@ -1,0 +1,209 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (ethioaa calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "ethioaa";
+
+// Years
+
+const date745302 = Temporal.PlainYearMonth.from({ year: 7453, monthCode: "M02", calendar });
+const date745303 = Temporal.PlainYearMonth.from({ year: 7453, monthCode: "M03", calendar });
+const date745403 = Temporal.PlainYearMonth.from({ year: 7454, monthCode: "M03", calendar });
+const date748912 = Temporal.PlainYearMonth.from({ year: 7489, monthCode: "M12", calendar });
+const date749007 = Temporal.PlainYearMonth.from({ year: 7490, monthCode: "M07", calendar });
+const date749012 = Temporal.PlainYearMonth.from({ year: 7490, monthCode: "M12", calendar });
+const date749013 = Temporal.PlainYearMonth.from({ year: 7490, monthCode: "M13", calendar });
+const date749305 = Temporal.PlainYearMonth.from({ year: 7493, monthCode: "M05", calendar });
+const date751212 = Temporal.PlainYearMonth.from({ year: 7512, monthCode: "M12", calendar });
+const date751213 = Temporal.PlainYearMonth.from({ year: 7512, monthCode: "M13", calendar });
+const date751303 = Temporal.PlainYearMonth.from({ year: 7513, monthCode: "M03", calendar });
+const date751313 = Temporal.PlainYearMonth.from({ year: 7513, monthCode: "M13", calendar });
+const date751401 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M01", calendar });
+const date751402 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M02", calendar });
+const date751403 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M03", calendar });
+const date751404 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M04", calendar });
+const date751406 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M06", calendar });
+const date751407 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M07", calendar });
+const date751408 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M08", calendar });
+const date751412 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M12", calendar });
+const date751507 = Temporal.PlainYearMonth.from({ year: 7515, monthCode: "M07", calendar });
+const date751509 = Temporal.PlainYearMonth.from({ year: 7515, monthCode: "M09", calendar });
+const date751607 = Temporal.PlainYearMonth.from({ year: 7516, monthCode: "M07", calendar });
+const date752407 = Temporal.PlainYearMonth.from({ year: 7524, monthCode: "M07", calendar });
+const date752412 = Temporal.PlainYearMonth.from({ year: 7524, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date751407, date751407, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date751407, date751408, "1 month in same year (30-day month to 29-day month)",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date751313, date751401, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date751401, date751402, "1 month in same year (29-day month to 30-day month)",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date751407, date751507, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    date751407, date752407, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 130],
+  ],
+  [
+    date751407, date751509, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date751407, date752412, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date749012, date751406, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date749007, date751407, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date749007, date751406, "23 years, 12 months",
+    ["years", 23, 12],
+  ],
+  [
+    date745302, date751303, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date751403, date751407, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date751303, date751407, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date748912, date749305, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date745303, date751407, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date751212, date751407, "1 year, 8 months",
+    ["years", 1, 8],
+  ],
+  [
+    date751313, date751406, "6 months",
+    ["years", 0, 6],
+  ],
+  [
+    date749013, date751406, "23 years, 6 months",
+    ["years", 23, 6],
+  ],
+  [
+    date751213, date751402, "1 year, 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date751408, date751407, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date751401, date751313, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date751404, date751402, "negative 2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date751507, date751407, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    date752407, date751407, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -130],
+  ],
+  [
+    date751509, date751407, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date752412, date751407, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date751407, date749012, "negative 23 years and 8 months",
+    ["years", -23, -8],
+  ],
+  [
+    date751407, date749007, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date751303, date745302, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date751407, date751403, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date751507, date751403, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date751507, date745403, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date751607, date751412, "negative 1 year, 8 months",
+    ["years", -1, -8],
+  ],
+  [
+    date751507, date751412, "negative 8 months",
+    ["years", 0, -8],
+  ],
+  [
+    date751407, date749012, "negative 23 years, 8 months",
+    ["years", -23, -8],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      `${descr} (largestUnit = ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-ethiopic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-ethiopic.js
@@ -1,0 +1,214 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (ethiopic calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "ethiopic";
+
+// Years
+
+const date196002 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M02", calendar });
+const date196003 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M03", calendar });
+const date196103 = Temporal.PlainYearMonth.from({ year: 1961, monthCode: "M03", calendar });
+const date199707 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M07", calendar });
+const date199712 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M12", calendar });
+const date199713 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M13", calendar });
+const date200001 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M01", calendar });
+const date200010 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M10", calendar });
+const date200105 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M05", calendar });
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar });
+const date201913 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M13", calendar });
+const date202003 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M03", calendar });
+const date202012 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M12", calendar });
+const date202013 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M13", calendar });
+const date202101 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar });
+const date202102 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M02", calendar });
+const date202103 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar });;
+const date202104 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M04", calendar });
+const date202106 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M06", calendar });
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+const date202108 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar });
+const date202112 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M12", calendar });
+const date202207 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M07", calendar });
+const date202209 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M09", calendar });
+const date202307 = Temporal.PlainYearMonth.from({ year: 2023, monthCode: "M07", calendar });
+const date203107 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M07", calendar });
+const date203112 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date202107, date202107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date202107, date202108, "1 month in same year (30-day month to 29-day month)",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202013, date202101, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202101, date202102, "1 month in same year (29-day month to 30-day month)",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202207, date202307, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    date202107, date203107, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 130],
+  ],
+  [
+    date202107, date202209, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date202107, date203112, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date199712, date202106, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date199707, date202107, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date199707, date202106, "23 years, 12 months",
+    ["years", 23, 12],
+  ],
+  [
+    date196002, date202003, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date202103, date202107, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date202003, date202107, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date199712, date200105, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date196003, date202107, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date201912, date202107, "1 year, 8 months",
+    ["years", 1, 8],
+  ],
+  [
+    date202013, date202106, "6 months",
+    ["years", 0, 6],
+  ],
+  [
+    date200001, date200010, "40 weeks",
+  ],
+  [
+    date199713, date202106, "23 years, 6 months",
+    ["years", 23, 6],
+  ],
+  [
+    date201913, date202102, "1 year, 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date202108, date202107, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202101, date202013, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202104, date202102, "negative 2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date202307, date202207, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    date203107, date202107, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -130],
+  ],
+  [
+    date202209, date202107, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date203112, date202107, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date202107, date199712, "negative 23 years and 8 months",
+    ["years", -23, -8],
+  ],
+  [
+    date202107, date199707, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date202003, date196002, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date202107, date202103, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date202207, date202103, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date202207, date196103, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date202307, date202112, "negative 1 year, 8 months",
+    ["years", -1, -8],
+  ],
+  [
+    date202107, date202012, "negative 8 months",
+    ["years", 0, -8],
+  ],
+  [
+    date202107, date199712, "negative 23 years, 8 months",
+    ["years", -23, -8],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      `${descr} (largestUnit = ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-gregory.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-gregory.js
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (gregory calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "gregory";
+
+// Years
+
+const date196002 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M02", calendar });
+const date196003 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M03", calendar });
+const date196907 = Temporal.PlainYearMonth.from({ year: 1969, monthCode: "M07", calendar });
+const date199707 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M07", calendar });
+const date199712 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M12", calendar });
+const date200106 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M06", calendar });
+const date201907 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M07", calendar });
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar });
+const date202003 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M03", calendar });
+const date202012 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M12", calendar });
+const date202101 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar });
+const date202103 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar });
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+const date202108 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar });
+const date202109 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M09", calendar });
+const date202207 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M07", calendar });
+const date202209 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M09", calendar });
+const date203107 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M07", calendar });
+const date203112 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date202107, date202107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date202107, date202108, "1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202012, date202101, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202107, date202109, "2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date202107, date202207, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date202107, date203107, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date202107, date202209, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date202107, date203112, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date199712, date202107, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date199707, date202107, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date196002, date202003, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date202103, date202107, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date202003, date202107, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date199712, date200106, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date196003, date202107, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date201912, date202107, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date202012, date202107, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date199712, date202107, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date201912, date202103, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date196907, date201907, "crossing epoch",
+    ["years", 50, 0],
+  ],
+  [
+    date202108, date202107, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202101, date202012, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202109, date202107, "negative 2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date202207, date202107, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date203107, date202107, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date202209, date202107, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date203112, date202107, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date202107, date199712, "negative 23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date202107, date199707, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date202003, date196002, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date202107, date202103, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date202107, date202003, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date202107, date196003, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date202107, date201912, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date202107, date202012, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date202107, date199712, "negative 23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date202103, date201912, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date201907, date196907, "crossing epoch",
+    ["years", -50, 0],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-hebrew.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-hebrew.js
@@ -1,0 +1,206 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (hebrew calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "hebrew";
+
+// Years
+
+const date572202 = Temporal.PlainYearMonth.from({ year: 5722, monthCode: "M02", calendar });
+const date572203 = Temporal.PlainYearMonth.from({ year: 5722, monthCode: "M03", calendar });
+const date572302 = Temporal.PlainYearMonth.from({ year: 5723, monthCode: "M02", calendar });
+const date572303 = Temporal.PlainYearMonth.from({ year: 5723, monthCode: "M03", calendar });
+const date575912 = Temporal.PlainYearMonth.from({ year: 5759, monthCode: "M12", calendar });
+const date576001 = Temporal.PlainYearMonth.from({ year: 5760, monthCode: "M01", calendar });
+const date576007 = Temporal.PlainYearMonth.from({ year: 5760, monthCode: "M07", calendar });
+const date576012 = Temporal.PlainYearMonth.from({ year: 5760, monthCode: "M12", calendar });
+const date576206 = Temporal.PlainYearMonth.from({ year: 5762, monthCode: "M06", calendar });
+const date578112 = Temporal.PlainYearMonth.from({ year: 5781, monthCode: "M12", calendar });
+const date578203 = Temporal.PlainYearMonth.from({ year: 5782, monthCode: "M03", calendar });
+const date578207 = Temporal.PlainYearMonth.from({ year: 5782, monthCode: "M07", calendar });
+const date578212 = Temporal.PlainYearMonth.from({ year: 5782, monthCode: "M12", calendar });
+const date578301 = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M01", calendar });
+const date578303 = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M03", calendar });
+const date578307 = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M07", calendar });
+const date578308 = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M08", calendar });
+const date578309 = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M09", calendar });
+const date578407 = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M07", calendar });
+const date578409 = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M09", calendar });
+const date579307 = Temporal.PlainYearMonth.from({ year: 5793, monthCode: "M07", calendar });
+const date579312 = Temporal.PlainYearMonth.from({ year: 5793, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date578307, date578307, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date578307, date578308, "1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date578212, date578301, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date578307, date578309, "2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date578207, date578307, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date578307, date579307, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 124],
+  ],
+  [
+    date578307, date578409, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date575912, date576206, "2 years 6 months",
+    ["years", 2, 6],
+  ],
+  [
+    date578307, date579312, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date576012, date578407, "23 years and 8 months",
+    ["years", 23, 8],
+  ],
+  [
+    date576007, date578407, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date572302, date578303, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date578303, date578307, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date578203, date578307, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date572303, date578407, "61 years, 5 months",
+    ["years", 61, 5],
+  ],
+  [
+    date578112, date578307, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date578212, date578307, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date576001, date578307, "23 years, 6 months",
+    ["years", 23, 6],
+  ],
+  [
+    date578112, date578303, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date578308, date578307, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date578301, date578212, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date578309, date578307, "negative 2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date578307, date578207, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date579307, date578307, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -124],
+  ],
+  [
+    date578409, date578307, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date579312, date578307, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date578407, date576012, "negative 23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date578407, date576007, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date578203, date572202, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date578307, date578303, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date578307, date578203, "negative 1 year, 5 months",
+    ["years", -1, -5],
+  ],
+  [
+    date578307, date572203, "negative 61 years, 5 months",
+    ["years", -61, -5],
+  ],
+  [
+    date578307, date578112, "negative 1 year, 8 months",
+    ["years", -1, -8],
+  ],
+  [
+    date578307, date578212, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date578307, date575912, "negative 23 years, 8 months",
+    ["years", -23, -8],
+  ],
+  [
+    date578303, date578112, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-indian.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-indian.js
@@ -1,0 +1,205 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (indian calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "indian";
+
+// Years
+
+const date188102 = Temporal.PlainYearMonth.from({ year: 1881, monthCode: "M02", calendar });
+const date188202 = Temporal.PlainYearMonth.from({ year: 1882, monthCode: "M02", calendar });
+const date188203 = Temporal.PlainYearMonth.from({ year: 1882, monthCode: "M03", calendar });
+const date191907 = Temporal.PlainYearMonth.from({ year: 1919, monthCode: "M07", calendar });
+const date191912 = Temporal.PlainYearMonth.from({ year: 1919, monthCode: "M12", calendar });
+const date192306 = Temporal.PlainYearMonth.from({ year: 1923, monthCode: "M06", calendar });
+const date194103 = Temporal.PlainYearMonth.from({ year: 1941, monthCode: "M03", calendar });
+const date194112 = Temporal.PlainYearMonth.from({ year: 1941, monthCode: "M12", calendar });
+const date194203 = Temporal.PlainYearMonth.from({ year: 1942, monthCode: "M03", calendar });
+const date194212 = Temporal.PlainYearMonth.from({ year: 1942, monthCode: "M12", calendar });
+const date194301 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M01", calendar });
+const date194302 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M02", calendar });
+const date194303 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M03", calendar });;
+const date194304 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M04", calendar });
+const date194306 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M06", calendar });
+const date194307 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M07", calendar });
+const date194308 = Temporal.PlainYearMonth.from({ year: 1943, monthCode: "M08", calendar });
+const date194407 = Temporal.PlainYearMonth.from({ year: 1944, monthCode: "M07", calendar });
+const date194409 = Temporal.PlainYearMonth.from({ year: 1944, monthCode: "M09", calendar });
+const date195307 = Temporal.PlainYearMonth.from({ year: 1953, monthCode: "M07", calendar });
+const date195312 = Temporal.PlainYearMonth.from({ year: 1953, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date194307, date194307, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date194307, date194308, "1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date194212, date194301, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date194302, date194304, "2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date194307, date194407, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date194307, date195307, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date194307, date194409, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date194307, date195312, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date191912, date194307, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date191907, date194307, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date188202, date194203, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date194303, date194307, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date194203, date194307, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date191912, date192306, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date188203, date194307, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date194112, date194307, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date194212, date194307, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date191912, date194307, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date194112, date194303, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date194308, date194307, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date194301, date194212, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date194306, date194304, "negative 2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date194407, date194307, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date195307, date194307, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date194409, date194307, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date195312, date194307, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date194307, date191912, "negative 23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date194307, date191907, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date194103, date188102, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date194307, date194303, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date194307, date194203, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date194307, date188203, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date194307, date194112, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date194307, date194212, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date194307, date191912, "negative 23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date194303, date194112, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-islamic-civil.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-islamic-civil.js
@@ -1,0 +1,204 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (Islamic civil calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-civil";
+
+// Years
+
+const date137702 = Temporal.PlainYearMonth.from({ year: 1377, monthCode: "M02", calendar });
+const date137802 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M02", calendar });
+const date137803 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M03", calendar });
+const date141507 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M07", calendar });
+const date141512 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M12", calendar });
+const date141712 = Temporal.PlainYearMonth.from({ year: 1417, monthCode: "M12", calendar });
+const date142106 = Temporal.PlainYearMonth.from({ year: 1421, monthCode: "M06", calendar });
+const date143703 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M03", calendar });
+const date143712 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M12", calendar });
+const date143803 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M03", calendar });
+const date143812 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M12", calendar });
+const date143901 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M01", calendar });
+const date143903 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M03", calendar });
+const date143905 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M05", calendar });
+const date143907 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M07", calendar });
+const date143908 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M08", calendar });
+const date144007 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M07", calendar });
+const date144009 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M09", calendar });
+const date144907 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M07", calendar });
+const date144912 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date143907, date143907, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date143907, date143908, "1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143812, date143901, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143903, date143905, "2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date143907, date144007, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date143907, date144907, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date143907, date144009, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date143907, date144912, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date141512, date143907, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date141507, date143907, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date137802, date143803, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date143903, date143907, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date143803, date143907, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date141712, date142106, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date137803, date143907, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date143712, date143907, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date143812, date143907, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date141512, date143907, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date143712, date143903, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date143908, date143907, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143901, date143812, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143907, date143905, "negative 2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date144007, date143907, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date144907, date143907, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date144009, date143907, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date144912, date143907, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date143907, date141512, "negative 23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date143907, date141507, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date143703, date137702, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date143907, date143903, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date143907, date143803, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date143907, date137803, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date143907, date143712, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date143907, date143812, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date143907, date141512, "negative 23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date143903, date143712, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-islamic-tbla.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-islamic-tbla.js
@@ -1,0 +1,204 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (Islamic tbla calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-tbla";
+
+// Years
+
+const date137702 = Temporal.PlainYearMonth.from({ year: 1377, monthCode: "M02", calendar });
+const date137802 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M02", calendar });
+const date137803 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M03", calendar });
+const date141507 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M07", calendar });
+const date141512 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M12", calendar });
+const date141712 = Temporal.PlainYearMonth.from({ year: 1417, monthCode: "M12", calendar });
+const date142106 = Temporal.PlainYearMonth.from({ year: 1421, monthCode: "M06", calendar });
+const date143703 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M03", calendar });
+const date143712 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M12", calendar });
+const date143803 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M03", calendar });
+const date143812 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M12", calendar });
+const date143901 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M01", calendar });
+const date143903 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M03", calendar });
+const date143905 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M05", calendar });
+const date143907 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M07", calendar });
+const date143908 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M08", calendar });
+const date144007 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M07", calendar });
+const date144009 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M09", calendar });
+const date144907 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M07", calendar });
+const date144912 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date143907, date143907, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date143907, date143908, "1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143812, date143901, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143903, date143905, "2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date143907, date144007, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date143907, date144907, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date143907, date144009, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date143907, date144912, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date141512, date143907, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date141507, date143907, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date137802, date143803, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date143903, date143907, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date143803, date143907, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date141712, date142106, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date137803, date143907, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date143712, date143907, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date143812, date143907, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date141512, date143907, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date143712, date143903, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date143908, date143907, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143901, date143812, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143907, date143905, "negative 2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date144007, date143907, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date144907, date143907, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date144009, date143907, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date144912, date143907, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date143907, date141512, "negative 23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date143907, date141507, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date143703, date137702, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date143907, date143903, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date143907, date143803, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date143907, date137803, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date143907, date143712, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date143907, date143812, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date143907, date141512, "negative 23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date143903, date143712, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-islamic-umalqura.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-islamic-umalqura.js
@@ -1,0 +1,204 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (Islamic umalqura calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-umalqura";
+
+// Years
+
+const date137702 = Temporal.PlainYearMonth.from({ year: 1377, monthCode: "M02", calendar });
+const date137802 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M02", calendar });
+const date137803 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M03", calendar });
+const date141507 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M07", calendar });
+const date141512 = Temporal.PlainYearMonth.from({ year: 1415, monthCode: "M12", calendar });
+const date141712 = Temporal.PlainYearMonth.from({ year: 1417, monthCode: "M12", calendar });
+const date142106 = Temporal.PlainYearMonth.from({ year: 1421, monthCode: "M06", calendar });
+const date143703 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M03", calendar });
+const date143712 = Temporal.PlainYearMonth.from({ year: 1437, monthCode: "M12", calendar });
+const date143803 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M03", calendar });
+const date143812 = Temporal.PlainYearMonth.from({ year: 1438, monthCode: "M12", calendar });
+const date143901 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M01", calendar });
+const date143903 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M03", calendar });;
+const date143905 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M05", calendar });
+const date143907 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M07", calendar });
+const date143908 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M08", calendar });
+const date144007 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M07", calendar });
+const date144009 = Temporal.PlainYearMonth.from({ year: 1440, monthCode: "M09", calendar });
+const date144907 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M07", calendar });
+const date144912 = Temporal.PlainYearMonth.from({ year: 1449, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date143907, date143907, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date143907, date143908, "1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143812, date143901, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date143903, date143905, "2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date143907, date144007, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date143907, date144907, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date143907, date144009, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date143907, date144912, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date141512, date143907, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date141507, date143907, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date137802, date143803, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date143903, date143907, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date143803, date143907, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date141712, date142106, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date137803, date143907, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date143712, date143907, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date143812, date143907, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date141512, date143907, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date143712, date143903, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date143908, date143907, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143901, date143812, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date143907, date143905, "negative 2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date144007, date143907, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date144907, date143907, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date144009, date143907, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date144912, date143907, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date143907, date141512, "negative 23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date143907, date141507, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date143703, date137702, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date143907, date143903, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date143907, date143803, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date143907, date137803, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date143907, date143712, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date143907, date143812, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date143907, date141512, "negative 23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date143903, date143712, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-japanese.js
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (japanese calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "japanese";
+
+// Years
+
+const date196002 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M02", calendar });
+const date196003 = Temporal.PlainYearMonth.from({ year: 1960, monthCode: "M03", calendar });
+const date196907 = Temporal.PlainYearMonth.from({ year: 1969, monthCode: "M07", calendar });
+const date199707 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M07", calendar });
+const date199712 = Temporal.PlainYearMonth.from({ year: 1997, monthCode: "M12", calendar });
+const date200106 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M06", calendar });
+const date201907 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M07", calendar });
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar });
+const date202003 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M03", calendar });
+const date202012 = Temporal.PlainYearMonth.from({ year: 2020, monthCode: "M12", calendar });
+const date202101 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar });
+const date202103 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar });
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+const date202108 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar });
+const date202109 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M09", calendar });
+const date202207 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M07", calendar });
+const date202209 = Temporal.PlainYearMonth.from({ year: 2022, monthCode: "M09", calendar });
+const date203107 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M07", calendar });
+const date203112 = Temporal.PlainYearMonth.from({ year: 2031, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date202107, date202107, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date202107, date202108, "1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202012, date202101, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date202107, date202109, "2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date202107, date202207, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date202107, date203107, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date202107, date202209, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date202107, date203112, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date199712, date202107, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date199707, date202107, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date196002, date202003, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date202103, date202107, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date202003, date202107, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date199712, date200106, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date196003, date202107, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date201912, date202107, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date202012, date202107, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date199712, date202107, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date201912, date202103, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date196907, date201907, "crossing epoch",
+    ["years", 50, 0],
+  ],
+  [
+    date202108, date202107, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202101, date202012, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date202109, date202107, "negative 2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date202207, date202107, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date203107, date202107, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date202209, date202107, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date203112, date202107, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date202107, date199712, "negative 23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date202107, date199707, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date202003, date196002, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date202107, date202103, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date202107, date202003, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date202107, date196003, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date202107, date201912, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date202107, date202012, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date202107, date199712, "negative 23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date202103, date201912, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date201907, date196907, "crossing epoch",
+    ["years", -50, 0],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-persian.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-persian.js
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (Persian calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "persian";
+
+// Years
+
+const date137512 = Temporal.PlainYearMonth.from({ year: 1375, monthCode: "M12", calendar });
+const date137906 = Temporal.PlainYearMonth.from({ year: 1379, monthCode: "M06", calendar });
+const date134202 = Temporal.PlainYearMonth.from({ year: 1342, monthCode: "M02", calendar });
+const date134302 = Temporal.PlainYearMonth.from({ year: 1343, monthCode: "M02", calendar });
+const date134303 = Temporal.PlainYearMonth.from({ year: 1343, monthCode: "M03", calendar });
+const date138007 = Temporal.PlainYearMonth.from({ year: 1380, monthCode: "M07", calendar });
+const date138012 = Temporal.PlainYearMonth.from({ year: 1380, monthCode: "M12", calendar });
+const date140203 = Temporal.PlainYearMonth.from({ year: 1402, monthCode: "M03", calendar });
+const date140212 = Temporal.PlainYearMonth.from({ year: 1402, monthCode: "M12", calendar });
+const date140303 = Temporal.PlainYearMonth.from({ year: 1403, monthCode: "M03", calendar });
+const date140312 = Temporal.PlainYearMonth.from({ year: 1403, monthCode: "M12", calendar });
+const date140401 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M01", calendar });
+const date140403 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M03", calendar });
+const date140404 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M04", calendar });
+const date140406 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M06", calendar });
+const date140407 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M07", calendar });
+const date140408 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M08", calendar });
+const date140409 = Temporal.PlainYearMonth.from({ year: 1404, monthCode: "M09", calendar });
+const date140507 = Temporal.PlainYearMonth.from({ year: 1405, monthCode: "M07", calendar });
+const date140509 = Temporal.PlainYearMonth.from({ year: 1405, monthCode: "M09", calendar });
+const date141407 = Temporal.PlainYearMonth.from({ year: 1414, monthCode: "M07", calendar });
+const date141412 = Temporal.PlainYearMonth.from({ year: 1414, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date140407, date140407, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date140407, date140408, "1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date140312, date140401, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date140407, date140409, "2 months which both have 30 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date140404, date140406, "2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date140407, date140507, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date140407, date141407, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date140407, date140509, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date137512, date137906, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date140407, date141412, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date138012, date140407, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date138007, date140407, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date134302, date140303, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date140403, date140407, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date140303, date140407, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date134303, date140407, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date140212, date140407, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date140312, date140407, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date138012, date140407, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date140212, date140403, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date140408, date140407, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date140401, date140312, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date140409, date140407, "negative 2 months which both have 30 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date140507, date140407, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date141407, date140407, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date140509, date140407, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date141412, date140407, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date140407, date138012, "negative 23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date140407, date138007, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date140203, date134202, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date140407, date140403, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date140407, date140303, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date140407, date134303, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date140407, date140212, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date140407, date140312, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date140407, date138012, "negative 23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date140403, date140212, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ]
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-roc.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/basic-roc.js
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (roc calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "roc";
+
+// Years
+
+const date04902 = Temporal.PlainYearMonth.from({ year: 49, monthCode: "M02", calendar });
+const date04903 = Temporal.PlainYearMonth.from({ year: 49, monthCode: "M03", calendar });
+const date05807 = Temporal.PlainYearMonth.from({ year: 58, monthCode: "M07", calendar });
+const date08607 = Temporal.PlainYearMonth.from({ year: 86, monthCode: "M07", calendar });
+const date08612 = Temporal.PlainYearMonth.from({ year: 86, monthCode: "M12", calendar });
+const date09006 = Temporal.PlainYearMonth.from({ year: 90, monthCode: "M06", calendar });
+const date10807 = Temporal.PlainYearMonth.from({ year: 108, monthCode: "M07", calendar });
+const date10812 = Temporal.PlainYearMonth.from({ year: 108, monthCode: "M12", calendar });
+const date10903 = Temporal.PlainYearMonth.from({ year: 109, monthCode: "M03", calendar });
+const date10912 = Temporal.PlainYearMonth.from({ year: 109, monthCode: "M12", calendar });
+const date11001 = Temporal.PlainYearMonth.from({ year: 110, monthCode: "M01", calendar });
+const date11003 = Temporal.PlainYearMonth.from({ year: 110, monthCode: "M03", calendar });
+const date11007 = Temporal.PlainYearMonth.from({ year: 110, monthCode: "M07", calendar });
+const date11008 = Temporal.PlainYearMonth.from({ year: 110, monthCode: "M08", calendar });
+const date11009 = Temporal.PlainYearMonth.from({ year: 110, monthCode: "M09", calendar });
+const date11107 = Temporal.PlainYearMonth.from({ year: 111, monthCode: "M07", calendar });
+const date11109 = Temporal.PlainYearMonth.from({ year: 111, monthCode: "M09", calendar });
+const date12007 = Temporal.PlainYearMonth.from({ year: 120, monthCode: "M07", calendar });
+const date12012 = Temporal.PlainYearMonth.from({ year: 120, monthCode: "M12", calendar });
+
+const tests = [
+  [
+    date11007, date11007, "same day",
+    ["years", 0, 0],
+    ["months", 0, 0],
+  ],
+  [
+    date11007, date11008, "1 month in same year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date10912, date11001, "1 month in different year",
+    ["years", 0, 1],
+    ["months", 0, 1],
+  ],
+  [
+    date11007, date11009, "2 months which both have 31 days",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    date11007, date11107, "1 year",
+    ["years", 1, 0],
+    ["months", 0, 12],
+  ],
+  [
+    date11007, date12007, "10 years",
+    ["years", 10, 0],
+    ["months", 0, 120],
+  ],
+  [
+    date11007, date11109, "1 year 2 months",
+    ["years", 1, 2],
+  ],
+  [
+    date11007, date12012, "10 years and 5 months",
+    ["years", 10, 5],
+  ],
+  [
+    date08612, date11007, "23 years and 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date08607, date11007, "24 years",
+    ["years", 24, 0],
+  ],
+  [
+    date04902, date10903, "60 years, 1 month",
+    ["years", 60, 1],
+  ],
+  [
+    date11003, date11007, "4 months",
+    ["years", 0, 4],
+  ],
+  [
+    date10903, date11007, "1 year, 4 months",
+    ["years", 1, 4],
+  ],
+  [
+    date04903, date11007, "61 years, 4 months",
+    ["years", 61, 4],
+  ],
+  [
+    date10812, date11007, "1 year, 7 months",
+    ["years", 1, 7],
+  ],
+  [
+    date08612, date09006, "3 years, 6 months",
+    ["years", 3, 6],
+  ],
+  [
+    date10912, date11007, "7 months",
+    ["years", 0, 7],
+  ],
+  [
+    date08612, date11007, "23 years, 7 months",
+    ["years", 23, 7],
+  ],
+  [
+    date10812, date11003, "1 year, 3 months",
+    ["years", 1, 3],
+  ],
+  [
+    date05807, date10807, "crossing epoch",
+    ["years", 50, 0],
+  ],
+  [
+    date11008, date11007, "negative 1 month in same year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date11001, date10912, "negative 1 month in different year",
+    ["years", 0, -1],
+    ["months", 0, -1],
+  ],
+  [
+    date11009, date11007, "negative 2 months which both have 31 days",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    date11107, date11007, "negative 1 year",
+    ["years", -1, 0],
+    ["months", 0, -12],
+  ],
+  [
+    date12007, date11007, "negative 10 years",
+    ["years", -10, 0],
+    ["months", 0, -120],
+  ],
+  [
+    date11109, date11007, "negative 1 year 2 months",
+    ["years", -1, -2],
+  ],
+  [
+    date12012, date11007, "negative 10 years and 5 months",
+    ["years", -10, -5],
+  ],
+  [
+    date11007, date08612, "negative 23 years and 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date11007, date08607, "negative 24 years",
+    ["years", -24, 0],
+  ],
+  [
+    date10903, date04902, "negative 60 years, 1 month",
+    ["years", -60, -1],
+  ],
+  [
+    date11007, date11003, "negative 4 months",
+    ["years", 0, -4],
+  ],
+  [
+    date11007, date10903, "negative 1 year, 4 months",
+    ["years", -1, -4],
+  ],
+  [
+    date11007, date04903, "negative 61 years, 4 months",
+    ["years", -61, -4],
+  ],
+  [
+    date11007, date10812, "negative 1 year, 7 months",
+    ["years", -1, -7],
+  ],
+  [
+    date11007, date10912, "negative 7 months",
+    ["years", 0, -7],
+  ],
+  [
+    date11007, date08612, "negative 23 years, 7 months",
+    ["years", -23, -7],
+  ],
+  [
+    date11003, date10812, "negative 1 year, 3 months",
+    ["years", -1, -3],
+  ],
+  [
+    date10807, date05807, "crossing epoch",
+    ["years", -50, 0],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/calendar-mismatch.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/calendar-mismatch.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: RangeError thrown if calendars' IDs do not match
+features: [Temporal]
+---*/
+
+const plainYearMonth1 = new Temporal.PlainYearMonth(2000, 1, "gregory", 1);
+const plainYearMonth2 = new Temporal.PlainYearMonth(2000, 1, "japanese", 1);
+assert.throws(RangeError, () => plainYearMonth1.until(plainYearMonth2));

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-ethiopic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-ethiopic.js
@@ -1,0 +1,77 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "ethiopic";
+const options = { overflow: "reject" };
+
+const aa5500 = Temporal.PlainYearMonth.from({ era: "aa", eraYear: 5500, monthCode: "M01", calendar }, options);
+const am1 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 1, monthCode: "M01", calendar }, options);
+const am2000 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 2000, monthCode: "M06", calendar }, options);
+const am2005 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 2005, monthCode: "M06", calendar }, options);
+const aa5450 = Temporal.PlainYearMonth.from({ era: "aa", eraYear: 5450, monthCode: "M07", calendar }, options);
+const aa5455 = Temporal.PlainYearMonth.from({ era: "aa", eraYear: 5455, monthCode: "M07", calendar }, options);
+const am5 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 5, monthCode: "M01", calendar }, options);
+
+const tests = [
+  // From 5500 AA to 1 AM
+  [
+    aa5500, am1,
+    [1, 0, "1y  from 5500 AA to 1 AM"],
+    [0, 13, "13mo  from 5500 AA to 1 AM"],
+  ],
+  [
+    am1, aa5500,
+    [-1, 0, "-1y backwards  from 5500 AA to 1 AM"],
+    [0, -13, "-13mo backwards  from 1 AM to 5500 AA"],
+  ],
+  // From 2000 AM to 2005 AM
+  [
+    am2000, am2005,
+    [5, 0, "5y from 2000 AM to 2005 AM"],
+    [0, 65, "65mo from 2000 AM to 2005 AM"],
+  ],
+  [
+    am2005, am2000,
+    [-5, 0, "-5y backwards from 2000 AM to 2005 AM"],
+    [0, -65, "-65mo backwards from 2000 AM to 2005 AM"],
+  ],
+  // From 5450 AA to 5455 AA
+  [
+    aa5450, aa5455,
+    [5, 0, "5y from 5450 AA to 5455 AA"],
+    [0, 65, "65mo from 5450 AA to 5455 AA"],
+  ],
+  [
+    aa5455, aa5450,
+    [-5, 0, "-5y  backwards from 5450 AA to 5455 AA"],
+    [0, -65, "-65mo backwards from 5450 AA to 5455 AA"],
+  ],
+  // From 5 AM to 5500 AA
+  [
+    aa5500, am5,
+    [5, 0, "5y from 5 AM to 5500 AA"],
+    [0, 65, "65mo from 5 AM to 5500 AA"],
+  ],
+  [
+    am5, aa5500,
+    [-5, 0, "-5y backwards from 5 AM to 5500 AA"],
+    [0, -65, "-65mo backwards from 5 AM to 5500 AA"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-gregory.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-gregory.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "gregory";
+const options = { overflow: "reject" };
+
+const bce5 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 5, monthCode: "M06", calendar }, options);
+const bce2 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 2, monthCode: "M12", calendar }, options);
+const bce1 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 1, monthCode: "M06", calendar }, options);
+const ce1 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1, monthCode: "M06", calendar }, options);
+const ce2 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 2, monthCode: "M01", calendar }, options);
+const ce5 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 5, monthCode: "M06", calendar }, options);
+
+const tests = [
+  // From 5 BCE to 5 CE
+  [
+    bce5, ce5,
+    [9, 0, "9y  from 5 BCE to 5 CE (no year 0)"],
+    [0, 108, "108mo  from 5 BCE to 5 CE (no year 0)"],
+  ],
+  [
+    ce5, bce5,
+    [-9, 0, "-9y backwards  from 5 BCE to 5 CE (no year 0)"],
+    [0, -108, "-108mo backwards  from 5 BCE to 5 CE (no year 0)"],
+  ],
+  // CE-BCE boundary
+  [
+    bce1, ce1,
+    [1, 0, "1y from 1 BCE to 1 CE"],
+    [0, 12, "12mo from 1 BCE to 1 CE"],
+  ],
+  [
+    ce1, bce1,
+    [-1, 0, "-1y backwards from 1 BCE to 1 CE"],
+    [0, -12, "-12mo backwards from 1 BCE to 1 CE"],
+  ],
+  [
+    bce2, ce2,
+    [2, 1, "2y 1mo from 2 BCE Dec to 2 CE Jan"],
+    [0, 25, "25mo from 2 BCE Dec to 2 CE Jan"],
+  ],
+  [
+    ce2, bce2,
+    [-2, -1, "-2y -1mo backwards from 2 BCE Dec to 2 CE Jan"],
+    [0, -25, "-25mo backwards from 2 BCE Dec to 2 CE Jan"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-islamic-civil.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-islamic-civil.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-civil";
+const options = { overflow: "reject" };
+
+const bh5 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M06", calendar }, options);
+const bh2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M12", calendar }, options);
+const bh1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah1 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah2 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M01", calendar }, options);
+const ah5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M06", calendar }, options);
+
+const tests = [
+  // From 5 BH to 5 AH
+  [
+    bh5, ah5,
+    [9, 0, "9y  from 5 BH to 5 AH (no year 0)"],
+    [0, 108, "108mo  from 5 BH to 5 AH (no year 0)"],
+  ],
+  [
+    ah5, bh5,
+    [-9, 0, "-9y backwards  from 5 BH to 5 AH (no year 0)"],
+    [0, -108, "-108mo backwards  from 5 BH to 5 AH (no year 0)"],
+  ],
+  // AH-BH boundary
+  [
+    bh1, ah1,
+    [1, 0, "1y from 1 BH to 1 AH"],
+    [0, 12, "12mo from 1 BH to 1 AH"],
+  ],
+  [
+    ah1, bh1,
+    [-1, 0, "-1y backwards from 1 BH to 1 AH"],
+    [0, -12, "-12mo backwards from 1 BH to 1 AH"],
+  ],
+  [
+    bh2, ah2,
+    [2, 1, "2y 1mo from 2 BH Dec to 2 AH Jan"],
+    [0, 25, "25mo from 2 BH Dec to 2 AH Jan"],
+  ],
+  [
+    ah2, bh2,
+    [-2, -1, "-2y -1mo backwards from 2 BH Dec to 2 AH Jan"],
+    [0, -25, "-25mo backwards from 2 BH Dec to 2 AH Jan"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-islamic-tbla.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-islamic-tbla.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-tbla";
+const options = { overflow: "reject" };
+
+const bh5 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M06", calendar }, options);
+const bh2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M12", calendar }, options);
+const bh1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah1 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah2 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M01", calendar }, options);
+const ah5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M06", calendar }, options);
+
+const tests = [
+  // From 5 BH to 5 AH
+  [
+    bh5, ah5,
+    [9, 0, "9y  from 5 BH to 5 AH (no year 0)"],
+    [0, 108, "108mo  from 5 BH to 5 AH (no year 0)"],
+  ],
+  [
+    ah5, bh5,
+    [-9, 0, "-9y backwards  from 5 BH to 5 AH (no year 0)"],
+    [0, -108, "-108mo backwards  from 5 BH to 5 AH (no year 0)"],
+  ],
+  // AH-BH boundary
+  [
+    bh1, ah1,
+    [1, 0, "1y from 1 BH to 1 AH"],
+    [0, 12, "12mo from 1 BH to 1 AH"],
+  ],
+  [
+    ah1, bh1,
+    [-1, 0, "-1y backwards from 1 BH to 1 AH"],
+    [0, -12, "-12mo backwards from 1 BH to 1 AH"],
+  ],
+  [
+    bh2, ah2,
+    [2, 1, "2y 1mo from 2 BH Dec to 2 AH Jan"],
+    [0, 25, "25mo from 2 BH Dec to 2 AH Jan"],
+  ],
+  [
+    ah2, bh2,
+    [-2, -1, "-2y -1mo backwards from 2 BH Dec to 2 AH Jan"],
+    [0, -25, "-25mo backwards from 2 BH Dec to 2 AH Jan"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-islamic-umalqura.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-islamic-umalqura.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-umalqura";
+const options = { overflow: "reject" };
+
+const bh5 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M06", calendar }, options);
+const bh2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M12", calendar }, options);
+const bh1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah1 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+const ah2 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M01", calendar }, options);
+const ah5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M06", calendar }, options);
+
+const tests = [
+  // From 5 BH to 5 AH
+  [
+    bh5, ah5,
+    [9, 0, "9y  from 5 BH to 5 AH (no year 0)"],
+    [0, 108, "108mo  from 5 BH to 5 AH (no year 0)"],
+  ],
+  [
+    ah5, bh5,
+    [-9, 0, "-9y backwards  from 5 BH to 5 AH (no year 0)"],
+    [0, -108, "-108mo backwards  from 5 BH to 5 AH (no year 0)"],
+  ],
+  // AH-BH boundary
+  [
+    bh1, ah1,
+    [1, 0, "1y from 1 BH to 1 AH"],
+    [0, 12, "12mo from 1 BH to 1 AH"],
+  ],
+  [
+    ah1, bh1,
+    [-1, 0, "-1y backwards from 1 BH to 1 AH"],
+    [0, -12, "-12mo backwards from 1 BH to 1 AH"],
+  ],
+  [
+    bh2, ah2,
+    [2, 1, "2y 1mo from 2 BH Dec to 2 AH Jan"],
+    [0, 25, "25mo from 2 BH Dec to 2 AH Jan"],
+  ],
+  [
+    ah2, bh2,
+    [-2, -1, "-2y -1mo backwards from 2 BH Dec to 2 AH Jan"],
+    [0, -25, "-25mo backwards from 2 BH Dec to 2 AH Jan"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-japanese.js
@@ -1,0 +1,127 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "japanese";
+const options = { overflow: "reject" };
+
+const bce1 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 1, monthCode: "M06", calendar }, options);
+const ce1 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1, monthCode: "M06", calendar }, options);
+const meiji5 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 5, monthCode: "M01", calendar }, options);
+const meiji45 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 45, monthCode: "M05", calendar }, options);
+const taisho1 = Temporal.PlainYearMonth.from({ era: "taisho", eraYear: 1, monthCode: "M08", calendar }, options);
+const taisho6 = Temporal.PlainYearMonth.from({ era: "taisho", eraYear: 6, monthCode: "M03", calendar }, options);
+const showa55 = Temporal.PlainYearMonth.from({ era: "showa", eraYear: 55, monthCode: "M03", calendar }, options);
+const showa64 = Temporal.PlainYearMonth.from({ era: "showa", eraYear: 64, monthCode: "M01", calendar }, options);
+const heisei1 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 1, monthCode: "M02", calendar }, options);
+const heisei30 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 30, monthCode: "M03", calendar }, options);
+const heisei31 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 31, monthCode: "M04", calendar }, options);
+const reiwa1 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 1, monthCode: "M06", calendar }, options);
+const reiwa2 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 2, monthCode: "M03", calendar }, options);
+
+const tests = [
+  // From Heisei 30 (2018) to Reiwa 2 (2020) - crossing era boundary
+  [
+    heisei30, reiwa2,
+    [2, 0, "2y from Heisei 30 March to Reiwa 2 March"],
+    [0, 24, "24mo from Heisei 30 March to Reiwa 2 March"],
+  ],
+  [
+    reiwa2, heisei30,
+    [-2, 0, "-2y backwards from Heisei 30 March to Reiwa 2 March"],
+    [0, -24, "-24mo backwards from Heisei 30 March to Reiwa 2 March"],
+  ],
+  // Within same year but different eras
+  [
+    heisei31, reiwa1,
+    [0, 2, "2mo from Heisei 31 April to Reiwa 1 June"],
+    [0, 2, "2mo from Heisei 31 April to Reiwa 1 June"],
+  ],
+  [
+    reiwa1, heisei31,
+    [0, -2, "-2mo backwards from Heisei 31 April to Reiwa 1 June"],
+    [0, -2, "-2mo backwards from Heisei 31 April to Reiwa 1 June"],
+  ],
+  // From Showa 55 (1980) to Heisei 30 (2018) - crossing era boundary
+  [
+    showa55, heisei30,
+    [38, 0, "38y from Showa 55 March to Heisei 30 March"],
+    [0, 456, "456mo from Showa 55 March to Heisei 30 March"],
+  ],
+  [
+    heisei30, showa55,
+    [-38, 0, "-38y backwards from Showa 55 March to Heisei 30 March"],
+    [0, -456, "-456mo backwards from Showa 55 March to Heisei 30 March"],
+  ],
+  // Within same year but different eras
+  [
+    showa64, heisei1,
+    [0, 1, "1mo from Showa 64 January to Heisei 1 February"],
+    [0, 1, "1mo from Showa 64 January to Heisei 1 February"],
+  ],
+  [
+    heisei1, showa64,
+    [0, -1, "-1mo from Showa 64 January to Heisei 1 February"],
+    [0, -1, "-1mo from Showa 64 January to Heisei 1 February"],
+  ],
+  // From Taisho 6 (1917) to Showa 55 (1980) - crossing era boundary
+  [
+    taisho6, showa55,
+    [63, 0, "63y from Taisho 6 March to Showa 55 March"],
+    [0, 756, "756mo from Taisho 6 March to Showa 55 March"],
+  ],
+  [
+    showa55, taisho6,
+    [-63, 0, "-63y backwards from Taisho 6 March to Showa 55 March"],
+    [0, -756, "-756mo backwards from Taisho 6 March to Showa 55 March"],
+  ],
+  // From Meiji 5 (1872) to Taisho 6 (1917) - crossing era boundary
+  [
+    meiji5, taisho6,
+    [45, 2, "45y 2mo from Meiji 5 January to Taisho 6 March"],
+    [0, 542, "542mo from Meiji 5 January to Taisho 6 March"],
+  ],
+  [
+    taisho6, meiji5,
+    [-45, -2, "-45y -2mo backwards from Meiji 5 January to Taisho 6 March"],
+    [0, -542, "-542mo backwards from Meiji 5 January to Taisho 6 March"],
+  ],
+  // Within same year but different eras
+  [
+    meiji45, taisho1,
+    [0, 3, "3mo from Meiji 45 May to Taisho 1 August"],
+    [0, 3, "3mo from Meiji 45 May to Taisho 1 August"],
+  ],
+  [
+    taisho1, meiji45,
+    [0, -3, "-3mo backwards from Meiji 45 May to Taisho 1 August"],
+    [0, -3, "-3mo backwards from Meiji 45 May to Taisho 1 August"],
+  ],
+  // CE-BCE boundary
+  [
+    bce1, ce1,
+    [1, 0, "1y from 1 BCE to 1 CE"],
+    [0, 12, "12mo from 1 BCE to 1 CE"],
+  ],
+  [
+    ce1, bce1,
+    [-1, 0, "-1y backwards from 1 BCE to 1 CE"],
+    [0, -12, "-12mo backwards from 1 BCE to 1 CE"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-roc.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-roc.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Date difference works correctly across era boundaries
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "roc";
+const options = { overflow: "reject" };
+
+const broc5 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 5, monthCode: "M03", calendar }, options);
+const broc3 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 3, monthCode: "M01", calendar }, options);
+const broc1 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 1, monthCode: "M06", calendar }, options);
+const roc1 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 1, monthCode: "M06", calendar }, options);
+const roc5 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 5, monthCode: "M03", calendar }, options);
+const roc10 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 10, monthCode: "M01", calendar }, options);
+
+const tests = [
+  // From BROC 5 to ROC 5
+  [
+    broc5, roc5,
+    [9, 0, "9y  from BROC 5 to ROC 5 (no year 0)"],
+    [0, 108, "108mo  from BROC 5 to ROC 5 (no year 0)"],
+  ],
+  [
+    roc5, broc5,
+    [-9, 0, "-9y backwards  from BROC 5 to ROC 5 (no year 0)"],
+    [0, -108, "-108mo backwards  from BROC 5 to ROC 5 (no year 0)"],
+  ],
+  // Era boundary
+  [
+    broc1, roc1,
+    [1, 0, "1y from BROC 1 to ROC 1"],
+    [0, 12, "12mo from BROC 1 to ROC 1"],
+  ],
+  [
+    roc1, broc1,
+    [-1, 0, "-1y backwards from BROC 1 to ROC 1"],
+    [0, -12, "-12mo backwards from BROC 1 to ROC 1"],
+  ],
+  [
+    broc3, roc10,
+    [12, 0, "12y from BROC 3 to ROC 10"],
+    [0, 144, "144mo from BROC 3 to ROC 10"],
+  ],
+  [
+    roc10, broc3,
+    [-12, 0, "-12y backwards from BROC 3 to ROC 10"],
+    [0, -144, "-144mo backwards from BROC 3 to ROC 10"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/intercalary-month-coptic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/intercalary-month-coptic.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations involving the intercalary month (coptic
+  calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "coptic";
+const options = { overflow: "reject" };
+
+const commonM12 = Temporal.PlainYearMonth.from({ year: 1738, monthCode: "M12", calendar}, options);
+const commonIntercalary = Temporal.PlainYearMonth.from({ year: 1738, monthCode: "M13", calendar}, options);
+const leapFirst = Temporal.PlainYearMonth.from({ year: 1739, monthCode: "M01", calendar}, options);
+const leapM12 = Temporal.PlainYearMonth.from({ year: 1739, monthCode: "M12", calendar}, options);
+const leapIntercalary = Temporal.PlainYearMonth.from({ year: 1739, monthCode: "M13", calendar}, options);
+const common2First = Temporal.PlainYearMonth.from({ year: 1740, monthCode: "M01", calendar }, options);
+const common2Intercalary = Temporal.PlainYearMonth.from({ year: 1740, monthCode: "M13", calendar }, options);
+
+const tests = [
+  [
+    commonIntercalary, leapIntercalary, "last month of common year to last month of leap year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    leapIntercalary, common2Intercalary, "last month of leap year to last month of common year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    commonM12, leapFirst, "2mo passing through intercalary month in common year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    leapM12, common2First, "2mo passing through intercalary month in leap year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    common2Intercalary, leapIntercalary, "backwards last month of common year to last month of leap year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    leapIntercalary, commonIntercalary, "backwards last month of leap year to last month of common year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    leapFirst, commonM12, "backwards 2mo passing through intercalary month in common year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    common2First, leapM12, "backwards 2mo passing through intercalary month in leap year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr + ` (largest unit ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/intercalary-month-ethioaa.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/intercalary-month-ethioaa.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations involving the intercalary month (ethioaa
+  calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "ethioaa";
+const options = { overflow: "reject" };
+
+const commonM12 = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M12", calendar}, options);
+const commonIntercalary = Temporal.PlainYearMonth.from({ year: 7514, monthCode: "M13", calendar}, options);
+const leapFirst = Temporal.PlainYearMonth.from({ year: 7515, monthCode: "M01", calendar}, options);
+const leapM12 = Temporal.PlainYearMonth.from({ year: 7515, monthCode: "M12", calendar}, options);
+const leapIntercalary = Temporal.PlainYearMonth.from({ year: 7515, monthCode: "M13", calendar}, options);
+const common2First = Temporal.PlainYearMonth.from({ year: 7516, monthCode: "M01", calendar }, options);
+const common2Intercalary = Temporal.PlainYearMonth.from({ year: 7516, monthCode: "M13", calendar }, options);
+
+const tests = [
+  [
+    commonIntercalary, leapIntercalary, "last month of common year to last month of leap year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    leapIntercalary, common2Intercalary, "last month of leap year to last month of common year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    commonM12, leapFirst, "2mo passing through intercalary month in common year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    leapM12, common2First, "2mo passing through intercalary month in leap year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    common2Intercalary, leapIntercalary, "backwards last month of common year to last month of leap year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    leapIntercalary, commonIntercalary, "backwards last month of leap year to last month of common year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    leapFirst, commonM12, "backwards 2mo passing through intercalary month in common year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    common2First, leapM12, "backwards 2mo passing through intercalary month in leap year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr + ` (largest unit ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/intercalary-month-ethiopic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/intercalary-month-ethiopic.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Check various basic calculations involving the intercalary month (ethiopic
+  calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "ethiopic";
+const options = { overflow: "reject" };
+
+const commonM12 = Temporal.PlainYearMonth.from({ year: 2014, monthCode: "M12", calendar}, options);
+const commonIntercalary = Temporal.PlainYearMonth.from({ year: 2014, monthCode: "M13", calendar}, options);
+const leapFirst = Temporal.PlainYearMonth.from({ year: 2015, monthCode: "M01", calendar}, options);
+const leapM12 = Temporal.PlainYearMonth.from({ year: 2015, monthCode: "M12", calendar}, options);
+const leapIntercalary = Temporal.PlainYearMonth.from({ year: 2015, monthCode: "M13", calendar}, options);
+const common2First = Temporal.PlainYearMonth.from({ year: 2016, monthCode: "M01", calendar }, options);
+const common2Intercalary = Temporal.PlainYearMonth.from({ year: 2016, monthCode: "M13", calendar }, options);
+
+const tests = [
+  [
+    commonIntercalary, leapIntercalary, "last month of common year to last month of leap year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    leapIntercalary, common2Intercalary, "last month of leap year to last month of common year",
+    ["years", 1, 0],
+    ["months", 0, 13],
+  ],
+  [
+    commonM12, leapFirst, "2mo passing through intercalary month in common year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    leapM12, common2First, "2mo passing through intercalary month in leap year",
+    ["years", 0, 2],
+    ["months", 0, 2],
+  ],
+  [
+    common2Intercalary, leapIntercalary, "backwards last month of common year to last month of leap year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    leapIntercalary, commonIntercalary, "backwards last month of leap year to last month of common year",
+    ["years", -1, 0],
+    ["months", 0, -13],
+  ],
+  [
+    leapFirst, commonM12, "backwards 2mo passing through intercalary month in common year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+  [
+    common2First, leapM12, "backwards 2mo passing through intercalary month in leap year",
+    ["years", 0, -2],
+    ["months", 0, -2],
+  ],
+];
+
+for (const [one, two, descr, ...units] of tests) {
+  for (const [largestUnit, years, months] of units) {
+    TemporalHelpers.assertDuration(
+      one.until(two, { largestUnit }),
+      years, months, 0, 0, 0, 0, 0, 0, 0, 0,
+      descr + ` (largest unit ${largestUnit})`
+    );
+  }
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/leap-months-chinese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/leap-months-chinese.js
@@ -1,0 +1,149 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in chinese calendar
+esid: sec-temporal.plainyearmonth.prototype.until
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 2001 is a leap year with a M04L leap month.
+
+const calendar = "chinese";
+const options = { overflow: "reject" };
+
+const common1Month4 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M04", calendar }, options);
+const common1Month5 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M05", calendar }, options);
+const common1Month6 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M06", calendar }, options);
+const leapMonth4 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M04", calendar }, options);
+const leapMonth4L = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M04L", calendar }, options);
+const leapMonth5 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M05", calendar }, options);
+const common2Month4 = Temporal.PlainYearMonth.from({ year: 2002, monthCode: "M04", calendar }, options);
+const common2Month5 = Temporal.PlainYearMonth.from({ year: 2002, monthCode: "M05", calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+const tests = [
+  [
+    common1Month4, leapMonth4,
+    [1, 0, "M04-M04 common-leap is 1y"],
+    [0, 12, "M04-M04 common-leap is 12mo"],
+  ],
+  [
+    leapMonth4, common2Month4,
+    [1, 0, "M04-M04 leap-common is 1y"],
+    [0, 13, "M04-M04 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common1Month4, common2Month4,
+    [2, 0, "M04-M04 common-common is 2y"],
+    [0, 25, "M04-M04 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Month5, leapMonth5,
+    [1, 0, "M05-M05 common-leap is 1y"],
+    [0, 13, "M05-M05 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapMonth5, common2Month5,
+    [1, 0, "M05-M05 leap-common is 1y"],
+    [0, 12, "M05-M05 leap-common is 12mo"],
+  ],
+  [
+    common1Month5, common2Month5,
+    [2, 0, "M05-M05 common-common is 2y"],
+    [0, 25, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Month4, leapMonth4L,
+    [1, 1, "M04-M04L is 1y 1mo"],
+    [0, 13, "M04-M04L is 13mo"],
+  ],
+  [
+    leapMonth4L, common2Month4,
+    [0, 12, "M04L-M04 is 12mo not 1y"],
+    [0, 12, "M04L-M04 is 12mo"],
+  ],
+  [
+    common1Month5, leapMonth4L,
+    [0, 12, "M05-M04L is 12mo not 1y"],
+    [0, 12, "M05-M04L is 12mo"],
+  ],
+  [
+    leapMonth4L, common2Month5,
+    [1, 1, "M04L-M05 is 1y 1mo (exhibits calendar-specific constraining)"],
+    [0, 13, "M04L-M05 is 13mo"],
+  ],
+  [
+    common1Month6, leapMonth5,
+    [0, 12, "M06-M05 common-leap is 12mo not 11mo"],
+    [0, 12, "M06-M05 common-leap is 12mo not 11mo"],
+  ],
+
+  // Negative
+  [
+    common2Month4, leapMonth4,
+    [-1, 0, "M04-M04 common-leap backwards is -1y"],
+    [0, -13, "M04-M04 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapMonth4, common1Month4,
+    [-1, 0, "M04-M04 leap-common backwards is -1y"],
+    [0, -12, "M04-M04 leap-common backwards is -12mo not -13mo"],
+  ],
+  [
+    common2Month4, common1Month4,
+    [-2, 0, "M04-M04 common-common backwards is -2y"],
+    [0, -25, "M04-M04 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Month5, leapMonth5,
+    [-1, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -12, "M05-M05 common-leap backwards is -12mo not -13mo"],
+  ],
+  [
+    leapMonth5, common1Month5,
+    [-1, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -13, "M05-M05 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common2Month5, common1Month5,
+    [-2, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Month4, leapMonth4L,
+    [0, -12, "M04-M04L backwards is -12mo not -1y"],
+    [0, -12, "M04-M04L backwards is -12mo"],
+  ],
+  [
+    leapMonth4L, common1Month4,
+    [-1, 0, "M04L-M04 backwards is -1y not -1y -1mo (exhibits calendar-specific constraining)"],
+    [0, -13, "M04L-M04 backwards is -13mo"],
+  ],
+  [
+    common2Month5, leapMonth4L,
+    [-1, -1, "M05-M04L backwards is -1y -1mo"],
+    [0, -13, "M05-M04L backwards is -13mo"],
+  ],
+  [
+    leapMonth4L, common1Month5,
+    [0, -12, "M04L-M05 backwards is -12mo not -1y"],
+    [0, -12, "M04L-M05 backwards is -12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/leap-months-dangi.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/leap-months-dangi.js
@@ -1,0 +1,149 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in dangi calendar
+esid: sec-temporal.plainyearmonth.prototype.until
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 2001 is a leap year with a M04L leap month.
+
+const calendar = "dangi";
+const options = { overflow: "reject" };
+
+const common1Month4 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M04", calendar }, options);
+const common1Month5 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M05", calendar }, options);
+const common1Month6 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M06", calendar }, options);
+const leapMonth4 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M04", calendar }, options);
+const leapMonth4L = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M04L", calendar }, options);
+const leapMonth5 = Temporal.PlainYearMonth.from({ year: 2001, monthCode: "M05", calendar }, options);
+const common2Month4 = Temporal.PlainYearMonth.from({ year: 2002, monthCode: "M04", calendar }, options);
+const common2Month5 = Temporal.PlainYearMonth.from({ year: 2002, monthCode: "M05", calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+const tests = [
+  [
+    common1Month4, leapMonth4,
+    [1, 0, "M04-M04 common-leap is 1y"],
+    [0, 12, "M04-M04 common-leap is 12mo"],
+  ],
+  [
+    leapMonth4, common2Month4,
+    [1, 0, "M04-M04 leap-common is 1y"],
+    [0, 13, "M04-M04 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common1Month4, common2Month4,
+    [2, 0, "M04-M04 common-common is 2y"],
+    [0, 25, "M04-M04 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Month5, leapMonth5,
+    [1, 0, "M05-M05 common-leap is 1y"],
+    [0, 13, "M05-M05 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapMonth5, common2Month5,
+    [1, 0, "M05-M05 leap-common is 1y"],
+    [0, 12, "M05-M05 leap-common is 12mo"],
+  ],
+  [
+    common1Month5, common2Month5,
+    [2, 0, "M05-M05 common-common is 2y"],
+    [0, 25, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Month4, leapMonth4L,
+    [1, 1, "M04-M04L is 1y 1mo"],
+    [0, 13, "M04-M04L is 13mo"],
+  ],
+  [
+    leapMonth4L, common2Month4,
+    [0, 12, "M04L-M04 is 12mo not 1y"],
+    [0, 12, "M04L-M04 is 12mo"],
+  ],
+  [
+    common1Month5, leapMonth4L,
+    [0, 12, "M05-M04L is 12mo not 1y"],
+    [0, 12, "M05-M04L is 12mo"],
+  ],
+  [
+    leapMonth4L, common2Month5,
+    [1, 1, "M04L-M05 is 1y 1mo (exhibits calendar-specific constraining)"],
+    [0, 13, "M04L-M05 is 13mo"],
+  ],
+  [
+    common1Month6, leapMonth5,
+    [0, 12, "M06-M05 common-leap is 12mo not 11mo"],
+    [0, 12, "M06-M05 common-leap is 12mo not 11mo"],
+  ],
+
+  // Negative
+  [
+    common2Month4, leapMonth4,
+    [-1, 0, "M04-M04 common-leap backwards is -1y"],
+    [0, -13, "M04-M04 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapMonth4, common1Month4,
+    [-1, 0, "M04-M04 leap-common backwards is -1y"],
+    [0, -12, "M04-M04 leap-common backwards is -12mo not -13mo"],
+  ],
+  [
+    common2Month4, common1Month4,
+    [-2, 0, "M04-M04 common-common backwards is -2y"],
+    [0, -25, "M04-M04 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Month5, leapMonth5,
+    [-1, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -12, "M05-M05 common-leap backwards is -12mo not -13mo"],
+  ],
+  [
+    leapMonth5, common1Month5,
+    [-1, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -13, "M05-M05 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common2Month5, common1Month5,
+    [-2, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Month4, leapMonth4L,
+    [0, -12, "M04-M04L backwards is -12mo not -1y"],
+    [0, -12, "M04-M04L backwards is -12mo"],
+  ],
+  [
+    leapMonth4L, common1Month4,
+    [-1, 0, "M04L-M04 backwards is -1y not -1y -1mo (exhibits calendar-specific constraining)"],
+    [0, -13, "M04L-M04 backwards is -13mo"],
+  ],
+  [
+    common2Month5, leapMonth4L,
+    [-1, -1, "M05-M04L backwards is -1y -1mo"],
+    [0, -13, "M05-M04L backwards is -13mo"],
+  ],
+  [
+    leapMonth4L, common1Month5,
+    [0, -12, "M04L-M05 backwards is -12mo not -1y"],
+    [0, -12, "M04L-M05 backwards is -12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/leap-months-hebrew.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/leap-months-hebrew.js
@@ -1,0 +1,153 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Difference across leap months in hebrew calendar
+esid: sec-temporal.plainyearmonth.prototype.until
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// 5784 is a leap year.
+// M05 - Shevat
+// M05L - Adar I
+// M06 - Adar II
+// M07 - Nisan
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+const common1Shevat = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M05", calendar }, options);
+const common1Adar = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M06", calendar }, options);
+const common1Nisan = Temporal.PlainYearMonth.from({ year: 5783, monthCode: "M07", calendar }, options);
+const leapShevat = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M05", calendar }, options);
+const leapAdarI = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M05L", calendar }, options);
+const leapAdarII = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M06", calendar }, options);
+const common2Shevat = Temporal.PlainYearMonth.from({ year: 5785, monthCode: "M05", calendar }, options);
+const common2Adar = Temporal.PlainYearMonth.from({ year: 5785, monthCode: "M06", calendar }, options);
+
+// (receiver, argument, years test data, months test data)
+// test data: expected years, months, description
+// largestUnit years: make sure some cases where the answer is 12 months do not
+// balance up to 1 year
+// largestUnit months: similar to years, but make sure number of months in year
+// is computed correctly
+const tests = [
+  [
+    common1Shevat, leapShevat,
+    [1, 0, "M05-M05 common-leap is 1y"],
+    [0, 12, "M05-M05 common-leap is 12mo"],
+  ],
+  [
+    leapShevat, common2Shevat,
+    [1, 0, "M05-M05 leap-common is 1y"],
+    [0, 13, "M05-M05 leap-common is 13mo not 12mo"],
+  ],
+  [
+    common1Shevat, common2Shevat,
+    [2, 0, "M05-M05 common-common is 2y"],
+    [0, 25, "M05-M05 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Adar, leapAdarII,
+    [1, 0, "M06-M06 common-leap is 1y"],
+    [0, 13, "M06-M06 common-leap is 13mo not 12mo"],
+  ],
+  [
+    leapAdarII, common2Adar,
+    [1, 0, "M06-M06 leap-common is 1y"],
+    [0, 12, "M06-M06 leap-common is 12mo"],
+  ],
+  [
+    common1Adar, common2Adar,
+    [2, 0, "M06-M06 common-common is 2y"],
+    [0, 25, "M06-M06 common-common is 25mo not 24mo"],
+  ],
+  [
+    common1Shevat, leapAdarI,
+    [1, 1, "M05-M05L is 1y 1mo"],
+    [0, 13, "M05-M05L is 13mo"],
+  ],
+  [
+    leapAdarI, common2Shevat,
+    [0, 12, "M05L-M05 is 12mo not 1y"],
+    [0, 12, "M05L-M05 is 12mo"],
+  ],
+  [
+    common1Adar, leapAdarI,
+    [0, 12, "M06-M05L is 12mo not 1y"],
+    [0, 12, "M06-M05L is 12mo"],
+  ],
+  [
+    leapAdarI, common2Adar,
+    [1, 0, "M05L-M06 is 1y (exhibits calendar-specific constraining)"],
+    [0, 13, "M05L-M06 is 13mo"],
+  ],
+  [
+    common1Nisan, leapAdarII,
+    [0, 12, "M07-M06 common-leap is 12mo not 11mo"],
+    [0, 12, "M07-M06 common-leap is 12mo not 11mo"],
+  ],
+
+  // Negative
+  [
+    common2Shevat, leapShevat,
+    [-1, 0, "M05-M05 common-leap backwards is -1y"],
+    [0, -13, "M05-M05 common-leap backwards is -13mo not -12mo"],
+  ],
+  [
+    leapShevat, common1Shevat,
+    [-1, 0, "M05-M05 leap-common backwards is -1y"],
+    [0, -12, "M05-M05 leap-common backwards is -12mo not -13mo"],
+  ],
+  [
+    common2Shevat, common1Shevat,
+    [-2, 0, "M05-M05 common-common backwards is -2y"],
+    [0, -25, "M05-M05 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Adar, leapAdarII,
+    [-1, 0, "M06-M06 common-leap backwards is -1y"],
+    [0, -12, "M06-M06 common-leap backwards is -12mo not -13mo"],
+  ],
+  [
+    leapAdarII, common1Adar,
+    [-1, 0, "M06-M06 leap-common backwards is -1y"],
+    [0, -13, "M06-M06 leap-common backwards is -13mo not -12mo"],
+  ],
+  [
+    common2Adar, common1Adar,
+    [-2, 0, "M06-M06 common-common backwards is -2y"],
+    [0, -25, "M06-M06 common-common backwards is -25mo not -24mo"],
+  ],
+  [
+    common2Shevat, leapAdarI,
+    [0, -12, "M05-M05L backwards is -12mo not -1y"],
+    [0, -12, "M05-M05L backwards is -12mo"],
+  ],
+  [
+    leapAdarI, common1Shevat,
+    [-1, -1, "M05L-M05 backwards is -1y -1mo (exhibits calendar-specific constraining)"],
+    [0, -13, "M05L-M05 backwards is -13mo"],
+  ],
+  [
+    common2Adar, leapAdarI,
+    [-1, -1, "M06-M05L backwards is -1y -1mo"],
+    [0, -13, "M06-M05L backwards is -13mo"],
+  ],
+  [
+    leapAdarI, common1Adar,
+    [0, -12, "M05L-M06 backwards is -12mo not -1y"],
+    [0, -12, "M05L-M06 backwards is -12mo"],
+  ],
+];
+
+for (const [one, two, yearsTest, monthsTest] of tests) {
+  let [years, months, descr] = yearsTest;
+  let result = one.until(two, { largestUnit: "years" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+
+  [years, months, descr] = monthsTest;
+  result = one.until(two, { largestUnit: "months" });
+  TemporalHelpers.assertDuration(result, years, months, 0, 0, 0, 0, 0, 0, 0, 0, descr);
+}


### PR DESCRIPTION
This commit copies all of the PlainDate `since()` and `until()` tests that would apply to PlainYearMonth, and adapts them where necessary.

To follow: `add()`, `subtract()`. See #4762 for part 1.

It's very large so most likely the best way to review it is spot-checking and searching for extraneous `day:` properties.