### PR TITLE
Case for uvalue subtags is canonicalized

### DIFF
--- a/test/intl402/Locale/prototype/calendar/canonicalize-case.js
+++ b/test/intl402/Locale/prototype/calendar/canonicalize-case.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-makelocalerecord
+description: >
+  MakeLocaleRecord calls CanonicalizeUValue for option values
+info: |
+  MakeLocaleRecord ( tag, options, localeExtensionKeys )
+
+  ...
+  4. For each element key of localeExtensionKeys, do
+    ...
+    d. Let overrideValue be options.[[<key>]].
+    e. If overrideValue is not undefined, then
+      i. Set value to CanonicalizeUValue(key, overrideValue).
+      ii.If entry is not empty, then
+        1. Set entry.[[Value]] to value.
+      iii. Else,
+        1. Append the Record { [[Key]]: key, [[Value]]: value } to keywords.
+    f. Set result.[[<key>]] to value.
+  ...
+features: [Intl.Locale]
+---*/
+
+const locales = [
+  // Unicode extension "ca" not present in locale id.
+  "de",
+
+  // Unicode extension "ca" is present in locale id.
+  "de-u-ca-iso8601",
+];
+
+const calendars = [
+  // Known and valid value for Unicode extension "ca".
+  "gregory",
+
+  // Unknown and invalid value for Unicode extension "ca".
+  "unknown",
+];
+
+for (let locale of locales) {
+  for (let calendar of calendars) {
+    let uppercase = calendar.toUpperCase();
+    let loc = new Intl.Locale(locale, {calendar: uppercase});
+
+    assert.sameValue(
+      loc.calendar,
+      calendar,
+      `new Intl.Locale("${locale}", {calendar: "${uppercase}"}).calendar`
+    );
+  }
+}

--- a/test/intl402/Locale/prototype/collation/canonicalize-case.js
+++ b/test/intl402/Locale/prototype/collation/canonicalize-case.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-makelocalerecord
+description: >
+  MakeLocaleRecord calls CanonicalizeUValue for option values
+info: |
+  MakeLocaleRecord ( tag, options, localeExtensionKeys )
+
+  ...
+  4. For each element key of localeExtensionKeys, do
+    ...
+    d. Let overrideValue be options.[[<key>]].
+    e. If overrideValue is not undefined, then
+      i. Set value to CanonicalizeUValue(key, overrideValue).
+      ii.If entry is not empty, then
+        1. Set entry.[[Value]] to value.
+      iii. Else,
+        1. Append the Record { [[Key]]: key, [[Value]]: value } to keywords.
+    f. Set result.[[<key>]] to value.
+  ...
+features: [Intl.Locale]
+---*/
+
+const locales = [
+  // Unicode extension "co" not present in locale id.
+  "de",
+
+  // Unicode extension "co" is present in locale id.
+  "de-u-co-emoji",
+];
+
+const collations = [
+  // Known and valid value for Unicode extension "co".
+  "phonebk",
+
+  // Unknown and invalid value for Unicode extension "co".
+  "unknown",
+];
+
+for (let locale of locales) {
+  for (let collation of collations) {
+    let uppercase = collation.toUpperCase();
+    let loc = new Intl.Locale(locale, {collation: uppercase});
+
+    assert.sameValue(
+      loc.collation,
+      collation,
+      `new Intl.Locale("${locale}", {collation: "${uppercase}"}).collation`
+    );
+  }
+}

--- a/test/intl402/Locale/prototype/numberingSystem/canonicalize-case.js
+++ b/test/intl402/Locale/prototype/numberingSystem/canonicalize-case.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-makelocalerecord
+description: >
+  MakeLocaleRecord calls CanonicalizeUValue for option values
+info: |
+  MakeLocaleRecord ( tag, options, localeExtensionKeys )
+
+  ...
+  4. For each element key of localeExtensionKeys, do
+    ...
+    d. Let overrideValue be options.[[<key>]].
+    e. If overrideValue is not undefined, then
+      i. Set value to CanonicalizeUValue(key, overrideValue).
+      ii.If entry is not empty, then
+        1. Set entry.[[Value]] to value.
+      iii. Else,
+        1. Append the Record { [[Key]]: key, [[Value]]: value } to keywords.
+    f. Set result.[[<key>]] to value.
+  ...
+features: [Intl.Locale]
+---*/
+
+const locales = [
+  // Unicode extension "nu" not present in locale id.
+  "de",
+
+  // Unicode extension "nu" is present in locale id.
+  "de-u-nu-thai",
+];
+
+const numberingSystems = [
+  // Known and valid value for Unicode extension "nu".
+  "latn",
+
+  // Unknown and invalid value for Unicode extension "nu".
+  "unknown",
+];
+
+for (let locale of locales) {
+  for (let numberingSystem of numberingSystems) {
+    let uppercase = numberingSystem.toUpperCase();
+    let loc = new Intl.Locale(locale, {numberingSystem: uppercase});
+
+    assert.sameValue(
+      loc.numberingSystem,
+      numberingSystem,
+      `new Intl.Locale("${locale}", {numberingSystem: "${uppercase}"}).numberingSystem`
+    );
+  }
+}


### PR DESCRIPTION
Test failures in JSC and V8 are because of ICU4C bugs. 