### PR TITLE
Add coverage for uvalue "true" and "yes"

### DIFF
--- a/test/intl402/Locale/constructor-unicode-extension-uvalue-true.js
+++ b/test/intl402/Locale/constructor-unicode-extension-uvalue-true.js
@@ -1,0 +1,36 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale
+description: >
+  Remove any uvalue (aka type) equal to "true".
+info: |
+  Intl.Locale ( tag [ , options ] )
+    ...
+    13. Set tag to CanonicalizeUnicodeLocaleId(tag).
+    ...
+    35. Let r be MakeLocaleRecord(tag, opt, localeExtensionKeys).
+    ...
+features: [Intl.Locale]
+---*/
+
+// Generate all possible `ukey` values.
+function* ukeys() {
+  const lowerA = 'a'.charCodeAt(0);
+  const lowerZ = 'z'.charCodeAt(0);
+
+  for (let first = lowerA; first <= lowerZ; ++first) {
+    for (let second = lowerA; second <= lowerZ; ++second) {
+      yield String.fromCharCode(first, second);
+    }
+  }
+}
+
+for (let ukey of ukeys()) {
+  assert.sameValue(
+    new Intl.Locale(`en-u-${ukey}-true`).toString(),
+    `en-u-${ukey}`,
+    `new Intl.Locale("en-u-${ukey}-true").toString() returns "en-u-${ukey}"`
+  );
+}

--- a/test/intl402/Locale/constructor-unicode-extension-uvalue-yes.js
+++ b/test/intl402/Locale/constructor-unicode-extension-uvalue-yes.js
@@ -1,0 +1,62 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale
+description: >
+  Remove any uvalue (aka type) equal to "true".
+info: |
+  Intl.Locale ( tag [ , options ] )
+    ...
+    13. Set tag to CanonicalizeUnicodeLocaleId(tag).
+    ...
+    35. Let r be MakeLocaleRecord(tag, opt, localeExtensionKeys).
+    ...
+features: [Intl.Locale]
+---*/
+
+// Generate all possible `ukey` values.
+function* ukeys() {
+  const lowerA = 'a'.charCodeAt(0);
+  const lowerZ = 'z'.charCodeAt(0);
+
+  for (let first = lowerA; first <= lowerZ; ++first) {
+    for (let second = lowerA; second <= lowerZ; ++second) {
+      yield String.fromCharCode(first, second);
+    }
+  }
+}
+
+function canonicalizeUValue(ukey, uvalue) {
+  assert.sameValue(uvalue, "yes", "unexpected uvalue");
+
+  switch (ukey) {
+    case "kb":
+    case "kc":
+    case "kh":
+    case "kk":
+    case "kn":
+      // Canonicalized to "true", which then gets removed.
+      return "";
+    default:
+      return uvalue;
+  }
+}
+
+for (let ukey of ukeys()) {
+  let canonicalized = new Intl.Locale(`en-u-${ukey}-yes`).toString();
+
+  if (canonicalizeUValue(ukey, "yes") === "yes") {
+    assert.sameValue(
+      canonicalized,
+      `en-u-${ukey}-yes`,
+      `new Intl.Locale("en-u-${ukey}-yes").toString() returns "en-u-${ukey}-yes"`
+    );
+  } else {
+    assert.sameValue(
+      canonicalized,
+      `en-u-${ukey}`,
+      `new Intl.Locale("en-u-${ukey}-yes").toString() returns "en-u-${ukey}"`
+    );
+  }
+}


### PR DESCRIPTION
Ensure `yes` is only canonicalized to `true` for some ukeys.