### PR TITLE
Document the CLDR grace period in a new MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,6 @@
+# Test262 Maintainer Guidelines
+
+## CLDR
+
+Some tests presume data/behaviours/etc. propagated via [CLDR](https://cldr.unicode.org/), such as those asserting the association of properties with Unicode code points as exposed in regular expressions at [test/built-ins/RegExp/property-escapes](./test/built-ins/RegExp/property-escapes).
+To protect implementations from spurious test failures before they incorporate a new CLDR release, we provide a one month grace period for merging tests dependent upon its contents.


### PR DESCRIPTION
To be discussed with implementers in plenary, in case they prefer a different grace period (or none at all—cf. https://github.com/tc39/test262/pull/4573#issuecomment-3572483974 : "<em>engines might not want to update their version of CLDR before relevant tests have landed, e.g. https://github.com/quickjs-ng/quickjs/issues/1168</em>").