### PR TITLE
Drop tests for plural categories of scientific & engineering notation

### DIFF
--- a/test/intl402/PluralRules/prototype/select/notation.js
+++ b/test/intl402/PluralRules/prototype/select/notation.js
@@ -21,36 +21,26 @@ var values = [
   {
     value: 1e6,
     standard: "many",
-    engineering: "many",
-    scientific: "many",
     compact: "many",
   },
 
   {
     value: 1.5e6,
     standard: "other",
-    engineering: "many",
-    scientific: "many",
     compact: "many",
   },
 
   {
     value: 1e-6,
     standard: "one",
-    engineering: "many",
-    scientific: "many",
     compact: "one",
   },
 ];
 
 var prstandard = new Intl.PluralRules("fr", { notation: "standard" });
-var prengineering = new Intl.PluralRules("fr", { notation: "engineering" });
-var prscientific = new Intl.PluralRules("fr", { notation: "scientific" });
 var prcompact = new Intl.PluralRules("fr", { notation: "compact" });
 
-for (var {value, standard, engineering, scientific, compact} of values) {
+for (var {value, standard, compact} of values) {
   assert.sameValue(prstandard.select(value), standard, `standard notation: ${value}`);
-  assert.sameValue(prengineering.select(value), engineering, `engineering notation: ${value}`);
-  assert.sameValue(prscientific.select(value), scientific, `scientific notation: ${value}`);
   assert.sameValue(prcompact.select(value), compact, `compact notation: ${value}`);
 }


### PR DESCRIPTION
PR #4503 added tests that include the expected plural categorization of values that are formatted as "1E6", "1,5E6", and "1E-6" in French. These tests should be dropped, because no data exists on the actually appropriate plural categorization of values with exponential notation; see for instance the [CLDR instructions](https://cldr.unicode.org/index/cldr-spec/plural-rules) for determining a language's plural rules, which make no mention of exponential notation.

The values currently in the test are likely whatever ICU4C produces for exponential notation, but those are effectively random; see for instance how the plural category of "1E-6" is expected to be `many`, which makes no sense.

CC @anba, @ryzokuken 