### PR TITLE
[Temporal] Remove v8 staging test instant-equals

### DIFF
--- a/test/built-ins/Temporal/Instant/prototype/equals/basic.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/basic.js
@@ -2,10 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: pending
-description: >
-  Automatically ported from instant-equals test
-  in V8's mjsunit test instant-equals.js
+esid: sec-temporal.instant.prototype.equals
+description: Basic functionality for Temporal.Instant.prototype.equals.
 features: [Temporal]
 ---*/
 
@@ -14,5 +12,3 @@ let inst2 = new Temporal.Instant(1234567890123456000n);
 let inst3 = new Temporal.Instant(1234567890123456000n);
 assert(!inst1.equals(inst2));
 assert(inst2.equals(inst3));
-let badInst = { equals: inst1.equals };
-assert.throws(TypeError, () => badInst.equals(inst1));


### PR DESCRIPTION
Move the test `test/staging/Temporal/v8/instant-equals.js` to `test/built-ins/Temporal/Instant/prototype/equals/basic.js`

Remove call of `.equals` on a plain object, as this is covered by `/test/built-ins/Temporal/Instant/prototype/equals/branding.js`