### PR TITLE
Intl Era Monthcode: Update Meiji era start date

### DIFF
--- a/test/intl402/Temporal/PlainDate/from/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainDate/from/era-boundary-japanese.js
@@ -115,6 +115,24 @@ TemporalHelpers.assertPlainDate(
   1868, 10, "M10", 22, "Meiji 1 resolves to CE 1868 before era start date",
   "ce", 1868);
 
+const meiji1AfterStart = Temporal.PlainDate.from({ era: "meiji", eraYear: 1, monthCode: "M10", day: 23, calendar }, options);
+TemporalHelpers.assertPlainDate(
+  meiji1AfterStart,
+  1868, 10, "M10", 23, "Meiji 1 still resolves to CE 1868 after era start date",
+  "ce", 1868);
+
+const meiji5 = Temporal.PlainDate.from({ era: "meiji", eraYear: 5, monthCode: "M12", day: 31, calendar }, options);
+TemporalHelpers.assertPlainDate(
+  meiji5,
+  1872, 12, "M12", 31, "Meiji 5 resolves to CE 1872",
+  "ce", 1872);
+
+const ce1873 = Temporal.PlainDate.from({ era: "ce", eraYear: 1873, monthCode: "M01", day: 1, calendar }, options);
+TemporalHelpers.assertPlainDate(
+  ce1873,
+  1873, 1, "M01", 1, "CE 1873 resolves to Meiji 6",
+  "meiji", 6);
+
 const meiji0 = Temporal.PlainDate.from({ era: "meiji", eraYear: 0, monthCode: "M10", day: 23, calendar }, options);
 TemporalHelpers.assertPlainDate(
   meiji0,
@@ -126,12 +144,6 @@ TemporalHelpers.assertPlainDate(
   meiji1n,
   1866, 10, "M10", 23, "Meiji -1 resolves to CE 1866",
   "ce", 1866);
-
-const ce1868AfterStart = Temporal.PlainDate.from({ era: "ce", eraYear: 1868, monthCode: "M10", day: 23, calendar }, options);
-TemporalHelpers.assertPlainDate(
-  ce1868AfterStart,
-  1868, 10, "M10", 23, "CE 1868 resolves to Meiji 1 after era start date",
-  "meiji", 1);
 
 const ce0 = Temporal.PlainDate.from({ era: "ce", eraYear: 0, monthCode: "M01", day: 1, calendar }, options);
 TemporalHelpers.assertPlainDate(

--- a/test/intl402/Temporal/PlainDate/from/era-japanese.js
+++ b/test/intl402/Temporal/PlainDate/from/era-japanese.js
@@ -15,7 +15,7 @@ const reiwa = Temporal.PlainDate.from({ era: "reiwa", eraYear: 2, month: 1, day:
 const heisei = Temporal.PlainDate.from({ era: "heisei", eraYear: 2, month: 1, day: 1,  calendar });
 const showa = Temporal.PlainDate.from({ era: "showa", eraYear: 2, month: 1, day: 1,  calendar });
 const taisho = Temporal.PlainDate.from({ era: "taisho", eraYear: 2, month: 1, day: 1,  calendar });
-const meiji = Temporal.PlainDate.from({ era: "meiji", eraYear: 2, month: 1, day: 1,  calendar });
+const meiji = Temporal.PlainDate.from({ era: "meiji", eraYear: 6, month: 1, day: 1,  calendar });
 const ce = Temporal.PlainDate.from({ era: "ce", eraYear: 1000, month: 1, day: 1,  calendar });
 const bce = Temporal.PlainDate.from({ era: "bce", eraYear: 1, month: 1, day: 1,  calendar });
 
@@ -27,7 +27,7 @@ TemporalHelpers.assertPlainDate(showa, 1927, 1, "M01", 1,  `${showa}`, "showa", 
 
 TemporalHelpers.assertPlainDate(taisho, 1913, 1, "M01", 1,  `${taisho}`, "taisho", 2);
 
-TemporalHelpers.assertPlainDate(meiji, 1869, 1, "M01", 1,  `${meiji}`, "meiji", 2);
+TemporalHelpers.assertPlainDate(meiji, 1873, 1, "M01", 1,  `${meiji}`, "meiji", 6);
 
 TemporalHelpers.assertPlainDate(ce, 1000, 1, "M01", 1,  `${ce} (CE)`, "ce", 1000);
 

--- a/test/intl402/Temporal/PlainDate/prototype/since/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainDate/prototype/since/era-boundary-japanese.js
@@ -13,9 +13,9 @@ const options = { overflow: "reject" };
 
 const bce1 = Temporal.PlainDate.from({ era: "bce", eraYear: 1, monthCode: "M06", day: 1, calendar }, options);
 const ce1 = Temporal.PlainDate.from({ era: "ce", eraYear: 1, monthCode: "M06", day: 1, calendar }, options);
-const ce1868 = Temporal.PlainDate.from({ era: "ce", eraYear: 1868, monthCode: "M10", day: 22, calendar }, options);
-const meiji1 = Temporal.PlainDate.from({ era: "meiji", eraYear: 1, monthCode: "M10", day: 23, calendar}, options);
-const meiji5 = Temporal.PlainDate.from({ era: "meiji", eraYear: 5, monthCode: "M01", day: 15, calendar }, options);
+const ce1872 = Temporal.PlainDate.from({ era: "ce", eraYear: 1872, monthCode: "M12", day: 31, calendar }, options);
+const meiji6 = Temporal.PlainDate.from({ era: "meiji", eraYear: 6, monthCode: "M01", day: 1, calendar}, options);
+const meiji7 = Temporal.PlainDate.from({ era: "meiji", eraYear: 7, monthCode: "M01", day: 15, calendar }, options);
 const meiji45 = Temporal.PlainDate.from({ era: "meiji", eraYear: 45, monthCode: "M05", day: 19, calendar }, options);
 const taisho1 = Temporal.PlainDate.from({ era: "taisho", eraYear: 1, monthCode: "M08", day: 9, calendar }, options);
 const taisho6 = Temporal.PlainDate.from({ era: "taisho", eraYear: 6, monthCode: "M03", day: 15, calendar }, options);
@@ -96,18 +96,16 @@ const tests = [
     [0, 7, 0, 10, "7mo 10d from Taisho 15 July 20 to Showa 1 December 30"],
     [0, 7, 0, 10, "7mo 10d from Taisho 15 July 20 to Showa 1 December 30"],
   ],
-  // From Meiji 5 (1872) to Taisho 6 (1917) - crossing era boundary
-  // Note that contemporarily January 15 1872 would have been Meiji 4 in the
-  // pre-1873 lunisolar calendar, but the spec-mandated behaviour is proleptic
+  // From Meiji 7 (1874) to Taisho 6 (1917) - crossing era boundary
   [
-    meiji5, taisho6,
-    [-45, -2, 0, 0, "-45y -2mo backwards from Meiji 5 January to Taisho 6 March"],
-    [0, -542, 0, 0, "-542mo backwards from Meiji 5 January to Taisho 6 March"],
+    meiji7, taisho6,
+    [-43, -2, 0, 0, "-43y -2mo backwards from Meiji 7 January to Taisho 6 March"],
+    [0, -518, 0, 0, "-518mo backwards from Meiji 7 January to Taisho 6 March"],
   ],
   [
-    taisho6, meiji5,
-    [45, 2, 0, 0, "45y 2mo from Meiji 5 January to Taisho 6 March"],
-    [0, 542, 0, 0, "542mo from Meiji 5 January to Taisho 6 March"],
+    taisho6, meiji7,
+    [43, 2, 0, 0, "43y 2mo from Meiji 7 January to Taisho 6 March"],
+    [0, 518, 0, 0, "518mo from Meiji 7 January to Taisho 6 March"],
   ],
   // Within same year but different eras
   [
@@ -120,16 +118,16 @@ const tests = [
     [0, 2, 0, 21, "2mo 21d from Meiji 45 May 19 to Taisho 1 August 9"],
     [0, 2, 0, 21, "2mo 21d from Meiji 45 May 19 to Taisho 1 August 9"],
   ],
-  // Last pre-Meiji day to first day of Meiji era
+  // Last pre-solar-calendar CE day to first solar-calendar day of Meiji era
   [
-    ce1868, meiji1,
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
+    ce1872, meiji6,
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
   ],
   [
-    meiji1, ce1868,
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
+    meiji6, ce1872,
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
   ],
   // CE-BCE boundary
   [

--- a/test/intl402/Temporal/PlainDate/prototype/until/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainDate/prototype/until/era-boundary-japanese.js
@@ -13,9 +13,9 @@ const options = { overflow: "reject" };
 
 const bce1 = Temporal.PlainDate.from({ era: "bce", eraYear: 1, monthCode: "M06", day: 1, calendar }, options);
 const ce1 = Temporal.PlainDate.from({ era: "ce", eraYear: 1, monthCode: "M06", day: 1, calendar }, options);
-const ce1868 = Temporal.PlainDate.from({ era: "ce", eraYear: 1868, monthCode: "M10", day: 22, calendar }, options);
-const meiji1 = Temporal.PlainDate.from({ era: "meiji", eraYear: 1, monthCode: "M10", day: 23, calendar}, options);
-const meiji5 = Temporal.PlainDate.from({ era: "meiji", eraYear: 5, monthCode: "M01", day: 15, calendar }, options);
+const ce1872 = Temporal.PlainDate.from({ era: "ce", eraYear: 1872, monthCode: "M12", day: 31, calendar }, options);
+const meiji6 = Temporal.PlainDate.from({ era: "meiji", eraYear: 6, monthCode: "M01", day: 1, calendar}, options);
+const meiji7 = Temporal.PlainDate.from({ era: "meiji", eraYear: 7, monthCode: "M01", day: 15, calendar }, options);
 const meiji45 = Temporal.PlainDate.from({ era: "meiji", eraYear: 45, monthCode: "M05", day: 19, calendar }, options);
 const taisho1 = Temporal.PlainDate.from({ era: "taisho", eraYear: 1, monthCode: "M08", day: 9, calendar }, options);
 const taisho6 = Temporal.PlainDate.from({ era: "taisho", eraYear: 6, monthCode: "M03", day: 15, calendar }, options);
@@ -96,18 +96,16 @@ const tests = [
     [0, -7, 0, -10, "-7mo -10d backwards from Taisho 15 July 20 to Showa 1 December 30"],
     [0, -7, 0, -10, "-7mo -10d backwards from Taisho 15 July 20 to Showa 1 December 30"],
   ],
-  // From Meiji 5 (1872) to Taisho 6 (1917) - crossing era boundary
-  // Note that contemporarily January 15 1872 would have been Meiji 4 in the
-  // pre-1873 lunisolar calendar, but the spec-mandated behaviour is proleptic
+  // From Meiji 7 (1874) to Taisho 6 (1917) - crossing era boundary
   [
-    meiji5, taisho6,
-    [45, 2, 0, 0, "45y 2mo from Meiji 5 January to Taisho 6 March"],
-    [0, 542, 0, 0, "542mo from Meiji 5 January to Taisho 6 March"],
+    meiji7, taisho6,
+    [43, 2, 0, 0, "43y 2mo from Meiji 7 January to Taisho 6 March"],
+    [0, 518, 0, 0, "518mo from Meiji 7 January to Taisho 6 March"],
   ],
   [
-    taisho6, meiji5,
-    [-45, -2, 0, 0, "-45y -2mo backwards from Meiji 5 January to Taisho 6 March"],
-    [0, -542, 0, 0, "-542mo backwards from Meiji 5 January to Taisho 6 March"],
+    taisho6, meiji7,
+    [-43, -2, 0, 0, "-43y -2mo backwards from Meiji 7 January to Taisho 6 March"],
+    [0, -518, 0, 0, "-518mo backwards from Meiji 7 January to Taisho 6 March"],
   ],
   // Within same year but different eras
   [
@@ -120,16 +118,16 @@ const tests = [
     [0, -2, 0, -21, "-2mo -21d backwards from Meiji 45 May 19 to Taisho 1 August 9"],
     [0, -2, 0, -21, "-2mo -21d backwards from Meiji 45 May 19 to Taisho 1 August 9"],
   ],
-  // Last pre-Meiji day to first day of Meiji era
+  // Last pre-solar-calendar CE day to first solar-calendar day of Meiji era
   [
-    ce1868, meiji1,
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
+    ce1872, meiji6,
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
   ],
   [
-    meiji1, ce1868,
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
+    meiji6, ce1872,
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
   ],
   // CE-BCE boundary
   [

--- a/test/intl402/Temporal/PlainDate/prototype/year/arithmetic-year.js
+++ b/test/intl402/Temporal/PlainDate/prototype/year/arithmetic-year.js
@@ -102,7 +102,7 @@ const tests = {
     [{ era: "bce", eraYear: 2, monthCode: "M06", day: 14 }, -1],
     [{ era: "bce", eraYear: 1, monthCode: "M12", day: 3 }, 0],
     [{ era: "ce", eraYear: 1, monthCode: "M07", day: 26 }, 1],
-    [{ era: "meiji", eraYear: 1, monthCode: "M12", day: 31 }, 1868],
+    [{ era: "meiji", eraYear: 6, monthCode: "M12", day: 31 }, 1873],
     [{ era: "taisho", eraYear: 1, monthCode: "M12", day: 31 }, 1912],
     [{ era: "showa", eraYear: 1, monthCode: "M12", day: 31 }, 1926],
     [{ era: "heisei", eraYear: 1, monthCode: "M12", day: 31 }, 1989],

--- a/test/intl402/Temporal/PlainDateTime/from/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainDateTime/from/era-boundary-japanese.js
@@ -115,6 +115,24 @@ TemporalHelpers.assertPlainDateTime(
   1868, 10, "M10", 22, 12, 34, 0, 0, 0, 0, "Meiji 1 resolves to CE 1868 before era start date",
   "ce", 1868);
 
+const meiji1AfterStart = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 1, monthCode: "M10", day: 23, hour: 12, minute: 34, calendar }, options);
+TemporalHelpers.assertPlainDateTime(
+  meiji1AfterStart,
+  1868, 10, "M10", 23, 12, 34, 0, 0, 0, 0, "Meiji 1 still resolves to CE 1868 after era start date",
+  "ce", 1868);
+
+const meiji5 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 5, monthCode: "M12", day: 31, hour: 12, minute: 34, calendar }, options);
+TemporalHelpers.assertPlainDateTime(
+  meiji5,
+  1872, 12, "M12", 31, 12, 34, 0, 0, 0, 0, "Meiji 5 resolves to CE 1872",
+  "ce", 1872);
+
+const ce1873 = Temporal.PlainDateTime.from({ era: "ce", eraYear: 1873, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar }, options);
+TemporalHelpers.assertPlainDateTime(
+  ce1873,
+  1873, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "CE 1873 resolves to Meiji 6",
+  "meiji", 6);
+
 const meiji0 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 0, monthCode: "M10", day: 23, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(
   meiji0,
@@ -126,12 +144,6 @@ TemporalHelpers.assertPlainDateTime(
   meiji1n,
   1866, 10, "M10", 23, 12, 34, 0, 0, 0, 0, "Meiji -1 resolves to CE 1866",
   "ce", 1866);
-
-const ce1868AfterStart = Temporal.PlainDateTime.from({ era: "ce", eraYear: 1868, monthCode: "M10", day: 23, hour: 12, minute: 34, calendar }, options);
-TemporalHelpers.assertPlainDateTime(
-  ce1868AfterStart,
-  1868, 10, "M10", 23, 12, 34, 0, 0, 0, 0, "CE 1868 resolves to Meiji 1 after era start date",
-  "meiji", 1);
 
 const ce0 = Temporal.PlainDateTime.from({ era: "ce", eraYear: 0, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar }, options);
 TemporalHelpers.assertPlainDateTime(

--- a/test/intl402/Temporal/PlainDateTime/from/era-japanese.js
+++ b/test/intl402/Temporal/PlainDateTime/from/era-japanese.js
@@ -15,7 +15,7 @@ const reiwa = Temporal.PlainDateTime.from({ era: "reiwa", eraYear: 2, month: 1, 
 const heisei = Temporal.PlainDateTime.from({ era: "heisei", eraYear: 2, month: 1, day: 1, hour: 12, minute: 34,  calendar });
 const showa = Temporal.PlainDateTime.from({ era: "showa", eraYear: 2, month: 1, day: 1, hour: 12, minute: 34,  calendar });
 const taisho = Temporal.PlainDateTime.from({ era: "taisho", eraYear: 2, month: 1, day: 1, hour: 12, minute: 34,  calendar });
-const meiji = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 2, month: 1, day: 1, hour: 12, minute: 34,  calendar });
+const meiji = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 6, month: 1, day: 1, hour: 12, minute: 34,  calendar });
 const ce = Temporal.PlainDateTime.from({ era: "ce", eraYear: 1000, month: 1, day: 1, hour: 12, minute: 34,  calendar });
 const bce = Temporal.PlainDateTime.from({ era: "bce", eraYear: 1, month: 1, day: 1, hour: 12, minute: 34,  calendar });
 
@@ -27,7 +27,7 @@ TemporalHelpers.assertPlainDateTime(showa, 1927, 1, "M01", 1, 12, 34, 0, 0, 0, 0
 
 TemporalHelpers.assertPlainDateTime(taisho, 1913, 1, "M01", 1, 12, 34, 0, 0, 0, 0,  `${taisho}`, "taisho", 2);
 
-TemporalHelpers.assertPlainDateTime(meiji, 1869, 1, "M01", 1, 12, 34, 0, 0, 0, 0,  `${meiji}`, "meiji", 2);
+TemporalHelpers.assertPlainDateTime(meiji, 1873, 1, "M01", 1, 12, 34, 0, 0, 0, 0,  `${meiji}`, "meiji", 6);
 
 TemporalHelpers.assertPlainDateTime(ce, 1000, 1, "M01", 1, 12, 34, 0, 0, 0, 0,  `${ce} (CE)`, "ce", 1000);
 

--- a/test/intl402/Temporal/PlainDateTime/prototype/since/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/since/era-boundary-japanese.js
@@ -13,9 +13,9 @@ const options = { overflow: "reject" };
 
 const bce1 = Temporal.PlainDateTime.from({ era: "bce", eraYear: 1, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
 const ce1 = Temporal.PlainDateTime.from({ era: "ce", eraYear: 1, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
-const ce1868 = Temporal.PlainDateTime.from({ era: "ce", eraYear: 1868, monthCode: "M10", day: 22, hour: 12, minute: 34, calendar }, options);
-const meiji1 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 1, monthCode: "M10", day: 23, hour: 12, minute: 34, calendar}, options);
-const meiji5 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 5, monthCode: "M01", day: 15, hour: 12, minute: 34, calendar }, options);
+const ce1872 = Temporal.PlainDateTime.from({ era: "ce", eraYear: 1872, monthCode: "M12", day: 31, hour: 12, minute: 34, calendar }, options);
+const meiji6 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 6, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar}, options);
+const meiji7 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 7, monthCode: "M01", day: 15, hour: 12, minute: 34, calendar }, options);
 const meiji45 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 45, monthCode: "M05", day: 19, hour: 12, minute: 34, calendar }, options);
 const taisho1 = Temporal.PlainDateTime.from({ era: "taisho", eraYear: 1, monthCode: "M08", day: 9, hour: 12, minute: 34, calendar }, options);
 const taisho6 = Temporal.PlainDateTime.from({ era: "taisho", eraYear: 6, monthCode: "M03", day: 15, hour: 12, minute: 34, calendar }, options);
@@ -96,18 +96,16 @@ const tests = [
     [0, 7, 0, 10, "7mo 10d from Taisho 15 July 20 to Showa 1 December 30"],
     [0, 7, 0, 10, "7mo 10d from Taisho 15 July 20 to Showa 1 December 30"],
   ],
-  // From Meiji 5 (1872) to Taisho 6 (1917) - crossing era boundary
-  // Note that contemporarily January 15 1872 would have been Meiji 4 in the
-  // pre-1873 lunisolar calendar, but the spec-mandated behaviour is proleptic
+  // From Meiji 7 (1874) to Taisho 6 (1917) - crossing era boundary
   [
-    meiji5, taisho6,
-    [-45, -2, 0, 0, "-45y -2mo backwards from Meiji 5 January to Taisho 6 March"],
-    [0, -542, 0, 0, "-542mo backwards from Meiji 5 January to Taisho 6 March"],
+    meiji7, taisho6,
+    [-43, -2, 0, 0, "-43y -2mo backwards from Meiji 7 January to Taisho 6 March"],
+    [0, -518, 0, 0, "-518mo backwards from Meiji 7 January to Taisho 6 March"],
   ],
   [
-    taisho6, meiji5,
-    [45, 2, 0, 0, "45y 2mo from Meiji 5 January to Taisho 6 March"],
-    [0, 542, 0, 0, "542mo from Meiji 5 January to Taisho 6 March"],
+    taisho6, meiji7,
+    [43, 2, 0, 0, "43y 2mo from Meiji 7 January to Taisho 6 March"],
+    [0, 518, 0, 0, "518mo from Meiji 7 January to Taisho 6 March"],
   ],
   // Within same year but different eras
   [
@@ -120,16 +118,16 @@ const tests = [
     [0, 2, 0, 21, "2mo 21d from Meiji 45 May 19 to Taisho 1 August 9"],
     [0, 2, 0, 21, "2mo 21d from Meiji 45 May 19 to Taisho 1 August 9"],
   ],
-  // Last pre-Meiji day to first day of Meiji era
+  // Last pre-solar-calendar CE day to first solar-calendar day of Meiji era
   [
-    ce1868, meiji1,
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
+    ce1872, meiji6,
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
   ],
   [
-    meiji1, ce1868,
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
+    meiji6, ce1872,
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
   ],
   // CE-BCE boundary
   [

--- a/test/intl402/Temporal/PlainDateTime/prototype/until/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/until/era-boundary-japanese.js
@@ -13,9 +13,9 @@ const options = { overflow: "reject" };
 
 const bce1 = Temporal.PlainDateTime.from({ era: "bce", eraYear: 1, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
 const ce1 = Temporal.PlainDateTime.from({ era: "ce", eraYear: 1, monthCode: "M06", day: 1, hour: 12, minute: 34, calendar }, options);
-const ce1868 = Temporal.PlainDateTime.from({ era: "ce", eraYear: 1868, monthCode: "M10", day: 22, hour: 12, minute: 34, calendar }, options);
-const meiji1 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 1, monthCode: "M10", day: 23, hour: 12, minute: 34, calendar}, options);
-const meiji5 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 5, monthCode: "M01", day: 15, hour: 12, minute: 34, calendar }, options);
+const ce1872 = Temporal.PlainDateTime.from({ era: "ce", eraYear: 1872, monthCode: "M12", day: 31, hour: 12, minute: 34, calendar }, options);
+const meiji6 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 6, monthCode: "M01", day: 1, hour: 12, minute: 34, calendar}, options);
+const meiji7 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 7, monthCode: "M01", day: 15, hour: 12, minute: 34, calendar }, options);
 const meiji45 = Temporal.PlainDateTime.from({ era: "meiji", eraYear: 45, monthCode: "M05", day: 19, hour: 12, minute: 34, calendar }, options);
 const taisho1 = Temporal.PlainDateTime.from({ era: "taisho", eraYear: 1, monthCode: "M08", day: 9, hour: 12, minute: 34, calendar }, options);
 const taisho6 = Temporal.PlainDateTime.from({ era: "taisho", eraYear: 6, monthCode: "M03", day: 15, hour: 12, minute: 34, calendar }, options);
@@ -96,18 +96,16 @@ const tests = [
     [0, -7, 0, -10, "-7mo -10d backwards from Taisho 15 July 20 to Showa 1 December 30"],
     [0, -7, 0, -10, "-7mo -10d backwards from Taisho 15 July 20 to Showa 1 December 30"],
   ],
-  // From Meiji 5 (1872) to Taisho 6 (1917) - crossing era boundary
-  // Note that contemporarily January 15 1872 would have been Meiji 4 in the
-  // pre-1873 lunisolar calendar, but the spec-mandated behaviour is proleptic
+  // From Meiji 7 (1874) to Taisho 6 (1917) - crossing era boundary
   [
-    meiji5, taisho6,
-    [45, 2, 0, 0, "45y 2mo from Meiji 5 January to Taisho 6 March"],
-    [0, 542, 0, 0, "542mo from Meiji 5 January to Taisho 6 March"],
+    meiji7, taisho6,
+    [43, 2, 0, 0, "43y 2mo from Meiji 7 January to Taisho 6 March"],
+    [0, 518, 0, 0, "518mo from Meiji 7 January to Taisho 6 March"],
   ],
   [
-    taisho6, meiji5,
-    [-45, -2, 0, 0, "-45y -2mo backwards from Meiji 5 January to Taisho 6 March"],
-    [0, -542, 0, 0, "-542mo backwards from Meiji 5 January to Taisho 6 March"],
+    taisho6, meiji7,
+    [-43, -2, 0, 0, "-43y -2mo backwards from Meiji 7 January to Taisho 6 March"],
+    [0, -518, 0, 0, "-518mo backwards from Meiji 7 January to Taisho 6 March"],
   ],
   // Within same year but different eras
   [
@@ -120,16 +118,16 @@ const tests = [
     [0, -2, 0, -21, "-2mo -21d backwards from Meiji 45 May 19 to Taisho 1 August 9"],
     [0, -2, 0, -21, "-2mo -21d backwards from Meiji 45 May 19 to Taisho 1 August 9"],
   ],
-  // Last pre-Meiji day to first day of Meiji era
+  // Last pre-solar-calendar CE day to first solar-calendar day of Meiji era
   [
-    ce1868, meiji1,
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
+    ce1872, meiji6,
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
   ],
   [
-    meiji1, ce1868,
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
+    meiji6, ce1872,
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
   ],
   // CE-BCE boundary
   [

--- a/test/intl402/Temporal/PlainDateTime/prototype/year/arithmetic-year.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/year/arithmetic-year.js
@@ -102,7 +102,7 @@ const tests = {
     [{ era: "bce", eraYear: 2, monthCode: "M06", day: 14 }, -1],
     [{ era: "bce", eraYear: 1, monthCode: "M12", day: 3 }, 0],
     [{ era: "ce", eraYear: 1, monthCode: "M07", day: 26 }, 1],
-    [{ era: "meiji", eraYear: 1, monthCode: "M12", day: 31 }, 1868],
+    [{ era: "meiji", eraYear: 6, monthCode: "M12", day: 31 }, 1873],
     [{ era: "taisho", eraYear: 1, monthCode: "M12", day: 31 }, 1912],
     [{ era: "showa", eraYear: 1, monthCode: "M12", day: 31 }, 1926],
     [{ era: "heisei", eraYear: 1, monthCode: "M12", day: 31 }, 1989],

--- a/test/intl402/Temporal/PlainYearMonth/from/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/era-boundary-japanese.js
@@ -116,6 +116,24 @@ TemporalHelpers.assertPlainYearMonth(
   1868, 10, "M10", "Meiji 1 resolves to CE 1868 before era start date",
   "ce", 1868);
 
+const meiji1AfterStart = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 1, monthCode: "M11", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  meiji1AfterStart,
+  1868, 11, "M11", "Meiji 1 still resolves to CE 1868 after era start date",
+  "ce", 1868);
+
+const meiji5 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 5, monthCode: "M12", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  meiji5,
+  1872, 12, "M12", "Meiji 5 resolves to CE 1872",
+  "ce", 1872);
+
+const ce1873 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1873, monthCode: "M01", calendar }, options);
+TemporalHelpers.assertPlainYearMonth(
+  ce1873,
+  1873, 1, "M01", "CE 1873 resolves to Meiji 6",
+  "meiji", 6);
+
 const meiji0 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 0, monthCode: "M10", calendar }, options);
 TemporalHelpers.assertPlainYearMonth(
   meiji0,
@@ -127,12 +145,6 @@ TemporalHelpers.assertPlainYearMonth(
   meiji1n,
   1866, 10, "M10", "Meiji -1 resolves to CE 1866",
   "ce", 1866);
-
-const ce1868AfterStart = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1868, monthCode: "M11", calendar }, options);
-TemporalHelpers.assertPlainYearMonth(
-  ce1868AfterStart,
-  1868, 11, "M11", "CE 1868 resolves to Meiji 1 after era start date",
-  "meiji", 1);
 
 const ce0 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 0, monthCode: "M01", calendar }, options);
 TemporalHelpers.assertPlainYearMonth(

--- a/test/intl402/Temporal/PlainYearMonth/from/era-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/era-japanese.js
@@ -15,7 +15,7 @@ const reiwa = Temporal.PlainYearMonth.from({ era: "reiwa", eraYear: 2, month: 1,
 const heisei = Temporal.PlainYearMonth.from({ era: "heisei", eraYear: 2, month: 1,  calendar });
 const showa = Temporal.PlainYearMonth.from({ era: "showa", eraYear: 2, month: 1,  calendar });
 const taisho = Temporal.PlainYearMonth.from({ era: "taisho", eraYear: 2, month: 1,  calendar });
-const meiji = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 2, month: 1,  calendar });
+const meiji = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 6, month: 1,  calendar });
 const ce = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1000, month: 1,  calendar });
 const bce = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 1, month: 1,  calendar });
 
@@ -27,7 +27,7 @@ TemporalHelpers.assertPlainYearMonth(showa, 1927, 1, "M01",  `${showa}`, "showa"
 
 TemporalHelpers.assertPlainYearMonth(taisho, 1913, 1, "M01",  `${taisho}`, "taisho", 2);
 
-TemporalHelpers.assertPlainYearMonth(meiji, 1869, 1, "M01",  `${meiji}`, "meiji", 2);
+TemporalHelpers.assertPlainYearMonth(meiji, 1873, 1, "M01",  `${meiji}`, "meiji", 6);
 
 TemporalHelpers.assertPlainYearMonth(ce, 1000, 1, "M01",  `${ce} (CE)`, "ce", 1000);
 

--- a/test/intl402/Temporal/PlainYearMonth/from/reference-day-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/reference-day-japanese.js
@@ -18,7 +18,7 @@ const result1 = Temporal.PlainYearMonth.from({calendar: "japanese", era: "heisei
 TemporalHelpers.assertPlainYearMonth(
   result1,
   1989, 1, "M01",
-  "era is corrected based on reference day (Showa begins on January 8)",
+  "era is corrected based on reference day (Heisei begins on January 8)",
   "showa", 64
 );
 
@@ -26,7 +26,7 @@ const result2 = Temporal.PlainYearMonth.from({calendar: "japanese", era: "showa"
 TemporalHelpers.assertPlainYearMonth(
   result2,
   1926, 12, "M12",
-  "era is corrected based on reference day (Taishō begins on December 25)",
+  "era is corrected based on reference day (Showa begins on December 25)",
   "taisho", 15
 );
 
@@ -34,6 +34,6 @@ const result3 = Temporal.PlainYearMonth.from({calendar: "japanese", era: "taisho
 TemporalHelpers.assertPlainYearMonth(
   result3,
   1912, 7, "M07",
-  "era is corrected based on reference day (Meiji begins on July 30)",
+  "era is corrected based on reference day (Taishō begins on July 30)",
   "meiji", 45
 );

--- a/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/since/era-boundary-japanese.js
@@ -13,7 +13,9 @@ const options = { overflow: "reject" };
 
 const bce1 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 1, monthCode: "M06", calendar }, options);
 const ce1 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1, monthCode: "M06", calendar }, options);
-const meiji5 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 5, monthCode: "M01", calendar }, options);
+const ce1872 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1872, monthCode: "M12", calendar }, options);
+const meiji6 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 6, monthCode: "M01", calendar}, options);
+const meiji7 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 7, monthCode: "M01", calendar }, options);
 const meiji45 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 45, monthCode: "M05", calendar }, options);
 const taisho1 = Temporal.PlainYearMonth.from({ era: "taisho", eraYear: 1, monthCode: "M08", calendar }, options);
 const taisho6 = Temporal.PlainYearMonth.from({ era: "taisho", eraYear: 6, monthCode: "M03", calendar }, options);
@@ -81,16 +83,16 @@ const tests = [
     [63, 0, "63y from Taisho 6 March to Showa 55 March"],
     [0, 756, "756mo from Taisho 6 March to Showa 55 March"],
   ],
-  // From Meiji 5 (1872) to Taisho 6 (1917) - crossing era boundary
+  // From Meiji 7 (1874) to Taisho 6 (1917) - crossing era boundary
   [
-    meiji5, taisho6,
-    [-45, -2, "-45y -2mo backwards from Meiji 5 January to Taisho 6 March"],
-    [0, -542, "-542mo backwards from Meiji 5 January to Taisho 6 March"],
+    meiji7, taisho6,
+    [-43, -2, "-43y -2mo backwards from Meiji 7 January to Taisho 6 March"],
+    [0, -518, "-518mo backwards from Meiji 7 January to Taisho 6 March"],
   ],
   [
-    taisho6, meiji5,
-    [45, 2, "45y 2mo from Meiji 5 January to Taisho 6 March"],
-    [0, 542, "542mo from Meiji 5 January to Taisho 6 March"],
+    taisho6, meiji7,
+    [43, 2, "43y 2mo from Meiji 7 January to Taisho 6 March"],
+    [0, 518, "518mo from Meiji 7 January to Taisho 6 March"],
   ],
   // Within same year but different eras
   [
@@ -102,6 +104,17 @@ const tests = [
     taisho1, meiji45,
     [0, 3, "3mo from Meiji 45 May to Taisho 1 August"],
     [0, 3, "3mo from Meiji 45 May to Taisho 1 August"],
+  ],
+  // Last pre-solar-calendar CE month to first solar-calendar month of Meiji era
+  [
+    ce1872, meiji6,
+    [0, -1, "backwards from month before solar Meiji era to first month"],
+    [0, -1, "backwards from month before solar Meiji era to first month"],
+  ],
+  [
+    meiji6, ce1872,
+    [0, 1, "from month before solar Meiji era to first month"],
+    [0, 1, "from month before solar Meiji era to first month"],
   ],
   // CE-BCE boundary
   [

--- a/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-japanese.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/until/era-boundary-japanese.js
@@ -13,7 +13,9 @@ const options = { overflow: "reject" };
 
 const bce1 = Temporal.PlainYearMonth.from({ era: "bce", eraYear: 1, monthCode: "M06", calendar }, options);
 const ce1 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1, monthCode: "M06", calendar }, options);
-const meiji5 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 5, monthCode: "M01", calendar }, options);
+const ce1872 = Temporal.PlainYearMonth.from({ era: "ce", eraYear: 1872, monthCode: "M12", calendar }, options);
+const meiji6 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 6, monthCode: "M01", calendar}, options);
+const meiji7 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 7, monthCode: "M01", calendar }, options);
 const meiji45 = Temporal.PlainYearMonth.from({ era: "meiji", eraYear: 45, monthCode: "M05", calendar }, options);
 const taisho1 = Temporal.PlainYearMonth.from({ era: "taisho", eraYear: 1, monthCode: "M08", calendar }, options);
 const taisho6 = Temporal.PlainYearMonth.from({ era: "taisho", eraYear: 6, monthCode: "M03", calendar }, options);
@@ -81,16 +83,16 @@ const tests = [
     [-63, 0, "-63y backwards from Taisho 6 March to Showa 55 March"],
     [0, -756, "-756mo backwards from Taisho 6 March to Showa 55 March"],
   ],
-  // From Meiji 5 (1872) to Taisho 6 (1917) - crossing era boundary
+  // From Meiji 7 (1874) to Taisho 6 (1917) - crossing era boundary
   [
-    meiji5, taisho6,
-    [45, 2, "45y 2mo from Meiji 5 January to Taisho 6 March"],
-    [0, 542, "542mo from Meiji 5 January to Taisho 6 March"],
+    meiji7, taisho6,
+    [43, 2, "43y 2mo from Meiji 7 January to Taisho 6 March"],
+    [0, 518, "518mo from Meiji 7 January to Taisho 6 March"],
   ],
   [
-    taisho6, meiji5,
-    [-45, -2, "-45y -2mo backwards from Meiji 5 January to Taisho 6 March"],
-    [0, -542, "-542mo backwards from Meiji 5 January to Taisho 6 March"],
+    taisho6, meiji7,
+    [-43, -2, "-43y -2mo backwards from Meiji 7 January to Taisho 6 March"],
+    [0, -518, "-518mo backwards from Meiji 7 January to Taisho 6 March"],
   ],
   // Within same year but different eras
   [
@@ -102,6 +104,17 @@ const tests = [
     taisho1, meiji45,
     [0, -3, "-3mo backwards from Meiji 45 May to Taisho 1 August"],
     [0, -3, "-3mo backwards from Meiji 45 May to Taisho 1 August"],
+  ],
+  // Last pre-solar-calendar CE month to first solar-calendar month of Meiji era
+  [
+    ce1872, meiji6,
+    [0, 1, "from month before solar Meiji era to first month"],
+    [0, 1, "from month before solar Meiji era to first month"],
+  ],
+  [
+    meiji6, ce1872,
+    [0, -1, "backwards from month before solar Meiji era to first month"],
+    [0, -1, "backwards from month before solar Meiji era to first month"],
   ],
   // CE-BCE boundary
   [

--- a/test/intl402/Temporal/PlainYearMonth/prototype/year/arithmetic-year.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/year/arithmetic-year.js
@@ -102,7 +102,7 @@ const tests = {
     [{ era: "bce", eraYear: 2, monthCode: "M06" }, -1],
     [{ era: "bce", eraYear: 1, monthCode: "M12" }, 0],
     [{ era: "ce", eraYear: 1, monthCode: "M07" }, 1],
-    [{ era: "meiji", eraYear: 1, monthCode: "M12" }, 1868],
+    [{ era: "meiji", eraYear: 6, monthCode: "M12" }, 1873],
     [{ era: "taisho", eraYear: 1, monthCode: "M12" }, 1912],
     [{ era: "showa", eraYear: 1, monthCode: "M12" }, 1926],
     [{ era: "heisei", eraYear: 1, monthCode: "M12" }, 1989],

--- a/test/intl402/Temporal/ZonedDateTime/from/era-boundary-japanese.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/era-boundary-japanese.js
@@ -115,6 +115,24 @@ TemporalHelpers.assertPlainDateTime(
   1868, 10, "M10", 22, 12, 34, 0, 0, 0, 0, "Meiji 1 resolves to CE 1868 before era start date",
   "ce", 1868);
 
+const meiji1AfterStart = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 1, monthCode: "M10", day: 23, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+TemporalHelpers.assertPlainDateTime(
+  meiji1AfterStart.toPlainDateTime(),
+  1868, 10, "M10", 23, 12, 34, 0, 0, 0, 0, "Meiji 1 still resolves to CE 1868 after era start date",
+  "ce", 1868);
+
+const meiji5 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 5, monthCode: "M12", day: 31, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+TemporalHelpers.assertPlainDateTime(
+  meiji5.toPlainDateTime(),
+  1872, 12, "M12", 31, 12, 34, 0, 0, 0, 0, "Meiji 5 resolves to CE 1872",
+  "ce", 1872);
+
+const ce1873 = Temporal.ZonedDateTime.from({ era: "ce", eraYear: 1873, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+TemporalHelpers.assertPlainDateTime(
+  ce1873.toPlainDateTime(),
+  1873, 1, "M01", 1, 12, 34, 0, 0, 0, 0, "CE 1873 resolves to Meiji 6",
+  "meiji", 6);
+
 const meiji0 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 0, monthCode: "M10", day: 23, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(
   meiji0.toPlainDateTime(),
@@ -126,12 +144,6 @@ TemporalHelpers.assertPlainDateTime(
   meiji1n.toPlainDateTime(),
   1866, 10, "M10", 23, 12, 34, 0, 0, 0, 0, "Meiji -1 resolves to CE 1866",
   "ce", 1866);
-
-const ce1868AfterStart = Temporal.ZonedDateTime.from({ era: "ce", eraYear: 1868, monthCode: "M10", day: 23, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
-TemporalHelpers.assertPlainDateTime(
-  ce1868AfterStart.toPlainDateTime(),
-  1868, 10, "M10", 23, 12, 34, 0, 0, 0, 0, "CE 1868 resolves to Meiji 1 after era start date",
-  "meiji", 1);
 
 const ce0 = Temporal.ZonedDateTime.from({ era: "ce", eraYear: 0, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 TemporalHelpers.assertPlainDateTime(

--- a/test/intl402/Temporal/ZonedDateTime/from/era-japanese.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/era-japanese.js
@@ -15,7 +15,7 @@ const reiwa = Temporal.ZonedDateTime.from({ era: "reiwa", eraYear: 2, month: 1, 
 const heisei = Temporal.ZonedDateTime.from({ era: "heisei", eraYear: 2, month: 1, day: 1, hour: 12, minute: 34, timeZone: "UTC",  calendar });
 const showa = Temporal.ZonedDateTime.from({ era: "showa", eraYear: 2, month: 1, day: 1, hour: 12, minute: 34, timeZone: "UTC",  calendar });
 const taisho = Temporal.ZonedDateTime.from({ era: "taisho", eraYear: 2, month: 1, day: 1, hour: 12, minute: 34, timeZone: "UTC",  calendar });
-const meiji = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 2, month: 1, day: 1, hour: 12, minute: 34, timeZone: "UTC",  calendar });
+const meiji = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 6, month: 1, day: 1, hour: 12, minute: 34, timeZone: "UTC",  calendar });
 const ce = Temporal.ZonedDateTime.from({ era: "ce", eraYear: 1000, month: 1, day: 1, hour: 12, minute: 34, timeZone: "UTC",  calendar });
 const bce = Temporal.ZonedDateTime.from({ era: "bce", eraYear: 1, month: 1, day: 1, hour: 12, minute: 34, timeZone: "UTC",  calendar });
 
@@ -27,7 +27,7 @@ TemporalHelpers.assertPlainDateTime(showa.toPlainDateTime(), 1927, 1, "M01", 1, 
 
 TemporalHelpers.assertPlainDateTime(taisho.toPlainDateTime(), 1913, 1, "M01", 1, 12, 34, 0, 0, 0, 0,  `${taisho}`, "taisho", 2);
 
-TemporalHelpers.assertPlainDateTime(meiji.toPlainDateTime(), 1869, 1, "M01", 1, 12, 34, 0, 0, 0, 0,  `${meiji}`, "meiji", 2);
+TemporalHelpers.assertPlainDateTime(meiji.toPlainDateTime(), 1873, 1, "M01", 1, 12, 34, 0, 0, 0, 0,  `${meiji}`, "meiji", 6);
 
 TemporalHelpers.assertPlainDateTime(ce.toPlainDateTime(), 1000, 1, "M01", 1, 12, 34, 0, 0, 0, 0,  `${ce} (CE)`, "ce", 1000);
 

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/era-boundary-japanese.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/era-boundary-japanese.js
@@ -13,9 +13,9 @@ const options = { overflow: "reject" };
 
 const bce1 = Temporal.ZonedDateTime.from({ era: "bce", eraYear: 1, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 const ce1 = Temporal.ZonedDateTime.from({ era: "ce", eraYear: 1, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
-const ce1868 = Temporal.ZonedDateTime.from({ era: "ce", eraYear: 1868, monthCode: "M10", day: 22, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
-const meiji1 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 1, monthCode: "M10", day: 23, hour: 12, minute: 34, timeZone: "UTC", calendar}, options);
-const meiji5 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 5, monthCode: "M01", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const ce1872 = Temporal.ZonedDateTime.from({ era: "ce", eraYear: 1872, monthCode: "M12", day: 31, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const meiji6 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 6, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar}, options);
+const meiji7 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 7, monthCode: "M01", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 const meiji45 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 45, monthCode: "M05", day: 19, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 const taisho1 = Temporal.ZonedDateTime.from({ era: "taisho", eraYear: 1, monthCode: "M08", day: 9, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 const taisho6 = Temporal.ZonedDateTime.from({ era: "taisho", eraYear: 6, monthCode: "M03", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
@@ -96,18 +96,16 @@ const tests = [
     [0, 7, 0, 10, "7mo 10d from Taisho 15 July 20 to Showa 1 December 30"],
     [0, 7, 0, 10, "7mo 10d from Taisho 15 July 20 to Showa 1 December 30"],
   ],
-  // From Meiji 5 (1872) to Taisho 6 (1917) - crossing era boundary
-  // Note that contemporarily January 15 1872 would have been Meiji 4 in the
-  // pre-1873 lunisolar calendar, but the spec-mandated behaviour is proleptic
+  // From Meiji 7 (1874) to Taisho 6 (1917) - crossing era boundary
   [
-    meiji5, taisho6,
-    [-45, -2, 0, 0, "-45y -2mo backwards from Meiji 5 January to Taisho 6 March"],
-    [0, -542, 0, 0, "-542mo backwards from Meiji 5 January to Taisho 6 March"],
+    meiji7, taisho6,
+    [-43, -2, 0, 0, "-43y -2mo backwards from Meiji 7 January to Taisho 6 March"],
+    [0, -518, 0, 0, "-518mo backwards from Meiji 7 January to Taisho 6 March"],
   ],
   [
-    taisho6, meiji5,
-    [45, 2, 0, 0, "45y 2mo from Meiji 5 January to Taisho 6 March"],
-    [0, 542, 0, 0, "542mo from Meiji 5 January to Taisho 6 March"],
+    taisho6, meiji7,
+    [43, 2, 0, 0, "43y 2mo from Meiji 7 January to Taisho 6 March"],
+    [0, 518, 0, 0, "518mo from Meiji 7 January to Taisho 6 March"],
   ],
   // Within same year but different eras
   [
@@ -120,16 +118,16 @@ const tests = [
     [0, 2, 0, 21, "2mo 21d from Meiji 45 May 19 to Taisho 1 August 9"],
     [0, 2, 0, 21, "2mo 21d from Meiji 45 May 19 to Taisho 1 August 9"],
   ],
-  // Last pre-Meiji day to first day of Meiji era
+  // Last pre-solar-calendar CE day to first solar-calendar day of Meiji era
   [
-    ce1868, meiji1,
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
+    ce1872, meiji6,
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
   ],
   [
-    meiji1, ce1868,
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
+    meiji6, ce1872,
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
   ],
   // CE-BCE boundary
   [

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/era-boundary-japanese.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/era-boundary-japanese.js
@@ -13,9 +13,9 @@ const options = { overflow: "reject" };
 
 const bce1 = Temporal.ZonedDateTime.from({ era: "bce", eraYear: 1, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 const ce1 = Temporal.ZonedDateTime.from({ era: "ce", eraYear: 1, monthCode: "M06", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
-const ce1868 = Temporal.ZonedDateTime.from({ era: "ce", eraYear: 1868, monthCode: "M10", day: 22, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
-const meiji1 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 1, monthCode: "M10", day: 23, hour: 12, minute: 34, timeZone: "UTC", calendar}, options);
-const meiji5 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 5, monthCode: "M01", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const ce1872 = Temporal.ZonedDateTime.from({ era: "ce", eraYear: 1872, monthCode: "M12", day: 31, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
+const meiji6 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 6, monthCode: "M01", day: 1, hour: 12, minute: 34, timeZone: "UTC", calendar}, options);
+const meiji7 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 7, monthCode: "M01", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 const meiji45 = Temporal.ZonedDateTime.from({ era: "meiji", eraYear: 45, monthCode: "M05", day: 19, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 const taisho1 = Temporal.ZonedDateTime.from({ era: "taisho", eraYear: 1, monthCode: "M08", day: 9, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
 const taisho6 = Temporal.ZonedDateTime.from({ era: "taisho", eraYear: 6, monthCode: "M03", day: 15, hour: 12, minute: 34, timeZone: "UTC", calendar }, options);
@@ -96,18 +96,16 @@ const tests = [
     [0, -7, 0, -10, "-7mo -10d backwards from Taisho 15 July 20 to Showa 1 December 30"],
     [0, -7, 0, -10, "-7mo -10d backwards from Taisho 15 July 20 to Showa 1 December 30"],
   ],
-  // From Meiji 5 (1872) to Taisho 6 (1917) - crossing era boundary
-  // Note that contemporarily January 15 1872 would have been Meiji 4 in the
-  // pre-1873 lunisolar calendar, but the spec-mandated behaviour is proleptic
+  // From Meiji 7 (1874) to Taisho 6 (1917) - crossing era boundary
   [
-    meiji5, taisho6,
-    [45, 2, 0, 0, "45y 2mo from Meiji 5 January to Taisho 6 March"],
-    [0, 542, 0, 0, "542mo from Meiji 5 January to Taisho 6 March"],
+    meiji7, taisho6,
+    [43, 2, 0, 0, "43y 2mo from Meiji 7 January to Taisho 6 March"],
+    [0, 518, 0, 0, "518mo from Meiji 7 January to Taisho 6 March"],
   ],
   [
-    taisho6, meiji5,
-    [-45, -2, 0, 0, "-45y -2mo backwards from Meiji 5 January to Taisho 6 March"],
-    [0, -542, 0, 0, "-542mo backwards from Meiji 5 January to Taisho 6 March"],
+    taisho6, meiji7,
+    [-43, -2, 0, 0, "-43y -2mo backwards from Meiji 7 January to Taisho 6 March"],
+    [0, -518, 0, 0, "-518mo backwards from Meiji 7 January to Taisho 6 March"],
   ],
   // Within same year but different eras
   [
@@ -120,16 +118,16 @@ const tests = [
     [0, -2, 0, -21, "-2mo -21d backwards from Meiji 45 May 19 to Taisho 1 August 9"],
     [0, -2, 0, -21, "-2mo -21d backwards from Meiji 45 May 19 to Taisho 1 August 9"],
   ],
-  // Last pre-Meiji day to first day of Meiji era
+  // Last pre-solar-calendar CE day to first solar-calendar day of Meiji era
   [
-    ce1868, meiji1,
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
-    [0, 0, 0, 1, "from day before Meiji era to first day"],
+    ce1872, meiji6,
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
+    [0, 0, 0, 1, "from day before solar Meiji era to first day"],
   ],
   [
-    meiji1, ce1868,
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
-    [0, 0, 0, -1, "backwards from day before Meiji era to first day"],
+    meiji6, ce1872,
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
+    [0, 0, 0, -1, "backwards from day before solar Meiji era to first day"],
   ],
   // CE-BCE boundary
   [

--- a/test/intl402/Temporal/ZonedDateTime/prototype/year/arithmetic-year.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/year/arithmetic-year.js
@@ -102,7 +102,7 @@ const tests = {
     [{ era: "bce", eraYear: 2, monthCode: "M06", day: 14 }, -1],
     [{ era: "bce", eraYear: 1, monthCode: "M12", day: 3 }, 0],
     [{ era: "ce", eraYear: 1, monthCode: "M07", day: 26 }, 1],
-    [{ era: "meiji", eraYear: 1, monthCode: "M12", day: 31 }, 1868],
+    [{ era: "meiji", eraYear: 6, monthCode: "M12", day: 31 }, 1873],
     [{ era: "taisho", eraYear: 1, monthCode: "M12", day: 31 }, 1912],
     [{ era: "showa", eraYear: 1, monthCode: "M12", day: 31 }, 1926],
     [{ era: "heisei", eraYear: 1, monthCode: "M12", day: 31 }, 1989],


### PR DESCRIPTION
See https://github.com/tc39/proposal-intl-era-monthcode/pull/102

The historical regnal period starts on 1868-10-23 but at that point the lunisolar calendar was still in use. On 1873-01-01 we start using the era code "meiji", before that we use eras and era years identical to the "gregory" calendar.