### PR TITLE
Temporal: Add coverage for all values of fractionalSecondDigits

### DIFF
--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-number.js
@@ -16,6 +16,8 @@ assert.sameValue(fewSeconds.toString({ fractionalSecondDigits: 0 }), "1976-02-04
   "pads parts with 0");
 assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 0 }), "1976-11-18T15:23:30",
   "truncates 4 decimal places to 0");
+assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 1 }), "1976-11-18T15:23:00.0",
+  "pads zero seconds to 1 decimal place");
 assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 2 }), "1976-11-18T15:23:00.00",
   "pads zero seconds to 2 decimal places");
 assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 2 }), "1976-11-18T15:23:30.00",
@@ -24,6 +26,10 @@ assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 2 }), "1976-11-18
   "truncates 4 decimal places to 2");
 assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 3 }), "1976-11-18T15:23:30.123",
   "truncates 4 decimal places to 3");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 4 }), "1976-11-18T15:23:30.1234",
+  "does not pad");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 5 }), "1976-11-18T15:23:30.12340",
+  "pads 4 decimal places to 5");
 assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 6 }), "1976-11-18T15:23:30.123400",
   "pads 4 decimal places to 6");
 assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 7 }), "1976-11-18T15:23:00.0000000",
@@ -32,5 +38,7 @@ assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 7 }), "1976-11-
   "pads whole seconds to 7 decimal places");
 assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 7 }), "1976-11-18T15:23:30.1234000",
   "pads 4 decimal places to 7");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 8 }), "1976-11-18T15:23:30.12340000",
+  "pads 4 decimal places to 8");
 assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 9 }), "1976-11-18T15:23:30.123400000",
   "pads 4 decimal places to 9");


### PR DESCRIPTION
Values 1, 4, 5, and 8 were previously missing from this test.