### PR TITLE
Clarify behavior when AsyncTestComplete/Failure are both present

### DIFF
--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -361,9 +361,11 @@ following strings:
   In the event of a passing test run, this function will be invoked with the
   string `'Test262:AsyncTestComplete'`. If invoked with a string that is
   prefixed with the character sequence `Test262:AsyncTestFailure:`, the test
-  must be interpreted as failed. The implementation is free to select an
-  appropriate length of time to wait before considering the test "timed out"
-  and failing.
+  must be interpreted as failed. If the `print` function is invoked with both
+  `'Test262:AsyncTestComplete'` and a string prefixed with
+  `'Test262:AsyncTestFailure:'`, the test must be interpreted as failed.
+  The implementation is free to select an appropriate length of time to wait
+  before considering the test "timed out" and failing.
 
   *Example*
 


### PR DESCRIPTION
Common sense and [this test](https://github.com/tc39/test262/blob/main/test/language/expressions/object/cpn-obj-lit-computed-property-name-from-await-expression.js) dictate that failure should be preferred. This is apparently not obvious to LLM agents, see this [issue](https://github.com/sebastienros/jint/issues/2354) / [commit](
https://github.com/sebastienros/jint/pull/2359/changes/13514bc6b68f8821003bfd68a8236172f19a0fb6#diff-7689d1dd0e7c63746d76d6c33c7212c47fe527d603db42917f7346d7e61d4c49).