### PR TITLE
[Temporal] Add coverage for "ethiopic-amete-alem" calendar ID

### DIFF
--- a/test/intl402/Temporal/PlainDate/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDate/canonicalize-calendar.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -7,5 +7,10 @@ description: Calendar ID is canonicalized
 features: [Temporal]
 ---*/
 
-const result = new Temporal.PlainDate(2024, 7, 2, "islamicc");
+var result = new Temporal.PlainDate(2024, 7, 2, "islamicc");
 assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");
+
+// May need to be removed in the future.
+// See https://github.com/tc39/ecma402/issues/285
+result = new Temporal.PlainDate(2024, 7, 2, "ethiopic-amete-alem");
+assert.sameValue(result.calendarId, "ethioaa", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/PlainDateTime/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/canonicalize-calendar.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -7,5 +7,10 @@ description: Calendar ID is canonicalized
 features: [Temporal]
 ---*/
 
-const result = new Temporal.PlainDateTime(2024, 7, 2, 12, 34, 56, 987, 654, 321, "islamicc");
+var result = new Temporal.PlainDateTime(2024, 7, 2, 12, 34, 56, 987, 654, 321, "islamicc");
 assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");
+
+// May need to be removed in the future.
+// See https://github.com/tc39/ecma402/issues/285
+result = new Temporal.PlainDateTime(2024, 7, 2, 12, 34, 56, 987, 654, 321, "ethiopic-amete-alem");
+assert.sameValue(result.calendarId, "ethioaa", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/PlainMonthDay/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainMonthDay/canonicalize-calendar.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -7,5 +7,10 @@ description: Calendar ID is canonicalized
 features: [Temporal]
 ---*/
 
-const result = new Temporal.PlainMonthDay(2, 11, "islamicc", 1972);
+var result = new Temporal.PlainMonthDay(2, 11, "islamicc", 1972);
 assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");
+
+// May need to be removed in the future.
+// See https://github.com/tc39/ecma402/issues/285
+result = new Temporal.PlainMonthDay(2, 11, "ethiopic-amete-alem");
+assert.sameValue(result.calendarId, "ethioaa", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/PlainYearMonth/canonicalize-calendar.js
+++ b/test/intl402/Temporal/PlainYearMonth/canonicalize-calendar.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -7,5 +7,10 @@ description: Calendar ID is canonicalized
 features: [Temporal]
 ---*/
 
-const result = new Temporal.PlainYearMonth(2024, 6, "islamicc", 8);
+var result = new Temporal.PlainYearMonth(2024, 6, "islamicc", 8);
 assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");
+
+// May need to be removed in the future.
+// See https://github.com/tc39/ecma402/issues/285
+result = new Temporal.PlainYearMonth(2024, 6, "ethiopic-amete-alem");
+assert.sameValue(result.calendarId, "ethioaa", "calendar ID is canonicalized");

--- a/test/intl402/Temporal/ZonedDateTime/canonicalize-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/canonicalize-calendar.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+// Copyright (C) 2025 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -7,5 +7,10 @@ description: Calendar ID is canonicalized
 features: [Temporal]
 ---*/
 
-const result = new Temporal.ZonedDateTime(1719923640_000_000_000n, "UTC", "islamicc");
+var result = new Temporal.ZonedDateTime(1719923640_000_000_000n, "UTC", "islamicc");
 assert.sameValue(result.calendarId, "islamic-civil", "calendar ID is canonicalized");
+
+// May need to be removed in the future.
+// See https://github.com/tc39/ecma402/issues/285
+result = new Temporal.ZonedDateTime(1719923640_000_000_000n, "UTC", "ethiopic-amete-alem");
+assert.sameValue(result.calendarId, "ethioaa", "calendar ID is canonicalized");


### PR DESCRIPTION
Test that "ethiopic-amete-alem" is canonicalized to "ethioaa".