### PR TITLE
Fix running Temporal tests in strict mode

### DIFF
--- a/test/built-ins/Temporal/Duration/from/argument-non-string.js
+++ b/test/built-ins/Temporal/Duration/from/argument-non-string.js
@@ -29,7 +29,7 @@ for (const [arg, description] of primitiveTests) {
     `${description} does not convert to a valid ISO string`
   );
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(
       TypeError,
       () => Temporal.Duration.from(arg, options),

--- a/test/built-ins/Temporal/Instant/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/from/argument-wrong-type.js
@@ -29,7 +29,7 @@ for (const [arg, description] of primitiveTests) {
     `${description} does not convert to a valid ISO string`
   );
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(
       TypeError,
       () => Temporal.Instant.from(arg, options),

--- a/test/built-ins/Temporal/PlainDate/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-wrong-type.js
@@ -27,7 +27,7 @@ for (const [arg, description] of primitiveTests) {
     `${description} does not convert to a valid ISO string`
   );
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(
       typeof arg === 'string' ? RangeError : TypeError,
       () => Temporal.PlainDate.from(arg, options),
@@ -46,7 +46,7 @@ const typeErrorTests = [
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => Temporal.PlainDate.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(TypeError, () => Temporal.PlainDate.from(arg, options), `${description} is not a valid property bag and does not convert to a string with options ${options}`);
   }
 }

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-wrong-type.js
@@ -27,7 +27,7 @@ for (const [arg, description] of primitiveTests) {
     `${description} does not convert to a valid ISO string`
   );
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(
       typeof arg === 'string' ? RangeError : TypeError,
       () => Temporal.PlainDateTime.from(arg, options),
@@ -46,7 +46,7 @@ const typeErrorTests = [
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => Temporal.PlainDateTime.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(TypeError, () => Temporal.PlainDateTime.from(arg, options), `${description} is not a valid property bag and does not convert to a string with options ${options}`);
   }
 }

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-wrong-type.js
@@ -27,7 +27,7 @@ for (const [arg, description] of primitiveTests) {
     `${description} does not convert to a valid ISO string`
   );
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(
       typeof arg === 'string' ? RangeError : TypeError,
       () => Temporal.PlainMonthDay.from(arg, options),
@@ -46,7 +46,7 @@ const typeErrorTests = [
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => Temporal.PlainMonthDay.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(TypeError, () => Temporal.PlainMonthDay.from(arg, options), `${description} is not a valid property bag and does not convert to a string with options ${options}`);
   }
 }

--- a/test/built-ins/Temporal/PlainTime/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-wrong-type.js
@@ -27,7 +27,7 @@ for (const [arg, description] of primitiveTests) {
     `${description} does not convert to a valid ISO string`
   );
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(
       typeof arg === 'string' ? RangeError : TypeError,
       () => Temporal.PlainTime.from(arg, options),
@@ -46,7 +46,7 @@ const typeErrorTests = [
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => Temporal.PlainTime.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(TypeError, () => Temporal.PlainTime.from(arg, options), `${description} is not a valid property bag and does not convert to a string with options ${options}`);
   }
 }

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-wrong-type.js
@@ -27,7 +27,7 @@ for (const [arg, description] of primitiveTests) {
     `${description} does not convert to a valid ISO string`
   );
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(
       typeof arg === 'string' ? RangeError : TypeError,
       () => Temporal.PlainYearMonth.from(arg, options),
@@ -46,7 +46,7 @@ const typeErrorTests = [
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => Temporal.PlainYearMonth.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(TypeError, () => Temporal.PlainYearMonth.from(arg, options), `${description} is not a valid property bag and does not convert to a string with options ${options}`);
   }
 }

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-wrong-type.js
@@ -28,7 +28,7 @@ for (const [arg, description] of primitiveTests) {
     `${description} does not convert to a valid ISO string`
   );
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(
       typeof arg === 'string' ? RangeError : TypeError,
       () => Temporal.ZonedDateTime.from(arg, options),
@@ -47,7 +47,7 @@ const typeErrorTests = [
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => Temporal.ZonedDateTime.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 
-  for (options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
+  for (const options of [undefined, { overflow: 'constrain' }, { overflow: 'reject' }]) {
     assert.throws(TypeError, () => Temporal.ZonedDateTime.from(arg, options), `${description} is not a valid property bag and does not convert to a string with options ${options}`);
   }
 }


### PR DESCRIPTION
Previously, a ReferenceError would be thrown for the options object in these loops.