### PR TITLE
String.prototype.lastIndexOf must be able to return -1

### DIFF
--- a/test/built-ins/String/prototype/lastIndexOf/not-a-substring.js
+++ b/test/built-ins/String/prototype/lastIndexOf/not-a-substring.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Garham Lee. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-string.prototype.lastindexof
+description: >
+    String.prototype.lastIndexOf must be able to return -1
+info: |
+    String.prototype.lastIndexOf ( _searchString_ [ , _position_ ] )
+
+    12. Let _result_ be StringLastIndexOf(_S_, _searchStr_, _start_).
+
+    StringLastIndexOf (_string_, _searchValue_, _fromIndex_)
+
+    4. For each integer _i_ such that 0 ≤ _i_ ≤ _fromIndex_, in descending order, do
+        a. Let _candidate_ be the substring of _string_ from _i_ to _i_ + _searchLen_.
+        b. If _candidate_ is _searchValue_, return _i_.
+    5. Return ~not-found~.
+---*/
+
+assert.sameValue("abc".lastIndexOf("d"), -1, "String.prototype.lastIndexOf returns -1 when searchString is shorter than this and searchString is not a substring of this.");


### PR DESCRIPTION
Hello.

This PR covers the false branch (of loop condition) in [StringLastIndexOf](https://tc39.es/ecma262/#sec-stringlastindexof) step 4 which is called in [String.prototype.lastIndexOf(searchString[,position])](https://tc39.es/ecma262/#sec-string.prototype.lastindexof).

In order to cover the false branch, first StringLastIndexOf must be called in String.prototype.lastIndexOf. However, in the latest version, in String.prototype.lastIndexOf step 10, a condition(If len < searchLen, return -1𝔽.) has been added. (ref: [ECMA-262#3660](https://github.com/tc39/ecma262/pull/3660)) So [test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A1_T4.js](https://github.com/tc39/test262/blob/main/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A1_T4.js) does not call StringLastIndexOf, because it early returns. And therefore does not cover the false branch.

And the second condition to cover the false case is that the for loop starting in StringLastIndexOf step 4 must run without returning anything. To do that, _candidate_ should not be equal to _searchValue_, which means the _searchString_ must not be a substring of this.