### PR TITLE
[Temporal] Add coverage for ZonedDateTime offsets before 1883

### DIFF
--- a/test/intl402/Temporal/ZonedDateTime/prototype/add/offset-before-1883.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/add/offset-before-1883.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Justin Grant. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: Addition resulting in a pre-1883 date returns the correct offset
+features: [Temporal]
+---*/
+
+const instance = Temporal.ZonedDateTime.from("2001-09-08T18:46:40-07:00[America/Vancouver]");
+const expectedOffset = "-08:12:28"; // Offset before introduction of standard time zones
+
+assert.sameValue(instance.add(Temporal.Duration.from("-P5432Y1837M")).offset, expectedOffset, `add -P5432Y1837M, offset should be ${expectedOffset}`);
+assert.sameValue(instance.add(Temporal.Duration.from("-P5432Y1836M")).offset, expectedOffset, `add -P5432Y1836M, offset should be ${expectedOffset}`);
+assert.sameValue(instance.add(Temporal.Duration.from("-P5432Y1835M")).offset, expectedOffset, `add -P5432Y1835M, offset should be ${expectedOffset}`);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/subtract/offset-before-1883.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/subtract/offset-before-1883.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Justin Grant. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: Subtraction resulting in a pre-1883 date returns the correct offset
+features: [Temporal]
+---*/
+
+const instance = Temporal.ZonedDateTime.from("2001-09-08T18:46:40-07:00[America/Vancouver]");
+const expectedOffset = "-08:12:28"; // Offset before introduction of standard time zones
+
+assert.sameValue(instance.subtract(Temporal.Duration.from("P5432Y1837M")).offset, expectedOffset, `subtract -P5432Y1837M, offset should be ${expectedOffset}`);
+assert.sameValue(instance.subtract(Temporal.Duration.from("P5432Y1836M")).offset, expectedOffset, `subtract -P5432Y1836M, offset should be ${expectedOffset}`);
+assert.sameValue(instance.subtract(Temporal.Duration.from("P5432Y1835M")).offset, expectedOffset, `subtract -P5432Y1835M, offset should be ${expectedOffset}`);


### PR DESCRIPTION
Add test that adding/subtracting a large duration to a ZonedDateTime in the America/Vancouver time zone results in a ZonedDateTime with the correct offset (prior to the introduction of standard time zones).

This provides coverage for a bug observed in GraalJS.