### PR TITLE
Use $DETACHBUFFER helper in test/staging/sm/

### DIFF
--- a/test/staging/sm/Atomics/detached-buffers.js
+++ b/test/staging/sm/Atomics/detached-buffers.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -19,7 +20,7 @@ const intArrayConstructors = [
 function badValue(ta) {
   return {
     valueOf() {
-      $262.detachArrayBuffer(ta.buffer);
+      $DETACHBUFFER(ta.buffer);
       return 0;
     }
   };

--- a/test/staging/sm/DataView/detach-after-construction.js
+++ b/test/staging/sm/DataView/detach-after-construction.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -10,6 +11,6 @@ esid: pending
 var buf = new ArrayBuffer([1,2]);
 var bufView = new DataView(buf);
 
-$262.detachArrayBuffer(buf);
+$DETACHBUFFER(buf);
 
 assert.throws(TypeError, () => bufView.getInt8(0));

--- a/test/staging/sm/DataView/get-set-index-range.js
+++ b/test/staging/sm/DataView/get-set-index-range.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -31,7 +32,7 @@ for (let fun of ['getInt8', 'getInt16']) {
 
 // ToIndex is called before detachment check, so we can tell the difference
 // between a ToIndex failure and a real out of bounds failure.
-$262.detachArrayBuffer(buffer);
+$DETACHBUFFER(buffer);
 
 check(view);
 

--- a/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+++ b/test/staging/sm/TypedArray/constructor-buffer-sequence.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -15,7 +16,7 @@ const otherGlobal = $262.createRealm().global;
 function* createBuffers(lengths = [0, 8]) {
     for (let length of lengths) {
         let buffer = new ArrayBuffer(length);
-        yield {buffer, detach: () => $262.detachArrayBuffer(buffer)};
+        yield {buffer, detach: () => $DETACHBUFFER(buffer)};
     }
 
     for (let length of lengths) {

--- a/test/staging/sm/TypedArray/constructor-non-detached.js
+++ b/test/staging/sm/TypedArray/constructor-non-detached.js
@@ -2,18 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-includes: [sm/non262-TypedArray-shell.js]
+includes: [sm/non262-TypedArray-shell.js, detachArrayBuffer.js]
 description: |
   pending
 esid: pending
 ---*/
 for (var constructor of typedArrayConstructors) {
     var buf = new constructor();
-    $262.detachArrayBuffer(buf.buffer);
+    $DETACHBUFFER(buf.buffer);
     assert.throws(TypeError, () => new constructor(buf));
 
     var buffer = new ArrayBuffer();
-    $262.detachArrayBuffer(buffer);
+    $DETACHBUFFER(buffer);
     assert.throws(TypeError, () => new constructor(buffer));
 }
 

--- a/test/staging/sm/TypedArray/detached-array-buffer-checks.js
+++ b/test/staging/sm/TypedArray/detached-array-buffer-checks.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -11,7 +12,7 @@ esid: pending
 // all relevant functions.
 let buffer = new ArrayBuffer(32);
 let array  = new Int32Array(buffer);
-$262.detachArrayBuffer(buffer);
+$DETACHBUFFER(buffer);
 
 // A nice poisoned callable to ensure that we fail on a detached buffer check
 // before a method attempts to do anything with its arguments.

--- a/test/staging/sm/TypedArray/fill-detached.js
+++ b/test/staging/sm/TypedArray/fill-detached.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -11,7 +12,7 @@ esid: pending
 function DetachArrayBufferValue(buffer, value) {
     return {
         valueOf() {
-            $262.detachArrayBuffer(buffer);
+            $DETACHBUFFER(buffer);
             return value;
         }
     };
@@ -20,7 +21,7 @@ function DetachArrayBufferValue(buffer, value) {
 function DetachTypedArrayValue(ta, value) {
     return {
         valueOf() {
-            $262.detachArrayBuffer(ta.buffer);
+            $DETACHBUFFER(ta.buffer);
             return value;
         }
     };

--- a/test/staging/sm/TypedArray/from_typedarray_fastpath_detached.js
+++ b/test/staging/sm/TypedArray/from_typedarray_fastpath_detached.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -10,7 +11,7 @@ esid: pending
 // checks for detached buffers.
 
 var ta = new Int32Array(4);
-$262.detachArrayBuffer(ta.buffer);
+$DETACHBUFFER(ta.buffer);
 
 assert.throws(TypeError, () => Int32Array.from(ta));
 

--- a/test/staging/sm/TypedArray/set-detached-bigint.js
+++ b/test/staging/sm/TypedArray/set-detached-bigint.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -10,7 +11,7 @@ let ta = new BigInt64Array(10);
 
 let obj = {
   get length() {
-    $262.detachArrayBuffer(ta.buffer);
+    $DETACHBUFFER(ta.buffer);
     return 1;
   },
   0: {

--- a/test/staging/sm/TypedArray/set-detached.js
+++ b/test/staging/sm/TypedArray/set-detached.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -22,7 +23,7 @@ class ExpectedError extends Error {}
 
 // No detached check on function entry.
 for (let {typedArray, buffer} of createTypedArrays()) {
-    $262.detachArrayBuffer(buffer);
+    $DETACHBUFFER(buffer);
 
     assert.throws(ExpectedError, () => typedArray.set(null, {
         valueOf() {
@@ -40,7 +41,7 @@ for (let [offset, error] of [[0, TypeError], [1000000, TypeError], [-1, RangeErr
         for (let {typedArray, buffer} of createTypedArrays()) {
             assert.throws(error, () => typedArray.set(source, {
                 valueOf() {
-                    $262.detachArrayBuffer(buffer);
+                    $DETACHBUFFER(buffer);
                     return offset;
                 }
             }));
@@ -51,7 +52,7 @@ for (let [offset, error] of [[0, TypeError], [1000000, TypeError], [-1, RangeErr
 // Tests when called with detached typed array as source.
 for (let {typedArray} of createTypedArrays()) {
     for (let {typedArray: source, buffer: sourceBuffer} of createTypedArrays()) {
-        $262.detachArrayBuffer(sourceBuffer);
+        $DETACHBUFFER(sourceBuffer);
 
         assert.throws(ExpectedError, () => typedArray.set(source, {
             valueOf() {
@@ -70,7 +71,7 @@ for (let [offset, error] of [[0, TypeError], [1000000, TypeError], [-1, RangeErr
         for (let {typedArray: source, buffer: sourceBuffer} of createTypedArrays()) {
             assert.throws(error, () => typedArray.set(source, {
                 valueOf() {
-                    $262.detachArrayBuffer(sourceBuffer);
+                    $DETACHBUFFER(sourceBuffer);
                     return offset;
                 }
             }));
@@ -88,7 +89,7 @@ for (let src of [ta => ta, ta => new Int32Array(ta.buffer), ta => new Float32Arr
         let source = src(typedArray);
         assert.throws(TypeError, () => typedArray.set(source, {
             valueOf() {
-                $262.detachArrayBuffer(buffer);
+                $DETACHBUFFER(buffer);
                 return 0;
             }
         }));
@@ -102,7 +103,7 @@ for (let offset of [() => 0, ta => Math.min(1, ta.length), ta => Math.max(0, ta.
     for (let {typedArray, buffer} of createTypedArrays()) {
         let source = {
             get length() {
-                $262.detachArrayBuffer(buffer);
+                $DETACHBUFFER(buffer);
                 return 0;
             }
         };
@@ -118,7 +119,7 @@ for (let offset of [() => 0, ta => Math.min(1, ta.length), ta => Math.max(0, ta.
         let source = {
             length: {
                 valueOf() {
-                    $262.detachArrayBuffer(buffer);
+                    $DETACHBUFFER(buffer);
                     return 0;
                 }
             }
@@ -133,7 +134,7 @@ for (let {typedArray, buffer} of createTypedArrays()) {
     let source = {
         length: {
             valueOf() {
-                $262.detachArrayBuffer(buffer);
+                $DETACHBUFFER(buffer);
                 return 1;
             }
         }
@@ -153,7 +154,7 @@ for (let {typedArray, buffer} of createTypedArrays()) {
         },
         length: {
             valueOf() {
-                $262.detachArrayBuffer(buffer);
+                $DETACHBUFFER(buffer);
                 return 1;
             }
         }
@@ -174,7 +175,7 @@ for (let {typedArray, buffer} of createTypedArrays()) {
         },
         length: {
             valueOf() {
-                $262.detachArrayBuffer(buffer);
+                $DETACHBUFFER(buffer);
                 return 1;
             }
         }
@@ -188,7 +189,7 @@ for (let {typedArray, buffer} of createTypedArrays()) {
     let source = Object.defineProperties([], {
         0: {
             get() {
-                $262.detachArrayBuffer(buffer);
+                $DETACHBUFFER(buffer);
                 return 1;
             }
         }
@@ -207,7 +208,7 @@ for (let {typedArray, buffer} of createTypedArrays()) {
     let source = Object.defineProperties([], {
         0: {
             get() {
-                $262.detachArrayBuffer(buffer);
+                $DETACHBUFFER(buffer);
                 return 1;
             }
         },
@@ -232,7 +233,7 @@ for (let {typedArray, buffer} of createTypedArrays()) {
 for (let {typedArray, buffer} of createTypedArrays()) {
     let source = [{
         valueOf() {
-            $262.detachArrayBuffer(buffer);
+            $DETACHBUFFER(buffer);
             return 1;
         }
     }];
@@ -249,7 +250,7 @@ for (let {typedArray, buffer} of createTypedArrays()) {
     let accessed = false;
     let source = [{
         valueOf() {
-            $262.detachArrayBuffer(buffer);
+            $DETACHBUFFER(buffer);
             return 1;
         }
     }, {

--- a/test/staging/sm/TypedArray/set-with-receiver.js
+++ b/test/staging/sm/TypedArray/set-with-receiver.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-includes: [sm/non262-TypedArray-shell.js]
+includes: [sm/non262-TypedArray-shell.js, detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -23,7 +23,7 @@ for (var constructor of anyTypedArrayConstructors) {
 
     // Detached
     if (!isSharedConstructor(constructor)) {
-        $262.detachArrayBuffer(ta.buffer)
+        $DETACHBUFFER(ta.buffer)
 
         assert.sameValue(ta[0], undefined);
         assert.sameValue(Reflect.set(ta, 0, 42, receiver), true);

--- a/test/staging/sm/TypedArray/slice-detached.js
+++ b/test/staging/sm/TypedArray/slice-detached.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -28,7 +29,7 @@ function* createTypedArrays(lengths = [0, 1, 4, 4096]) {
 
 // ArrayBuffer is detached when entering slice().
 for (let {typedArray, buffer} of createTypedArrays()) {
-    $262.detachArrayBuffer(buffer());
+    $DETACHBUFFER(buffer());
     assert.throws(TypeError, () => {
         typedArray.slice(0);
     }, "ArrayBuffer is detached on function entry");
@@ -40,7 +41,7 @@ for (let {typedArray, length, buffer} of createTypedArrays()) {
     let start = {
         valueOf() {
             assert.sameValue(detached, false);
-            $262.detachArrayBuffer(buffer());
+            $DETACHBUFFER(buffer());
             assert.sameValue(detached, false);
             detached = true;
             return 0;
@@ -64,7 +65,7 @@ for (let {typedArray, length, buffer} of createTypedArrays()) {
     let end = {
         valueOf() {
             assert.sameValue(detached, false);
-            $262.detachArrayBuffer(buffer());
+            $DETACHBUFFER(buffer());
             assert.sameValue(detached, false);
             detached = true;
             return length;
@@ -88,7 +89,7 @@ for (let {typedArray, length, buffer} of createTypedArrays()) {
     typedArray.constructor = {
         [Symbol.species]: function(...args) {
             assert.sameValue(detached, false);
-            $262.detachArrayBuffer(buffer());
+            $DETACHBUFFER(buffer());
             assert.sameValue(detached, false);
             detached = true;
             return new Int32Array(...args);

--- a/test/staging/sm/TypedArray/sort_errors.js
+++ b/test/staging/sm/TypedArray/sort_errors.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -11,7 +12,7 @@ esid: pending
 assert.throws(TypeError, () => {
     let buffer = new ArrayBuffer(32);
     let array  = new Int32Array(buffer);
-    $262.detachArrayBuffer(buffer);
+    $DETACHBUFFER(buffer);
     array.sort();
 });
 
@@ -22,7 +23,7 @@ assert.throws(TypeError, () => {
     ta.sort(function(a, b) {
         if (!detached) {
             detached = true;
-            $262.detachArrayBuffer(ta.buffer);
+            $DETACHBUFFER(ta.buffer);
         }
         return a - b;
     });
@@ -46,7 +47,7 @@ let otherGlobal = $262.createRealm().global;
     otherGlobal.Int32Array.prototype.sort.call(ta, function(a,b) {
         if (!detached) {
             detached = true;
-            $262.detachArrayBuffer(ta.buffer);
+            $DETACHBUFFER(ta.buffer);
         }
         return a - b;
     });

--- a/test/staging/sm/TypedArray/subarray.js
+++ b/test/staging/sm/TypedArray/subarray.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-includes: [sm/non262-TypedArray-shell.js]
+includes: [sm/non262-TypedArray-shell.js, detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -23,7 +23,7 @@ for (let constructor of typedArrayConstructors) {
 
     let beginIndex = {
         valueOf() {
-            $262.detachArrayBuffer(buffer);
+            $DETACHBUFFER(buffer);
             return 0;
         }
     };

--- a/test/staging/sm/TypedArray/test-integrity-level-detached.js
+++ b/test/staging/sm/TypedArray/test-integrity-level-detached.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -13,7 +14,7 @@ const NON_INLINE_STORAGE = 1024;
 class DetachedInt32Array extends Int32Array {
     constructor(...args) {
         super(...args);
-        $262.detachArrayBuffer(this.buffer);
+        $DETACHBUFFER(this.buffer);
     }
 }
 

--- a/test/staging/sm/TypedArray/toLocaleString-detached.js
+++ b/test/staging/sm/TypedArray/toLocaleString-detached.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-includes: [sm/non262-TypedArray-shell.js]
+includes: [sm/non262-TypedArray-shell.js, detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -15,7 +15,7 @@ const separator = ["", ""].toLocaleString();
 // Throws if array buffer is detached.
 for (let constructor of typedArrayConstructors) {
     let typedArray = new constructor(42);
-    $262.detachArrayBuffer(typedArray.buffer);
+    $DETACHBUFFER(typedArray.buffer);
     assert.throws(TypeError, () => typedArray.toLocaleString());
 }
 
@@ -24,7 +24,7 @@ for (let constructor of typedArrayConstructors) {
     Number.prototype.toLocaleString = function() {
         "use strict";
         if (!detached) {
-            $262.detachArrayBuffer(typedArray.buffer);
+            $DETACHBUFFER(typedArray.buffer);
             detached = true;
         }
         return this;

--- a/test/staging/sm/TypedArray/toReversed-detached.js
+++ b/test/staging/sm/TypedArray/toReversed-detached.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -9,7 +10,7 @@ esid: pending
 
 var ta = new Int32Array([3, 2, 1]);
 
-$262.detachArrayBuffer(ta.buffer);
+$DETACHBUFFER(ta.buffer);
 
 assert.throws(TypeError, () => ta.toReversed());
 

--- a/test/staging/sm/TypedArray/toSorted-detached.js
+++ b/test/staging/sm/TypedArray/toSorted-detached.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -9,7 +10,7 @@ esid: pending
 
 var ta = new Int32Array([3, 2, 1]);
 
-$262.detachArrayBuffer(ta.buffer);
+$DETACHBUFFER(ta.buffer);
 
 assert.throws(TypeError, () => ta.toSorted());
 

--- a/test/staging/sm/TypedArray/with-detached.js
+++ b/test/staging/sm/TypedArray/with-detached.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -9,7 +10,7 @@ esid: pending
 
 var ta = new Int32Array([3, 2, 1]);
 
-$262.detachArrayBuffer(ta.buffer);
+$DETACHBUFFER(ta.buffer);
 
 assert.throws(TypeError, () => ta.with(0, 0));
 

--- a/test/staging/sm/TypedArray/with.js
+++ b/test/staging/sm/TypedArray/with.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -29,7 +30,7 @@ for (let index of indices) {
 
   let value = {
     valueOf() {
-      $262.detachArrayBuffer(ta.buffer);
+      $DETACHBUFFER(ta.buffer);
       return 0;
     }
   };

--- a/test/staging/sm/extensions/ArrayBuffer-slice-arguments-detaching.js
+++ b/test/staging/sm/extensions/ArrayBuffer-slice-arguments-detaching.js
@@ -4,6 +4,7 @@
  */
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   ArrayBuffer.prototype.slice shouldn't misbehave horribly if index-argument conversion detaches the ArrayBuffer being sliced
 info: bugzilla.mozilla.org/show_bug.cgi?id=991981
@@ -19,7 +20,7 @@ function testStart()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         $262.gc();
         return 0x800;
       }
@@ -40,7 +41,7 @@ function testEnd()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         $262.gc();
         return 0x1000;
       }

--- a/test/staging/sm/extensions/DataView-construct-arguments-detaching.js
+++ b/test/staging/sm/extensions/DataView-construct-arguments-detaching.js
@@ -4,6 +4,7 @@
  */
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   new DataView(...) shouldn't misbehave horribly if index-argument conversion detaches the ArrayBuffer to be viewed
 info: bugzilla.mozilla.org/show_bug.cgi?id=991981
@@ -19,7 +20,7 @@ function testByteOffset()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         $262.gc();
         return 0x800;
       }
@@ -40,7 +41,7 @@ function testByteLength()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         $262.gc();
         return 0x800;
       }

--- a/test/staging/sm/extensions/DataView-set-arguments-detaching.js
+++ b/test/staging/sm/extensions/DataView-set-arguments-detaching.js
@@ -4,6 +4,7 @@
  */
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   DataView.prototype.set* methods shouldn't misbehave horribly if index-argument conversion detaches the ArrayBuffer being modified
 info: bugzilla.mozilla.org/show_bug.cgi?id=991981
@@ -21,7 +22,7 @@ function testIndex()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         $262.gc();
         return 0xFFF;
       }
@@ -44,7 +45,7 @@ function testValue()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         $262.gc();
         return 0x42;
       }

--- a/test/staging/sm/extensions/TypedArray-set-object-funky-length-detaches.js
+++ b/test/staging/sm/extensions/TypedArray-set-object-funky-length-detaches.js
@@ -4,6 +4,7 @@
  */
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   %TypedArray%.prototype.set(object w/funky length property, offset) shouldn't misbehave if the funky length property detaches this typed array's buffer
 info: bugzilla.mozilla.org/show_bug.cgi?id=991981
@@ -32,7 +33,7 @@ ctors.forEach(function(TypedArray) {
         9: 0,
         get length()
         {
-          $262.detachArrayBuffer(buf);
+          $DETACHBUFFER(buf);
           return 10;
         }
       };

--- a/test/staging/sm/extensions/TypedArray-subarray-arguments-detaching.js
+++ b/test/staging/sm/extensions/TypedArray-subarray-arguments-detaching.js
@@ -4,6 +4,7 @@
  */
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   %TypedArray.prototype.subarray shouldn't misbehave horribly if index-argument conversion detaches the underlying ArrayBuffer
 info: bugzilla.mozilla.org/show_bug.cgi?id=991981
@@ -18,7 +19,7 @@ function testBegin()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         return 0x800;
       }
     };
@@ -40,7 +41,7 @@ function testBeginWithEnd()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         return 0x800;
       }
     };
@@ -62,7 +63,7 @@ function testEnd()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         return 0x1000;
       }
     };

--- a/test/staging/sm/extensions/element-setting-ToNumber-detaches.js
+++ b/test/staging/sm/extensions/element-setting-ToNumber-detaches.js
@@ -4,6 +4,7 @@
  */
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   Don't assert assigning into memory detached while converting the value to assign into a number
 info: bugzilla.mozilla.org/show_bug.cgi?id=1001547
@@ -12,4 +13,4 @@ esid: pending
 
 var ab = new ArrayBuffer(64);
 var ta = new Uint32Array(ab);
-ta[4] = { valueOf() { $262.detachArrayBuffer(ab); return 5; } };
+ta[4] = { valueOf() { $DETACHBUFFER(ab); return 5; } };

--- a/test/staging/sm/extensions/typedarray-copyWithin-arguments-detaching.js
+++ b/test/staging/sm/extensions/typedarray-copyWithin-arguments-detaching.js
@@ -4,6 +4,7 @@
  */
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   %TypedArray.prototype.copyWithin shouldn't misbehave horribly if index-argument conversion detaches the underlying ArrayBuffer
 info: bugzilla.mozilla.org/show_bug.cgi?id=991981
@@ -18,7 +19,7 @@ function testBegin()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         return 0x800;
       }
     };
@@ -40,7 +41,7 @@ function testEnd()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         return 0x1000;
       }
     };
@@ -62,7 +63,7 @@ function testDest()
     {
       valueOf: function()
       {
-        $262.detachArrayBuffer(ab);
+        $DETACHBUFFER(ab);
         return 0;
       }
     };

--- a/test/staging/sm/extensions/typedarray-set-detach.js
+++ b/test/staging/sm/extensions/typedarray-set-detach.js
@@ -4,6 +4,7 @@
  */
 
 /*---
+includes: [detachArrayBuffer.js]
 description: |
   Uint8Array.prototype.set issues when this array changes during setting
 info: bugzilla.mozilla.org/show_bug.cgi?id=983344
@@ -28,7 +29,7 @@ var src = [ 10, 20, 30, 40,
             ];
 Object.defineProperty(src, 4, {
   get: function () {
-    $262.detachArrayBuffer(ab);
+    $DETACHBUFFER(ab);
     $262.gc();
     return 200;
   }

--- a/test/staging/sm/object/values-entries-typedarray.js
+++ b/test/staging/sm/object/values-entries-typedarray.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-includes: [compareArray.js]
+includes: [compareArray.js, detachArrayBuffer.js]
 description: |
   pending
 esid: pending
@@ -23,7 +23,7 @@ for (let len of [0, 1, 10]) {
     assert.compareArray(Object.values(ta), Object.values(array));
     assertSameEntries(Object.entries(ta), Object.entries(array));
 
-    $262.detachArrayBuffer(ta.buffer);
+    $DETACHBUFFER(ta.buffer);
 
     assert.compareArray(Object.keys(ta), []);
     assert.compareArray(Object.values(ta), []);


### PR DESCRIPTION
Switch the tests in test/staging/sm/ that use `$262.detachArrayBuffer` directly to the style in non-staging tests: add `includes: detachArrayBuffer.js` and use `$DETACHBUFFER` helper (except for a few cross-realm calls).

Rationale:

While investigating diffs between my test262 runner and V8's, I noticed V8 is failing most of these tests - V8 defines `$262.detachArrayBuffer` in a custom `detachArrayBuffer.js` harness file so `includes: detachArrayBuffer.js` is critical for them:
* https://github.com/v8/v8/blob/49ea3f849cc11df40c166fa1711ebcaa97fc749d/test/test262/detachArrayBuffer.js
* https://github.com/v8/v8/blob/49ea3f849cc11df40c166fa1711ebcaa97fc749d/test/test262/testcfg.py#L257
