### PR TITLE
Add coverage when ToNumber in set{Full,UTCFull,}Year modifies date

### DIFF
--- a/test/annexB/built-ins/Date/prototype/setYear/date-value-read-before-tonumber-time-part-correct-when-set-to-invalid.js
+++ b/test/annexB/built-ins/Date/prototype/setYear/date-value-read-before-tonumber-time-part-correct-when-set-to-invalid.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.setyear
+description: >
+  Read [[DateValue]] and in ToNumber modify date-time to an invalid value
+info: |
+  Date.prototype.setYear ( year )
+
+  ...
+  3. Let t be dateObject.[[DateValue]].
+  4. Let y be ? ToNumber(year).
+  5. If t is NaN, set t to +0𝔽; otherwise, set t to LocalTime(t).
+  6. Let yyyy be MakeFullYear(y).
+  ...
+---*/
+
+var dt = new Date(0);
+dt.setHours(1, 2, 3, 4);
+
+var valueOfCalled = 0;
+
+var value = {
+  valueOf() {
+    valueOfCalled++;
+
+    // This call should get ignored.
+    dt.setTime(NaN);
+
+    return 1;
+  }
+};
+
+var result = dt.setYear(value);
+
+assert.sameValue(valueOfCalled, 1, "valueOf called exactly once");
+
+assert.notSameValue(result, NaN, "result is not NaN");
+
+assert.sameValue(result, dt.getTime(), "result is equal to getTime");
+
+assert.sameValue(dt.getYear(), 1, "date value correctly updated");
+
+assert.sameValue(dt.getHours(), 1, "hours value still intact");
+assert.sameValue(dt.getMinutes(), 2, "minutes value correctly updated");
+assert.sameValue(dt.getSeconds(), 3, "seconds value correctly updated");
+assert.sameValue(dt.getMilliseconds(), 4, "milliseconds value correctly updated");

--- a/test/annexB/built-ins/Date/prototype/setYear/date-value-read-before-tonumber-time-part-correct-when-set-to-valid.js
+++ b/test/annexB/built-ins/Date/prototype/setYear/date-value-read-before-tonumber-time-part-correct-when-set-to-valid.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.setyear
+description: >
+  Read [[DateValue]] and in ToNumber modify date-time to a valid value
+info: |
+  Date.prototype.setYear ( year )
+
+  ...
+  3. Let t be dateObject.[[DateValue]].
+  4. Let y be ? ToNumber(year).
+  5. If t is NaN, set t to +0𝔽; otherwise, set t to LocalTime(t).
+  6. Let yyyy be MakeFullYear(y).
+  ...
+---*/
+
+var dt = new Date(0);
+dt.setHours(1, 2, 3, 4);
+
+var valueOfCalled = 0;
+
+var value = {
+  valueOf() {
+    valueOfCalled++;
+
+    // This call should get ignored.
+    dt.setTime(36 * 60 * 60 * 1000);
+
+    return 1;
+  }
+};
+
+var result = dt.setYear(value);
+
+assert.sameValue(valueOfCalled, 1, "valueOf called exactly once");
+
+assert.notSameValue(result, NaN, "result is not NaN");
+
+assert.sameValue(result, dt.getTime(), "result is equal to getTime");
+
+assert.sameValue(dt.getYear(), 1, "date value correctly updated");
+
+assert.sameValue(dt.getHours(), 1, "hours value still intact");
+assert.sameValue(dt.getMinutes(), 2, "minutes value correctly updated");
+assert.sameValue(dt.getSeconds(), 3, "seconds value correctly updated");
+assert.sameValue(dt.getMilliseconds(), 4, "milliseconds value correctly updated");

--- a/test/built-ins/Date/prototype/setFullYear/date-value-read-before-tonumber-time-part-correct-when-set-to-invalid.js
+++ b/test/built-ins/Date/prototype/setFullYear/date-value-read-before-tonumber-time-part-correct-when-set-to-invalid.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.setfullyear
+description: >
+  Read [[DateValue]] and in ToNumber modify date-time to an invalid value
+info: |
+  Date.prototype.setFullYear ( year [ , month [ , date ] ] )
+
+  ...
+  3. Let t be dateObject.[[DateValue]].
+  4. Let y be ? ToNumber(year).
+  5. If t is NaN, set t to +0𝔽; otherwise, set t to LocalTime(t).
+  ...
+---*/
+
+var dt = new Date(0);
+dt.setHours(1, 2, 3, 4);
+
+var valueOfCalled = 0;
+
+var value = {
+  valueOf() {
+    valueOfCalled++;
+
+    // This call should get ignored.
+    dt.setTime(NaN);
+
+    return 1;
+  }
+};
+
+var result = dt.setFullYear(value);
+
+assert.sameValue(valueOfCalled, 1, "valueOf called exactly once");
+
+assert.notSameValue(result, NaN, "result is not NaN");
+
+assert.sameValue(result, dt.getTime(), "result is equal to getTime");
+
+assert.sameValue(dt.getFullYear(), 1, "date value correctly updated");
+
+assert.sameValue(dt.getHours(), 1, "hours value still intact");
+assert.sameValue(dt.getMinutes(), 2, "minutes value correctly updated");
+assert.sameValue(dt.getSeconds(), 3, "seconds value correctly updated");
+assert.sameValue(dt.getMilliseconds(), 4, "milliseconds value correctly updated");

--- a/test/built-ins/Date/prototype/setFullYear/date-value-read-before-tonumber-time-part-correct-when-set-to-valid.js
+++ b/test/built-ins/Date/prototype/setFullYear/date-value-read-before-tonumber-time-part-correct-when-set-to-valid.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.setfullyear
+description: >
+  Read [[DateValue]] and in ToNumber modify date-time to a valid value
+info: |
+  Date.prototype.setFullYear ( year [ , month [ , date ] ] )
+
+  ...
+  3. Let t be dateObject.[[DateValue]].
+  4. Let y be ? ToNumber(year).
+  5. If t is NaN, set t to +0𝔽; otherwise, set t to LocalTime(t).
+  ...
+---*/
+
+var dt = new Date(0);
+dt.setHours(1, 2, 3, 4);
+
+var valueOfCalled = 0;
+
+var value = {
+  valueOf() {
+    valueOfCalled++;
+
+    // This call should get ignored.
+    dt.setTime(36 * 60 * 60 * 1000);
+
+    return 1;
+  }
+};
+
+var result = dt.setFullYear(value);
+
+assert.sameValue(valueOfCalled, 1, "valueOf called exactly once");
+
+assert.notSameValue(result, NaN, "result is not NaN");
+
+assert.sameValue(result, dt.getTime(), "result is equal to getTime");
+
+assert.sameValue(dt.getFullYear(), 1, "date value correctly updated");
+
+assert.sameValue(dt.getHours(), 1, "hours value still intact");
+assert.sameValue(dt.getMinutes(), 2, "minutes value correctly updated");
+assert.sameValue(dt.getSeconds(), 3, "seconds value correctly updated");
+assert.sameValue(dt.getMilliseconds(), 4, "milliseconds value correctly updated");

--- a/test/built-ins/Date/prototype/setUTCFullYear/date-value-read-before-tonumber-time-part-correct-when-set-to-invalid.js
+++ b/test/built-ins/Date/prototype/setUTCFullYear/date-value-read-before-tonumber-time-part-correct-when-set-to-invalid.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.setutcfullyear
+description: >
+  Read [[DateValue]] and in ToNumber modify date-time to an invalid value
+info: |
+  Date.prototype.setUTCFullYear ( year [ , month [ , date ] ] )
+
+  ...
+  3. Let t be dateObject.[[DateValue]].
+  4. If t is NaN, set t to +0𝔽.
+  5. Let y be ? ToNumber(year).
+  ...
+---*/
+
+var dt = new Date(0);
+dt.setUTCHours(1, 2, 3, 4);
+
+var valueOfCalled = 0;
+
+var value = {
+  valueOf() {
+    valueOfCalled++;
+
+    // This call should get ignored.
+    dt.setTime(NaN);
+
+    return 1;
+  }
+};
+
+var result = dt.setUTCFullYear(value);
+
+assert.sameValue(valueOfCalled, 1, "valueOf called exactly once");
+
+assert.notSameValue(result, NaN, "result is not NaN");
+
+assert.sameValue(result, dt.getTime(), "result is equal to getTime");
+
+assert.sameValue(dt.getUTCFullYear(), 1, "date value correctly updated");
+
+assert.sameValue(dt.getUTCHours(), 1, "hours value still intact");
+assert.sameValue(dt.getUTCMinutes(), 2, "minutes value correctly updated");
+assert.sameValue(dt.getUTCSeconds(), 3, "seconds value correctly updated");
+assert.sameValue(dt.getUTCMilliseconds(), 4, "milliseconds value correctly updated");

--- a/test/built-ins/Date/prototype/setUTCFullYear/date-value-read-before-tonumber-time-part-correct-when-set-to-valid.js
+++ b/test/built-ins/Date/prototype/setUTCFullYear/date-value-read-before-tonumber-time-part-correct-when-set-to-valid.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.setutcfullyear
+description: >
+  Read [[DateValue]] and in ToNumber modify date-time to a valid value
+info: |
+  Date.prototype.setUTCFullYear ( year [ , month [ , date ] ] )
+
+  ...
+  3. Let t be dateObject.[[DateValue]].
+  4. If t is NaN, set t to +0𝔽.
+  5. Let y be ? ToNumber(year).
+  ...
+---*/
+
+var dt = new Date(0);
+dt.setUTCHours(1, 2, 3, 4);
+
+var valueOfCalled = 0;
+
+var value = {
+  valueOf() {
+    valueOfCalled++;
+
+    // This call should get ignored.
+    dt.setTime(36 * 60 * 60 * 1000);
+
+    return 1;
+  }
+};
+
+var result = dt.setUTCFullYear(value);
+
+assert.sameValue(valueOfCalled, 1, "valueOf called exactly once");
+
+assert.notSameValue(result, NaN, "result is not NaN");
+
+assert.sameValue(result, dt.getTime(), "result is equal to getTime");
+
+assert.sameValue(dt.getUTCFullYear(), 1, "date value correctly updated");
+
+assert.sameValue(dt.getUTCHours(), 1, "hours value still intact");
+assert.sameValue(dt.getUTCMinutes(), 2, "minutes value correctly updated");
+assert.sameValue(dt.getUTCSeconds(), 3, "seconds value correctly updated");
+assert.sameValue(dt.getUTCMilliseconds(), 4, "milliseconds value correctly updated");


### PR DESCRIPTION
The tests pass in JSC and SM, but fail in V8. 