### PR TITLE
Temporal: Further adjustments to formatToParts with calendars

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js
@@ -22,10 +22,14 @@ function compareFormatRangeToPartsSnapshot(isoString1, isoString2, expectedCompo
       const part = actualComponents.find(({type, source}) => type === expectedType && source == sourceVal);
       const contextMessage = `${expectedType} component of ${isoString} formatted in ${calendar}`;
       assert.notSameValue(part, undefined, contextMessage);
-      if (typeof part.value === "string")
-        assert(part.value === expectedValue || (expectedValue.length === 1 && part.value === '0' + expectedValue));
-      else
+      if (typeof part.value === "string") {
+        assert(
+          part.value === String(expectedValue) || (expectedValue.length === 1 && part.value === '0' + expectedValue),
+          contextMessage + `: ${part.value} either ${expectedValue} or 0${expectedValue}`
+        );
+      } else {
         assert.sameValue(part.value, `${expectedValue}`, contextMessage);
+      }
     }
   }
 

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js
@@ -22,10 +22,14 @@ function compareFormatRangeToPartsSnapshot(isoString1, isoString2, expectedCompo
       const part = actualComponents.find(({type, source}) => type === expectedType && source == sourceVal);
       const contextMessage = `${expectedType} component of ${isoString} formatted in ${calendar}`;
       assert.notSameValue(part, undefined, contextMessage);
-      if (typeof part.value === "string")
-        assert(part.value === expectedValue || (expectedValue.length === 1 && part.value === '0' + expectedValue));
-      else
+      if (typeof part.value === "string") {
+        assert(
+          part.value === String(expectedValue) || (expectedValue.length === 1 && part.value === '0' + expectedValue),
+          contextMessage + `: ${part.value} either ${expectedValue} or 0${expectedValue}`
+        );
+      } else {
         assert.sameValue(part.value, `${expectedValue}`, contextMessage);
+      }
     }
   }
 

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/chinese-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/chinese-calendar-dates.js
@@ -19,10 +19,14 @@ function compareFormatToPartsSnapshot(isoString, expectedComponents) {
     const part = actualComponents.find(({type}) => type === expectedType);
     const contextMessage = `${expectedType} component of ${isoString} formatted in ${calendar}`;
     assert.notSameValue(part, undefined, contextMessage);
-    if (typeof part.value === "string")
-      assert(part.value === expectedValue || (expectedValue.length === 1 && part.value === '0' + expectedValue));
-    else
+    if (typeof part.value === "string") {
+      assert(
+        part.value === String(expectedValue) || (expectedValue.length === 1 && part.value === '0' + expectedValue),
+        contextMessage + `: ${part.value} either ${expectedValue} or 0${expectedValue}`
+      );
+    } else {
       assert.sameValue(part.value, `${expectedValue}`, contextMessage);
+    }
   }
 }
 

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/dangi-calendar-dates.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/dangi-calendar-dates.js
@@ -22,10 +22,14 @@ function compareFormatToPartsSnapshot(isoString, expectedComponents) {
     const part = actualComponents.find(({type}) => type === expectedType);
     const contextMessage = `${expectedType} component of ${isoString} formatted in ${calendar}`;
     assert.notSameValue(part, undefined, contextMessage);
-    if (typeof part.value === "string")
-      assert(part.value === expectedValue || (expectedValue.length === 1 && part.value === '0' + expectedValue));
-    else
+    if (typeof part.value === "string") {
+      assert(
+        part.value === String(expectedValue) || (expectedValue.length === 1 && part.value === '0' + expectedValue),
+        contextMessage + `: ${part.value} either ${expectedValue} or 0${expectedValue}`
+      );
+    } else {
       assert.sameValue(part.value, `${expectedValue}`, contextMessage);
+    }
   }
 }
 


### PR DESCRIPTION
Follow up to #4771. The expectedValue here is a number, while part.value is a string. Before the previous change, we'd convert expectedValue to a string, so do that again here.

Add an assertion message for debugging.