### PR TITLE
Add coverage for abrupt completion from ToNumber via ToUint16 in String.fromCharCode

### DIFF
--- a/test/built-ins/String/fromCharCode/touint16-tonumber-throws-bigint.js
+++ b/test/built-ins/String/fromCharCode/touint16-tonumber-throws-bigint.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Hyunjoon Kim. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-string.fromcharcode
+description: >
+    String.fromCharCode propagates abrupt completion from ToNumber when argument is BigInt via ToUint16.
+info: |
+    String.fromCharCode ( ..._codeUnits_ )
+
+    2. For each element _next_ of _codeUnits_, do
+      a. Let _nextCU_ be the code unit whose numeric value is ℝ(? ToUint16(_next_)).
+
+    ToUint16 ( _argument_ )
+
+    1. Let _number_ be ? ToNumber(_argument_).
+
+    ToNumber ( _argument_ )
+    
+    2. If _argument_ is either a Symbol or a BigInt, throw a *TypeError* exception.
+features: [BigInt]
+---*/
+
+assert.throws(TypeError, function () {
+  String.fromCharCode(0n);
+}, "ToNumber throws when argument is BigInt, and String.fromCharCode must propagate it.");

--- a/test/built-ins/String/fromCharCode/touint16-tonumber-throws-valueof.js
+++ b/test/built-ins/String/fromCharCode/touint16-tonumber-throws-valueof.js
@@ -4,11 +4,8 @@
 /*---
 esid: sec-string.fromcharcode
 description: >
-    String.fromCharCode propagates abrupt completion from ToNumber via ToUint16.
+    String.fromCharCode propagates abrupt completion from ToNumber via ToUint16. (ToPrimitive/valueOf throws)
 info: |
-    String.fromCharCode applies ToUint16 to each argument, and ToUint16 begins
-    with ToNumber, so abrupt completion from ToNumber is propagated.
-
     String.fromCharCode ( ..._codeUnits_ )
 
     2. For each element _next_ of _codeUnits_, do
@@ -17,12 +14,11 @@ info: |
     ToUint16 ( _argument_ )
 
     1. Let _number_ be ? ToNumber(_argument_).
-features: [BigInt]
----*/
 
-assert.throws(TypeError, function () {
-  String.fromCharCode(0n);
-}, "ToNumber throws when argument is BigInt, and String.fromCharCode must propagate it");
+    ToNumber ( _argument_ )
+    
+    8. Let _primValue_ be ? ToPrimitive(_argument_, ~number~).    
+---*/
 
 assert.throws(Test262Error, function () {
   String.fromCharCode({


### PR DESCRIPTION
This PR adds coverage for the case where [ToUint16](https://tc39.es/ecma262/#sec-touint16) produces an abrupt completion because its initial [ToNumber](https://tc39.es/ecma262/#sec-tonumber) step throws. (ToUint16 step 1)

[String.fromCharCode](https://tc39.es/ecma262/#sec-string.fromcharcode) converts each argument with ToUint16, and ToUint16 begins by applying ToNumber. So if the argument triggers an abrupt completion during ToNumber, that abrupt completion must be observable at the String.fromCharCode call site.

String.fromCharCode is a representative builtin that exercises ToUint16, so String.fromCharCode(0n) is a straightforward way to cover this path: ToNumber(0n) throws, and the builtin must propagate that error.

More generally, should test262 aim to add similar coverage for other observable abrupt-completion paths that currently aren’t covered? Or is there a consensus in test262 to keep this kind of coverage limited to a few representative cases?