### PR TITLE
Add tests that bound compare/format functions are cached

### DIFF
--- a/test/intl402/Collator/prototype/compare/bound-compare-stored-in-instance.js
+++ b/test/intl402/Collator/prototype/compare/bound-compare-stored-in-instance.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.collator.prototype.compare
+description: >
+  Bound compare function is stored in the Intl.Collator instance
+info: |
+  get Intl.Collator.prototype.compare
+
+  ...
+  3. If collator.[[BoundCompare]] is undefined, then
+    a. Let F be a new built-in function object as defined in 10.3.3.1.
+    ...
+    c. Set collator.[[BoundCompare]] to F.
+  4. Return collator.[[BoundCompare]].
+---*/
+
+var collator = new Intl.Collator();
+var compare = collator.compare;
+
+assert.sameValue(
+  typeof compare,
+  "function",
+  "compare getter returns a function object"
+);
+
+assert.sameValue(
+  collator.compare,
+  compare,
+  "compare getter returns the same bound compare function"
+);
+
+var otherCollator = new Intl.Collator().compare;
+
+assert.notSameValue(
+  otherCollator.compare,
+  compare,
+  "compare functions are bound to a single collator"
+);

--- a/test/intl402/DateTimeFormat/prototype/format/bound-format-stored-in-instance.js
+++ b/test/intl402/DateTimeFormat/prototype/format/bound-format-stored-in-instance.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.datetimeformat.prototype.format
+description: >
+  Bound format function is stored in the Intl.DateTimeFormat instance
+info: |
+  get Intl.DateTimeFormat.prototype.format
+
+  ...
+  4. If dtf.[[BoundFormat]] is undefined, then
+    a. Let F be a new built-in function object as defined in DateTime Format Functions (11.5.4).
+    ...
+    c. Set dtf.[[BoundFormat]] to F.
+  5. Return dtf.[[BoundFormat]].
+---*/
+
+var dateTimeFormat = new Intl.DateTimeFormat();
+var format = dateTimeFormat.format;
+
+assert.sameValue(
+  typeof format,
+  "function",
+  "format getter returns a function object"
+);
+
+assert.sameValue(
+  dateTimeFormat.format,
+  format,
+  "format getter returns the same bound format function"
+);
+
+var otherDateTimeFormat = new Intl.DateTimeFormat().format;
+
+assert.notSameValue(
+  otherDateTimeFormat.format,
+  format,
+  "format functions are bound to a single date time formatter"
+);

--- a/test/intl402/NumberFormat/prototype/format/bound-format-stored-in-instance.js
+++ b/test/intl402/NumberFormat/prototype/format/bound-format-stored-in-instance.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  Bound format function is stored in the Intl.NumberFormat instance
+info: |
+  get Intl.NumberFormat.prototype.format
+
+  ...
+  4. If nf.[[BoundFormat]] is undefined, then
+    a. Let F be a new built-in function object as defined in Number Format Functions (16.5.2).
+    ...
+    c. Set nf.[[BoundFormat]] to F.
+  5. Return nf.[[BoundFormat]].
+---*/
+
+var numberFormat = new Intl.NumberFormat();
+var format = numberFormat.format;
+
+assert.sameValue(
+  typeof format,
+  "function",
+  "format getter returns a function object"
+);
+
+assert.sameValue(
+  numberFormat.format,
+  format,
+  "format getter returns the same bound format function"
+);
+
+var otherNumberFormat = new Intl.NumberFormat().format;
+
+assert.notSameValue(
+  otherNumberFormat.format,
+  format,
+  "format functions are bound to a single number formatter"
+);


### PR DESCRIPTION
There aren't currently any tests which verify that the same bound functions are returned by the `compare` resp. `format` getters.