### PR TITLE
[Temporal] Avoid legacy octal usage

### DIFF
--- a/test/built-ins/Temporal/PlainDate/compare/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDate/compare/no-fractional-minutes-hours.js
@@ -15,12 +15,12 @@ const invalidStrings = [
 for (const [arg, description] of invalidStrings) {
   assert.throws(
     RangeError,
-      () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(2025, 04, 03)),
+      () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(2025, 4, 3)),
     `${description} not allowed in time string (first argument)`
   );
   assert.throws(
     RangeError,
-      () => Temporal.PlainDate.compare(new Temporal.PlainDate(2025, 04, 03), arg),
+      () => Temporal.PlainDate.compare(new Temporal.PlainDate(2025, 4, 3), arg),
     `${description} not allowed in time string (second argument)`
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/compare/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/no-fractional-minutes-hours.js
@@ -15,12 +15,12 @@ const invalidStrings = [
 for (const [arg, description] of invalidStrings) {
   assert.throws(
     RangeError,
-      () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(2025, 04, 03, 20, 04, 03)),
+      () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(2025, 4, 3, 20, 4, 3)),
     `${description} not allowed in time string (first argument)`
   );
   assert.throws(
     RangeError,
-      () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(2025, 04, 03, 20, 04, 03), arg),
+      () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(2025, 4, 3, 20, 4, 3), arg),
     `${description} not allowed in time string (second argument)`
   );
 }

--- a/test/built-ins/Temporal/PlainTime/compare/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainTime/compare/no-fractional-minutes-hours.js
@@ -15,12 +15,12 @@ const invalidStrings = [
 for (const [arg, description] of invalidStrings) {
   assert.throws(
     RangeError,
-      () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(20, 04, 03)),
+      () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(20, 4, 3)),
     `${description} not allowed in time string (first argument)`
   );
   assert.throws(
     RangeError,
-      () => Temporal.PlainTime.compare(new Temporal.PlainTime(20, 04, 03), arg),
+      () => Temporal.PlainTime.compare(new Temporal.PlainTime(20, 4, 3), arg),
     `${description} not allowed in time string (second argument)`
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/compare/no-fractional-minutes-hours.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/no-fractional-minutes-hours.js
@@ -15,12 +15,12 @@ const invalidStrings = [
 for (const [arg, description] of invalidStrings) {
   assert.throws(
     RangeError,
-      () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2025, 04)),
+      () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2025, 4)),
     `${description} not allowed in time string (first argument)`
   );
   assert.throws(
     RangeError,
-      () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2025, 04), arg),
+      () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2025, 4), arg),
     `${description} not allowed in time string (second argument)`
   );
 }


### PR DESCRIPTION
This PR fixes syntax errors introduced in https://github.com/tc39/test262/pull/4814, first reported from the Babel test262 integration test update: https://github.com/babel/babel/pull/17699

The legacy octal literals are not allowed in the strict mode. Since the tests are for Temporal usage, here we replaced legacy octal literals by plain decimal literals.