### PR TITLE
[Temporal] Ensure that toLocaleString can use both dateStyle and timeStyle

### DIFF
--- a/test/intl402/Temporal/Instant/prototype/toLocaleString/datestyle-and-timestyle.js
+++ b/test/intl402/Temporal/Instant/prototype/toLocaleString/datestyle-and-timestyle.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-temporal.instant.prototype.tolocalestring
-description: Using both dateStyle and timeStyle should now throw
+description: Using both dateStyle and timeStyle should not throw
 features: [Temporal]
 ---*/
 

--- a/test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/datestyle-and-timestyle.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/datestyle-and-timestyle.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.tolocalestring
-description: Using both dateStyle and timeStyle should now throw
+description: Using both dateStyle and timeStyle should not throw
 features: [Temporal]
 ---*/
 

--- a/test/intl402/Temporal/PlainTime/prototype/toLocaleString/datestyle-and-timestyle.js
+++ b/test/intl402/Temporal/PlainTime/prototype/toLocaleString/datestyle-and-timestyle.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-temporal.plaintime.prototype.tolocalestring
-description: Using both dateStyle and timeStyle should now throw
+description: Using both dateStyle and timeStyle should not throw
 features: [Temporal]
 ---*/
 

--- a/test/intl402/Temporal/ZonedDateTime/prototype/toLocaleString/datestyle-and-timestyle.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/toLocaleString/datestyle-and-timestyle.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-temporal.zoneddatetime.prototype.tolocalestring
-description: Using both dateStyle and timeStyle should now throw
+description: Using both dateStyle and timeStyle should not throw
 features: [Temporal]
 ---*/
 


### PR DESCRIPTION
Ensure that using both dateStyle and timeStyle when calling toLocaleString doesn't throw.

Closes https://github.com/tc39/proposal-temporal/issues/3061