### PR TITLE
The "timeZoneName" option can't be used in a standalone context

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/format/temporal-plaindatetime-unsupported-options.js
+++ b/test/intl402/DateTimeFormat/prototype/format/temporal-plaindatetime-unsupported-options.js
@@ -17,5 +17,5 @@ const pdt = new Temporal.PlainDateTime(2026, 1, 5, 11, 22);
 for (const timeZoneNameStyle of timeZoneNameStyles) {
   const dtf = new Intl.DateTimeFormat(locale, { timeZoneName: timeZoneNameStyle });
   assert.sameValue(typeof dtf.format(pdt), "string",
-    `cannot format a PlainDateTime with timeZoneName = ${timeZoneNameStyle}`);
+    `can format a PlainDateTime with timeZoneName = ${timeZoneNameStyle}`);
 }

--- a/test/intl402/DateTimeFormat/prototype/formatRange/temporal-plaindatetime-unsupported-options.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRange/temporal-plaindatetime-unsupported-options.js
@@ -18,5 +18,5 @@ const pdt2 = new Temporal.PlainDateTime(2026, 1, 5, 11, 23);
 for (const timeZoneNameStyle of timeZoneNameStyles) {
   const dtf = new Intl.DateTimeFormat(locale, { timeZoneName: timeZoneNameStyle });
   assert.sameValue(typeof dtf.formatRange(pdt1, pdt2), "string",
-    `cannot format a PlainDateTime with timeZoneName = ${timeZoneNameStyle}`);
+    `can format a PlainDateTime with timeZoneName = ${timeZoneNameStyle}`);
 }

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plaindatetime-unsupported-options.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plaindatetime-unsupported-options.js
@@ -18,5 +18,5 @@ const pdt2 = new Temporal.PlainDateTime(2026, 1, 5, 11, 23);
 for (const timeZoneNameStyle of timeZoneNameStyles) {
   const dtf = new Intl.DateTimeFormat(locale, { timeZoneName: timeZoneNameStyle });
   assert(Array.isArray(dtf.formatRangeToParts(pdt1, pdt2)),
-    `cannot format a PlainDateTime with timeZoneName = ${timeZoneNameStyle}`);
+    `can format a PlainDateTime with timeZoneName = ${timeZoneNameStyle}`);
 }

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/temporal-plaindatetime-unsupported-options.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/temporal-plaindatetime-unsupported-options.js
@@ -17,5 +17,5 @@ const pdt = new Temporal.PlainDateTime(2026, 1, 5, 11, 22);
 for (const timeZoneNameStyle of timeZoneNameStyles) {
   const dtf = new Intl.DateTimeFormat(locale, { timeZoneName: timeZoneNameStyle });
   assert(Array.isArray(dtf.formatToParts(pdt)),
-    `cannot format a PlainDateTime with timeZoneName = ${timeZoneNameStyle}`);
+    `can format a PlainDateTime with timeZoneName = ${timeZoneNameStyle}`);
 }


### PR DESCRIPTION
See <https://github.com/tc39/ecma402/issues/461>.