### PR TITLE
Add more tests for Intl.Locale.prototype.getNumberingSystems

### DIFF
--- a/test/intl402/Locale/prototype/getNumberingSystems/language-subtag-with-more-than-three-letters.js
+++ b/test/intl402/Locale/prototype/getNumberingSystems/language-subtag-with-more-than-three-letters.js
@@ -1,0 +1,35 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getNumberingSystems
+description: >
+  Language subtags with more than three letters are supported.
+info: |
+  NumberingSystemsOfLocale ( loc )
+  1. If loc.[[NumberingSystem]] is not undefined, then
+    a. Return CreateArrayFromList(« loc.[[NumberingSystem]] »).
+  2. Let r be LookupMatchingLocaleByPrefix(%Intl.NumberFormat%.[[AvailableLocales]], « loc.[[Locale]] »).
+  3. If r is not undefined, then
+    ...
+  4. Else,
+    a. Let list be « "latn" ».
+  5. Return CreateArrayFromList(list).
+
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// "abcdefgh" is not a registered language, so it always returns the default
+// numbering system "latn".
+assert.compareArray(
+  new Intl.Locale("abcdefgh").getNumberingSystems(),
+  ["latn"],
+  `with locale "abcdefgh"`
+);
+
+// Except if an explicit "nu" Unicode extension subtag is present.
+assert.compareArray(
+  new Intl.Locale("abcdefgh-u-nu-arab").getNumberingSystems(),
+  ["arab"],
+  `with locale "abcdefgh-u-nu-arab"`
+);

--- a/test/intl402/Locale/prototype/getNumberingSystems/lookup-locale-by-prefix.js
+++ b/test/intl402/Locale/prototype/getNumberingSystems/lookup-locale-by-prefix.js
@@ -1,0 +1,39 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getNumberingSystems
+description: >
+  Matches the resolved numbering system from Intl.NumberFormat using the "lookup" matching.
+info: |
+  NumberingSystemsOfLocale ( loc )
+  ...
+  2. Let r be LookupMatchingLocaleByPrefix(%Intl.NumberFormat%.[[AvailableLocales]], « loc.[[Locale]] »).
+  3. If r is not undefined, then
+    ...
+  4. Else,
+    a. Let list be « "latn" ».
+  5. Return CreateArrayFromList(list).
+
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const locales = [
+  "und-BD",
+  "und-SA",
+];
+
+for (let locale of locales) {
+  // Skip if the locale is (somehow) supported by this implementation.
+  if (Intl.NumberFormat.supportedLocalesOf(locale, {localeMatcher: "lookup"}).length > 0) {
+    continue;
+  }
+
+  let numberingSystems = new Intl.Locale(locale).getNumberingSystems();
+
+  assert.compareArray(
+    numberingSystems,
+    ["latn"],
+    `with locale "${locale}"`
+  );
+}

--- a/test/intl402/Locale/prototype/getNumberingSystems/output-array.js
+++ b/test/intl402/Locale/prototype/getNumberingSystems/output-array.js
@@ -8,9 +8,14 @@ description: >
 info: |
   NumberingSystemsOfLocale ( loc )
   ...
-  5. Return ! CreateArrayFromListAndPreferred( list, preferred ).
+  3. If r is not undefined, then
+    ...
+    d. Let list be « numberingSystems[0] ».
+  ...
+  5. Return CreateArrayFromList(list).
 features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
-assert(Array.isArray(new Intl.Locale('en').getNumberingSystems()));
-assert(new Intl.Locale('en').getNumberingSystems().length > 0, 'array has at least one element');
+var numberingSystems = new Intl.Locale('en').getNumberingSystems();
+assert(Array.isArray(numberingSystems));
+assert.sameValue(numberingSystems.length, 1, 'array has exactly one element');

--- a/test/intl402/Locale/prototype/getNumberingSystems/preferred-from-unicode-extension-true-empty.js
+++ b/test/intl402/Locale/prototype/getNumberingSystems/preferred-from-unicode-extension-true-empty.js
@@ -1,0 +1,46 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.getNumberingSystems
+description: >
+  Returns the preferred numbering systems from the "nu" Unicode extension.
+info: |
+  NumberingSystemsOfLocale ( loc )
+  1. If loc.[[NumberingSystem]] is not undefined, then
+    a. Return CreateArrayFromList(« loc.[[NumberingSystem]] »).
+  ...
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const languages = [
+  "und",
+  "en",
+];
+
+const extensions = [
+  "",
+  "true",
+];
+
+for (let language of languages) {
+  for (let extension of extensions) {
+    let locale = extension
+                 ? `${language}-u-nu-${extension}`
+                 : `${language}-u-nu`;
+    let loc = new Intl.Locale(locale);
+    let numberingSystems = loc.getNumberingSystems();
+
+    assert.sameValue(
+      loc.numberingSystem,
+      "",
+      `numberingSystem with locale "${locale}"`
+    );
+
+    assert.compareArray(
+      numberingSystems,
+      [""],
+      `numberingSystems with locale "${locale}"`
+    );
+  }
+}

--- a/test/intl402/Locale/prototype/getNumberingSystems/preferred-from-unicode-extension.js
+++ b/test/intl402/Locale/prototype/getNumberingSystems/preferred-from-unicode-extension.js
@@ -1,0 +1,58 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.getNumberingSystems
+description: >
+  Returns the preferred numbering systems from the "nu" Unicode extension.
+info: |
+  NumberingSystemsOfLocale ( loc )
+  1. If loc.[[NumberingSystem]] is not undefined, then
+    a. Return CreateArrayFromList(« loc.[[NumberingSystem]] »).
+  ...
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const languages = [
+  "und",
+  "en",
+];
+
+const extensions = [
+  // Empty uvalue.
+  // "",
+
+  // uvalue with a valid numbering system.
+  "latn",
+  "arab",
+  "arabext",
+  "beng",
+  "deva",
+
+  // uvalue with an invalid numbering system.
+  "abcdefgh",
+  "latnlatn",
+  "latnext",
+];
+
+for (let language of languages) {
+  for (let extension of extensions) {
+    let locale = extension
+                 ? `${language}-u-nu-${extension}`
+                 : `${language}-u-nu`;
+    let loc = new Intl.Locale(locale)
+    let numberingSystems = loc.getNumberingSystems();
+
+    assert.sameValue(
+      loc.numberingSystem,
+      extension,
+      `numberingSystem with locale "${locale}"`
+    );
+
+    assert.compareArray(
+      numberingSystems,
+      [extension],
+      `numberingSystems with locale "${locale}"`
+    );
+  }
+}

--- a/test/intl402/Locale/prototype/getNumberingSystems/unsupported-defaults-to-latn.js
+++ b/test/intl402/Locale/prototype/getNumberingSystems/unsupported-defaults-to-latn.js
@@ -1,0 +1,41 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.getNumberingSystems
+description: >
+  Defaults to "latn" if the locale is not supported by Intl.NumberFormat.
+info: |
+  NumberingSystemsOfLocale ( loc )
+  ...
+  4. Else,
+    a. Let list be « "latn" ».
+  5. Return CreateArrayFromList(list).
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const locales = [
+  // Undetermined language.
+  "und",
+
+  // Klingon as a sample constructed language.
+  "tlh",
+
+  // "qfz" as a CLDR private use, excluded language subtag.
+  "qfz",
+];
+
+for (let locale of locales) {
+  // Skip if the locale is (somehow) supported by this implementation.
+  if (Intl.NumberFormat.supportedLocalesOf(locale).length > 0) {
+    continue;
+  }
+
+  let numberingSystems = new Intl.Locale(locale).getNumberingSystems();
+
+  assert.compareArray(
+    numberingSystems,
+    ["latn"],
+    `with locale "${locale}"`
+  );
+}


### PR DESCRIPTION
Add coverage for:
- Language subtag has more than three letters.
- Lookup locale uses prefix matching.
- Unicode extension is present.
- Unicode extension is empty or the string "true".
- "latn" is returned for an unsupported locale.

Also update existing tests and test meta data to match current spec text.