### PR TITLE
Intl Era Monthcode: Calendar PlainYearMonth tests, part 3

### DIFF
--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-buddhist.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-buddhist.js
@@ -1,0 +1,111 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years4 = new Temporal.Duration(4);
+const years4n = new Temporal.Duration(-4);
+
+const date256407 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date256407.add(years1),
+  2565, 7, "M07", "add 1y",
+  "be", 2565, null);
+TemporalHelpers.assertPlainYearMonth(
+  date256407.add(years4),
+  2568, 7, "M07", "add 4y",
+  "be", 2568, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date256407.add(years1n),
+  2563, 7, "M07", "subtract 1y",
+  "be", 2563, null);
+TemporalHelpers.assertPlainYearMonth(
+  date256407.add(years4n),
+  2560, 7, "M07", "subtract 4y",
+  "be", 2560, null);
+
+// Months
+
+const months5 = new Temporal.Duration(0, 5);
+const months5n = new Temporal.Duration(0, -5);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+const years1months2 = new Temporal.Duration(1, 2);
+const years1months2n = new Temporal.Duration(-1, -2);
+
+const date255512 = Temporal.PlainYearMonth.from({ year: 2555, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date256407.add(months5),
+  2564, 12, "M12", "add 5mo with result in the same year",
+  "be", 2564, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M08", calendar }).add(months5),
+  2565, 1, "M01", "add 5mo with result in the next year",
+  "be", 2565, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2562, monthCode: "M10", calendar }).add(months5),
+  2563, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "be", 2563, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M10", calendar }).add(months5),
+  2565, 3, "M03", "add 5mo with result in the next year on day 31 of month",
+  "be", 2565, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date256407.add(years1months2),
+  2565, 9, "M09", "add 1y 2mo",
+  "be", 2565, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M11", calendar }).add(years1months2),
+  2566, 1, "M01", "add 1y 2mo with result in the next year",
+  "be", 2566, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date256407.add(months5n),
+  2564, 2, "M02", "subtract 5mo with result in the same year",
+  "be", 2564, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M01", calendar }).add(months5n),
+  2563, 8, "M08", "subtract 5mo with result in the previous year",
+  "be", 2563, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2562, monthCode: "M02", calendar }).add(months5n),
+  2561, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "be", 2561, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M03", calendar }).add(months5n),
+  2563, 10, "M10", "subtract 5mo with result in the previous year on day 31 of month",
+  "be", 2563, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date256407.add(years1months2n),
+  2563, 5, "M05", "subtract 1y 2mo",
+  "be", 2563, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M02", calendar }).add(years1months2n),
+  2562, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "be", 2562, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date255512.add(months6),
+  2556, 6, "M06", "add 6mo",
+  "be", 2556, null);
+const calculatedStart = date255512.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  2555, 12, "M12", "subtract 6mo",
+  "be", 2555, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-chinese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-chinese.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Basic addition and subtraction in the chinese calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "chinese";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years5 = new Temporal.Duration(5);
+const years5n = new Temporal.Duration(-5);
+
+const date201802 = Temporal.PlainYearMonth.from({ year: 2018, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years1),
+  2019, 2, "M02", "Adding 1 year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years5),
+  2023, 2, "M02", "Adding 5 years",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years1n),
+  2017, 2, "M02", "Subtracting 1 year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years5n),
+  2013, 2, "M02", "Subtracting 5 years",
+  undefined, undefined, null);
+
+// Months
+
+const months1 = new Temporal.Duration(0, 1);
+const months1n = new Temporal.Duration(0, -1);
+const months4 = new Temporal.Duration(0, 4);
+const months4n = new Temporal.Duration(0, -4);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+
+const date201901 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M01", calendar }, options);
+const date201906 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M06", calendar }, options);
+const date201911 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M11", calendar }, options);
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar }, options);
+const date200012 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M12", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.add(months1),
+  2019, 12, "M12", "Adding 1 month, with result in same year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201912.add(months1),
+  2020, 1, "M01", "Adding 1 month, with result in next year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.add(months4),
+  2019, 10, "M10", "Adding 4 months, with result in same year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201912.add(months4),
+  2020, 4, "M04", "Adding 4 months, with result in next year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.add(months1n),
+  2019, 10, "M10", "Subtracting 1 month, with result in same year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.add(months1n),
+  2018, 12, "M12", "Subtracting 1 month, with result in previous year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.add(months4n),
+  2019, 2, "M02", "Subtracting 4 months, with result in same year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.add(months4n),
+  2018, 9, "M09", "Subtracting 4 months, with result in previous year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.add(months6),
+  2001, 6, "M05", "Adding 6 months, with result in next year (leap year)",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.add(months6n),
+  2000, 6, "M06", "Subtracting 6 months, with result in same year",
+  undefined, undefined, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-coptic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-coptic.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Basic addition and subtraction in the coptic calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "coptic";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years5 = new Temporal.Duration(5);
+const years5n = new Temporal.Duration(-5);
+
+const date174202 = Temporal.PlainYearMonth.from({ year: 1742, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174202.add(years1),
+  1743, 2, "M02", "Adding 1 year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174202.add(years5),
+  1747, 2, "M02", "Adding 5 years", "am", 1747, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174202.add(years1n),
+  1741, 2, "M02", "Subtracting 1 year", "am", 1741, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174202.add(years5n),
+  1737, 2, "M02", "Subtracting 5 years", "am", 1737, null
+);
+
+// Months
+
+const months1 = new Temporal.Duration(0, 1);
+const months1n = new Temporal.Duration(0, -1);
+const months4 = new Temporal.Duration(0, 4);
+const months4n = new Temporal.Duration(0, -4);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+
+const date171612 = Temporal.PlainYearMonth.from({ year: 1716, monthCode: "M12", calendar }, options);
+const date174301 = Temporal.PlainYearMonth.from({ year: 1743, monthCode: "M01", calendar }, options);
+const date174306 = Temporal.PlainYearMonth.from({ year: 1743, monthCode: "M06", calendar }, options);
+const date174311 = Temporal.PlainYearMonth.from({ year: 1743, monthCode: "M11", calendar }, options);
+const date174213 = Temporal.PlainYearMonth.from({ year: 1742, monthCode: "M13", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174311.add(months1),
+  1743, 12, "M12", "Adding 1 month, with result in same year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174213.add(months1),
+  1743, 1, "M01", "Adding 1 month, with result in next year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174306.add(months4),
+  1743, 10, "M10", "Adding 4 months, with result in same year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174213.add(months4),
+  1743, 4, "M04", "Adding 4 months, with result in next year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174311.add(months1n),
+  1743, 10, "M10", "Subtracting 1 month, with result in same year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174301.add(months1n),
+  1742, 13, "M13", "Subtracting 1 month, with result in previous year", "am", 1742, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174306.add(months4n),
+  1743, 2, "M02", "Subtracting 4 months, with result in same year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174301.add(months4n),
+  1742, 10, "M10", "Subtracting 4 months, with result in previous year", "am", 1742, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date171612.add(months6),
+  1717, 5, "M05", "Adding 6 months, with result in next year", "am", 1717, null
+);
+const calculatedStart = date171612.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1716, 12, "M12", "Subtracting 6 months, with result in previous year", "am", 1716, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-dangi.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-dangi.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Basic addition and subtraction in the dangi calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "dangi";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years5 = new Temporal.Duration(5);
+const years5n = new Temporal.Duration(-5);
+
+const date201802 = Temporal.PlainYearMonth.from({ year: 2018, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years1),
+  2019, 2, "M02", "Adding 1 year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years5),
+  2023, 2, "M02", "Adding 5 years",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years1n),
+  2017, 2, "M02", "Subtracting 1 year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years5n),
+  2013, 2, "M02", "Subtracting 5 years",
+  undefined, undefined, null);
+
+// Months
+
+const months1 = new Temporal.Duration(0, 1);
+const months1n = new Temporal.Duration(0, -1);
+const months4 = new Temporal.Duration(0, 4);
+const months4n = new Temporal.Duration(0, -4);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+
+const date201901 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M01", calendar }, options);
+const date201906 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M06", calendar }, options);
+const date201911 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M11", calendar }, options);
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar }, options);
+const date200012 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M12", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.add(months1),
+  2019, 12, "M12", "Adding 1 month, with result in same year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201912.add(months1),
+  2020, 1, "M01", "Adding 1 month, with result in next year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.add(months4),
+  2019, 10, "M10", "Adding 4 months, with result in same year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201912.add(months4),
+  2020, 4, "M04", "Adding 4 months, with result in next year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.add(months1n),
+  2019, 10, "M10", "Subtracting 1 month, with result in same year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.add(months1n),
+  2018, 12, "M12", "Subtracting 1 month, with result in previous year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.add(months4n),
+  2019, 2, "M02", "Subtracting 4 months, with result in same year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.add(months4n),
+  2018, 9, "M09", "Subtracting 4 months, with result in previous year",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.add(months6),
+  2001, 6, "M05", "Adding 6 months, with result in next year (leap year)",
+  undefined, undefined, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.add(months6n),
+  2000, 6, "M06", "Subtracting 6 months, with result in same year",
+  undefined, undefined, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-ethioaa.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-ethioaa.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Basic addition and subtraction in the ethioaa calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "ethioaa";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years5 = new Temporal.Duration(5);
+const years5n = new Temporal.Duration(-5);
+
+const date750302 = Temporal.PlainYearMonth.from({ year: 7503, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750302.add(years1),
+  7504, 2, "M02", "Adding 1 year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750302.add(years5),
+  7508, 2, "M02", "Adding 5 years", "aa", 7508, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750302.add(years1n),
+  7502, 2, "M02", "Subtracting 1 year", "aa", 7502, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750302.add(years5n),
+  7498, 2, "M02", "Subtracting 5 years", "aa", 7498, null
+);
+
+// Months
+
+const months1 = new Temporal.Duration(0, 1);
+const months1n = new Temporal.Duration(0, -1);
+const months4 = new Temporal.Duration(0, 4);
+const months4n = new Temporal.Duration(0, -4);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+
+const date749212 = Temporal.PlainYearMonth.from({ year: 7492, monthCode: "M12", calendar }, options);
+const date750401 = Temporal.PlainYearMonth.from({ year: 7504, monthCode: "M01", calendar }, options);
+const date750406 = Temporal.PlainYearMonth.from({ year: 7504, monthCode: "M06", calendar }, options);
+const date750411 = Temporal.PlainYearMonth.from({ year: 7504, monthCode: "M11", calendar }, options);
+const date750313 = Temporal.PlainYearMonth.from({ year: 7503, monthCode: "M13", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750411.add(months1),
+  7504, 12, "M12", "Adding 1 month, with result in same year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750313.add(months1),
+  7504, 1, "M01", "Adding 1 month, with result in next year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750406.add(months4),
+  7504, 10, "M10", "Adding 4 months, with result in same year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750313.add(months4),
+  7504, 4, "M04", "Adding 4 months, with result in next year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750411.add(months1n),
+  7504, 10, "M10", "Subtracting 1 month, with result in same year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750401.add(months1n),
+  7503, 13, "M13", "Subtracting 1 month, with result in previous year", "aa", 7503, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750406.add(months4n),
+  7504, 2, "M02", "Subtracting 4 months, with result in same year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750401.add(months4n),
+  7503, 10, "M10", "Subtracting 4 months, with result in previous year", "aa", 7503, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date749212.add(months6),
+  7493, 5, "M05", "Adding 6 months, with result in next year", "aa", 7493, null
+);
+const calculatedStart = date749212.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  7492, 12, "M12", "Subtracting 6 months, with result in previous year", "aa", 7492, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-ethiopic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-ethiopic.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Basic addition and subtraction in the ethiopic calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "ethiopic";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years5 = new Temporal.Duration(5);
+const years5n = new Temporal.Duration(-5);
+
+const date201802 = Temporal.PlainYearMonth.from({ year: 2018, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years1),
+  2019, 2, "M02", "Adding 1 year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years5),
+  2023, 2, "M02", "Adding 5 years", "am", 2023, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years1n),
+  2017, 2, "M02", "Subtracting 1 year", "am", 2017, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.add(years5n),
+  2013, 2, "M02", "Subtracting 5 years", "am", 2013, null
+);
+
+// Months
+
+const months1 = new Temporal.Duration(0, 1);
+const months1n = new Temporal.Duration(0, -1);
+const months4 = new Temporal.Duration(0, 4);
+const months4n = new Temporal.Duration(0, -4);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+
+const date200012 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M12", calendar }, options);
+const date201901 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M01", calendar }, options);
+const date201906 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M06", calendar }, options);
+const date201911 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M11", calendar }, options);
+const date201813 = Temporal.PlainYearMonth.from({ year: 2018, monthCode: "M13", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.add(months1),
+  2019, 12, "M12", "Adding 1 month, with result in same year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201813.add(months1),
+  2019, 1, "M01", "Adding 1 month, with result in next year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.add(months4),
+  2019, 10, "M10", "Adding 4 months, with result in same year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201813.add(months4),
+  2019, 4, "M04", "Adding 4 months, with result in next year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.add(months1n),
+  2019, 10, "M10", "Subtracting 1 month, with result in same year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.add(months1n),
+  2018, 13, "M13", "Subtracting 1 month, with result in previous year", "am", 2018, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.add(months4n),
+  2019, 2, "M02", "Subtracting 4 months, with result in same year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.add(months4n),
+  2018, 10, "M10", "Subtracting 4 months, with result in previous year", "am", 2018, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.add(months6),
+  2001, 5, "M05", "Adding 6 months, with result in next year", "am", 2001, null
+);
+const calculatedStart = date200012.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  2000, 12, "M12", "Subtracting 6 months, with result in previous year", "am", 2000, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-gregory.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-gregory.js
@@ -1,0 +1,111 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years4 = new Temporal.Duration(4);
+const years4n = new Temporal.Duration(-4);
+
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years1),
+  2022, 7, "M07", "add 1y",
+  "ce", 2022);
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years4),
+  2025, 7, "M07", "add 4y",
+  "ce", 2025);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years1n),
+  2020, 7, "M07", "subtract 1y",
+  "ce", 2020);
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years4n),
+  2017, 7, "M07", "subtract 4y",
+  "ce", 2017);
+
+// Months
+
+const months5 = new Temporal.Duration(0, 5);
+const months5n = new Temporal.Duration(0, -5);
+const years1months2 = new Temporal.Duration(1, 2);
+const years1months2n = new Temporal.Duration(-1, -2);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+
+const date200012 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(months5),
+  2021, 12, "M12", "add 5mo with result in the same year",
+  "ce", 2021);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar }).add(months5),
+  2022, 1, "M01", "add 5mo with result in the next year",
+  "ce", 2022);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M10", calendar }).add(months5),
+  2020, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "ce", 2020);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M10", calendar }).add(months5),
+  2022, 3, "M03", "add 5mo with result in the next year on day 31 of month",
+  "ce", 2022);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years1months2),
+  2022, 9, "M09", "add 1y 2mo",
+  "ce", 2022);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M11", calendar }).add(years1months2),
+  2023, 1, "M01", "add 1y 2mo with result in the next year",
+  "ce", 2023);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(months5n),
+  2021, 2, "M02", "subtract 5mo with result in the same year",
+  "ce", 2021);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar }).add(months5n),
+  2020, 8, "M08", "subtract 5mo with result in the previous year",
+  "ce", 2020);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M02", calendar }).add(months5n),
+  2018, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "ce", 2018);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar }).add(months5n),
+  2020, 10, "M10", "subtract 5mo with result in the previous year on day 31 of month",
+  "ce", 2020);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years1months2n),
+  2020, 5, "M05", "subtract 1y 2mo",
+  "ce", 2020);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M02", calendar }).add(years1months2n),
+  2019, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "ce", 2019);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.add(months6),
+  2001, 6, "M06", "Adding 6 months, with result in next year", "ce", 2001
+);
+const calculatedStart = date200012.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  2000, 12, "M12", "Subtracting 6 months, with result in previous year", "ce", 2000
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-hebrew.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-hebrew.js
@@ -1,0 +1,118 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Basic addition and subtraction in the hebrew calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years5 = new Temporal.Duration(5);
+const years5n = new Temporal.Duration(-5);
+
+const date577902 = Temporal.PlainYearMonth.from({ year: 5779, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date577902.add(years1),
+  5780, 2, "M02", "Adding 1 year",
+  "am", 5780, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date577902.add(years5),
+  5784, 2, "M02", "Adding 5 years",
+  "am", 5784, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date577902.add(years1n),
+  5778, 2, "M02", "Subtracting 1 year",
+  "am", 5778, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date577902.add(years5n),
+  5774, 2, "M02", "Subtracting 5 years",
+  "am", 5774, null
+);
+
+// Months
+
+const months1 = new Temporal.Duration(0, 1);
+const months1n = new Temporal.Duration(0, -1);
+const months4 = new Temporal.Duration(0, 4);
+const months4n = new Temporal.Duration(0, -4);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+
+const date576012 = Temporal.PlainYearMonth.from({ year: 5760, monthCode: "M12", calendar }, options);
+const date578001 = Temporal.PlainYearMonth.from({ year: 5780, monthCode: "M01", calendar }, options);
+const date578006 = Temporal.PlainYearMonth.from({ year: 5780, monthCode: "M06", calendar }, options);
+const date578011 = Temporal.PlainYearMonth.from({ year: 5780, monthCode: "M11", calendar }, options);
+const date578012 = Temporal.PlainYearMonth.from({ year: 5780, monthCode: "M12", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578011.add(months1),
+  5780, 12, "M12", "Adding 1 month, with result in same year",
+  "am", 5780, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578012.add(months1),
+  5781, 1, "M01", "Adding 1 month, with result in next year",
+  "am", 5781, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578006.add(months4),
+  5780, 10, "M10", "Adding 4 months, with result in same year",
+  "am", 5780, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578012.add(months4),
+  5781, 4, "M04", "Adding 4 months, with result in next year",
+  "am", 5781, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578011.add(months1n),
+  5780, 10, "M10", "Subtracting 1 month, with result in same year",
+  "am", 5780, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578001.add(months1n),
+  5779, 13, "M12", "Subtracting 1 month, with result in previous year",
+  "am", 5779, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578006.add(months4n),
+  5780, 2, "M02", "Subtracting 4 months, with result in same year",
+  "am", 5780, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578001.add(months4n),
+  5779, 10, "M09", "Subtracting 4 months, with result in previous year",
+  "am", 5779, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date576012.add(months6),
+  5761, 6, "M06", "add 6 months, with result in next year",
+  "am", 5761, null);
+const calculatedStart = date576012.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  5760, 13, "M12", "subtract 6 months, with result in previous year",
+  "am", 5760, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-indian.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-indian.js
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (indian calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "indian";
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years4 = new Temporal.Duration(4);
+const years4n = new Temporal.Duration(-4);
+
+const date192007 = Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.add(years1),
+  1921, 7, "M07", "add 1y",
+  "shaka", 1921, null);
+TemporalHelpers.assertPlainYearMonth(
+  date192007.add(years4),
+  1924, 7, "M07", "add 4y",
+  "shaka", 1924, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.add(years1n),
+  1919, 7, "M07", "subtract 1y",
+  "shaka", 1919, null);
+TemporalHelpers.assertPlainYearMonth(
+  date192007.add(years4n),
+  1916, 7, "M07", "subtract 4y",
+  "shaka", 1916, null);
+
+// Months
+
+const months5 = new Temporal.Duration(0, 5);
+const months5n = new Temporal.Duration(0, -5);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+const months8 = new Temporal.Duration(0, 8);
+const months8n = new Temporal.Duration(0, -8);
+const years1months2 = new Temporal.Duration(1, 2);
+const years1months2n = new Temporal.Duration(-1, -2);
+
+const date19221201 = Temporal.PlainYearMonth.from({ year: 1922, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.add(months5),
+  1920, 12, "M12", "add 5mo with result in the same year",
+  "shaka", 1920, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M08", calendar }).add(months5),
+  1921, 1, "M01", "add 5mo with result in the next year",
+  "shaka", 1921, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1918, monthCode: "M10", calendar }).add(months5),
+  1919, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "shaka", 1919, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M06", calendar }).add(months8),
+  1921, 2, "M02", "add 8mo with result in the next year on day 31 of month",
+  "shaka", 1921, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.add(years1months2),
+  1921, 9, "M09", "add 1y 2mo",
+  "shaka", 1921, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M11", calendar }).add(years1months2),
+  1922, 1, "M01", "add 1y 2mo with result in the next year",
+  "shaka", 1922, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.add(months5n),
+  1920, 2, "M02", "subtract 5mo with result in the same year",
+  "shaka", 1920, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M01", calendar }).add(months5n),
+  1919, 8, "M08", "subtract 5mo with result in the previous year",
+  "shaka", 1919, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1918, monthCode: "M02", calendar }).add(months5n),
+  1917, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "shaka", 1917, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M02", calendar }).add(months8n),
+  1919, 6, "M06", "subtract 8mo with result in the previous year on day 31 of month",
+  "shaka", 1919, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.add(years1months2n),
+  1919, 5, "M05", "subtract 1y 2mo",
+  "shaka", 1919, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M02", calendar }).add(years1months2n),
+  1918, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "shaka", 1918, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date19221201.add(months6),
+  1923, 6, "M06", "add 6 months, with result in next year",
+  "shaka", 1923, null);
+const calculatedStart = date19221201.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1922, 12, "M12", "subtract 6 months, with result in previous year",
+  "shaka", 1922, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-islamic-civil.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-islamic-civil.js
@@ -1,0 +1,122 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Basic addition and subtraction in the islamic-civil calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-civil";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years5 = new Temporal.Duration(5);
+const years5n = new Temporal.Duration(-5);
+
+const date143902 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years1),
+  1440, 2, "M02", "Adding 1 year",
+  "ah", 1440, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years5),
+  1444, 2, "M02", "Adding 5 years",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years1n),
+  1438, 2, "M02", "Subtracting 1 year",
+  "ah", 1438, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years5n),
+  1434, 2, "M02", "Subtracting 5 years",
+  "ah", 1434, null
+);
+
+// Months
+
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+
+const date142012 = Temporal.PlainYearMonth.from({ year: 1420, monthCode: "M12", calendar }, options);
+const date144501 = Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date144501.add(new Temporal.Duration(0, 8)),
+  1445, 9, "M09", "Adding 8 months to Muharram 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144501.add(new Temporal.Duration(0, 11)),
+  1445, 12, "M12", "Adding 11 months to Muharram 1445 lands in Dhu al-Hijjah",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144501.add(new Temporal.Duration(0, 12)),
+  1446, 1, "M01", "Adding 12 months to Muharram 1445 lands in Muharram 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }).add(new Temporal.Duration(0, 13)),
+  1446, 7, "M07", "Adding 13 months to Jumada II 1445 lands in Rajab 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M03", calendar }, options).add(new Temporal.Duration(0, 6)),
+  1445, 9, "M09", "Adding 6 months to Rabi I 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1444, monthCode: "M10", calendar }).add(new Temporal.Duration(0, 5)),
+  1445, 3, "M03", "Adding 5 months to Shawwal 1444 crosses to 1445",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M01", calendar }).add(new Temporal.Duration(0, 100)),
+  1408, 5, "M05", "Adding a large number of months",
+  "ah", 1408, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M09", calendar }, options).add(new Temporal.Duration(0, -8)),
+  1445, 1, "M01", "Subtracting 8 months from Ramadan 1445 lands in Muharram",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }, options).add(new Temporal.Duration(0, -12)),
+  1444, 6, "M06", "Subtracting 12 months from Jumada II 1445 lands in Jumada II 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M02", calendar }, options).add(new Temporal.Duration(0, -5)),
+  1444, 9, "M09", "Subtracting 5 months from Safar 1445 crosses to Ramadan 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date142012.add(months6),
+  1421, 6, "M06", "add 6 months, with result in next year",
+  "ah", 1421, null);
+const calculatedStart = date142012.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1420, 12, "M12", "subtract 6 months, with result in previous year",
+  "ah", 1420, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-islamic-tbla.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-islamic-tbla.js
@@ -1,0 +1,122 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Basic addition and subtraction in the islamic-tbla calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-tbla";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years5 = new Temporal.Duration(5);
+const years5n = new Temporal.Duration(-5);
+
+const date143902 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years1),
+  1440, 2, "M02", "Adding 1 year",
+  "ah", 1440, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years5),
+  1444, 2, "M02", "Adding 5 years",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years1n),
+  1438, 2, "M02", "Subtracting 1 year",
+  "ah", 1438, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years5n),
+  1434, 2, "M02", "Subtracting 5 years",
+  "ah", 1434, null
+);
+
+// Months
+
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+
+const date142012 = Temporal.PlainYearMonth.from({ year: 1420, monthCode: "M12", calendar }, options);
+const date1 = Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(new Temporal.Duration(0, 8)),
+  1445, 9, "M09", "Adding 8 months to Muharram 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(new Temporal.Duration(0, 11)),
+  1445, 12, "M12", "Adding 11 months to Muharram 1445 lands in Dhu al-Hijjah",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(new Temporal.Duration(0, 12)),
+  1446, 1, "M01", "Adding 12 months to Muharram 1445 lands in Muharram 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }).add(new Temporal.Duration(0, 13)),
+  1446, 7, "M07", "Adding 13 months to Jumada II 1445 lands in Rajab 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M03", calendar }, options).add(new Temporal.Duration(0, 6)),
+  1445, 9, "M09", "Adding 6 months to Rabi I 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1444, monthCode: "M10", calendar }).add(new Temporal.Duration(0, 5)),
+  1445, 3, "M03", "Adding 5 months to Shawwal 1444 crosses to 1445",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M01", calendar }).add(new Temporal.Duration(0, 100)),
+  1408, 5, "M05", "Adding a large number of months",
+  "ah", 1408, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M09", calendar }, options).add(new Temporal.Duration(0, -8)),
+  1445, 1, "M01", "Subtracting 8 months from Ramadan 1445 lands in Muharram",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }, options).add(new Temporal.Duration(0, -12)),
+  1444, 6, "M06", "Subtracting 12 months from Jumada II 1445 lands in Jumada II 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M02", calendar }, options).add(new Temporal.Duration(0, -5)),
+  1444, 9, "M09", "Subtracting 5 months from Safar 1445 crosses to Ramadan 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date142012.add(months6),
+  1421, 6, "M06", "add 6 months, with result in next year",
+  "ah", 1421, null);
+const calculatedStart = date142012.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1420, 12, "M12", "subtract 6 months, with result in previous year",
+  "ah", 1420, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-islamic-umalqura.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-islamic-umalqura.js
@@ -1,0 +1,122 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Basic addition and subtraction in the islamic-umalqura calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-umalqura";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years5 = new Temporal.Duration(5);
+const years5n = new Temporal.Duration(-5);
+
+const date143902 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years1),
+  1440, 2, "M02", "Adding 1 year",
+  "ah", 1440, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years5),
+  1444, 2, "M02", "Adding 5 years",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years1n),
+  1438, 2, "M02", "Subtracting 1 year",
+  "ah", 1438, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.add(years5n),
+  1434, 2, "M02", "Subtracting 5 years",
+  "ah", 1434, null
+);
+
+// Months
+
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+
+const date142012 = Temporal.PlainYearMonth.from({ year: 1420, monthCode: "M12", calendar }, options);
+const date1 = Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(new Temporal.Duration(0, 8)),
+  1445, 9, "M09", "Adding 8 months to Muharram 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(new Temporal.Duration(0, 11)),
+  1445, 12, "M12", "Adding 11 months to Muharram 1445 lands in Dhu al-Hijjah",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(new Temporal.Duration(0, 12)),
+  1446, 1, "M01", "Adding 12 months to Muharram 1445 lands in Muharram 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }).add(new Temporal.Duration(0, 13)),
+  1446, 7, "M07", "Adding 13 months to Jumada II 1445 lands in Rajab 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M03", calendar }, options).add(new Temporal.Duration(0, 6)),
+  1445, 9, "M09", "Adding 6 months to Rabi I 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1444, monthCode: "M10", calendar }).add(new Temporal.Duration(0, 5)),
+  1445, 3, "M03", "Adding 5 months to Shawwal 1444 crosses to 1445",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M01", calendar }).add(new Temporal.Duration(0, 100)),
+  1408, 5, "M05", "Adding a large number of months",
+  "ah", 1408, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M09", calendar }, options).add(new Temporal.Duration(0, -8)),
+  1445, 1, "M01", "Subtracting 8 months from Ramadan 1445 lands in Muharram",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }, options).add(new Temporal.Duration(0, -12)),
+  1444, 6, "M06", "Subtracting 12 months from Jumada II 1445 lands in Jumada II 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M02", calendar }, options).add(new Temporal.Duration(0, -5)),
+  1444, 9, "M09", "Subtracting 5 months from Safar 1445 crosses to Ramadan 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date142012.add(months6),
+  1421, 6, "M06", "add 6 months, with result in next year",
+  "ah", 1421, null);
+const calculatedStart = date142012.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1420, 12, "M12", "subtract 6 months, with result in previous year",
+  "ah", 1420, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-japanese.js
@@ -1,0 +1,111 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years4 = new Temporal.Duration(4);
+const years4n = new Temporal.Duration(-4);
+
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years1),
+  2022, 7, "M07", "add 1y",
+  "reiwa", 4);
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years4),
+  2025, 7, "M07", "add 4y",
+  "reiwa", 7);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years1n),
+  2020, 7, "M07", "subtract 1y",
+  "reiwa", 2);
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years4n),
+  2017, 7, "M07", "subtract 4y",
+  "heisei", 29);
+
+// Months
+
+const months5 = new Temporal.Duration(0, 5);
+const months5n = new Temporal.Duration(0, -5);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+const years1months2 = new Temporal.Duration(1, 2);
+const years1months2n = new Temporal.Duration(-1, -2);
+
+const date20001201 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(months5),
+  2021, 12, "M12", "add 5mo with result in the same year",
+  "reiwa", 3);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar }).add(months5),
+  2022, 1, "M01", "add 5mo with result in the next year",
+  "reiwa", 4);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M10", calendar }).add(months5),
+  2020, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "reiwa", 2);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M10", calendar }).add(months5),
+  2022, 3, "M03", "add 5mo with result in the next year on day 31 of month",
+  "reiwa", 4);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years1months2),
+  2022, 9, "M09", "add 1y 2mo",
+  "reiwa", 4);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M11", calendar }).add(years1months2),
+  2023, 1, "M01", "add 1y 2mo with result in the next year",
+  "reiwa", 5);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(months5n),
+  2021, 2, "M02", "subtract 5mo with result in the same year",
+  "reiwa", 3);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar }).add(months5n),
+  2020, 8, "M08", "subtract 5mo with result in the previous year",
+  "reiwa", 2);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M02", calendar }).add(months5n),
+  2018, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "heisei", 30);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar }).add(months5n),
+  2020, 10, "M10", "subtract 5mo with result in the previous year on day 31 of month",
+  "reiwa", 2);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.add(years1months2n),
+  2020, 5, "M05", "subtract 1y 2mo",
+  "reiwa", 2);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M02", calendar }).add(years1months2n),
+  2019, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "reiwa", 1);
+
+TemporalHelpers.assertPlainYearMonth(
+  date20001201.add(months6),
+  2001, 6, "M06", "add 6 months, with result in next year",
+  "heisei", 13);
+const calculatedStart = date20001201.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  2000, 12, "M12", "subtract 6 months, with result in previous year",
+  "heisei", 12);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-persian.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-persian.js
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (persian calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "persian";
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years4 = new Temporal.Duration(4);
+const years4n = new Temporal.Duration(-4);
+
+const date140007 = Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.add(years1),
+  1401, 7, "M07", "add 1y",
+  "ap", 1401, null);
+TemporalHelpers.assertPlainYearMonth(
+  date140007.add(years4),
+  1404, 7, "M07", "add 4y",
+  "ap", 1404, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.add(years1n),
+  1399, 7, "M07", "subtract 1y",
+  "ap", 1399, null);
+TemporalHelpers.assertPlainYearMonth(
+  date140007.add(years4n),
+  1396, 7, "M07", "subtract 4y",
+  "ap", 1396, null);
+
+// Months
+
+const months5 = new Temporal.Duration(0, 5);
+const months5n = new Temporal.Duration(0, -5);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+const months8 = new Temporal.Duration(0, 8);
+const months8n = new Temporal.Duration(0, -8);
+const years1months2 = new Temporal.Duration(1, 2);
+const years1months2n = new Temporal.Duration(-1, -2);
+
+const date137812 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.add(months5),
+  1400, 12, "M12", "add 5mo with result in the same year",
+  "ap", 1400, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M08", calendar }).add(months5),
+  1401, 1, "M01", "add 5mo with result in the next year",
+  "ap", 1401, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1398, monthCode: "M10", calendar }).add(months5),
+  1399, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "ap", 1399, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M06", calendar }).add(months8),
+  1401, 2, "M02", "add 8mo with result in the next year on day 31 of month",
+  "ap", 1401, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.add(years1months2),
+  1401, 9, "M09", "add 1y 2mo",
+  "ap", 1401, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M11", calendar }).add(years1months2),
+  1402, 1, "M01", "add 1y 2mo with result in the next year",
+  "ap", 1402, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.add(months5n),
+  1400, 2, "M02", "subtract 5mo with result in the same year",
+  "ap", 1400, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M01", calendar }).add(months5n),
+  1399, 8, "M08", "subtract 5mo with result in the previous year",
+  "ap", 1399, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1398, monthCode: "M02", calendar }).add(months5n),
+  1397, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "ap", 1397, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M02", calendar }).add(months8n),
+  1399, 6, "M06", "subtract 8mo with result in the previous year on day 31 of month",
+  "ap", 1399, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.add(years1months2n),
+  1399, 5, "M05", "subtract 1y 2mo",
+  "ap", 1399, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M02", calendar }).add(years1months2n),
+  1398, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "ap", 1398, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date137812.add(months6),
+  1379, 6, "M06", "add 6 months, with result in next year",
+  "ap", 1379, null);
+const calculatedStart = date137812.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1378, 12, "M12", "subtract 6 months, with result in previous year",
+  "ap", 1378, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-roc.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/basic-roc.js
@@ -1,0 +1,111 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+const years4 = new Temporal.Duration(4);
+const years4n = new Temporal.Duration(-4);
+
+const date11107 = Temporal.PlainYearMonth.from({ year: 111, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date11107.add(years1),
+  112, 7, "M07", "add 1y",
+  "roc", 112);
+TemporalHelpers.assertPlainYearMonth(
+  date11107.add(years4),
+  115, 7, "M07", "add 4y",
+  "roc", 115);
+
+TemporalHelpers.assertPlainYearMonth(
+  date11107.add(years1n),
+  110, 7, "M07", "subtract 1y",
+  "roc", 110);
+TemporalHelpers.assertPlainYearMonth(
+  date11107.add(years4n),
+  107, 7, "M07", "subtract 4y",
+  "roc", 107);
+
+// Months
+
+const months5 = new Temporal.Duration(0, 5);
+const months5n = new Temporal.Duration(0, -5);
+const months6 = new Temporal.Duration(0, 6);
+const months6n = new Temporal.Duration(0, -6);
+const years1months2 = new Temporal.Duration(1, 2);
+const years1months2n = new Temporal.Duration(-1, -2);
+
+const date901201 = Temporal.PlainYearMonth.from({ year: 90, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date11107.add(months5),
+  111, 12, "M12", "add 5mo with result in the same year",
+  "roc", 111);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M08", calendar }).add(months5),
+  112, 1, "M01", "add 5mo with result in the next year",
+  "roc", 112);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 109, monthCode: "M10", calendar }).add(months5),
+  110, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "roc", 110);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M10", calendar }).add(months5),
+  112, 3, "M03", "add 5mo with result in the next year on day 31 of month",
+  "roc", 112);
+
+TemporalHelpers.assertPlainYearMonth(
+  date11107.add(years1months2),
+  112, 9, "M09", "add 1y 2mo",
+  "roc", 112);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M11", calendar }).add(years1months2),
+  113, 1, "M01", "add 1y 2mo with result in the next year",
+  "roc", 113);
+
+TemporalHelpers.assertPlainYearMonth(
+  date11107.add(months5n),
+  111, 2, "M02", "subtract 5mo with result in the same year",
+  "roc", 111);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M01", calendar }).add(months5n),
+  110, 8, "M08", "subtract 5mo with result in the previous year",
+  "roc", 110);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 109, monthCode: "M02", calendar }).add(months5n),
+  108, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "roc", 108);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M03", calendar }).add(months5n),
+  110, 10, "M10", "subtract 5mo with result in the previous year on day 31 of month",
+  "roc", 110);
+
+TemporalHelpers.assertPlainYearMonth(
+  date11107.add(years1months2n),
+  110, 5, "M05", "subtract 1y 2mo",
+  "roc", 110);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M02", calendar }).add(years1months2n),
+  109, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "roc", 109);
+
+TemporalHelpers.assertPlainYearMonth(
+  date901201.add(months6),
+  91, 6, "M06", "add 6 months, with result in next year",
+  "roc", 91);
+const calculatedStart = date901201.add(months6).add(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  90, 12, "M12", "subtract 6 months, with result in previous year",
+  "roc", 90);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-ethiopic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-ethiopic.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Adding years works correctly across era boundaries in ethiopic calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration5 = new Temporal.Duration(5);
+const duration5n = new Temporal.Duration(-5);
+const calendar = "ethiopic";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "aa", eraYear: 5500, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(new Temporal.Duration(1)),
+  1, 1, "M01", "Adding 1 year to last year of Amete Alem era lands in year 1 of incarnation era",
+  "am", 1, null
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 2000, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration5),
+  2005, 6, "M06", "Adding 5 years within incarnation era",
+  "am", 2005, null
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "aa", eraYear: 5450, monthCode: "M07", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration5),
+  -45, 7, "M07", "Adding 5 years within Amete Alem era",
+  "aa", 5455, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration5n),
+  1995, 6, "M06", "Subtracting 5 years within incarnation era",
+  "am", 1995, null
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 5, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.add(duration5n),
+  0, 1, "M01", "Subtracting 5 years from year 5 lands in last year of Amete Alem era, arithmetic year 0",
+  "aa", 5500, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-gregory.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-gregory.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Adding years works correctly across era boundaries in gregory calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration1 = new Temporal.Duration(1);
+const duration1n = new Temporal.Duration(-1);
+const calendar = "gregory";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(duration1),
+  0, 6, "M06", "Adding 1 year to 2 BCE lands in 1 BCE (counts backwards)",
+  "bce", 1
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration1),
+  1, 6, "M06", "Adding 1 year to 1 BCE lands in 1 CE (no year zero)",
+  "ce", 1
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1),
+  2, 6, "M06", "Adding 1 year to 1 CE lands in 2 CE",
+  "ce", 2
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.add(new Temporal.Duration(10)),
+  6, 3, "M03", "Adding 10 years to 5 BCE lands in 6 CE (no year zero)",
+  "ce", 6
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.add(duration1n),
+  1, 6, "M06", "Subtracting 1 year from 2 CE lands in 1 CE",
+  "ce", 1
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1n),
+  0, 6, "M06", "Subtracting 1 year from 1 CE lands in 1 BCE",
+  "bce", 1
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration1n),
+  -1, 6, "M06", "Subtracting 1 year from 1 BCE lands in 2 BCE",
+  "bce", 2
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.add(new Temporal.Duration(-10)),
+  -5, 3, "M03", "Subtracting 10 years from 5 CE lands in 6 BCE",
+  "bce", 6
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-islamic-civil.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-islamic-civil.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Adding years works correctly across era boundaries in islamic-civil calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration1 = new Temporal.Duration(1);
+const duration1n = new Temporal.Duration(-1);
+const calendar = "islamic-civil";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(duration1),
+  0, 6, "M06", "Adding 1 year to 2 BH lands in 1 BH (counts backwards)",
+  "bh", 1, null
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration1),
+  1, 6, "M06", "Adding 1 year to 1 BH lands in 1 AH (no year zero)",
+  "ah", 1, null
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1),
+  2, 6, "M06", "Adding 1 year to 1 AH lands in 2 AH",
+  "ah", 2, null
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.add(new Temporal.Duration(10)),
+  6, 3, "M03", "Adding 10 years to 5 BH lands in 6 AH (no year zero)",
+  "ah", 6, null
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.add(duration1n),
+  1, 6, "M06", "Subtracting 1 year from 2 AH lands in 1 AH",
+  "ah", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1n),
+  0, 6, "M06", "Subtracting 1 year from 1 AH lands in 1 BH",
+  "bh", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration1n),
+  -1, 6, "M06", "Subtracting 1 year from 1 BH lands in 2 BH",
+  "bh", 2, null
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.add(new Temporal.Duration(-10)),
+  -5, 3, "M03", "Subtracting 10 years from 5 AH lands in 6 BH",
+  "bh", 6, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-islamic-tbla.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-islamic-tbla.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Adding years works correctly across era boundaries in islamic-tbla calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration1 = new Temporal.Duration(1);
+const duration1n = new Temporal.Duration(-1);
+const calendar = "islamic-tbla";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(duration1),
+  0, 6, "M06", "Adding 1 year to 2 BH lands in 1 BH (counts backwards)",
+  "bh", 1, null
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration1),
+  1, 6, "M06", "Adding 1 year to 1 BH lands in 1 AH (no year zero)",
+  "ah", 1, null
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1),
+  2, 6, "M06", "Adding 1 year to 1 AH lands in 2 AH",
+  "ah", 2, null
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.add(new Temporal.Duration(10)),
+  6, 3, "M03", "Adding 10 years to 5 BH lands in 6 AH (no year zero)",
+  "ah", 6, null
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.add(duration1n),
+  1, 6, "M06", "Subtracting 1 year from 2 AH lands in 1 AH",
+  "ah", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1n),
+  0, 6, "M06", "Subtracting 1 year from 1 AH lands in 1 BH",
+  "bh", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration1n),
+  -1, 6, "M06", "Subtracting 1 year from 1 BH lands in 2 BH",
+  "bh", 2, null
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.add(new Temporal.Duration(-10)),
+  -5, 3, "M03", "Subtracting 10 years from 5 AH lands in 6 BH",
+  "bh", 6, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-islamic-umalqura.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-islamic-umalqura.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Adding years works correctly across era boundaries in islamic-umalqura calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration1 = new Temporal.Duration(1);
+const duration1n = new Temporal.Duration(-1);
+const calendar = "islamic-umalqura";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(duration1),
+  0, 6, "M06", "Adding 1 year to 2 BH lands in 1 BH (counts backwards)",
+  "bh", 1, null
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration1),
+  1, 6, "M06", "Adding 1 year to 1 BH lands in 1 AH (no year zero)",
+  "ah", 1, null
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1),
+  2, 6, "M06", "Adding 1 year to 1 AH lands in 2 AH",
+  "ah", 2, null
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.add(new Temporal.Duration(10)),
+  6, 3, "M03", "Adding 10 years to 5 BH lands in 6 AH (no year zero)",
+  "ah", 6, null
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.add(duration1n),
+  1, 6, "M06", "Subtracting 1 year from 2 AH lands in 1 AH",
+  "ah", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1n),
+  0, 6, "M06", "Subtracting 1 year from 1 AH lands in 1 BH",
+  "bh", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration1n),
+  -1, 6, "M06", "Subtracting 1 year from 1 BH lands in 2 BH",
+  "bh", 2, null
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.add(new Temporal.Duration(-10)),
+  -5, 3, "M03", "Subtracting 10 years from 5 AH lands in 6 BH",
+  "bh", 6, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-japanese.js
@@ -1,0 +1,81 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  Adding years works correctly across era boundaries in calendars with eras
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Reiwa era started on May 1, 2019 (Reiwa 1 = 2019)
+// Heisei era: 1989-2019 (Heisei 31 ended April 30, 2019)
+
+const duration1 = new Temporal.Duration(1);
+const duration1n = new Temporal.Duration(-1);
+const calendar = "japanese";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 30, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(duration1),
+  2019, 3, "M03", "Adding 1 year to Heisei 30 March (before May 1) lands in Heisei 31 March",
+  "heisei", 31
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 31, monthCode: "M04", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration1),
+  2020, 4, "M04", "Adding 1 year to Heisei 31 April (before May 1) lands in Reiwa 2 April",
+  "reiwa", 2
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 30, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1),
+  2019, 6, "M06", "Adding 1 year to Heisei 30 June (after May 1) lands in Reiwa 1 June",
+  "reiwa", 1
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.add(duration1),
+  2020, 6, "M06", "Adding 1 year to Reiwa 1 June lands in Reiwa 2 June",
+  "reiwa", 2
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 28, monthCode: "M07", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.add(new Temporal.Duration(3)),
+  2019, 7, "M07", "Multiple years across era boundary: Adding 3 years to Heisei 28 July lands in Reiwa 1 July",
+  "reiwa", 1
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.add(duration1n),
+  2019, 6, "M06", "Subtracting 1 year from Reiwa 2 June lands in Reiwa 1 June",
+  "reiwa", 1
+);
+
+const date7 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 2, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date7.add(duration1n),
+  2019, 3, "M03", "Subtracting 1 year from Reiwa 2 March lands in Heisei 31 March",
+  "heisei", 31
+);
+
+const date8 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 1, monthCode: "M07", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date8.add(duration1n),
+  2018, 7, "M07", "Subtracting 1 year from Reiwa 1 July lands in Heisei 30 July",
+  "heisei", 30
+);
+
+const date9 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 4, monthCode: "M02", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date9.add(new Temporal.Duration(-5)),
+  2017, 2, "M02", "Subtracting 5 years from Reiwa 4 February lands in Heisei 29 February",
+  "heisei", 29
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-roc.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/era-boundary-roc.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  Adding years works correctly across era boundaries in calendars with eras
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration1 = new Temporal.Duration(1);
+const duration1n = new Temporal.Duration(-1);
+const calendar = "roc";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.add(duration1),
+  0, 6, "M06", "Adding 1 year to 2 BROC lands in 1 BROC (counts backwards)",
+  "broc", 1
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.add(duration1),
+  1, 6, "M06", "Adding 1 year to 1 BROC lands in 1 ROC (no year zero)",
+  "roc", 1
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1),
+  2, 6, "M06", "Adding 1 year to 1 ROC lands in 2 ROC",
+  "roc", 2
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.add(new Temporal.Duration(10)),
+  6, 3, "M03", "Adding 10 years to 5 BROC lands in 6 ROC (no year zero)",
+  "roc", 6
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 5, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.add(duration1n),
+  4, 6, "M06", "Subtracting 1 year from ROC 5 lands in ROC 4",
+  "roc", 4
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date3.add(duration1n),
+  0, 6, "M06", "Subtracting 1 year from ROC 1 lands in BROC 1",
+  "broc", 1
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 10, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.add(new Temporal.Duration(-15)),
+  -5, 3, "M03", "Subtracting 15 years from ROC 10 lands in BROC 6",
+  "broc", 6
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/add/leap-year-hebrew.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/add/leap-year-hebrew.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Check constraining days due to leap years (hebrew calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Adar I (M05L) in common years will be constrained to Adar (M06).
+// See also leap-months-hebrew.js.
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+const years1 = new Temporal.Duration(1);
+const years1n = new Temporal.Duration(-1);
+
+const adarI = Temporal.PlainYearMonth.from({ year: 5782, monthCode: "M05L", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  adarI.add(years1),
+  5783, 6, "M06", "Adding 1 year to Adar I constrains to Adar",
+  "am", 5783, null);
+assert.throws(RangeError, function () {
+  adarI.add(years1, options);
+}, "Adding 1 year to 30 Adar I rejects because the month would be constrained");
+
+TemporalHelpers.assertPlainYearMonth(
+  adarI.add(years1n),
+  5781, 6, "M06", "Subtracting 1 year from Adar I constrains to Adar",
+  "am", 5781, null);
+assert.throws(RangeError, function () {
+  adarI.add(years1n, options);
+}, "Subtracting 1 year from 30 Adar I rejects because the month would be constrained");

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-buddhist.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-buddhist.js
@@ -1,0 +1,110 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (buddhist calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "buddhist";
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years4 = new Temporal.Duration(-4);
+const years4n = new Temporal.Duration(4);
+
+const date25551201 = Temporal.PlainYearMonth.from({ year: 2555, monthCode: "M12", calendar });
+const date25640716 = Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date25640716.subtract(years1),
+  2565, 7, "M07", "add 1y",
+  "be", 2565);
+TemporalHelpers.assertPlainYearMonth(
+  date25640716.subtract(years4),
+  2568, 7, "M07", "add 4y",
+  "be", 2568);
+
+TemporalHelpers.assertPlainYearMonth(
+  date25640716.subtract(years1n),
+  2563, 7, "M07", "subtract 1y",
+  "be", 2563);
+TemporalHelpers.assertPlainYearMonth(
+  date25640716.subtract(years4n),
+  2560, 7, "M07", "subtract 4y",
+  "be", 2560);
+
+// Months
+
+const months5 = new Temporal.Duration(0, -5);
+const months5n = new Temporal.Duration(0, 5);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+const years1months2 = new Temporal.Duration(-1, -2);
+const years1months2n = new Temporal.Duration(1, 2);
+
+TemporalHelpers.assertPlainYearMonth(
+  date25640716.subtract(months5),
+  2564, 12, "M12", "add 5mo with result in the same year",
+  "be", 2564);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M08", calendar }).subtract(months5),
+  2565, 1, "M01", "add 5mo with result in the next year",
+  "be", 2565);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2562, monthCode: "M10", calendar }).subtract(months5),
+  2563, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "be", 2563);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M10", calendar }).subtract(months5),
+  2565, 3, "M03", "add 5mo with result in the next year on day 31 of month",
+  "be", 2565);
+
+TemporalHelpers.assertPlainYearMonth(
+  date25640716.subtract(years1months2),
+  2565, 9, "M09", "add 1y 2mo",
+  "be", 2565);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M11", calendar }).subtract(years1months2),
+  2566, 1, "M01", "add 1y 2mo with result in the next year",
+  "be", 2566);
+
+TemporalHelpers.assertPlainYearMonth(
+  date25640716.subtract(months5n),
+  2564, 2, "M02", "subtract 5mo with result in the same year",
+  "be", 2564);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M01", calendar }).subtract(months5n),
+  2563, 8, "M08", "subtract 5mo with result in the previous year",
+  "be", 2563);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2562, monthCode: "M02", calendar }).subtract(months5n),
+  2561, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "be", 2561);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M03", calendar }).subtract(months5n),
+  2563, 10, "M10", "subtract 5mo with result in the previous year on day 31 of month",
+  "be", 2563);
+
+TemporalHelpers.assertPlainYearMonth(
+  date25640716.subtract(years1months2n),
+  2563, 5, "M05", "subtract 1y 2mo",
+  "be", 2563);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2564, monthCode: "M02", calendar }).subtract(years1months2n),
+  2562, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "be", 2562);
+
+TemporalHelpers.assertPlainYearMonth(
+  date25551201.subtract(months6),
+  2556, 6, "M06", "subtract 6mo",
+  "be", 2556);
+const calculatedStart = date25551201.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  2555, 12, "M12", "subtract 6mo",
+  "be", 2555);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-chinese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-chinese.js
@@ -1,0 +1,145 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Basic addition and subtraction in the chinese calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "chinese";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years5 = new Temporal.Duration(-5);
+const years5n = new Temporal.Duration(5);
+
+const date201802 = Temporal.PlainYearMonth.from({ year: 2018, monthCode: "M02", calendar }, options);
+const date202302 = Temporal.PlainYearMonth.from({ year: 2023, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years1),
+  2019, 2, "M02", "Adding 1 year to day 1 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202302.subtract(years1),
+  2024, 2, "M02", "Adding 1 year to day 29 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years5),
+  2023, 2, "M02", "Adding 5 years to day 1 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202302.subtract(years5),
+  2028, 2, "M02", "Adding 5 years to day 29 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years1n),
+  2017, 2, "M02", "Subtracting 1 year from day 1 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202302.subtract(years1n),
+  2022, 2, "M02", "Subtracting 1 year from day 29 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years5n),
+  2013, 2, "M02", "Subtracting 5 years from day 1 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202302.subtract(years5n),
+  2018, 2, "M02", "Subtracting 5 years from day 29 of a month",
+  undefined, undefined, null
+);
+
+// Months
+
+const months1 = new Temporal.Duration(0, -1);
+const months1n = new Temporal.Duration(0, 1);
+const months4 = new Temporal.Duration(0, -4);
+const months4n = new Temporal.Duration(0, 4);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+
+const date201901 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M01", calendar }, options);
+const date201906 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M06", calendar }, options);
+const date201911 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M11", calendar }, options);
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar }, options);
+const date200012 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M12", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.subtract(months1),
+  2019, 12, "M12", "Adding 1 month, with result in same year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201912.subtract(months1),
+  2020, 1, "M01", "Adding 1 month, with result in next year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.subtract(months4),
+  2019, 10, "M10", "Adding 4 months, with result in same year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201912.subtract(months4),
+  2020, 4, "M04", "Adding 4 months, with result in next year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.subtract(months1n),
+  2019, 10, "M10", "Subtracting 1 month, with result in same year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.subtract(months1n),
+  2018, 12, "M12", "Subtracting 1 month, with result in previous year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.subtract(months4n),
+  2019, 2, "M02", "Subtracting 4 months, with result in same year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.subtract(months4n),
+  2018, 9, "M09", "Subtracting 4 months, with result in previous year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.subtract(months6),
+  2001, 6, "M05", "Adding 6 months, with result in next year (leap year)",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.subtract(months6n),
+  2000, 6, "M06", "Subtracting 6 months, with result in same year",
+  undefined, undefined, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-coptic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-coptic.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Basic addition and subtraction in the coptic calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "coptic";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years5 = new Temporal.Duration(-5);
+const years5n = new Temporal.Duration(5);
+
+const date174202 = Temporal.PlainYearMonth.from({ year: 1742, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174202.subtract(years1),
+  1743, 2, "M02", "Adding 1 year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174202.subtract(years5),
+  1747, 2, "M02", "Adding 5 years", "am", 1747, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174202.subtract(years1n),
+  1741, 2, "M02", "Subtracting 1 year", "am", 1741, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174202.subtract(years5n),
+  1737, 2, "M02", "Subtracting 5 years", "am", 1737, null
+);
+
+// Months
+
+const months1 = new Temporal.Duration(0, -1);
+const months1n = new Temporal.Duration(0, 1);
+const months4 = new Temporal.Duration(0, -4);
+const months4n = new Temporal.Duration(0, 4);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+
+const date171612 = Temporal.PlainYearMonth.from({ year: 1716, monthCode: "M12", calendar }, options);
+const date174301 = Temporal.PlainYearMonth.from({ year: 1743, monthCode: "M01", calendar }, options);
+const date174306 = Temporal.PlainYearMonth.from({ year: 1743, monthCode: "M06", calendar }, options);
+const date174311 = Temporal.PlainYearMonth.from({ year: 1743, monthCode: "M11", calendar }, options);
+const date174213 = Temporal.PlainYearMonth.from({ year: 1742, monthCode: "M13", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174311.subtract(months1),
+  1743, 12, "M12", "Adding 1 month, with result in same year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174213.subtract(months1),
+  1743, 1, "M01", "Adding 1 month, with result in next year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174306.subtract(months4),
+  1743, 10, "M10", "Adding 4 months, with result in same year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174213.subtract(months4),
+  1743, 4, "M04", "Adding 4 months, with result in next year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174311.subtract(months1n),
+  1743, 10, "M10", "Subtracting 1 month, with result in same year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174301.subtract(months1n),
+  1742, 13, "M13", "Subtracting 1 month, with result in previous year", "am", 1742, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174306.subtract(months4n),
+  1743, 2, "M02", "Subtracting 4 months, with result in same year", "am", 1743, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date174301.subtract(months4n),
+  1742, 10, "M10", "Subtracting 4 months, with result in previous year", "am", 1742, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date171612.subtract(months6),
+  1717, 5, "M05", "Adding 6 months, with result in next year", "am", 1717, null
+);
+const calculatedStart = date171612.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1716, 12, "M12", "Subtracting 6 months, with result in previous year", "am", 1716, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-dangi.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-dangi.js
@@ -1,0 +1,145 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Basic addition and subtraction in the dangi calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "dangi";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years5 = new Temporal.Duration(-5);
+const years5n = new Temporal.Duration(5);
+
+const date201802 = Temporal.PlainYearMonth.from({ year: 2018, monthCode: "M02", calendar }, options);
+const date202302 = Temporal.PlainYearMonth.from({ year: 2023, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years1),
+  2019, 2, "M02", "Adding 1 year to day 1 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202302.subtract(years1),
+  2024, 2, "M02", "Adding 1 year to day 29 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years5),
+  2023, 2, "M02", "Adding 5 years to day 1 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202302.subtract(years5),
+  2028, 2, "M02", "Adding 5 years to day 29 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years1n),
+  2017, 2, "M02", "Subtracting 1 year from day 1 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202302.subtract(years1n),
+  2022, 2, "M02", "Subtracting 1 year from day 29 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years5n),
+  2013, 2, "M02", "Subtracting 5 years from day 1 of a month",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202302.subtract(years5n),
+  2018, 2, "M02", "Subtracting 5 years from day 29 of a month",
+  undefined, undefined, null
+);
+
+// Months
+
+const months1 = new Temporal.Duration(0, -1);
+const months1n = new Temporal.Duration(0, 1);
+const months4 = new Temporal.Duration(0, -4);
+const months4n = new Temporal.Duration(0, 4);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+
+const date201901 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M01", calendar }, options);
+const date201906 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M06", calendar }, options);
+const date201911 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M11", calendar }, options);
+const date201912 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M12", calendar }, options);
+const date200012 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M12", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.subtract(months1),
+  2019, 12, "M12", "Adding 1 month, with result in same year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201912.subtract(months1),
+  2020, 1, "M01", "Adding 1 month, with result in next year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.subtract(months4),
+  2019, 10, "M10", "Adding 4 months, with result in same year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201912.subtract(months4),
+  2020, 4, "M04", "Adding 4 months, with result in next year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.subtract(months1n),
+  2019, 10, "M10", "Subtracting 1 month, with result in same year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.subtract(months1n),
+  2018, 12, "M12", "Subtracting 1 month, with result in previous year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.subtract(months4n),
+  2019, 2, "M02", "Subtracting 4 months, with result in same year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.subtract(months4n),
+  2018, 9, "M09", "Subtracting 4 months, with result in previous year",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.subtract(months6),
+  2001, 6, "M05", "Adding 6 months, with result in next year (leap year)",
+  undefined, undefined, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.subtract(months6n),
+  2000, 6, "M06", "Subtracting 6 months, with result in same year",
+  undefined, undefined, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-ethioaa.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-ethioaa.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Basic addition and subtraction in the ethioaa calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "ethioaa";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years5 = new Temporal.Duration(-5);
+const years5n = new Temporal.Duration(5);
+
+const date750302 = Temporal.PlainYearMonth.from({ year: 7503, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750302.subtract(years1),
+  7504, 2, "M02", "Adding 1 year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750302.subtract(years5),
+  7508, 2, "M02", "Adding 5 years", "aa", 7508, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750302.subtract(years1n),
+  7502, 2, "M02", "Subtracting 1 year", "aa", 7502, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750302.subtract(years5n),
+  7498, 2, "M02", "Subtracting 5 years", "aa", 7498, null
+);
+
+// Months
+
+const months1 = new Temporal.Duration(0, -1);
+const months1n = new Temporal.Duration(0, 1);
+const months4 = new Temporal.Duration(0, -4);
+const months4n = new Temporal.Duration(0, 4);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+
+const date749212 = Temporal.PlainYearMonth.from({ year: 7492, monthCode: "M12", calendar }, options);
+const date750401 = Temporal.PlainYearMonth.from({ year: 7504, monthCode: "M01", calendar }, options);
+const date750406 = Temporal.PlainYearMonth.from({ year: 7504, monthCode: "M06", calendar }, options);
+const date750411 = Temporal.PlainYearMonth.from({ year: 7504, monthCode: "M11", calendar }, options);
+const date750313 = Temporal.PlainYearMonth.from({ year: 7503, monthCode: "M13", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750411.subtract(months1),
+  7504, 12, "M12", "Adding 1 month, with result in same year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750313.subtract(months1),
+  7504, 1, "M01", "Adding 1 month, with result in next year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750406.subtract(months4),
+  7504, 10, "M10", "Adding 4 months, with result in same year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750313.subtract(months4),
+  7504, 4, "M04", "Adding 4 months, with result in next year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750411.subtract(months1n),
+  7504, 10, "M10", "Subtracting 1 month, with result in same year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750401.subtract(months1n),
+  7503, 13, "M13", "Subtracting 1 month, with result in previous year", "aa", 7503, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750406.subtract(months4n),
+  7504, 2, "M02", "Subtracting 4 months, with result in same year", "aa", 7504, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date750401.subtract(months4n),
+  7503, 10, "M10", "Subtracting 4 months, with result in previous year", "aa", 7503, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date749212.subtract(months6),
+  7493, 5, "M05", "Adding 6 months, with result in next year", "aa", 7493, null
+);
+const calculatedStart = date749212.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  7492, 12, "M12", "Subtracting 6 months, with result in previous year", "aa", 7492, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-ethiopic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-ethiopic.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Basic addition and subtraction in the ethiopic calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "ethiopic";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years5 = new Temporal.Duration(-5);
+const years5n = new Temporal.Duration(5);
+
+const date201802 = Temporal.PlainYearMonth.from({ year: 2018, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years1),
+  2019, 2, "M02", "Adding 1 year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years5),
+  2023, 2, "M02", "Adding 5 years", "am", 2023, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years1n),
+  2017, 2, "M02", "Subtracting 1 year", "am", 2017, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201802.subtract(years5n),
+  2013, 2, "M02", "Subtracting 5 years", "am", 2013, null
+);
+
+// Months
+
+const months1 = new Temporal.Duration(0, -1);
+const months1n = new Temporal.Duration(0, 1);
+const months4 = new Temporal.Duration(0, -4);
+const months4n = new Temporal.Duration(0, 4);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+
+const date200012 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M12", calendar }, options);
+const date201901 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M01", calendar }, options);
+const date201906 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M06", calendar }, options);
+const date201911 = Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M11", calendar }, options);
+const date201813 = Temporal.PlainYearMonth.from({ year: 2018, monthCode: "M13", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.subtract(months1),
+  2019, 12, "M12", "Adding 1 month, with result in same year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201813.subtract(months1),
+  2019, 1, "M01", "Adding 1 month, with result in next year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.subtract(months4),
+  2019, 10, "M10", "Adding 4 months, with result in same year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201813.subtract(months4),
+  2019, 4, "M04", "Adding 4 months, with result in next year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201911.subtract(months1n),
+  2019, 10, "M10", "Subtracting 1 month, with result in same year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.subtract(months1n),
+  2018, 13, "M13", "Subtracting 1 month, with result in previous year", "am", 2018, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201906.subtract(months4n),
+  2019, 2, "M02", "Subtracting 4 months, with result in same year", "am", 2019, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date201901.subtract(months4n),
+  2018, 10, "M10", "Subtracting 4 months, with result in previous year", "am", 2018, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.subtract(months6),
+  2001, 5, "M05", "Adding 6 months, with result in next year", "am", 2001, null
+);
+const calculatedStart = date200012.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  2000, 12, "M12", "Subtracting 6 months, with result in previous year", "am", 2000, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-gregory.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-gregory.js
@@ -1,0 +1,111 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (gregory calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "gregory";
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years4 = new Temporal.Duration(-4);
+const years4n = new Temporal.Duration(4);
+
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years1),
+  2022, 7, "M07", "add 1y",
+  "ce", 2022);
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years4),
+  2025, 7, "M07", "add 4y",
+  "ce", 2025);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years1n),
+  2020, 7, "M07", "subtract 1y",
+  "ce", 2020);
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years4n),
+  2017, 7, "M07", "subtract 4y",
+  "ce", 2017);
+
+// Months
+
+const months5 = new Temporal.Duration(0, -5);
+const months5n = new Temporal.Duration(0, 5);
+const years1months2 = new Temporal.Duration(-1, -2);
+const years1months2n = new Temporal.Duration(1, 2);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+
+const date200012 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(months5),
+  2021, 12, "M12", "add 5mo with result in the same year",
+  "ce", 2021);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar }).subtract(months5),
+  2022, 1, "M01", "add 5mo with result in the next year",
+  "ce", 2022);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M10", calendar }).subtract(months5),
+  2020, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "ce", 2020);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M10", calendar }).subtract(months5),
+  2022, 3, "M03", "add 5mo with result in the next year on day 31 of month",
+  "ce", 2022);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years1months2),
+  2022, 9, "M09", "add 1y 2mo",
+  "ce", 2022);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M11", calendar }).subtract(years1months2),
+  2023, 1, "M01", "add 1y 2mo with result in the next year",
+  "ce", 2023);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(months5n),
+  2021, 2, "M02", "subtract 5mo with result in the same year",
+  "ce", 2021);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar }).subtract(months5n),
+  2020, 8, "M08", "subtract 5mo with result in the previous year",
+  "ce", 2020);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M02", calendar }).subtract(months5n),
+  2018, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "ce", 2018);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar }).subtract(months5n),
+  2020, 10, "M10", "subtract 5mo with result in the previous year on day 31 of month",
+  "ce", 2020);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years1months2n),
+  2020, 5, "M05", "subtract 1y 2mo",
+  "ce", 2020);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M02", calendar }).subtract(years1months2n),
+  2019, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "ce", 2019);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.subtract(months6),
+  2001, 6, "M06", "Adding 6 months, with result in next year", "ce", 2001
+);
+const calculatedStart = date200012.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  2000, 12, "M12", "Subtracting 6 months, with result in previous year", "ce", 2000
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-hebrew.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-hebrew.js
@@ -1,0 +1,143 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Basic addition and subtraction in the hebrew calendar
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years5 = new Temporal.Duration(-5);
+const years5n = new Temporal.Duration(5);
+
+const date577902 = Temporal.PlainYearMonth.from({ year: 5779, monthCode: "M02", calendar }, options);
+const date578402 = Temporal.PlainYearMonth.from({ year: 5784, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date577902.subtract(years1),
+  5780, 2, "M02", "Adding 1 year to day 1 of a month",
+  "am", 5780, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578402.subtract(years1),
+  5785, 2, "M02", "Adding 1 year to day 29 of a month",
+  "am", 5785, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date577902.subtract(years5),
+  5784, 2, "M02", "Adding 5 years to day 1 of a month",
+  "am", 5784, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578402.subtract(years5),
+  5789, 2, "M02", "Adding 5 years to day 29 of a month",
+  "am", 5789, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date577902.subtract(years1n),
+  5778, 2, "M02", "Subtracting 1 year from day 1 of a month",
+  "am", 5778, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578402.subtract(years1n),
+  5783, 2, "M02", "Subtracting 1 year from day 29 of a month",
+  "am", 5783, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date577902.subtract(years5n),
+  5774, 2, "M02", "Subtracting 5 years from day 1 of a month",
+  "am", 5774, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578402.subtract(years5n),
+  5779, 2, "M02", "Subtracting 5 years from day 29 of a month",
+  "am", 5779, null
+);
+
+// Months
+
+const months1 = new Temporal.Duration(0, -1);
+const months1n = new Temporal.Duration(0, 1);
+const months4 = new Temporal.Duration(0, -4);
+const months4n = new Temporal.Duration(0, 4);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+
+const date576012 = Temporal.PlainYearMonth.from({ year: 5760, monthCode: "M12", calendar }, options);
+const date578001 = Temporal.PlainYearMonth.from({ year: 5780, monthCode: "M01", calendar }, options);
+const date578006 = Temporal.PlainYearMonth.from({ year: 5780, monthCode: "M06", calendar }, options);
+const date578011 = Temporal.PlainYearMonth.from({ year: 5780, monthCode: "M11", calendar }, options);
+const date578012 = Temporal.PlainYearMonth.from({ year: 5780, monthCode: "M12", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578011.subtract(months1),
+  5780, 12, "M12", "Adding 1 month, with result in same year",
+  "am", 5780, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578012.subtract(months1),
+  5781, 1, "M01", "Adding 1 month, with result in next year",
+  "am", 5781, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578006.subtract(months4),
+  5780, 10, "M10", "Adding 4 months, with result in same year",
+  "am", 5780, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578012.subtract(months4),
+  5781, 4, "M04", "Adding 4 months, with result in next year",
+  "am", 5781, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578011.subtract(months1n),
+  5780, 10, "M10", "Subtracting 1 month, with result in same year",
+  "am", 5780, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578001.subtract(months1n),
+  5779, 13, "M12", "Subtracting 1 month, with result in previous year",
+  "am", 5779, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578006.subtract(months4n),
+  5780, 2, "M02", "Subtracting 4 months, with result in same year",
+  "am", 5780, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date578001.subtract(months4n),
+  5779, 10, "M09", "Subtracting 4 months, with result in previous year",
+  "am", 5779, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date576012.subtract(months6),
+  5761, 6, "M06", "add 6 months, with result in next year",
+  "am", 5761, null);
+const calculatedStart = date576012.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  5760, 13, "M12", "subtract 6 months, with result in previous year",
+  "am", 5760, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-indian.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-indian.js
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (indian calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "indian";
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years4 = new Temporal.Duration(-4);
+const years4n = new Temporal.Duration(4);
+
+const date192007 = Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.subtract(years1),
+  1921, 7, "M07", "add 1y",
+  "shaka", 1921, null);
+TemporalHelpers.assertPlainYearMonth(
+  date192007.subtract(years4),
+  1924, 7, "M07", "add 4y",
+  "shaka", 1924, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.subtract(years1n),
+  1919, 7, "M07", "subtract 1y",
+  "shaka", 1919, null);
+TemporalHelpers.assertPlainYearMonth(
+  date192007.subtract(years4n),
+  1916, 7, "M07", "subtract 4y",
+  "shaka", 1916, null);
+
+// Months
+
+const months5 = new Temporal.Duration(0, -5);
+const months5n = new Temporal.Duration(0, 5);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+const months8 = new Temporal.Duration(0, -8);
+const months8n = new Temporal.Duration(0, 8);
+const years1months2 = new Temporal.Duration(-1, -2);
+const years1months2n = new Temporal.Duration(1, 2);
+
+const date192212 = Temporal.PlainYearMonth.from({ year: 1922, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.subtract(months5),
+  1920, 12, "M12", "add 5mo with result in the same year",
+  "shaka", 1920, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M08", calendar }).subtract(months5),
+  1921, 1, "M01", "add 5mo with result in the next year",
+  "shaka", 1921, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1918, monthCode: "M10", calendar }).subtract(months5),
+  1919, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "shaka", 1919, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M06", calendar }).subtract(months8),
+  1921, 2, "M02", "add 8mo with result in the next year on day 31 of month",
+  "shaka", 1921, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.subtract(years1months2),
+  1921, 9, "M09", "add 1y 2mo",
+  "shaka", 1921, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M11", calendar }).subtract(years1months2),
+  1922, 1, "M01", "add 1y 2mo with result in the next year",
+  "shaka", 1922, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.subtract(months5n),
+  1920, 2, "M02", "subtract 5mo with result in the same year",
+  "shaka", 1920, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M01", calendar }).subtract(months5n),
+  1919, 8, "M08", "subtract 5mo with result in the previous year",
+  "shaka", 1919, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1918, monthCode: "M02", calendar }).subtract(months5n),
+  1917, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "shaka", 1917, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M02", calendar }).subtract(months8n),
+  1919, 6, "M06", "subtract 8mo with result in the previous year on day 31 of month",
+  "shaka", 1919, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date192007.subtract(years1months2n),
+  1919, 5, "M05", "subtract 1y 2mo",
+  "shaka", 1919, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1920, monthCode: "M02", calendar }).subtract(years1months2n),
+  1918, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "shaka", 1918, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date192212.subtract(months6),
+  1923, 6, "M06", "add 6 months, with result in next year",
+  "shaka", 1923, null);
+const calculatedStart = date192212.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1922, 12, "M12", "subtract 6 months, with result in previous year",
+  "shaka", 1922, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-islamic-civil.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-islamic-civil.js
@@ -1,0 +1,147 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Basic addition and subtraction in the islamic-civil calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-civil";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years5 = new Temporal.Duration(-5);
+const years5n = new Temporal.Duration(5);
+
+const date143902 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M02", calendar }, options);
+const date144402 = Temporal.PlainYearMonth.from({ year: 1444, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years1),
+  1440, 2, "M02", "Adding 1 year to day 1 of a month",
+  "ah", 1440, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years1),
+  1445, 2, "M02", "Adding 1 year to day 29 of a month",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years5),
+  1444, 2, "M02", "Adding 5 years to day 1 of a month",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years5),
+  1449, 2, "M02", "Adding 5 years to day 29 of a month",
+  "ah", 1449, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years1n),
+  1438, 2, "M02", "Subtracting 1 year from day 1 of a month",
+  "ah", 1438, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years1n),
+  1443, 2, "M02", "Subtracting 1 year from day 29 of a month",
+  "ah", 1443, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years5n),
+  1434, 2, "M02", "Subtracting 5 years from day 1 of a month",
+  "ah", 1434, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years5n),
+  1439, 2, "M02", "Subtracting 5 years from day 29 of a month",
+  "ah", 1439, null
+);
+
+// Months
+
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+
+const date142012 = Temporal.PlainYearMonth.from({ year: 1420, monthCode: "M12", calendar }, options);
+const date144501 = Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date144501.subtract(new Temporal.Duration(0, -8)),
+  1445, 9, "M09", "Adding 8 months to Muharram 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144501.subtract(new Temporal.Duration(0, -11)),
+  1445, 12, "M12", "Adding 11 months to Muharram 1445 lands in Dhu al-Hijjah",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144501.subtract(new Temporal.Duration(0, -12)),
+  1446, 1, "M01", "Adding 12 months to Muharram 1445 lands in Muharram 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }).subtract(new Temporal.Duration(0, -13)),
+  1446, 7, "M07", "Adding 13 months to Jumada II 1445 lands in Rajab 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M03", calendar }, options).subtract(new Temporal.Duration(0, -6)),
+  1445, 9, "M09", "Adding 6 months to Rabi I 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1444, monthCode: "M10", calendar }).subtract(new Temporal.Duration(0, -5)),
+  1445, 3, "M03", "Adding 5 months to Shawwal 1444 crosses to 1445",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M01", calendar }).subtract(new Temporal.Duration(0, -100)),
+  1408, 5, "M05", "Adding a large number of months",
+  "ah", 1408, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M09", calendar }, options).subtract(new Temporal.Duration(0, 8)),
+  1445, 1, "M01", "Subtracting 8 months from Ramadan 1445 lands in Muharram",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }, options).subtract(new Temporal.Duration(0, 12)),
+  1444, 6, "M06", "Subtracting 12 months from Jumada II 1445 lands in Jumada II 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M02", calendar }, options).subtract(new Temporal.Duration(0, 5)),
+  1444, 9, "M09", "Subtracting 5 months from Safar 1445 crosses to Ramadan 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date142012.subtract(months6),
+  1421, 6, "M06", "add 6 months, with result in next year",
+  "ah", 1421, null);
+const calculatedStart = date142012.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1420, 12, "M12", "subtract 6 months, with result in previous year",
+  "ah", 1420, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-islamic-tbla.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-islamic-tbla.js
@@ -1,0 +1,147 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Basic addition and subtraction in the islamic-tbla calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-tbla";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years5 = new Temporal.Duration(-5);
+const years5n = new Temporal.Duration(5);
+
+const date143902 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M02", calendar }, options);
+const date144402 = Temporal.PlainYearMonth.from({ year: 1444, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years1),
+  1440, 2, "M02", "Adding 1 year to day 1 of a month",
+  "ah", 1440, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years1),
+  1445, 2, "M02", "Adding 1 year to day 29 of a month",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years5),
+  1444, 2, "M02", "Adding 5 years to day 1 of a month",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years5),
+  1449, 2, "M02", "Adding 5 years to day 29 of a month",
+  "ah", 1449, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years1n),
+  1438, 2, "M02", "Subtracting 1 year from day 1 of a month",
+  "ah", 1438, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years1n),
+  1443, 2, "M02", "Subtracting 1 year from day 29 of a month",
+  "ah", 1443, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years5n),
+  1434, 2, "M02", "Subtracting 5 years from day 1 of a month",
+  "ah", 1434, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years5n),
+  1439, 2, "M02", "Subtracting 5 years from day 29 of a month",
+  "ah", 1439, null
+);
+
+// Months
+
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+
+const date142012 = Temporal.PlainYearMonth.from({ year: 1420, monthCode: "M12", calendar }, options);
+const date1 = Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(new Temporal.Duration(0, -8)),
+  1445, 9, "M09", "Adding 8 months to Muharram 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(new Temporal.Duration(0, -11)),
+  1445, 12, "M12", "Adding 11 months to Muharram 1445 lands in Dhu al-Hijjah",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(new Temporal.Duration(0, -12)),
+  1446, 1, "M01", "Adding 12 months to Muharram 1445 lands in Muharram 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }).subtract(new Temporal.Duration(0, -13)),
+  1446, 7, "M07", "Adding 13 months to Jumada II 1445 lands in Rajab 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M03", calendar }, options).subtract(new Temporal.Duration(0, -6)),
+  1445, 9, "M09", "Adding 6 months to Rabi I 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1444, monthCode: "M10", calendar }).subtract(new Temporal.Duration(0, -5)),
+  1445, 3, "M03", "Adding 5 months to Shawwal 1444 crosses to 1445",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M01", calendar }).subtract(new Temporal.Duration(0, -100)),
+  1408, 5, "M05", "Adding a large number of months",
+  "ah", 1408, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M09", calendar }, options).subtract(new Temporal.Duration(0, 8)),
+  1445, 1, "M01", "Subtracting 8 months from Ramadan 1445 lands in Muharram",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }, options).subtract(new Temporal.Duration(0, 12)),
+  1444, 6, "M06", "Subtracting 12 months from Jumada II 1445 lands in Jumada II 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M02", calendar }, options).subtract(new Temporal.Duration(0, 5)),
+  1444, 9, "M09", "Subtracting 5 months from Safar 1445 crosses to Ramadan 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date142012.subtract(months6),
+  1421, 6, "M06", "add 6 months, with result in next year",
+  "ah", 1421, null);
+const calculatedStart = date142012.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1420, 12, "M12", "subtract 6 months, with result in previous year",
+  "ah", 1420, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-islamic-umalqura.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-islamic-umalqura.js
@@ -1,0 +1,147 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Basic addition and subtraction in the islamic-umalqura calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const calendar = "islamic-umalqura";
+const options = { overflow: "reject" };
+
+// Years
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years5 = new Temporal.Duration(-5);
+const years5n = new Temporal.Duration(5);
+
+const date143902 = Temporal.PlainYearMonth.from({ year: 1439, monthCode: "M02", calendar }, options);
+const date144402 = Temporal.PlainYearMonth.from({ year: 1444, monthCode: "M02", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years1),
+  1440, 2, "M02", "Adding 1 year to day 1 of a month",
+  "ah", 1440, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years1),
+  1445, 2, "M02", "Adding 1 year to day 29 of a month",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years5),
+  1444, 2, "M02", "Adding 5 years to day 1 of a month",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years5),
+  1449, 2, "M02", "Adding 5 years to day 29 of a month",
+  "ah", 1449, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years1n),
+  1438, 2, "M02", "Subtracting 1 year from day 1 of a month",
+  "ah", 1438, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years1n),
+  1443, 2, "M02", "Subtracting 1 year from day 29 of a month",
+  "ah", 1443, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date143902.subtract(years5n),
+  1434, 2, "M02", "Subtracting 5 years from day 1 of a month",
+  "ah", 1434, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date144402.subtract(years5n),
+  1439, 2, "M02", "Subtracting 5 years from day 29 of a month",
+  "ah", 1439, null
+);
+
+// Months
+
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+
+const date142012 = Temporal.PlainYearMonth.from({ year: 1420, monthCode: "M12", calendar }, options);
+const date1 = Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(new Temporal.Duration(0, -8)),
+  1445, 9, "M09", "Adding 8 months to Muharram 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(new Temporal.Duration(0, -11)),
+  1445, 12, "M12", "Adding 11 months to Muharram 1445 lands in Dhu al-Hijjah",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(new Temporal.Duration(0, -12)),
+  1446, 1, "M01", "Adding 12 months to Muharram 1445 lands in Muharram 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }).subtract(new Temporal.Duration(0, -13)),
+  1446, 7, "M07", "Adding 13 months to Jumada II 1445 lands in Rajab 1446",
+  "ah", 1446, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M03", calendar }, options).subtract(new Temporal.Duration(0, -6)),
+  1445, 9, "M09", "Adding 6 months to Rabi I 1445 lands in Ramadan",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1444, monthCode: "M10", calendar }).subtract(new Temporal.Duration(0, -5)),
+  1445, 3, "M03", "Adding 5 months to Shawwal 1444 crosses to 1445",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M01", calendar }).subtract(new Temporal.Duration(0, -100)),
+  1408, 5, "M05", "Adding a large number of months",
+  "ah", 1408, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M09", calendar }, options).subtract(new Temporal.Duration(0, 8)),
+  1445, 1, "M01", "Subtracting 8 months from Ramadan 1445 lands in Muharram",
+  "ah", 1445, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M06", calendar }, options).subtract(new Temporal.Duration(0, 12)),
+  1444, 6, "M06", "Subtracting 12 months from Jumada II 1445 lands in Jumada II 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1445, monthCode: "M02", calendar }, options).subtract(new Temporal.Duration(0, 5)),
+  1444, 9, "M09", "Subtracting 5 months from Safar 1445 crosses to Ramadan 1444",
+  "ah", 1444, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date142012.subtract(months6),
+  1421, 6, "M06", "add 6 months, with result in next year",
+  "ah", 1421, null);
+const calculatedStart = date142012.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1420, 12, "M12", "subtract 6 months, with result in previous year",
+  "ah", 1420, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-japanese.js
@@ -1,0 +1,111 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (japanese calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "japanese";
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years4 = new Temporal.Duration(-4);
+const years4n = new Temporal.Duration(4);
+
+const date202107 = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years1),
+  2022, 7, "M07", "add 1y",
+  "reiwa", 4);
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years4),
+  2025, 7, "M07", "add 4y",
+  "reiwa", 7);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years1n),
+  2020, 7, "M07", "subtract 1y",
+  "reiwa", 2);
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years4n),
+  2017, 7, "M07", "subtract 4y",
+  "heisei", 29);
+
+// Months
+
+const months5 = new Temporal.Duration(0, -5);
+const months5n = new Temporal.Duration(0, 5);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+const years1months2 = new Temporal.Duration(-1, -2);
+const years1months2n = new Temporal.Duration(1, 2);
+
+const date200012 = Temporal.PlainYearMonth.from({ year: 2000, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(months5),
+  2021, 12, "M12", "add 5mo with result in the same year",
+  "reiwa", 3);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M08", calendar }).subtract(months5),
+  2022, 1, "M01", "add 5mo with result in the next year",
+  "reiwa", 4);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M10", calendar }).subtract(months5),
+  2020, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "reiwa", 2);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M10", calendar }).subtract(months5),
+  2022, 3, "M03", "add 5mo with result in the next year on day 31 of month",
+  "reiwa", 4);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years1months2),
+  2022, 9, "M09", "add 1y 2mo",
+  "reiwa", 4);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M11", calendar }).subtract(years1months2),
+  2023, 1, "M01", "add 1y 2mo with result in the next year",
+  "reiwa", 5);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(months5n),
+  2021, 2, "M02", "subtract 5mo with result in the same year",
+  "reiwa", 3);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01", calendar }).subtract(months5n),
+  2020, 8, "M08", "subtract 5mo with result in the previous year",
+  "reiwa", 2);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2019, monthCode: "M02", calendar }).subtract(months5n),
+  2018, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "heisei", 30);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M03", calendar }).subtract(months5n),
+  2020, 10, "M10", "subtract 5mo with result in the previous year on day 31 of month",
+  "reiwa", 2);
+
+TemporalHelpers.assertPlainYearMonth(
+  date202107.subtract(years1months2n),
+  2020, 5, "M05", "subtract 1y 2mo",
+  "reiwa", 2);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M02", calendar }).subtract(years1months2n),
+  2019, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "reiwa", 1);
+
+TemporalHelpers.assertPlainYearMonth(
+  date200012.subtract(months6),
+  2001, 6, "M06", "add 6 months, with result in next year",
+  "heisei", 13);
+const calculatedStart = date200012.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  2000, 12, "M12", "subtract 6 months, with result in previous year",
+  "heisei", 12);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-persian.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-persian.js
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (persian calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "persian";
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years4 = new Temporal.Duration(-4);
+const years4n = new Temporal.Duration(4);
+
+const date140007 = Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.subtract(years1),
+  1401, 7, "M07", "add 1y",
+  "ap", 1401, null);
+TemporalHelpers.assertPlainYearMonth(
+  date140007.subtract(years4),
+  1404, 7, "M07", "add 4y",
+  "ap", 1404, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.subtract(years1n),
+  1399, 7, "M07", "subtract 1y",
+  "ap", 1399, null);
+TemporalHelpers.assertPlainYearMonth(
+  date140007.subtract(years4n),
+  1396, 7, "M07", "subtract 4y",
+  "ap", 1396, null);
+
+// Months
+
+const months5 = new Temporal.Duration(0, -5);
+const months5n = new Temporal.Duration(0, 5);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+const months8 = new Temporal.Duration(0, -8);
+const months8n = new Temporal.Duration(0, 8);
+const years1months2 = new Temporal.Duration(-1, -2);
+const years1months2n = new Temporal.Duration(1, 2);
+
+const date137812 = Temporal.PlainYearMonth.from({ year: 1378, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.subtract(months5),
+  1400, 12, "M12", "add 5mo with result in the same year",
+  "ap", 1400, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M08", calendar }).subtract(months5),
+  1401, 1, "M01", "add 5mo with result in the next year",
+  "ap", 1401, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1398, monthCode: "M10", calendar }).subtract(months5),
+  1399, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "ap", 1399, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M06", calendar }).subtract(months8),
+  1401, 2, "M02", "add 8mo with result in the next year on day 31 of month",
+  "ap", 1401, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.subtract(years1months2),
+  1401, 9, "M09", "add 1y 2mo",
+  "ap", 1401, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M11", calendar }).subtract(years1months2),
+  1402, 1, "M01", "add 1y 2mo with result in the next year",
+  "ap", 1402, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.subtract(months5n),
+  1400, 2, "M02", "subtract 5mo with result in the same year",
+  "ap", 1400, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M01", calendar }).subtract(months5n),
+  1399, 8, "M08", "subtract 5mo with result in the previous year",
+  "ap", 1399, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1398, monthCode: "M02", calendar }).subtract(months5n),
+  1397, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "ap", 1397, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M02", calendar }).subtract(months8n),
+  1399, 6, "M06", "subtract 8mo with result in the previous year on day 31 of month",
+  "ap", 1399, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date140007.subtract(years1months2n),
+  1399, 5, "M05", "subtract 1y 2mo",
+  "ap", 1399, null);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 1400, monthCode: "M02", calendar }).subtract(years1months2n),
+  1398, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "ap", 1398, null);
+
+TemporalHelpers.assertPlainYearMonth(
+  date137812.subtract(months6),
+  1379, 6, "M06", "add 6 months, with result in next year",
+  "ap", 1379, null);
+const calculatedStart = date137812.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  1378, 12, "M12", "subtract 6 months, with result in previous year",
+  "ap", 1378, null);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-roc.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/basic-roc.js
@@ -1,0 +1,111 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  Check various basic calculations not involving leap years or constraining
+  (roc calendar)
+features: [Temporal, Intl.Era-monthcode]
+includes: [temporalHelpers.js]
+---*/
+
+const calendar = "roc";
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+const years4 = new Temporal.Duration(-4);
+const years4n = new Temporal.Duration(4);
+
+const date1110716 = Temporal.PlainYearMonth.from({ year: 111, monthCode: "M07", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date1110716.subtract(years1),
+  112, 7, "M07", "add 1y",
+  "roc", 112);
+TemporalHelpers.assertPlainYearMonth(
+  date1110716.subtract(years4),
+  115, 7, "M07", "add 4y",
+  "roc", 115);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1110716.subtract(years1n),
+  110, 7, "M07", "subtract 1y",
+  "roc", 110);
+TemporalHelpers.assertPlainYearMonth(
+  date1110716.subtract(years4n),
+  107, 7, "M07", "subtract 4y",
+  "roc", 107);
+
+// Months
+
+const months5 = new Temporal.Duration(0, -5);
+const months5n = new Temporal.Duration(0, 5);
+const months6 = new Temporal.Duration(0, -6);
+const months6n = new Temporal.Duration(0, 6);
+const years1months2 = new Temporal.Duration(-1, -2);
+const years1months2n = new Temporal.Duration(1, 2);
+
+const date901201 = Temporal.PlainYearMonth.from({ year: 90, monthCode: "M12", calendar });
+
+TemporalHelpers.assertPlainYearMonth(
+  date1110716.subtract(months5),
+  111, 12, "M12", "add 5mo with result in the same year",
+  "roc", 111);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M08", calendar }).subtract(months5),
+  112, 1, "M01", "add 5mo with result in the next year",
+  "roc", 112);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 109, monthCode: "M10", calendar }).subtract(months5),
+  110, 3, "M03", "add 5mo with result in the next year on day 1 of month",
+  "roc", 110);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M10", calendar }).subtract(months5),
+  112, 3, "M03", "add 5mo with result in the next year on day 31 of month",
+  "roc", 112);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1110716.subtract(years1months2),
+  112, 9, "M09", "add 1y 2mo",
+  "roc", 112);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M11", calendar }).subtract(years1months2),
+  113, 1, "M01", "add 1y 2mo with result in the next year",
+  "roc", 113);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1110716.subtract(months5n),
+  111, 2, "M02", "subtract 5mo with result in the same year",
+  "roc", 111);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M01", calendar }).subtract(months5n),
+  110, 8, "M08", "subtract 5mo with result in the previous year",
+  "roc", 110);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 109, monthCode: "M02", calendar }).subtract(months5n),
+  108, 9, "M09", "subtract 5mo with result in the previous year on day 1 of month",
+  "roc", 108);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M03", calendar }).subtract(months5n),
+  110, 10, "M10", "subtract 5mo with result in the previous year on day 31 of month",
+  "roc", 110);
+
+TemporalHelpers.assertPlainYearMonth(
+  date1110716.subtract(years1months2n),
+  110, 5, "M05", "subtract 1y 2mo",
+  "roc", 110);
+TemporalHelpers.assertPlainYearMonth(
+  Temporal.PlainYearMonth.from({ year: 111, monthCode: "M02", calendar }).subtract(years1months2n),
+  109, 12, "M12", "subtract 1y 2mo with result in the previous year",
+  "roc", 109);
+
+TemporalHelpers.assertPlainYearMonth(
+  date901201.subtract(months6),
+  91, 6, "M06", "add 6 months, with result in next year",
+  "roc", 91);
+const calculatedStart = date901201.subtract(months6).subtract(months6n);
+TemporalHelpers.assertPlainYearMonth(
+  calculatedStart,
+  90, 12, "M12", "subtract 6 months, with result in previous year",
+  "roc", 90);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-ethiopic.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-ethiopic.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Adding years works correctly across era boundaries in ethiopic calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration5 = new Temporal.Duration(-5);
+const duration5n = new Temporal.Duration(5);
+const calendar = "ethiopic";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "aa", eraYear: 5500, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(new Temporal.Duration(-1)),
+  1, 1, "M01", "Adding 1 year to last year of Amete Alem era lands in year 1 of incarnation era",
+  "am", 1, null
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 2000, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration5),
+  2005, 6, "M06", "Adding 5 years within incarnation era",
+  "am", 2005, null
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "aa", eraYear: 5450, monthCode: "M07", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration5),
+  -45, 7, "M07", "Adding 5 years within Amete Alem era",
+  "aa", 5455, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration5n),
+  1995, 6, "M06", "Subtracting 5 years within incarnation era",
+  "am", 1995, null
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "am", eraYear: 5, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.subtract(duration5n),
+  0, 1, "M01", "Subtracting 5 years from year 5 lands in last year of Amete Alem era, arithmetic year 0",
+  "aa", 5500, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-gregory.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-gregory.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Adding years works correctly across era boundaries in gregory calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration1 = new Temporal.Duration(-1);
+const duration1n = new Temporal.Duration(1);
+const calendar = "gregory";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(duration1),
+  0, 6, "M06", "Adding 1 year to 2 BCE lands in 1 BCE (counts backwards)",
+  "bce", 1
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration1),
+  1, 6, "M06", "Adding 1 year to 1 BCE lands in 1 CE (no year zero)",
+  "ce", 1
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1),
+  2, 6, "M06", "Adding 1 year to 1 CE lands in 2 CE",
+  "ce", 2
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.subtract(new Temporal.Duration(-10)),
+  6, 3, "M03", "Adding 10 years to 5 BCE lands in 6 CE (no year zero)",
+  "ce", 6
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.subtract(duration1n),
+  1, 6, "M06", "Subtracting 1 year from 2 CE lands in 1 CE",
+  "ce", 1
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1n),
+  0, 6, "M06", "Subtracting 1 year from 1 CE lands in 1 BCE",
+  "bce", 1
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration1n),
+  -1, 6, "M06", "Subtracting 1 year from 1 BCE lands in 2 BCE",
+  "bce", 2
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.subtract(new Temporal.Duration(10)),
+  -5, 3, "M03", "Subtracting 10 years from 5 CE lands in 6 BCE",
+  "bce", 6
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-islamic-civil.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-islamic-civil.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Adding years works correctly across era boundaries in islamic-civil calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration1 = new Temporal.Duration(-1);
+const duration1n = new Temporal.Duration(1);
+const calendar = "islamic-civil";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(duration1),
+  0, 6, "M06", "Adding 1 year to 2 BH lands in 1 BH (counts backwards)",
+  "bh", 1, null
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration1),
+  1, 6, "M06", "Adding 1 year to 1 BH lands in 1 AH (no year zero)",
+  "ah", 1, null
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1),
+  2, 6, "M06", "Adding 1 year to 1 AH lands in 2 AH",
+  "ah", 2, null
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.subtract(new Temporal.Duration(-10)),
+  6, 3, "M03", "Adding 10 years to 5 BH lands in 6 AH (no year zero)",
+  "ah", 6, null
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.subtract(duration1n),
+  1, 6, "M06", "Subtracting 1 year from 2 AH lands in 1 AH",
+  "ah", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1n),
+  0, 6, "M06", "Subtracting 1 year from 1 AH lands in 1 BH",
+  "bh", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration1n),
+  -1, 6, "M06", "Subtracting 1 year from 1 BH lands in 2 BH",
+  "bh", 2, null
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.subtract(new Temporal.Duration(10)),
+  -5, 3, "M03", "Subtracting 10 years from 5 AH lands in 6 BH",
+  "bh", 6, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-islamic-tbla.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-islamic-tbla.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Adding years works correctly across era boundaries in islamic-tbla calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration1 = new Temporal.Duration(-1);
+const duration1n = new Temporal.Duration(1);
+const calendar = "islamic-tbla";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(duration1),
+  0, 6, "M06", "Adding 1 year to 2 BH lands in 1 BH (counts backwards)",
+  "bh", 1, null
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration1),
+  1, 6, "M06", "Adding 1 year to 1 BH lands in 1 AH (no year zero)",
+  "ah", 1, null
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1),
+  2, 6, "M06", "Adding 1 year to 1 AH lands in 2 AH",
+  "ah", 2, null
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.subtract(new Temporal.Duration(-10)),
+  6, 3, "M03", "Adding 10 years to 5 BH lands in 6 AH (no year zero)",
+  "ah", 6, null
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.subtract(duration1n),
+  1, 6, "M06", "Subtracting 1 year from 2 AH lands in 1 AH",
+  "ah", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1n),
+  0, 6, "M06", "Subtracting 1 year from 1 AH lands in 1 BH",
+  "bh", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration1n),
+  -1, 6, "M06", "Subtracting 1 year from 1 BH lands in 2 BH",
+  "bh", 2, null
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.subtract(new Temporal.Duration(10)),
+  -5, 3, "M03", "Subtracting 10 years from 5 AH lands in 6 BH",
+  "bh", 6, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-islamic-umalqura.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-islamic-umalqura.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Adding years works correctly across era boundaries in islamic-umalqura calendar
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration1 = new Temporal.Duration(-1);
+const duration1n = new Temporal.Duration(1);
+const calendar = "islamic-umalqura";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(duration1),
+  0, 6, "M06", "Adding 1 year to 2 BH lands in 1 BH (counts backwards)",
+  "bh", 1, null
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration1),
+  1, 6, "M06", "Adding 1 year to 1 BH lands in 1 AH (no year zero)",
+  "ah", 1, null
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1),
+  2, 6, "M06", "Adding 1 year to 1 AH lands in 2 AH",
+  "ah", 2, null
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "bh", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.subtract(new Temporal.Duration(-10)),
+  6, 3, "M03", "Adding 10 years to 5 BH lands in 6 AH (no year zero)",
+  "ah", 6, null
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.subtract(duration1n),
+  1, 6, "M06", "Subtracting 1 year from 2 AH lands in 1 AH",
+  "ah", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1n),
+  0, 6, "M06", "Subtracting 1 year from 1 AH lands in 1 BH",
+  "bh", 1, null
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration1n),
+  -1, 6, "M06", "Subtracting 1 year from 1 BH lands in 2 BH",
+  "bh", 2, null
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "ah", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.subtract(new Temporal.Duration(10)),
+  -5, 3, "M03", "Subtracting 10 years from 5 AH lands in 6 BH",
+  "bh", 6, null
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-japanese.js
@@ -1,0 +1,81 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  Adding years works correctly across era boundaries in calendars with eras
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Reiwa era started on May 1, 2019 (Reiwa 1 = 2019)
+// Heisei era: 1989-2019 (Heisei 31 ended April 30, 2019)
+
+const duration1 = new Temporal.Duration(-1);
+const duration1n = new Temporal.Duration(1);
+const calendar = "japanese";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 30, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(duration1),
+  2019, 3, "M03", "Adding 1 year to Heisei 30 March (before May 1) lands in Heisei 31 March",
+  "heisei", 31
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 31, monthCode: "M04", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration1),
+  2020, 4, "M04", "Adding 1 year to Heisei 31 April (before May 1) lands in Reiwa 2 April",
+  "reiwa", 2
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 30, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1),
+  2019, 6, "M06", "Adding 1 year to Heisei 30 June (after May 1) lands in Reiwa 1 June",
+  "reiwa", 1
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.subtract(duration1),
+  2020, 6, "M06", "Adding 1 year to Reiwa 1 June lands in Reiwa 2 June",
+  "reiwa", 2
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 28, monthCode: "M07", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.subtract(new Temporal.Duration(-3)),
+  2019, 7, "M07", "Multiple years across era boundary: Adding 3 years to Heisei 28 July lands in Reiwa 1 July",
+  "reiwa", 1
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.subtract(duration1n),
+  2019, 6, "M06", "Subtracting 1 year from Reiwa 2 June lands in Reiwa 1 June",
+  "reiwa", 1
+);
+
+const date7 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 2, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date7.subtract(duration1n),
+  2019, 3, "M03", "Subtracting 1 year from Reiwa 2 March lands in Heisei 31 March",
+  "heisei", 31
+);
+
+const date8 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 1, monthCode: "M07", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date8.subtract(duration1n),
+  2018, 7, "M07", "Subtracting 1 year from Reiwa 1 July lands in Heisei 30 July",
+  "heisei", 30
+);
+
+const date9 = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 4, monthCode: "M02", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date9.subtract(new Temporal.Duration(5)),
+  2017, 2, "M02", "Subtracting 5 years from Reiwa 4 February lands in Heisei 29 February",
+  "heisei", 29
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-roc.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/era-boundary-roc.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  Adding years works correctly across era boundaries in calendars with eras
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+const duration1 = new Temporal.Duration(-1);
+const duration1n = new Temporal.Duration(1);
+const calendar = "roc";
+const options = { overflow: "reject" };
+
+const date1 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 2, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date1.subtract(duration1),
+  0, 6, "M06", "Adding 1 year to 2 BROC lands in 1 BROC (counts backwards)",
+  "broc", 1
+);
+
+const date2 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date2.subtract(duration1),
+  1, 6, "M06", "Adding 1 year to 1 BROC lands in 1 ROC (no year zero)",
+  "roc", 1
+);
+
+const date3 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 1, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1),
+  2, 6, "M06", "Adding 1 year to 1 ROC lands in 2 ROC",
+  "roc", 2
+);
+
+const date4 = Temporal.PlainYearMonth.from({ era: "broc", eraYear: 5, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date4.subtract(new Temporal.Duration(-10)),
+  6, 3, "M03", "Adding 10 years to 5 BROC lands in 6 ROC (no year zero)",
+  "roc", 6
+);
+
+const date5 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 5, monthCode: "M06", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date5.subtract(duration1n),
+  4, 6, "M06", "Subtracting 1 year from ROC 5 lands in ROC 4",
+  "roc", 4
+);
+
+TemporalHelpers.assertPlainYearMonth(
+  date3.subtract(duration1n),
+  0, 6, "M06", "Subtracting 1 year from ROC 1 lands in BROC 1",
+  "broc", 1
+);
+
+const date6 = Temporal.PlainYearMonth.from({ era: "roc", eraYear: 10, monthCode: "M03", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  date6.subtract(new Temporal.Duration(15)),
+  -5, 3, "M03", "Subtracting 15 years from ROC 10 lands in BROC 6",
+  "broc", 6
+);

--- a/test/intl402/Temporal/PlainYearMonth/prototype/subtract/leap-year-hebrew.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/subtract/leap-year-hebrew.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Check constraining days due to leap years (hebrew calendar)
+includes: [temporalHelpers.js]
+features: [Temporal, Intl.Era-monthcode]
+---*/
+
+// Adar I (M05L) in common years will be constrained to Adar (M06).
+// See also leap-months-hebrew.js
+
+const calendar = "hebrew";
+const options = { overflow: "reject" };
+
+const years1 = new Temporal.Duration(-1);
+const years1n = new Temporal.Duration(1);
+
+const adarI = Temporal.PlainYearMonth.from({ year: 5782, monthCode: "M05L", calendar }, options);
+
+TemporalHelpers.assertPlainYearMonth(
+  adarI.subtract(years1),
+  5783, 6, "M06", "Adding 1 year to Adar I constrains to Adar",
+  "am", 5783, null);
+assert.throws(RangeError, function () {
+  adarI.subtract(years1, options);
+}, "Adding 1 year to Adar I rejects because the month would be constrained");
+
+TemporalHelpers.assertPlainYearMonth(
+  adarI.subtract(years1n),
+  5781, 6, "M06", "Subtracting 1 year from Adar I constrains to Adar",
+  "am", 5781, null);
+assert.throws(RangeError, function () {
+  adarI.subtract(years1n, options);
+}, "Subtracting 1 year from Adar I rejects because the month would be constrained");


### PR DESCRIPTION
This commit copies all of the PlainDate.since and .until tests that would apply to PlainYearMonth, and adapts them where necessary.

(Except for the tests that would be affected by https://github.com/tc39/proposal-temporal/issues/3197, namely `leap-months-*.js` and `leap-year-*.js` [the latter except 'leap-year-hebrew.js' which is fine because of the month constraining behaviour].)

This is the final part. Previous parts: #4762, #4766 