### PR TITLE
[Temporal] Add coverage for adding durations to minimum and maximum dates

### DIFF
--- a/test/built-ins/Temporal/PlainDate/prototype/add/argument-duration-max-plus-min-date.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/add/argument-duration-max-plus-min-date.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.add
+description: Maximum allowed duration adding to minimum allowed date
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const min = Temporal.PlainDate.from({ year: -271821, month: 4, day: 19 });
+
+const maxCases = [
+  ["P547581Y4M25DT23H59M59.999999999S", "string with max years"],
+  [{ years: 547581, months: 4, days: 25, nanoseconds: 86399999999999 }, "property bag with max years"],
+  ["P6570976M25DT23H59M59.999999999S", "string with max months"],
+  [{ months: 6570976, days: 25, nanoseconds: 86399999999999 }, "property bag with max months"],
+  ["P28571428W5DT23H59M59.999999999S", "string with max weeks"],
+  [{ weeks: 28_571_428, days: 5, nanoseconds: 86399999999999 }, "property bag with max weeks"],
+  ["P200000001DT23H59M59.999999999S", "string with max days"],
+  [{ days: 200_000_001, nanoseconds: 86399999999999 }, "property bag with max days"],
+  ["PT4800000047H59M59.999999999S", "string with max hours"],
+  [{ hours: 4_800_000_047, minutes: 59, seconds: 59, milliseconds: 999, microseconds: 999, nanoseconds: 999 }, "property bag with max hours"],
+  ["PT288000002879M59.999999999S", "string with max minutes"],
+  [{ minutes: 288_000_002_879, seconds: 59, milliseconds: 999, microseconds: 999, nanoseconds: 999 }, "property bag with max minutes"],
+  ["PT17280000172799.999999998S", "string with max seconds"],
+  [{ seconds: 17_280_000_172_799, nanoseconds: 999999998 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of maxCases) {
+    const result = min.add(arg);
+    TemporalHelpers.assertPlainDate(result, 275760, 9, "M09", 13,  `operation succeeds with ${descr}`);
+}
+
+const max = Temporal.PlainDate.from({ year: 275760, month: 9, day: 13 });
+
+const minCases = [
+  ["-P547581Y4M24DT23H59M59.999999999S", "string with max years"],
+  [{ years: -547581, months: -4, days: -24, nanoseconds: -86399999999999 }, "property bag with max years"],
+  ["-P6570976M24DT23H59M59.999999999S", "string with max months"],
+  [{ months: -6570976, days: -24, nanoseconds: -86399999999999 }, "property bag with max months"],
+  ["-P28571428W5DT23H59M59.999999999S", "string with max weeks"],
+  [{ weeks: -28_571_428, days: -5, nanoseconds: -86399999999999 }, "property bag with max weeks"],
+  ["-P200000001DT23H59M59.999999999S", "string with max days"],
+  [{ days: -200_000_001, nanoseconds: -86399999999999 }, "property bag with max days"],
+  ["-PT4800000047H59M59.999999999S", "string with max hours"],
+  [{ hours: -4_800_000_047, minutes: -59, seconds: -59, milliseconds: -999, microseconds: -999, nanoseconds: -999 }, "property bag with max hours"],
+  ["-PT288000002879M59.999999999S", "string with max minutes"],
+  [{ minutes: -288_000_002_879, seconds: -59, milliseconds: -999, microseconds: -999, nanoseconds: -999 }, "property bag with max minutes"],
+  ["-PT17280000172799.999999998S", "string with max seconds"],
+  [{ seconds: -17_280_000_172_799, nanoseconds: -999999998 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of minCases) {
+    const result = max.add(arg);
+    TemporalHelpers.assertPlainDate(result, -271821, 4, "M04", 19,  `operation succeeds with ${descr}`);
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/subtract/argument-duration-max-plus-min-date.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/subtract/argument-duration-max-plus-min-date.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.subtract
+description: Maximum allowed duration subtracting from maximum allowed date
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const max = Temporal.PlainDate.from({ year: 275760, month: 9, day: 13 });
+
+const maxCases = [
+  ["P547581Y4M24DT23H59M59.999999999S", "string with max years"],
+  [{ years: 547581, months: 4, days: 24, nanoseconds: 86399999999999 }, "property bag with max years"],
+  ["P6570976M24DT23H59M59.999999999S", "string with max months"],
+  [{ months: 6570976, days: 24, nanoseconds: 86399999999999 }, "property bag with max months"],
+  ["P28571428W5DT23H59M59.999999999S", "string with max weeks"],
+  [{ weeks: 28_571_428, days: 5, nanoseconds: 86399999999999 }, "property bag with max weeks"],
+  ["P200000001DT23H59M59.999999999S", "string with max days"],
+  [{ days: 200_000_001, nanoseconds: 86399999999999 }, "property bag with max days"],
+  ["PT4800000047H59M59.999999999S", "string with max hours"],
+  [{ hours: 4_800_000_047, minutes: 59, seconds: 59, milliseconds: 999, microseconds: 999, nanoseconds: 999 }, "property bag with max hours"],
+  ["PT288000002879M59.999999999S", "string with max minutes"],
+  [{ minutes: 288_000_002_879, seconds: 59, milliseconds: 999, microseconds: 999, nanoseconds: 999 }, "property bag with max minutes"],
+  ["PT17280000172799.999999998S", "string with max seconds"],
+  [{ seconds: 17_280_000_172_799, nanoseconds: 999999998 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of maxCases) {
+    const result = max.subtract(arg);
+    TemporalHelpers.assertPlainDate(result, -271821, 4, "M04", 19,  `operation succeeds with ${descr}`);
+}
+
+const min = Temporal.PlainDate.from({ year: -271821, month: 4, day: 19 });
+
+const minCases = [
+  ["-P547581Y4M25DT23H59M59.999999999S", "string with max years"],
+  [{ years: -547581, months: -4, days: -25, nanoseconds: -86399999999999 }, "property bag with max years"],
+  ["-P6570976M25DT23H59M59.999999999S", "string with max months"],
+  [{ months: -6570976, days: -25, nanoseconds: -86399999999999 }, "property bag with max months"],
+  ["-P28571428W5DT23H59M59.999999999S", "string with max weeks"],
+  [{ weeks: -28_571_428, days: -5, nanoseconds: -86399999999999 }, "property bag with max weeks"],
+  ["-P200000001DT23H59M59.999999999S", "string with max days"],
+  [{ days: -200_000_001, nanoseconds: -86399999999999 }, "property bag with max days"],
+  ["-PT4800000047H59M59.999999999S", "string with max hours"],
+  [{ hours: -4_800_000_047, minutes: -59, seconds: -59, milliseconds: -999, microseconds: -999, nanoseconds: -999 }, "property bag with max hours"],
+  ["-PT288000002879M59.999999999S", "string with max minutes"],
+  [{ minutes: -288_000_002_879, seconds: -59, milliseconds: -999, microseconds: -999, nanoseconds: -999 }, "property bag with max minutes"],
+  ["-PT17280000172799.999999998S", "string with max seconds"],
+  [{ seconds: -17_280_000_172_799, nanoseconds: -999999998 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of minCases) {
+    const result = min.subtract(arg);
+    TemporalHelpers.assertPlainDate(result, 275760, 9, "M09", 13,  `operation succeeds with ${descr}`);
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/add/argument-duration-max-plus-min-date.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/add/argument-duration-max-plus-min-date.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: Maximum allowed duration adding to minimum allowed date
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const min = Temporal.PlainDateTime.from({ year: -271821, month: 4, day: 19, nanosecond: 1 });
+
+const maxCases = [
+  ["P547581Y4M24DT23H59M59.999999999S", "string with max years"],
+  [{ years: 547581, months: 4, days: 24, nanoseconds: 86399999999999 }, "property bag with max years"],
+  ["P6570976M24DT23H59M59.999999999S", "string with max months"],
+  [{ months: 6570976, days: 24, nanoseconds: 86399999999999 }, "property bag with max months"],
+  ["P28571428W4DT23H59M59.999999999S", "string with max weeks"],
+  [{ weeks: 28_571_428, days: 4, nanoseconds: 86399999999999 }, "property bag with max weeks"],
+  ["P200000000DT23H59M59.999999999S", "string with max days"],
+  [{ days: 200_000_000, nanoseconds: 86399999999999 }, "property bag with max days"],
+  ["PT4800000023H59M59.999999999S", "string with max hours"],
+  [{ hours: 4_800_000_023, minutes: 59, seconds: 59, milliseconds: 999, microseconds: 999, nanoseconds: 999 }, "property bag with max hours"],
+  ["PT288000001439M59.999999999S", "string with max minutes"],
+  [{ minutes: 288_000_001_439, seconds: 59, milliseconds: 999, microseconds: 999, nanoseconds: 999 }, "property bag with max minutes"],
+  ["PT17280000086399.999999999S", "string with max seconds"],
+  [{ seconds: 17_280_000_086_399, nanoseconds: 999999999 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of maxCases) {
+    const result = min.add(arg);
+    TemporalHelpers.assertPlainDateTime(result, 275760, 9, "M09", 13, 0, 0, 0, 0, 0, 0,  `operation succeeds with ${descr}`);
+}
+
+const max = Temporal.PlainDateTime.from({ year: 275760, month: 9, day: 13 });
+
+const minCases = [
+  ["-P547581Y4M23DT23H59M59.999999999S", "string with max years"],
+  [{ years: -547581, months: -4, days: -23, nanoseconds: -86399999999999 }, "property bag with max years"],
+  ["-P6570976M23DT23H59M59.999999999S", "string with max months"],
+  [{ months: -6570976, days: -23, nanoseconds: -86399999999999 }, "property bag with max months"],
+  ["-P28571428W4DT23H59M59.999999999S", "string with max weeks"],
+  [{ weeks: -28_571_428, days: -4, nanoseconds: -86399999999999 }, "property bag with max weeks"],
+  ["-P200000000DT23H59M59.999999999S", "string with max days"],
+  [{ days: -200_000_000, nanoseconds: -86399999999999 }, "property bag with max days"],
+  ["-PT4800000023H59M59.999999999S", "string with max hours"],
+  [{ hours: -4_800_000_023, minutes: -59, seconds: -59, milliseconds: -999, microseconds: -999, nanoseconds: -999 }, "property bag with max hours"],
+  ["-PT288000001439M59.999999999S", "string with max minutes"],
+  [{ minutes: -288_000_001_439, seconds: -59, milliseconds: -999, microseconds: -999, nanoseconds: -999 }, "property bag with max minutes"],
+  ["-PT17280000086399.999999999S", "string with max seconds"],
+  [{ seconds: -17_280_000_086_399, nanoseconds: -999999999 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of minCases) {
+    const result = max.add(arg);
+    TemporalHelpers.assertPlainDateTime(result, -271821, 4, "M04", 19, 0, 0, 0, 0, 0, 1,  `operation succeeds with ${descr}`);
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/subtract/argument-duration-max-plus-min-date.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/subtract/argument-duration-max-plus-min-date.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: Maximum allowed duration subtracting from maximum allowed date
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const max = Temporal.PlainDateTime.from({ year: 275760, month: 9, day: 13 });
+
+const maxCases = [
+  ["P547581Y4M23DT23H59M59.999999999S", "string with max years"],
+  [{ years: 547581, months: 4, days: 23, nanoseconds: 86399999999999 }, "property bag with max years"],
+  ["P6570976M23DT23H59M59.999999999S", "string with max months"],
+  [{ months: 6570976, days: 23, nanoseconds: 86399999999999 }, "property bag with max months"],
+  ["P28571428W4DT23H59M59.999999999S", "string with max weeks"],
+  [{ weeks: 28_571_428, days: 4, nanoseconds: 86399999999999 }, "property bag with max weeks"],
+  ["P200000000DT23H59M59.999999999S", "string with max days"],
+  [{ days: 200_000_000, nanoseconds: 86399999999999 }, "property bag with max days"],
+  ["PT4800000023H59M59.999999999S", "string with max hours"],
+  [{ hours: 4_800_000_023, minutes: 59, seconds: 59, milliseconds: 999, microseconds: 999, nanoseconds: 999 }, "property bag with max hours"],
+  ["PT288000001439M59.999999999S", "string with max minutes"],
+  [{ minutes: 288_000_001_439, seconds: 59, milliseconds: 999, microseconds: 999, nanoseconds: 999 }, "property bag with max minutes"],
+  ["PT17280000086399.999999999S", "string with max seconds"],
+  [{ seconds: 17_280_000_086_399, nanoseconds: 999999999 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of maxCases) {
+    const result = max.subtract(arg);
+    TemporalHelpers.assertPlainDateTime(result, -271821, 4, "M04", 19, 0, 0, 0, 0, 0, 1,  `operation succeeds with ${descr}`);
+}
+
+const min = Temporal.PlainDateTime.from({ year: -271821, month: 4, day: 19, nanosecond: 1 });
+
+const minCases = [
+  ["-P547581Y4M24DT23H59M59.999999999S", "string with max years"],
+  [{ years: -547581, months: -4, days: -24, nanoseconds: -86399999999999 }, "property bag with max years"],
+  ["-P6570976M24DT23H59M59.999999999S", "string with max months"],
+  [{ months: -6570976, days: -24, nanoseconds: -86399999999999 }, "property bag with max months"],
+  ["-P28571428W4DT23H59M59.999999999S", "string with max weeks"],
+  [{ weeks: -28_571_428, days: -4, nanoseconds: -86399999999999 }, "property bag with max weeks"],
+  ["-P200000000DT23H59M59.999999999S", "string with max days"],
+  [{ days: -200_000_000, nanoseconds: -86399999999999 }, "property bag with max days"],
+  ["-PT4800000023H59M59.999999999S", "string with max hours"],
+  [{ hours: -4_800_000_023, minutes: -59, seconds: -59, milliseconds: -999, microseconds: -999, nanoseconds: -999 }, "property bag with max hours"],
+  ["-PT288000001439M59.999999999S", "string with max minutes"],
+  [{ minutes: -288_000_001_439, seconds: -59, milliseconds: -999, microseconds: -999, nanoseconds: -999 }, "property bag with max minutes"],
+  ["-PT17280000086399.999999999S", "string with max seconds"],
+  [{ seconds: -17_280_000_086_399, nanoseconds: -999999999 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of minCases) {
+    const result = min.subtract(arg);
+    TemporalHelpers.assertPlainDateTime(result, 275760, 9, "M09", 13, 0, 0, 0, 0, 0, 0,  `operation succeeds with ${descr}`);
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/add/argument-duration-max-plus-min-date.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/add/argument-duration-max-plus-min-date.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: Maximum allowed duration adding to minimum allowed date
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const min = Temporal.ZonedDateTime.from({ year: -271821, month: 4, day: 20, timeZone: "UTC" });
+
+const maxCases = [
+  ["P547581Y4M24D", "string with max years"],
+  [{ years: 547581, months: 4, days: 24 }, "property bag with max years"],
+  ["P6570976M24D", "string with max months"],
+  [{ months: 6570976, days: 24 }, "property bag with max months"],
+  ["P28571428W4D", "string with max weeks"],
+  [{ weeks: 28_571_428, days: 4 }, "property bag with max weeks"],
+  ["P200000000D", "string with max days"],
+  [{ days: 200_000_000 }, "property bag with max days"],
+  ["PT4800000000H", "string with max hours"],
+  [{ hours: 4_800_000_000 }, "property bag with max hours"],
+  ["PT288000000000M", "string with max minutes"],
+  [{ minutes: 288_000_000_000 }, "property bag with max minutes"],
+  ["PT17280000000000S", "string with max seconds"],
+  [{ seconds: 17_280_000_000_000 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of maxCases) {
+    const result = min.add(arg);
+    TemporalHelpers.assertPlainDateTime(result.toPlainDateTime(), 275760, 9, "M09", 13, 0, 0, 0, 0, 0, 0,  `operation succeeds with ${descr}`)
+}
+
+const max = Temporal.ZonedDateTime.from({ year: 275760, month: 9, day: 13, timeZone: "UTC" });
+
+const minCases = [
+  ["-P547581Y4M23D", "string with max years"],
+  [{ years: -547581, months: -4, days: -23 }, "property bag with max years"],
+  ["-P6570976M23D", "string with max months"],
+  [{ months: -6570976, days: -23 }, "property bag with max months"],
+  ["-P28571428W4D", "string with max weeks"],
+  [{ weeks: -28_571_428, days: -4 }, "property bag with max weeks"],
+  ["-P200000000D", "string with max days"],
+  [{ days: -200_000_000 }, "property bag with max days"],
+  ["-PT4800000000H", "string with max hours"],
+  [{ hours: -4_800_000_000 }, "property bag with max hours"],
+  ["-PT288000000000M", "string with max minutes"],
+  [{ minutes: -288_000_000_000 }, "property bag with max minutes"],
+  ["-PT17280000000000S", "string with max seconds"],
+  [{ seconds: -17_280_000_000_000 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of minCases) {
+    const result = max.add(arg);
+    TemporalHelpers.assertPlainDateTime(result.toPlainDateTime(), -271821, 4, "M04", 20, 0, 0, 0, 0, 0, 0,  `operation succeeds with ${descr}`);
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/argument-duration-max-plus-min-date.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/argument-duration-max-plus-min-date.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: Maximum allowed duration subtracting from maximum allowed date
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const max = Temporal.ZonedDateTime.from({ year: 275760, month: 9, day: 13, timeZone: "UTC" });
+
+const maxCases = [
+  ["P547581Y4M23D", "string with max years"],
+  [{ years: 547581, months: 4, days: 23 }, "property bag with max years"],
+  ["P6570976M23D", "string with max months"],
+  [{ months: 6570976, days: 23 }, "property bag with max months"],
+  ["P28571428W4D", "string with max weeks"],
+  [{ weeks: 28_571_428, days: 4 }, "property bag with max weeks"],
+  ["P200000000D", "string with max days"],
+  [{ days: 200_000_000 }, "property bag with max days"],
+  ["PT4800000000H", "string with max hours"],
+  [{ hours: 4_800_000_000 }, "property bag with max hours"],
+  ["PT288000000000M", "string with max minutes"],
+  [{ minutes: 288_000_000_000 }, "property bag with max minutes"],
+  ["PT17280000000000S", "string with max seconds"],
+  [{ seconds: 17_280_000_000_000 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of maxCases) {
+    const result = max.subtract(arg);
+    TemporalHelpers.assertPlainDateTime(result.toPlainDateTime(), -271821, 4, "M04", 20, 0, 0, 0, 0, 0, 0,  `operation succeeds with ${descr}`);
+}
+
+const min = Temporal.ZonedDateTime.from({ year: -271821, month: 4, day: 20, timeZone: "UTC" });
+
+const minCases = [
+  ["-P547581Y4M24D", "string with max years"],
+  [{ years: -547581, months: -4, days: -24 }, "property bag with max years"],
+  ["-P6570976M24D", "string with max months"],
+  [{ months: -6570976, days: -24 }, "property bag with max months"],
+  ["-P28571428W4D", "string with max weeks"],
+  [{ weeks: -28_571_428, days: -4 }, "property bag with max weeks"],
+  ["-P200000000D", "string with max days"],
+  [{ days: -200_000_000 }, "property bag with max days"],
+  ["-PT4800000000H", "string with max hours"],
+  [{ hours: -4_800_000_000 }, "property bag with max hours"],
+  ["-PT288000000000M", "string with max minutes"],
+  [{ minutes: -288_000_000_000 }, "property bag with max minutes"],
+  ["-PT17280000000000S", "string with max seconds"],
+  [{ seconds: -17_280_000_000_000 }, "property bag with max seconds"],
+];
+
+for (const [arg, descr] of minCases) {
+    const result = min.subtract(arg);
+    TemporalHelpers.assertPlainDateTime(result.toPlainDateTime(), 275760, 9, "M09", 13, 0, 0, 0, 0, 0, 0,  `operation succeeds with ${descr}`)
+}


### PR DESCRIPTION
Add the largest possible duration to the minimum date and test that the maximum date is the result; likewise, subtract the largest possible duration from the maximum date and check that the minimum date is the result.

This provides coverage for a bug observed in GraalJS that resulted in a RangeError when adding a large duration to the minimum date, where the result should have been close to the maximum date.