### PR TITLE
Fix harness/sm/non262-strict-shell.js for strict mode

### DIFF
--- a/harness/sm/non262-strict-shell.js
+++ b/harness/sm/non262-strict-shell.js
@@ -15,7 +15,7 @@ defines: [completesNormally, raisesException, testLenientAndStrict, parsesSucces
    */
   globalThis.completesNormally = function completesNormally(code) {
     try {
-      eval(code);
+      Function('code', 'eval(code)')(code);
       return true;
     } catch (exception) {
       return false;
@@ -31,7 +31,7 @@ defines: [completesNormally, raisesException, testLenientAndStrict, parsesSucces
   globalThis.raisesException = function raisesException(exception) {
     return function (code) {
       try {
-        eval(code);
+        Function('code', 'eval(code)')(code);
         return false;
       } catch (actual) {
         return actual instanceof exception;
@@ -48,7 +48,7 @@ defines: [completesNormally, raisesException, testLenientAndStrict, parsesSucces
    * in loose mode, but fails in strict mode.
    */
   global.testLenientAndStrict = function testLenientAndStrict(code, lenient_pred, strict_pred) {
-    return (strict_pred("'use strict'; " + code) && 
+    return (strict_pred("'use strict'; " + code) &&
             lenient_pred(code));
   }
 
@@ -88,7 +88,7 @@ defines: [completesNormally, raisesException, testLenientAndStrict, parsesSucces
   global.returns = function returns(value) {
     return function(code) {
       try {
-        return eval(code) === value;
+        return Function('code', 'return eval(code)')(code) === value;
       } catch (exception) {
         return false;
       }


### PR DESCRIPTION
`harness/sm/non262-strict-shell.js` is problematic and causes discrepancies between different test262 runners in `test/staging/sm/strict/` tests depending on minor implementation details of the runners.

Some (most?) test262 runners e.g. test262-harness + eshost, boa, execute tests by concatenating `'use strict'` in strict mode, harness code and test code into a single file to be executed by the engine.  This causes `harness/sm/non262-strict-shell.js` to be run in strict scope and breaks its eval-based `testLenientAndStrict()` method as `eval()` inherits strictness.

Others e.g. libjs test262-runner run harness code in a separate scope from test code and able to pass `test/staging/sm/strict/` tests in both modes in this way. This is easy to do for a test262 runner integrated with an engine, but also an easy detail to miss for implementers (as evidenced by boa's test runner), and awkward to implement in a general eshost-style runner.

I propose fixing the harness code - wrap `eval()` which inherits strictness with a `Function()` which doesn't.