### PR TITLE
Added coverage for abrupt completion where ToString throws because of getter

### DIFF
--- a/test/built-ins/Error/prototype/toString/tostring-get-throws.js
+++ b/test/built-ins/Error/prototype/toString/tostring-get-throws.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Garham Lee. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-error.prototype.tostring
+description: >
+    Error.prototype.toString should throw when name or message getter throws
+info: |
+    Error.prototype.toString ( )
+
+    1. Let _O_ be the *this* value.
+
+    3. Let _name_ be ? Get(_O_, *"name"*).
+
+    5. Let _msg_ be ? Get(_O_, *"message"*).
+---*/
+//Check #1
+assert.throws(Test262Error, function() {
+    Error.prototype.toString.call({get name () {throw new Test262Error;}});
+}, "name field getter should throw to cover abrupt completion return case in step 3")
+
+//Check #2
+assert.throws(Test262Error, function() {
+    Error.prototype.toString.call({get message () {throw new Test262Error;}});
+}, "message field getter should throw to cover abrupt completion return case in step 5")


### PR DESCRIPTION
Hello.
This PR adds test cases to verify that [Error.prototype.toString()](https://tc39.es/ecma262/#sec-error.prototype.tostring) correctly handles abrupt completions during property lookups, as defined in Error.prototype.toString.

Specifically, it covers:
- Step 3: Get(O, "name") returning an abrupt completion.
- Step 5: Get(O, "message") returning an abrupt completion.

I have implemented these cases by using objects with getters that throw a Test262Error. Since both cases share a similar logic, I have included them in a single test file for clarity.