### PR TITLE
[Temporal] Formatting Plain* Temporal objects should ignore timezones

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/format/temporal-objects-ignore-timezone.js
+++ b/test/intl402/DateTimeFormat/prototype/format/temporal-objects-ignore-timezone.js
@@ -25,28 +25,29 @@ const dtf_apia = new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyl
 const dtf_los_angeles = new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short', timeZone: 'America/Los_Angeles' });
 
 // PlainDateTime
-assert.sameValue(
-  dtf_apia.format(pdt_apia),
-  "12/30/11, 12:00 PM",
+const pdt_apia_result = dtf_apia.format(pdt_apia);
+assert(
+  pdt_apia_result.includes('30') && !pdt_apia_result.includes('31'),
   "day is calculated correctly, ignoring the Pacific/Apia timezone"
 );
 
-assert.sameValue(
-  dtf_los_angeles.format(pdt_los_angeles),
-  "3/8/26, 2:00 AM",
+const pdt_los_angeles_result = dtf_los_angeles.format(pdt_los_angeles);
+assert(
+  pdt_los_angeles_result.includes('2:00') && !pdt_los_angeles_result.includes('3:00'),
   "hour is calculated correctly with the America/Los_Angeles timezone"
 );
 
 // PlainDate
-assert.sameValue(
-  dtf_apia.format(pd_apia),
-  "12/30/11",
+const pd_apia_result = dtf_apia.format(pd_apia);
+assert(
+  pd_apia_result.includes('30') && !pd_apia_result.includes('31'),
   "day is calculated correctly, ignoring the Pacific/Apia timezone"
 );
 
 // PlainTime
-assert.sameValue(
-  dtf_los_angeles.format(pt_los_angeles),
+const pt_los_angeles_result = dtf_los_angeles.format(pt_los_angeles);
+assert(
+  pt_los_angeles_result.includes('2:00') && !pt_los_angeles_result.includes('3:00'),
   "2:00 AM",
   "hour is calculated correctly with the America/Los_Angeles timezone"
 );

--- a/test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-ignore-timezone.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-ignore-timezone.js
@@ -24,33 +24,29 @@ const pt_los_angeles = Temporal.PlainTime.from(datetime_los_angeles);
 const dtf_apia = new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short', timeZone: 'Pacific/Apia' });
 const dtf_los_angeles = new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short', timeZone: 'America/Los_Angeles' });
 
-const usDateRangeSeparator = new Intl.DateTimeFormat("en-US", { dateStyle: "short" })
-  .formatRangeToParts(1 * 86400 * 1000, 366 * 86400 * 1000)
-  .find((part) => part.type === "literal" && part.source === "shared").value;
-
 // PlainDateTime
-assert.sameValue(
-  dtf_apia.formatRange(pdt_apia, pdt_los_angeles),
-  `12/30/11, 12:00 PM${usDateRangeSeparator}3/8/26, 2:00 AM`,
+const pdt_apia_result = dtf_apia.formatRange(pdt_apia, pdt_los_angeles);
+assert(
+  pdt_apia_result.includes('30') && !pdt_apia_result.includes('31'),
   "day is calculated correctly, ignoring the Pacific/Apia timezone"
 );
 
-assert.sameValue(
-  dtf_los_angeles.formatRange(pdt_apia, pdt_los_angeles),
-  `12/30/11, 12:00 PM${usDateRangeSeparator}3/8/26, 2:00 AM`,
+const pdt_los_angeles_result = dtf_los_angeles.formatRange(pdt_apia, pdt_los_angeles);
+assert(
+  pdt_los_angeles_result.includes('2:00') && !pdt_los_angeles_result.includes('3:00'),
   "hour is calculated correctly with the America/Los_Angeles timezone"
 );
 
 // PlainDate
-assert.sameValue(
-  dtf_apia.formatRange(pd_apia, pd_los_angeles),
-  `12/30/11${usDateRangeSeparator}3/8/26`,
+const pd_apia_result = dtf_apia.formatRange(pd_apia, pd_los_angeles);
+assert(
+  pd_apia_result.includes('30') && !pd_apia_result.includes('31'),
   "day is calculated correctly, ignoring the Pacific/Apia timezone"
 );
 
 // PlainTime
-assert.sameValue(
-  dtf_los_angeles.formatRange(pt_apia, pt_los_angeles),
-  `12:00 PM${usDateRangeSeparator}2:00 AM`,
+const pt_los_angeles_result = dtf_los_angeles.formatRange(pt_apia, pt_los_angeles);
+assert(
+  pt_los_angeles_result.includes('2:00') && !pt_los_angeles_result.includes('3:00'),
   "hour is calculated correctly with the America/Los_Angeles timezone"
 );

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-ignore-timezone.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-ignore-timezone.js
@@ -24,29 +24,35 @@ const pt_los_angeles = Temporal.PlainTime.from(datetime_los_angeles);
 const dtf_apia = new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short', timeZone: 'Pacific/Apia' });
 const dtf_los_angeles = new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short', timeZone: 'America/Los_Angeles' });
 
+function find_part(parts, expected_type, expected_source) {
+  return parts.find(({ type, source }) =>
+    type === expected_type && (source === expected_source || source === "shared")
+  ).value;
+}
+
 // PlainDateTime
 assert.sameValue(
-  dtf_apia.formatRangeToParts(pdt_apia, pdt_los_angeles)[2].value,
+  find_part(dtf_apia.formatRangeToParts(pdt_apia, pdt_los_angeles), "day", "startRange"),
   "30",
   "day is calculated correctly, ignoring the Pacific/Apia timezone"
 );
 
 assert.sameValue(
-  dtf_los_angeles.formatRangeToParts(pdt_apia, pdt_los_angeles)[18].value,
+  find_part(dtf_los_angeles.formatRangeToParts(pdt_apia, pdt_los_angeles), "hour", "endRange"),
   "2",
   "hour is calculated correctly with the America/Los_Angeles timezone"
 );
 
 // PlainDate
 assert.sameValue(
-  dtf_apia.formatRangeToParts(pd_apia, pd_los_angeles)[2].value,
+  find_part(dtf_apia.formatRangeToParts(pd_apia, pd_los_angeles), "day", "startRange"),
   "30",
   "day is calculated correctly, ignoring the Pacific/Apia timezone"
 );
 
 // PlainTime
 assert.sameValue(
-  dtf_los_angeles.formatRangeToParts(pt_apia, pt_los_angeles)[6].value,
+  find_part(dtf_los_angeles.formatRangeToParts(pt_apia, pt_los_angeles), "hour", "endRange"),
   "2",
   "hour is calculated correctly with the America/Los_Angeles timezone"
 );

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-ignore-timezone.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-ignore-timezone.js
@@ -24,29 +24,33 @@ const pt_los_angeles = Temporal.PlainTime.from(datetime_los_angeles);
 const dtf_apia = new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short', timeZone: 'Pacific/Apia' });
 const dtf_los_angeles = new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short', timeZone: 'America/Los_Angeles' });
 
+function find_part(parts, expected_type) {
+  return parts.find(({ type }) => type === expected_type).value;
+}
+
 // PlainDateTime
 assert.sameValue(
-  dtf_apia.formatToParts(pdt_apia)[2].value,
+  find_part(dtf_apia.formatToParts(pdt_apia), "day"),
   "30",
   "day is calculated correctly, ignoring the Pacific/Apia timezone"
 );
 
 assert.sameValue(
-  dtf_los_angeles.formatToParts(pdt_los_angeles)[6].value,
+  find_part(dtf_los_angeles.formatToParts(pdt_los_angeles), "hour"),
   "2",
   "hour is calculated correctly with the America/Los_Angeles timezone"
 );
 
 // PlainDate
 assert.sameValue(
-  dtf_apia.formatToParts(pd_apia)[2].value,
+  find_part(dtf_apia.formatToParts(pd_apia), "day"),
   "30",
   "day is calculated correctly, ignoring the Pacific/Apia timezone"
 );
 
 // PlainTime
 assert.sameValue(
-  dtf_los_angeles.formatToParts(pt_los_angeles)[0].value,
+  find_part(dtf_los_angeles.formatToParts(pt_los_angeles), "hour"),
   "2",
   "hour is calculated correctly with the America/Los_Angeles timezone"
 );

--- a/test/intl402/Temporal/Instant/prototype/toLocaleString/respect-timezone-after-formatting-plaindatetime.js
+++ b/test/intl402/Temporal/Instant/prototype/toLocaleString/respect-timezone-after-formatting-plaindatetime.js
@@ -11,25 +11,23 @@ const datestring = '2026-03-29T02:30:15+01:00';
 const instant = Temporal.Instant.from(datestring);
 const pdt = Temporal.PlainDateTime.from(datestring);
 
-assert.sameValue(
-  pdt.toLocaleString('en', { timeStyle: 'long' }),
-  '2:30:15 AM'
-);
+const legacyDate = new Date(instant.epochMilliseconds);
+const expected1 = legacyDate.toLocaleString("en", { timeStyle: "long", timeZone: "America/Los_Angeles" });
+const expected2 = legacyDate.toLocaleString("en", { timeStyle: "long", timeZone: "Europe/Berlin" });
+
+pdt.toLocaleString("en", { timeStyle: "long" });
 
 assert.sameValue(
   instant.toLocaleString('en', { timeStyle: 'long', timeZone: 'America/Los_Angeles' }),
-  '6:30:15 PM PDT'
+  expected1
 );
 
 assert.sameValue(
   instant.toLocaleString('en', { timeStyle: 'long', timeZone: 'Europe/Berlin' }),
-  '3:30:15 AM GMT+2'
+  expected2
 );
 
-assert.sameValue(
-  new Temporal.PlainDate(2011, 12, 30).toLocaleString('en'),
-  '12/30/2011'
-),
+new Temporal.PlainDate(2011, 12, 30).toLocaleString("en");
 
 assert.sameValue(
   new Temporal.Instant(0n).toLocaleString("en", { era: "narrow" }),

--- a/test/intl402/Temporal/PlainDate/prototype/toLocaleString/ignore-timezone.js
+++ b/test/intl402/Temporal/PlainDate/prototype/toLocaleString/ignore-timezone.js
@@ -10,10 +10,8 @@ features: [Temporal]
 // A non-existent date in the Pacific/Apia timezone.
 const instance = Temporal.PlainDate.from({ year: 2011, month: 12, day: 30 });
 
-assert.sameValue(
-  instance.toLocaleString('en-US', { timeZone: 'Pacific/Apia' }),
-  '12/30/2011'
-);
+const result = instance.toLocaleString('en-US', { timeZone: 'Pacific/Apia' });
+assert(result.includes('30') && !result.includes('31'));
 
 assert.sameValue(
   instance.toLocaleString('en-US', { timeZone: 'Pacific/Apia' }),

--- a/test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/ignore-timezone.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/ignore-timezone.js
@@ -10,10 +10,8 @@ features: [Temporal]
 // A non-existent date in the Pacific/Apia timezone.
 const instance1 = Temporal.PlainDateTime.from( { year: 2011, month: 12, day: 30 });
 
-assert.sameValue(
-  instance1.toLocaleString('en-US', { timeZone: 'Pacific/Apia' }),
-  '12/30/2011, 12:00:00 AM'
-);
+const result1 = instance1.toLocaleString('en-US', { timeZone: 'Pacific/Apia' });
+assert(result1.includes('30') && !result1.includes('31'));
 
 assert.sameValue(
   instance1.toLocaleString('en-US', { timeZone: 'Pacific/Apia' }),
@@ -33,10 +31,8 @@ assert.sameValue(
   instance2.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })
 )
 
-assert.sameValue(
-  instance2.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }),
-  '3/8/2026, 2:30:00 AM'
-)
+const result2 = instance2.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' });
+assert(result2.includes('2:30') && !result2.includes('3:'));
 
 assert.sameValue(
   instance2.toLocaleString('en-US', { timeZone: 'UTC' }),
@@ -47,10 +43,8 @@ assert.sameValue(
 
 const instance3 = Temporal.PlainDateTime.from('2026-03-29T02:30:15+01:00');
 
-assert.sameValue(
-  instance3.toLocaleString('en', { timeStyle: 'long' }),
-  '2:30:15 AM'
-);
+const result3 = instance3.toLocaleString('en', { timeStyle: 'long' });
+assert(result3.includes('2:30') && !result3.includes('3:'));
 
 assert.sameValue(
   instance3.toLocaleString('en', { timeStyle: 'long' }),

--- a/test/intl402/Temporal/PlainTime/prototype/toLocaleString/ignore-timezone.js
+++ b/test/intl402/Temporal/PlainTime/prototype/toLocaleString/ignore-timezone.js
@@ -15,10 +15,8 @@ assert.sameValue(
   instance1.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })
 )
 
-assert.sameValue(
-  instance1.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }),
-  '2:30:00 AM'
-)
+const result1 = instance1.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' });
+assert(result1.includes('2:30') && !result1.includes('3:'))
 
 assert.sameValue(
   instance1.toLocaleString('en-US', { timeZone: 'UTC' }),
@@ -29,10 +27,8 @@ assert.sameValue(
 
 const instance2 = Temporal.PlainTime.from('2026-03-29T02:30:15+01:00');
 
-assert.sameValue(
-  instance2.toLocaleString('en', { timeStyle: 'long' }),
-  '2:30:15 AM'
-);
+const result2 = instance2.toLocaleString('en', { timeStyle: 'long' });
+assert(result2.includes('2:30') && !result2.includes('3:'));
 
 assert.sameValue(
   instance2.toLocaleString('en', { timeStyle: 'long' }),


### PR DESCRIPTION
These are tests for proposal-temporal's normative change PR https://github.com/tc39/proposal-temporal/pull/3246 and polyfill fix PR https://github.com/tc39/proposal-temporal/pull/3257
