### PR TITLE
Fix format parts test

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js
@@ -21,11 +21,13 @@ function compareFormatRangeToPartsSnapshot(isoString1, isoString2, expectedCompo
     for (let [expectedType, expectedValue] of Object.entries(list)) {
       const part = actualComponents.find(({type, source}) => type === expectedType && source == sourceVal);
       const contextMessage = `${expectedType} component of ${isoString} formatted in ${calendar}`;
-      assert.notSameValue(part, undefined, contextMessage);
-      if (typeof part.value === "string")
-        assert(part.value === expectedValue || (expectedValue.length === 1 && part.value === '0' + expectedValue));
-      else
-        assert.sameValue(part.value, `${expectedValue}`, contextMessage);
+      assert.notSameValue(part, undefined, `${contextMessage} is missing`);
+      assert.sameValue(typeof part.value, "string", `${contextMessage} is not a string`);
+      assert(
+        part.value === String(expectedValue) ||
+          part.value === String(expectedValue).padStart(2, "0"),
+        `${contextMessage} has unexpected value`
+      );
     }
   }
 

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js
@@ -21,11 +21,13 @@ function compareFormatRangeToPartsSnapshot(isoString1, isoString2, expectedCompo
     for (let [expectedType, expectedValue] of Object.entries(list)) {
       const part = actualComponents.find(({type, source}) => type === expectedType && source == sourceVal);
       const contextMessage = `${expectedType} component of ${isoString} formatted in ${calendar}`;
-      assert.notSameValue(part, undefined, contextMessage);
-      if (typeof part.value === "string")
-        assert(part.value === expectedValue || (expectedValue.length === 1 && part.value === '0' + expectedValue));
-      else
-        assert.sameValue(part.value, `${expectedValue}`, contextMessage);
+      assert.notSameValue(part, undefined, `${contextMessage} is missing`);
+      assert.sameValue(typeof part.value, "string", `${contextMessage} is not a string`);
+      assert(
+        part.value === String(expectedValue) ||
+          part.value === String(expectedValue).padStart(2, "0"),
+        `${contextMessage} has unexpected value`
+      );
     }
   }
 

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/chinese-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/chinese-calendar-dates.js
@@ -18,11 +18,13 @@ function compareFormatToPartsSnapshot(isoString, expectedComponents) {
   for (let [expectedType, expectedValue] of Object.entries(expectedComponents)) {
     const part = actualComponents.find(({type}) => type === expectedType);
     const contextMessage = `${expectedType} component of ${isoString} formatted in ${calendar}`;
-    assert.notSameValue(part, undefined, contextMessage);
-    if (typeof part.value === "string")
-      assert(part.value === expectedValue || (expectedValue.length === 1 && part.value === '0' + expectedValue));
-    else
-      assert.sameValue(part.value, `${expectedValue}`, contextMessage);
+    assert.notSameValue(part, undefined, `${contextMessage} is missing`);
+    assert.sameValue(typeof part.value, "string", `${contextMessage} is not a string`);
+    assert(
+      part.value === String(expectedValue) ||
+        part.value === String(expectedValue).padStart(2, "0"),
+      `${contextMessage} has unexpected value`
+    );
   }
 }
 

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/dangi-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/dangi-calendar-dates.js
@@ -21,11 +21,13 @@ function compareFormatToPartsSnapshot(isoString, expectedComponents) {
   for (let [expectedType, expectedValue] of Object.entries(expectedComponents)) {
     const part = actualComponents.find(({type}) => type === expectedType);
     const contextMessage = `${expectedType} component of ${isoString} formatted in ${calendar}`;
-    assert.notSameValue(part, undefined, contextMessage);
-    if (typeof part.value === "string")
-      assert(part.value === expectedValue || (expectedValue.length === 1 && part.value === '0' + expectedValue));
-    else
-      assert.sameValue(part.value, `${expectedValue}`, contextMessage);
+    assert.notSameValue(part, undefined, `${contextMessage} is missing`);
+    assert.sameValue(typeof part.value, "string", `${contextMessage} is not a string`);
+    assert(
+      part.value === String(expectedValue) ||
+        part.value === String(expectedValue).padStart(2, "0"),
+      `${contextMessage} has unexpected value`
+    );
   }
 }
 


### PR DESCRIPTION
Two issues:
1. `typeof part.value` is always a String value.
2. `expectedValue` is a Number value, but the test expected a String.