### PR TITLE
[Temporal] Test that fractional minutes or hours throws a RangeError.

### DIFF
--- a/test/built-ins/Temporal/Duration/compare/relativeto-no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-no-fractional-minutes-hours.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: Fractional minutes or hours in time string in relativeTo option should throw RangeError
+features: [Temporal]
+---*/
+
+const instance1 = new Temporal.Duration(1, 0, 0, 0, 24)
+const instance2 = new Temporal.Duration(1, 0, 0, 0, 24)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.Duration.compare(instance1, instance2, { relativeTo: arg }),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: Fractional minutes or hours in time string in relativeTo option should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.round({ largestUnit: "months", relativeTo: arg }),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: Fractional minutes or hours in time string in relativeTo option should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.total({ unit: "months", relativeTo: arg }),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/Instant/compare/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/Instant/compare/no-fractional-minutes-hours.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.compare
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123[CET]", "Fractional minutes"],
+  ["2025-04-03T12.5[CET]", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.Instant.compare(arg, new Temporal.Instant(0n)),
+    `${description} not allowed in time string (first argument)`
+  );
+  assert.throws(
+    RangeError,
+      () => Temporal.Instant.compare(new Temporal.Instant(0n), arg),
+    `${description} not allowed in time string (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/Instant/from/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/Instant/from/no-fractional-minutes-hours.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.from
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123[CET]", "Fractional minutes"],
+  ["2025-04-03T12.5[CET]", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.Instant.from(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/Instant/prototype/equals/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.equals
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123[CET]", "Fractional minutes"],
+  ["2025-04-03T12.5[CET]", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.equals(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/Instant/prototype/since/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123[CET]", "Fractional minutes"],
+  ["2025-04-03T12.5[CET]", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.since(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/Instant/prototype/until/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123[CET]", "Fractional minutes"],
+  ["2025-04-03T12.5[CET]", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.until(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/compare/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDate/compare/no-fractional-minutes-hours.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(2025, 04, 03)),
+    `${description} not allowed in time string (first argument)`
+  );
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainDate.compare(new Temporal.PlainDate(2025, 04, 03), arg),
+    `${description} not allowed in time string (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/from/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDate/from/no-fractional-minutes-hours.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainDate.from(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.equals(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/since/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.since(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/until/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.until(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/compare/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/no-fractional-minutes-hours.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(2025, 04, 03, 20, 04, 03)),
+    `${description} not allowed in time string (first argument)`
+  );
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(2025, 04, 03, 20, 04, 03), arg),
+    `${description} not allowed in time string (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/from/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/no-fractional-minutes-hours.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainDateTime.from(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.equals(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.since(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.until(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainMonthDay/from/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/no-fractional-minutes-hours.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainMonthDay.from(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainMonthDay(5, 2)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.equals(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/compare/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainTime/compare/no-fractional-minutes-hours.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.compare
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["05:07.123", "Fractional minutes"],
+  ["12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(20, 04, 03)),
+    `${description} not allowed in time string (first argument)`
+  );
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainTime.compare(new Temporal.PlainTime(20, 04, 03), arg),
+    `${description} not allowed in time string (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/from/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainTime/from/no-fractional-minutes-hours.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.from
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["05:07.123", "Fractional minutes"],
+  ["12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainTime.from(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/compare/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/no-fractional-minutes-hours.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2025, 04)),
+    `${description} not allowed in time string (first argument)`
+  );
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2025, 04), arg),
+    `${description} not allowed in time string (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/from/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/no-fractional-minutes-hours.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.PlainYearMonth.from(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2000, 5)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.equals(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2000, 5)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.since(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2000, 5)
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.until(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/compare/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/no-fractional-minutes-hours.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.ZonedDateTime.compare(arg, new Temporal.ZonedDateTime(0n, "CET")),
+    `${description} not allowed in time string (first argument)`
+  );
+  assert.throws(
+    RangeError,
+      () => Temporal.ZonedDateTime.compare(new Temporal.ZonedDateTime(0n, "CET"), arg),
+    `${description} not allowed in time string (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/from/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/no-fractional-minutes-hours.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => Temporal.ZonedDateTime.from(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(0n, "CET")
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.equals(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(0n, "CET")
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.since(arg),
+    `${description} not allowed in time string`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/no-fractional-minutes-hours.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Fractional minutes or hours in time string should throw RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(0n, "CET")
+
+const invalidStrings = [
+  ["2025-04-03T05:07.123", "Fractional minutes"],
+  ["2025-04-03T12.5", "Fractional hours"],
+];
+
+for (const [arg, description] of invalidStrings) {
+  assert.throws(
+    RangeError,
+      () => instance.until(arg),
+    `${description} not allowed in time string`
+  );
+}


### PR DESCRIPTION
Time strings such as "05:07.123" (fractional minutes) and "12.5" (fractional hours) should throw a RangeError.

This addresses proposal-temporal issue: https://github.com/tc39/proposal-temporal/issues/3210

The tests pass in the polyfill with the fix in proposal-temporal PR: https://github.com/tc39/proposal-temporal/pull/3236