### PR TITLE
[Temporal] Add coverage for negative months and days in `from`

### DIFF
--- a/test/built-ins/Temporal/PlainDate/from/negative-month-or-day.js
+++ b/test/built-ins/Temporal/PlainDate/from/negative-month-or-day.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: Months and days must be non-negative integers
+features: [Temporal]
+---*/
+
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 2000, day: 1, month: -1 }));
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 2000, month: 1, day: -1 }));

--- a/test/built-ins/Temporal/PlainDateTime/from/negative-month-or-day.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/negative-month-or-day.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: Months and days must be non-negative integers
+features: [Temporal]
+---*/
+
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2000, day: 1, month: -1 }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2000, month: 1, day: -1 }));

--- a/test/built-ins/Temporal/PlainMonthDay/from/negative-month-or-day.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/negative-month-or-day.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: Months and days must be non-negative integers
+features: [Temporal]
+---*/
+
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ day: 1, month: -1 }));
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: 1, day: -1 }));

--- a/test/built-ins/Temporal/PlainYearMonth/from/negative-month.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/negative-month.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.from
+description: Months must be non-negative integers
+features: [Temporal]
+---*/
+
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: 1, month: -1 }));

--- a/test/built-ins/Temporal/ZonedDateTime/from/negative-month-or-day.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/negative-month-or-day.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Months and days must be non-negative integers
+features: [Temporal]
+---*/
+
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2000, day: 1, timeZone: "UTC", month: -1 }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2000, month: 1, timeZone: "UTC", day: -1 }));


### PR DESCRIPTION
In the `from` method for the five types that can accept a month or day property, test that negative months or days throw an exception.