### PR TITLE
Expect TypeError when calling Temporal.PlainTime.p.toLocaleString with dateStyle

### DIFF
--- a/test/intl402/Temporal/PlainTime/prototype/toLocaleString/datestyle-and-timestyle.js
+++ b/test/intl402/Temporal/PlainTime/prototype/toLocaleString/datestyle-and-timestyle.js
@@ -3,10 +3,12 @@
 
 /*---
 esid: sec-temporal.plaintime.prototype.tolocalestring
-description: Using both dateStyle and timeStyle should not throw
+description: Using dateStyle, even if timeStyle is present, should throw
 features: [Temporal]
 ---*/
 
 const item = new Temporal.PlainTime(0, 0);
-var result = item.toLocaleString("en", { dateStyle: "full", timeStyle: "full" });
-assert.sameValue(result.includes(":00"), true, "using both dateStyle and timeStyle should not throw");
+
+assert.throws(TypeError, function() {
+  item.toLocaleString("en", { dateStyle: "full", timeStyle: "full" });
+});


### PR DESCRIPTION
[Temporal.PlainTime.prototype.toLocaleString](https://tc39.es/proposal-temporal/#sup-temporal.plaintime.prototype.tolocalestring) calls `CreateDateTimeFormat` with `required = TIME`, so step 45.c will throw a `TypeError`. 