### PR TITLE
Add ResolveExport tests for star exports with cyclic indirect re-exports

### DIFF
--- a/test/language/module-code/instn-star-iee-multi-cycle-same-name-a_FIXTURE.js
+++ b/test/language/module-code/instn-star-iee-multi-cycle-same-name-a_FIXTURE.js
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export * from './instn-star-iee-multi-cycle-same-name-b_FIXTURE.js';
+export * from './instn-star-iee-multi-cycle-same-name-c_FIXTURE.js';
+export * from './instn-star-iee-multi-cycle-same-name-d_FIXTURE.js';

--- a/test/language/module-code/instn-star-iee-multi-cycle-same-name-b_FIXTURE.js
+++ b/test/language/module-code/instn-star-iee-multi-cycle-same-name-b_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export { foo } from './instn-star-iee-multi-cycle-same-name-a_FIXTURE.js';

--- a/test/language/module-code/instn-star-iee-multi-cycle-same-name-c_FIXTURE.js
+++ b/test/language/module-code/instn-star-iee-multi-cycle-same-name-c_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export let foo = 1;

--- a/test/language/module-code/instn-star-iee-multi-cycle-same-name-d_FIXTURE.js
+++ b/test/language/module-code/instn-star-iee-multi-cycle-same-name-d_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export { foo } from './instn-star-iee-multi-cycle-same-name-a_FIXTURE.js';

--- a/test/language/module-code/instn-star-iee-multi-cycle-same-name.js
+++ b/test/language/module-code/instn-star-iee-multi-cycle-same-name.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    Star export resolution skips multiple cyclic indirect named re-exports
+    and resolves the binding from a non-cyclic path.
+esid: sec-resolveexport
+info: |
+    ResolveExport ( exportName [ , resolveSet ] )
+
+    [...]
+    1. For each Record { [[Module]], [[ExportName]] } r of resolveSet, do
+      a. If module and r.[[Module]] are the same Module Record and exportName is r.[[ExportName]], then
+        i. Assert: This is a circular import request.
+        i. Return null.
+    1. Append the Record { [[Module]]: module, [[ExportName]]: exportName }
+       to resolveSet.
+    [...]
+    1. For each ExportEntry Record e of module.[[IndirectExportEntries]], do
+      a. If exportName is e.[[ExportName]], then
+        [...]
+        1. Return importedModule.ResolveExport(e.[[ImportName]],
+           resolveSet).
+    [...]
+    1. Let starResolution be null.
+    1. For each ExportEntry Record e of module.[[StarExportEntries]], do
+      a. Let importedModule be GetImportedModule(module,
+         e.[[ModuleRequest]]).
+      a. Let resolution be importedModule.ResolveExport(exportName,
+         resolveSet).
+      a. If resolution is AMBIGUOUS, return AMBIGUOUS.
+      a. If resolution is not null, then
+         i. If starResolution is null, let starResolution be resolution.
+         [...]
+    1. Return starResolution.
+
+    Module "a" has three star exports:
+    - "b" has `export { foo } from "a"` (cycles back, returns null).
+    - "c" has `export let foo = 1` (provides the binding).
+    - "d" has `export { foo } from "a"` (cycles back, returns null).
+    The two cyclic paths return null (cycle detection), the star loop
+    skips them, and the binding from "c" is used.
+flags: [module]
+---*/
+
+import { foo } from './instn-star-iee-multi-cycle-same-name-a_FIXTURE.js';
+
+assert.sameValue(foo, 1);

--- a/test/language/module-code/instn-star-iee-single-cycle-same-name-a_FIXTURE.js
+++ b/test/language/module-code/instn-star-iee-single-cycle-same-name-a_FIXTURE.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export * from './instn-star-iee-single-cycle-same-name-b_FIXTURE.js';
+export * from './instn-star-iee-single-cycle-same-name-c_FIXTURE.js';

--- a/test/language/module-code/instn-star-iee-single-cycle-same-name-b_FIXTURE.js
+++ b/test/language/module-code/instn-star-iee-single-cycle-same-name-b_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export { foo } from './instn-star-iee-single-cycle-same-name-a_FIXTURE.js';

--- a/test/language/module-code/instn-star-iee-single-cycle-same-name-c_FIXTURE.js
+++ b/test/language/module-code/instn-star-iee-single-cycle-same-name-c_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export let foo = 42;

--- a/test/language/module-code/instn-star-iee-single-cycle-same-name.js
+++ b/test/language/module-code/instn-star-iee-single-cycle-same-name.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    Star export resolution skips a single cyclic indirect named re-export
+    and resolves the binding from the remaining non-cyclic path.
+esid: sec-resolveexport
+info: |
+    ResolveExport ( exportName [ , resolveSet ] )
+
+    [...]
+    1. For each Record { [[Module]], [[ExportName]] } r of resolveSet, do
+      a. If module and r.[[Module]] are the same Module Record and exportName is r.[[ExportName]], then
+        i. Assert: This is a circular import request.
+        i. Return null.
+    1. Append the Record { [[Module]]: module, [[ExportName]]: exportName }
+       to resolveSet.
+    [...]
+    1. For each ExportEntry Record e of module.[[IndirectExportEntries]], do
+      a. If exportName is e.[[ExportName]], then
+        [...]
+        1. Return importedModule.ResolveExport(e.[[ImportName]],
+           resolveSet).
+    [...]
+    1. Let starResolution be null.
+    1. For each ExportEntry Record e of module.[[StarExportEntries]], do
+      a. Let importedModule be GetImportedModule(module,
+         e.[[ModuleRequest]]).
+      a. Let resolution be importedModule.ResolveExport(exportName,
+         resolveSet).
+      a. If resolution is AMBIGUOUS, return AMBIGUOUS.
+      a. If resolution is not null, then
+         i. If starResolution is null, let starResolution be resolution.
+         [...]
+    1. Return starResolution.
+
+    Module "a" has two star exports:
+    - One to "b", which has `export { foo } from "a"` (cycles back).
+    - One to "c", which has `export let foo = 42` (provides the binding).
+    The cyclic path returns null (cycle detection), the star loop skips it,
+    and the binding from "c" is used.
+flags: [module]
+---*/
+
+import { foo } from './instn-star-iee-single-cycle-same-name-a_FIXTURE.js';
+
+assert.sameValue(foo, 42);


### PR DESCRIPTION
Star export resolution must skip cyclic paths that go through indirect named re-exports (export { foo } from "mod") and continue resolving through other star export entries. This adds two tests covering the case where the same export name cycles back via indirect re-exports while another star-export path provides the actual binding.

This test comes from a bug report from @nicolo-ribaudo on https://issues.chromium.org/u/0/issues/500767600