### PR TITLE
Downgrade ES6+ syntax in a couple of key harness files

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -113,15 +113,15 @@ assert.compareArray = function (actual, expected, message) {
   }
 
   if (isPrimitive(actual)) {
-    assert(false, `Actual argument [${actual}] shouldn't be primitive. ${message}`);
+    assert(false, "Actual argument [" + actual + "] shouldn't be primitive. " + String(message));
   } else if (isPrimitive(expected)) {
-    assert(false, `Expected argument [${expected}] shouldn't be primitive. ${message}`);
+    assert(false, "Expected argument [" + expected + "] shouldn't be primitive. " + String(message));
   }
   var result = compareArray(actual, expected);
   if (result) return;
 
   var format = compareArray.format;
-  assert(false, `Actual ${format(actual)} and expected ${format(expected)} should have the same contents. ${message}`);
+  assert(false, "Actual " + format(actual) + " and expected " + format(expected) + " should have the same contents. " + String(message));
 };
 
 function compareArray(a, b) {
@@ -137,15 +137,15 @@ function compareArray(a, b) {
 }
 
 compareArray.format = function (arrayLike) {
-  return `[${Array.prototype.map.call(arrayLike, String).join(', ')}]`;
+  return "[" + Array.prototype.map.call(arrayLike, String).join(", ") + "]";
 };
 
 assert._formatIdentityFreeValue = function formatIdentityFreeValue(value) {
   switch (value === null ? 'null' : typeof value) {
     case 'string':
-      return typeof JSON !== "undefined" ? JSON.stringify(value) : `"${value}"`;
+      return typeof JSON !== "undefined" ? JSON.stringify(value) : '"' + value + '"';
     case 'bigint':
-      return `${value}n`;
+      return String(value) + "n";
     case 'number':
       if (value === 0 && 1 / value === -Infinity) return '-0';
       // falls through

--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -86,7 +86,7 @@ function verifyProperty(obj, name, desc, options) {
         names[i] === "configurable" ||
         names[i] === "get" ||
         names[i] === "set",
-      "Invalid descriptor field: " + names[i],
+      "Invalid descriptor field: " + names[i]
     );
   }
 


### PR DESCRIPTION
Replace template literals with equivalent string concatenation in assert.js and remove the trailing argument comma in propertyHelper.js.

This makes the harness ES5-friendlier and allows nearly a third of the tests to pass on old ES5 engines from a baseline of ~8.7% of all negative cases - assert.js is a key blocker.

---

Improvement in pass rate in my testing:

| engine  | 5c8206929d81b2d3d727ca6aac56c18358c8d790    | assert.js    | +propertyHelper.js |
| ------- | ----------- | ------------- | ------------------ |
| duktape | 4639 (8.7%) | 16675 (31.4%) | 18268 (34.4%)      |
| iv-lv5  | 4633 (8.7%) | 15911 (30.0%) | 17126 (32.2%)      |
| kjs     | 4631 (8.7%) | 13670 (25.7%) | 14585 (27.5%)      |
| mujs    | 4635 (8.7%) | 13630 (25.7%) | 14215 (26.8%)      |
