### PR TITLE
Fix locale metadata value on `Intl.DateTimeFormat` tests

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js
@@ -5,7 +5,7 @@
 esid: sec-partitiondatetimepattern
 description: >
   Check that Intl.DateTimeFormat.formatRangeToParts output matches snapshot data
-locale: en-US-u-ca-chinese
+locale: [en-US-u-ca-chinese]
 ---*/
 
 const calendar = "chinese";

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js
@@ -5,7 +5,7 @@
 esid: sec-partitiondatetimepattern
 description: >
   Check that Intl.DateTimeFormat.formatRangeToParts output matches snapshot data
-locale: en-US-u-ca-dangi
+locale: [en-US-u-ca-dangi]
 ---*/
 
 const calendar = "dangi";

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/chinese-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/chinese-calendar-dates.js
@@ -5,7 +5,7 @@
 esid: sec-partitiondatetimepattern
 description: >
   Check that Intl.DateTimeFormat.formatToParts output matches snapshot data
-locale: en-US-u-ca-chinese
+locale: [en-US-u-ca-chinese]
 ---*/
 
 const calendar = "chinese";

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/dangi-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/dangi-calendar-dates.js
@@ -5,7 +5,7 @@
 esid: sec-partitiondatetimepattern
 description: >
   Check that Intl.DateTimeFormat.formatToParts output matches snapshot data
-locale: en-US-u-ca-dangi
+locale: [en-US-u-ca-dangi]
 features: [Temporal]
 ---*/
 


### PR DESCRIPTION
Based off the documentation in [CONTRIBUTING.md](https://github.com/tc39/test262/blob/main/CONTRIBUTING.md?plain=1#L233), the locale key's value is expected to be an array of one or more language tags or subtags.

This broke Boa's test runner downstream when trying to pin our test262 commit to a more recent commit.