### PR TITLE
Add more tests for Intl.Locale.prototype.getCollations

### DIFF
--- a/test/intl402/Locale/prototype/getCollations/collations-supported-by-collator.js
+++ b/test/intl402/Locale/prototype/getCollations/collations-supported-by-collator.js
@@ -1,0 +1,57 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.getCollations
+description: >
+  The returned collations are supported by Intl.Collator.
+info: |
+  CollationsOfLocale ( loc )
+  ...
+  3. If language is not "und", then
+    a. Let r be LookupMatchingLocaleByPrefix(%Intl.Collator%.[[AvailableLocales]], « loc.[[Locale]] »).
+    b. If r is not undefined, then
+      i. Let foundLocale be r.[[locale]].
+    ...
+    d. Let foundLocaleData be %Intl.Collator%.[[SortLocaleData]].[[<foundLocale>]].
+    e. Let list be a copy of foundLocaleData.[[co]].
+    ...
+  ...
+  6. Return CreateArrayFromList(sorted).
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const locales = [
+  "en",
+
+  // Locales which have additional collations defined in CLDR.
+  "ar",
+  "bn",
+  "de",
+  "es",
+  "fi",
+  "ja",
+  "kn",
+  "ko",
+  "ln",
+  "si",
+  "sv",
+  "vi",
+  "zh",
+];
+
+for (let locale of locales) {
+  // Skip if this implementation doesn't have data for |locale|.
+  if (Intl.Collator.supportedLocalesOf(locale).length === 0) {
+    continue;
+  }
+
+  let collations = new Intl.Locale(locale).getCollations();
+  for (let collation of collations) {
+    assert.sameValue(
+      new Intl.Collator(locale, {collation}).resolvedOptions().collation,
+      collation,
+      `with locale "${locale}"`
+    );
+  }
+}

--- a/test/intl402/Locale/prototype/getCollations/language-subtag-is-und.js
+++ b/test/intl402/Locale/prototype/getCollations/language-subtag-is-und.js
@@ -1,0 +1,43 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.getCollations
+description: >
+  Returns the list « "emoji", "eor" » when the language is "und".
+info: |
+  CollationsOfLocale ( loc )
+  ...
+  2. Let language be GetLocaleLanguage(loc.[[Locale]]).
+  3. If language is not "und", then
+    ...
+  4. Else,
+     a. Let list be « "emoji", "eor" ».
+  ...
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const locales = [
+  // Undetermined language, also with unknown script and region.
+  "und",
+  "und-Zzzz",
+  "und-ZZ",
+  "und-Zzzz-ZZ",
+
+  // Undetermined language, but with a known script.
+  "und-Latn",
+  "und-Arab",
+  "und-Thai",
+
+  // Undetermined language, but with a known region.
+  "und-US",
+  "und-DE",
+  "und-SA",
+  "und-CN",
+];
+
+for (let locale of locales) {
+  let collations = new Intl.Locale(locale).getCollations();
+
+  assert.compareArray(collations, ["emoji", "eor"], `with locale "${locale}"`);
+}

--- a/test/intl402/Locale/prototype/getCollations/language-subtag-with-more-than-three-letters.js
+++ b/test/intl402/Locale/prototype/getCollations/language-subtag-with-more-than-three-letters.js
@@ -1,0 +1,39 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getCollations
+description: >
+  Language subtags with more than three letters are supported.
+info: |
+  CollationsOfLocale ( loc )
+  1. If loc.[[Collation]] is not undefined, then
+    a. Return CreateArrayFromList(« loc.[[Collation]] »).
+  ...
+  3. If language is not "und", then
+    a. Let r be LookupMatchingLocaleByPrefix(%Intl.Collator%.[[AvailableLocales]], « loc.[[Locale]] »).
+    b. If r is not undefined, then
+      ...
+    c. Else,
+      i. Let foundLocale be DefaultLocale().
+    d. Let foundLocaleData be %Intl.Collator%.[[SortLocaleData]].[[<foundLocale>]].
+  ...
+  6. Return CreateArrayFromList(sorted).
+
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// "abcdefgh" is not a registered language, so it always returns the default
+// locale's collations.
+assert.compareArray(
+  new Intl.Locale("abcdefgh").getCollations(),
+  new Intl.Locale(new Intl.Collator().resolvedOptions().locale).getCollations(),
+  `with locale "abcdefgh"`
+);
+
+// Except if an explicit "co" Unicode extension subtag is present.
+assert.compareArray(
+  new Intl.Locale("abcdefgh-u-co-phonebk").getCollations(),
+  ["phonebk"],
+  `with locale "abcdefgh-u-co-phonebk"`
+);

--- a/test/intl402/Locale/prototype/getCollations/output-array-is-sorted.js
+++ b/test/intl402/Locale/prototype/getCollations/output-array-is-sorted.js
@@ -1,0 +1,41 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.getCollations
+description: >
+  The returned array is sorted in lexicographic code unit order.
+info: |
+  CollationsOfLocale ( loc )
+  ...
+  5. Let sorted be a copy of list, sorted according to lexicographic code unit order.
+  6. Return CreateArrayFromList(sorted).
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const locales = [
+  "en",
+  "und",
+
+  // Locales which have additional collations defined in CLDR.
+  "ar",
+  "bn",
+  "de",
+  "es",
+  "fi",
+  "ja",
+  "kn",
+  "ko",
+  "ln",
+  "si",
+  "sv",
+  "vi",
+  "zh",
+];
+
+for (let locale of locales) {
+  let collations = new Intl.Locale(locale).getCollations();
+  let sorted = collations.slice(0).sort();
+
+  assert.compareArray(collations, sorted, `with locale "${locale}"`);
+}

--- a/test/intl402/Locale/prototype/getCollations/output-array-values.js
+++ b/test/intl402/Locale/prototype/getCollations/output-array-values.js
@@ -9,17 +9,23 @@ description: >
 info: |
   CollationsOfLocale ( loc )
   ...
-  4. Let list be a List of 1 or more unique collation identifiers, which must
-  be lower case String values conforming to the type sequence from UTS 35
-  Unicode Locale Identifier, section 3.2, sorted in descending preference of
-  those in common use for string comparison in locale. The values "standard"
-  and "search" must be excluded from list.
-features: [Intl.Locale, Intl.Locale-info, Array.prototype.includes]
+  3. If language is not "und", then
+    a. Let r be LookupMatchingLocaleByPrefix(%Intl.Collator%.[[AvailableLocales]], « loc.[[Locale]] »).
+    b. If r is not undefined, then
+      i. Let foundLocale be r.[[locale]].
+    ...
+    d. Let foundLocaleData be %Intl.Collator%.[[SortLocaleData]].[[<foundLocale>]].
+  ...
+  6. Return CreateArrayFromList(sorted).
+
+  Properties of the Intl.Collator Constructor - Internal slots:
+    The values "standard" and "search" must not be used as elements in any
+    [[SortLocaleData]].[[<locale>]].[[co]] and
+    [[SearchLocaleData]].[[<locale>]].[[co]] List.
+features: [Intl.Locale, Intl.Locale-info]
 ---*/
 
 const output = new Intl.Locale('en').getCollations();
 assert(output.length > 0, 'array has at least one element');
-output.forEach(c => {
-  if(['standard', 'search'].includes(c))
-    throw new Test262Error();
-});
+assert.sameValue(output.indexOf('standard'), -1, '"standard" collation');
+assert.sameValue(output.indexOf('search'), -1, '"sort" collation');

--- a/test/intl402/Locale/prototype/getCollations/output-array.js
+++ b/test/intl402/Locale/prototype/getCollations/output-array.js
@@ -8,7 +8,7 @@ description: >
 info: |
   CollationsOfLocale ( loc )
   ...
-  5. Return ! CreateArrayFromListAndPreferred( list, preferred ).
+  6. Return CreateArrayFromList(sorted).
 features: [Intl.Locale,Intl.Locale-info]
 ---*/
 

--- a/test/intl402/Locale/prototype/getCollations/preferred-from-unicode-extension-true-empty.js
+++ b/test/intl402/Locale/prototype/getCollations/preferred-from-unicode-extension-true-empty.js
@@ -1,0 +1,46 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.getCollations
+description: >
+  Returns the preferred collations from the "co" Unicode extension.
+info: |
+  CollationsOfLocale ( loc )
+  1. If loc.[[Collation]] is not undefined, then
+    a. Return CreateArrayFromList(« loc.[[Collation]] »).
+  ...
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const languages = [
+  "und",
+  "en",
+];
+
+const extensions = [
+  "",
+  "true",
+];
+
+for (let language of languages) {
+  for (let extension of extensions) {
+    let locale = extension
+                 ? `${language}-u-co-${extension}`
+                 : `${language}-u-co`;
+    let loc = new Intl.Locale(locale);
+    let collations = loc.getCollations();
+
+    assert.sameValue(
+      loc.collation,
+      "",
+      `collation with locale "${locale}"`
+    );
+
+    assert.compareArray(
+      collations,
+      [""],
+      `collations with locale "${locale}"`
+    );
+  }
+}

--- a/test/intl402/Locale/prototype/getCollations/preferred-from-unicode-extension.js
+++ b/test/intl402/Locale/prototype/getCollations/preferred-from-unicode-extension.js
@@ -1,0 +1,67 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.getCollations
+description: >
+  Returns the preferred collations from the "co" Unicode extension.
+info: |
+  CollationsOfLocale ( loc )
+  1. If loc.[[Collation]] is not undefined, then
+    a. Return CreateArrayFromList(« loc.[[Collation]] »).
+  ...
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const languages = [
+  "und",
+  "en",
+];
+
+const extensions = [
+  // uvalue with a valid collation.
+  "big5han",
+  "compat",
+  "dict",
+  "direct",
+  "ducet",
+  "emoji",
+  "eor",
+  "gb2312",
+  "phonebk",
+  "phonetic",
+  "pinyin",
+  "reformed",
+  "search",
+  "searchjl",
+  "standard",
+  "stroke",
+  "trad",
+  "unihan",
+  "zhuyin",
+
+  // uvalue with an invalid collation.
+  "abcdefgh",
+  "dictdict",
+  "reform",
+];
+
+for (let language of languages) {
+  for (let extension of extensions) {
+    let locale = `${language}-u-co-${extension}`;
+    let loc = new Intl.Locale(locale)
+    let collations = loc.getCollations();
+
+    assert.sameValue(
+      loc.collation,
+      extension,
+      `collation with locale "${locale}"`
+    );
+
+    assert.compareArray(
+      collations,
+      [extension],
+      `collation with locale "${locale}"`
+    );
+  }
+}


### PR DESCRIPTION
Add coverage for:
- Return collations are supported by `Intl.Collator`.
- Language subtag is `und`.
- Language subtag has more than three letters.
- Output array is sorted.

Also update existing test meta data to match current spec text and simplify checks in "output-array-values.js"