### PR TITLE
Temporal: Add coverage for modified Array iteration when called from GetPossibleEpochNanoseconds

### DIFF
--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/no-observable-array-iteration.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/no-observable-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tozoneddatetimeiso
+description: >
+  Calling GetPossibleEpochNanoseconds (from ToTemporalZonedDateTime > InterpretISODateTimeOffset)
+  causes no observable array iteration.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+let inst = new Temporal.Instant(0n);
+let zdt = inst.toZonedDateTimeISO("UTC");
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/no-observable-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/no-observable-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: >
+  Calling GetPossibleEpochNanoseconds (from ToTemporalZonedDateTime > InterpretISODateTimeOffset)
+  causes no observable array iteration.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+let pd = new Temporal.PlainDate(2000, 1, 1);
+let zdt = pd.toZonedDateTime("UTC");
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/no-observable-array-iteration.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/no-observable-array-iteration.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tozoneddatetime
+description: >
+  Calling GetPossibleEpochNanoseconds (from ToTemporalZonedDateTime > InterpretISODateTimeOffset)
+  causes no observable array iteration.
+features: [Temporal]
+---*/
+
+const arrayPrototypeSymbolIteratorOriginal = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function arrayIterator() {
+  throw new Test262Error("Array should not be iterated");
+}
+
+let pdt = new Temporal.PlainDateTime(2000, 1, 1, 12, 0, 0, 0);
+let zdt = pdt.toZonedDateTime("UTC");
+
+Array.prototype[Symbol.iterator] = arrayPrototypeSymbolIteratorOriginal;


### PR DESCRIPTION
Closes https://github.com/tc39/test262/issues/3851