### PR TITLE
[Temporal] Add coverage for ZonedDateTime object as time zone

### DIFF
--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-timezone-object.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-timezone-object.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: A ZonedDateTime is valid in a property bag for a time zone
+features: [Temporal]
+---*/
+
+const result = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: new Temporal.ZonedDateTime(0n, "UTC") });
+assert.sameValue(result.timeZoneId, "UTC", 'Time zone created from ZonedDateTime object');


### PR DESCRIPTION
Add coverage for ZonedDateTime object as time zone in property bag argument to ZonedDateTime.from