### PR TITLE
Temporal: Add tests for unbalanced date/time separators

### DIFF
--- a/test/built-ins/Temporal/PlainDate/from/argument-string-invalid.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-string-invalid.js
@@ -50,6 +50,9 @@ const invalidStrings = [
   // valid, but outside the supported range:
   "-999999-01-01",
   "+999999-01-01",
+  // non-matching separators
+  "2020-0101",
+  "202001-01",
 ];
 for (const arg of invalidStrings) {
   assert.throws(

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-string-invalid.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-string-invalid.js
@@ -50,7 +50,12 @@ const invalidStrings = [
   "+999999-01-01",
   // "00:0000" is invalid (the hour/minute and minute/second separator
   // or lack thereof needs to match).
-  "2025-01-01T00:00:00+00:0000"
+  "2025-01-01T00:00:00+00:0000",
+  "2025-01-01T00:00:00+0000:00",
+  "202501-01T00:00:00",
+  "2025-0101T00:00:00",
+  "2025-01-01T00:0000",
+  "2025-01-01T0000:00",
 ];
 
 invalidStrings.forEach((s) => {

--- a/test/built-ins/Temporal/PlainTime/from/argument-string-invalid.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-string-invalid.js
@@ -32,6 +32,9 @@ const invalidStrings = [
   // "00:0000" is invalid (the hour/minute and minute/second separator
   // or lack thereof needs to match).
   "00:00:00+00:0000",
+  "0000:00",
+  "00:0000",
+  "00:00:00+0000:00",
 ];
 for (const arg of invalidStrings) {
   assert.throws(

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-string-invalid.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-string-invalid.js
@@ -5,9 +5,25 @@
 esid: sec-temporal.zoneddatetime.from
 description: >
   Check that UTC offsets are parsed properly
-features: [Temporal, Intl.Era-monthcode]
+features: [Temporal]
 ---*/
 
-assert.throws(RangeError,
-  () => Temporal.ZonedDateTime.from("2025-01-01T00:00:00+00:0000[UTC]"),
-  "UTCOffset must be of the form hh:mm:ss or hhmmss");
+const invalidStrings = [
+  // UTCOffset must be of the form hh:mm:ss or hhmmss");
+  "2025-01-01T00:00:00+00:0000[UTC]",
+  "2025-01-01T00:00:00+0000:00[UTC]",
+  // Invalid date or time components, valid offset
+  "202501-01T00:00:00+00:00[UTC]",
+  "2025-0101T00:00:00+00:00[UTC]",
+  "2025-01-01T00:0000+00:00[UTC]",
+  "2025-01-01T0000:00+00:00[UTC]",
+];
+
+invalidStrings.forEach((s) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.from(s),
+    `invalid date-time string (${s})`
+  );
+});
+


### PR DESCRIPTION
Add tests that strings like "2020-0101", "202001-01" in a date context and "00:0000" and "0000:00" in a time context are rejected.