### PR TITLE
Remove substr in Temporal tests

### DIFF
--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
@@ -43,20 +43,20 @@ assert.throws(RangeError, () => instance.toString({ timeZone }), "bare date-time
 
 timeZone = "2021-08-19T17:30Z";
 const result1 = instance.toString({ timeZone });
-assert.sameValue(result1.substr(-6), "+00:00", "date-time + Z is UTC time zone");
+assert.sameValue(result1.slice(-6), "+00:00", "date-time + Z is UTC time zone");
 
 timeZone = "2021-08-19T17:30-07:00";
 const result2 = instance.toString({ timeZone });
-assert.sameValue(result2.substr(-6), "-07:00", "date-time + offset is the offset time zone");
+assert.sameValue(result2.slice(-6), "-07:00", "date-time + offset is the offset time zone");
 
 timeZone = "2021-08-19T17:30[UTC]";
 const result3 = instance.toString({ timeZone });
-assert.sameValue(result3.substr(-6), "+00:00", "date-time + IANA annotation is the offset time zone");
+assert.sameValue(result3.slice(-6), "+00:00", "date-time + IANA annotation is the offset time zone");
 
 timeZone = "2021-08-19T17:30Z[UTC]";
 const result4 = instance.toString({ timeZone });
-assert.sameValue(result4.substr(-6), "+00:00", "date-time + Z + IANA annotation is the offset time zone");
+assert.sameValue(result4.slice(-6), "+00:00", "date-time + Z + IANA annotation is the offset time zone");
 
 timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result5 = instance.toString({ timeZone });
-assert.sameValue(result5.substr(-6), "+00:00", "date-time + offset + IANA annotation is the offset time zone");
+assert.sameValue(result5.slice(-6), "+00:00", "date-time + offset + IANA annotation is the offset time zone");

--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-leap-second.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-leap-second.js
@@ -11,7 +11,7 @@ const instance = new Temporal.Instant(0n);
 let timeZone = "2016-12-31T23:59:60+00:00[UTC]";
 
 const result = instance.toString({ timeZone });
-assert.sameValue(result.substr(-6), "+00:00", "leap second is a valid ISO string for TimeZone");
+assert.sameValue(result.slice(-6), "+00:00", "leap second is a valid ISO string for TimeZone");
 
 timeZone = "2021-08-19T17:30:45.123456789+23:59[+23:59:60]";
 assert.throws(RangeError, () => instance.toString({ timeZone }), "leap second in time zone name not valid");

--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-multiple-offsets.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-multiple-offsets.js
@@ -11,4 +11,4 @@ const instance = new Temporal.Instant(0n);
 const timeZone = "2021-08-19T17:30:45.123456789-12:12[+01:46]";
 
 const result = instance.toString({ timeZone });
-assert.sameValue(result.substr(-6), "+01:46", "Time zone string determined from bracket name");
+assert.sameValue(result.slice(-6), "+01:46", "Time zone string determined from bracket name");

--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-string.js
@@ -10,7 +10,7 @@ features: [Temporal]
 const instance = new Temporal.Instant(0n);
 
 const result1 = instance.toString({ timeZone: "UTC" });
-assert.sameValue(result1.substr(-6), "+00:00", "Time zone created from string 'UTC'");
+assert.sameValue(result1.slice(-6), "+00:00", "Time zone created from string 'UTC'");
 
 const result2 = instance.toString({ timeZone: "-01:30" });
-assert.sameValue(result2.substr(-6), "-01:30", "Time zone created from string '-01:30'");
+assert.sameValue(result2.slice(-6), "-01:30", "Time zone created from string '-01:30'");


### PR DESCRIPTION
Currently, engine262 does not implement Annex B; therefore, those tests failed, but they pass after replacing substr with slice.