### PR TITLE
[Temporal] Add coverage for non-string month codes in `from` methods

### DIFF
--- a/test/built-ins/Temporal/PlainDate/from/month-code-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/from/month-code-wrong-type.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: Month code must be a string
+features: [Temporal]
+---*/
+
+const monthCodeValues = [
+  5, 5n, false, Symbol(), null, { toString: () => 5 }
+];
+
+const year = 2026;
+
+for (const monthCode of monthCodeValues) {
+  assert.throws(TypeError, () => Temporal.PlainDate.from({
+    year,
+    monthCode,
+    day: 1
+  }), typeof monthCode === 'symbol' ?
+      "Symbol should be rejected as month code" :
+      `month code ${monthCode} should be rejected`);
+}

--- a/test/built-ins/Temporal/PlainDateTime/from/month-code-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/month-code-wrong-type.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: Month code must be a string
+features: [Temporal]
+---*/
+
+const monthCodeValues = [
+  5, 5n, false, Symbol(), null, { toString: () => 5 }
+];
+
+const year = 2026;
+
+for (const monthCode of monthCodeValues) {
+  assert.throws(TypeError, () => Temporal.PlainDateTime.from({
+    year,
+    monthCode,
+    day: 1, hour: 12, minute: 34
+  }), typeof monthCode === 'symbol' ?
+      "Symbol should be rejected as month code" :
+      `month code ${monthCode} should be rejected`);
+}

--- a/test/built-ins/Temporal/PlainYearMonth/from/month-code-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/month-code-wrong-type.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: Month code must be a string
+features: [Temporal]
+---*/
+
+const monthCodeValues = [
+  5, 5n, false, Symbol(), null, { toString: () => 5 }
+];
+
+const year = 2026;
+
+for (const monthCode of monthCodeValues) {
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.from({
+    year,
+    monthCode,
+    
+  }), typeof monthCode === 'symbol' ?
+      "Symbol should be rejected as month code" :
+      `month code ${monthCode} should be rejected`);
+}

--- a/test/built-ins/Temporal/ZonedDateTime/from/month-code-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/month-code-wrong-type.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Month code must be a string
+features: [Temporal]
+---*/
+
+const monthCodeValues = [
+  5, 5n, false, Symbol(), null, { toString: () => 5 }
+];
+
+const year = 2026;
+
+for (const monthCode of monthCodeValues) {
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.from({
+    year,
+    monthCode,
+    day: 1, hour: 12, minute: 34, timeZone: "UTC"
+  }), typeof monthCode === 'symbol' ?
+      "Symbol should be rejected as month code" :
+      `month code ${monthCode} should be rejected`);
+}


### PR DESCRIPTION
Add coverage for primitive non-string values passed in for the `monthCode` option in the `from` method for PlainDate, PlainDateTime, PlainYearMonth, and ZonedDateTime.