### PR TITLE
Add more tests for Intl.Locale.prototype.getTextInfo

### DIFF
--- a/test/intl402/Locale/prototype/getTextInfo/language-subtag-with-more-than-three-letters.js
+++ b/test/intl402/Locale/prototype/getTextInfo/language-subtag-with-more-than-three-letters.js
@@ -1,0 +1,59 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getTextInfo
+description: >
+  Language subtags with more than three letters are supported.
+info: |
+  TextDirectionOfLocale ( loc )
+  ...
+  2. Let script be GetLocaleScript(locale).
+  3. If script is undefined, then
+    a. Let maximal be the result of the Add Likely Subtags algorithm applied to locale. If an error is signaled, return undefined.
+    b. Set script to GetLocaleScript(maximal).
+    c. If script is undefined, return undefined.
+  4. If the default general ordering of characters within a line in script is right-to-left, return "rtl".
+  5. If the default general ordering of characters within a line in script is left-to-right, return "ltr".
+  6. Return undefined.
+
+  NOTE 1:
+  When the direction of default general ordering of characters within a line in
+  the script cannot be determined, or the direction is neither right-to-left nor
+  left-to-right, then undefined will be returned.
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// "abcdefgh" is not a registered language, so it's not possible to infer its script
+// through adding likely subtags.
+assert.sameValue(
+  new Intl.Locale("abcdefgh").maximize().script,
+  undefined,
+  `can't infer script for locale "abcdefgh" by adding likely subtags`
+);
+assert.sameValue(
+  new Intl.Locale("abcdefgh").getTextInfo().direction,
+  undefined,
+  `with locale "abcdefgh"`
+);
+
+// Script subtag is present, "Latn" is written left-to-right.
+assert.sameValue(
+  new Intl.Locale("abcdefgh-Latn").getTextInfo().direction,
+  "ltr",
+  `with locale "abcdefgh-Latn"`
+);
+
+// Script subtag is present, "Arab" is written right-to-left.
+assert.sameValue(
+  new Intl.Locale("abcdefgh-Arab").getTextInfo().direction,
+  "rtl",
+  `with locale "abcdefgh-Arab"`
+);
+
+// Script subtag is present, "Zzzz" is neither written left-to-right nor right-to-left.
+assert.sameValue(
+  new Intl.Locale("abcdefgh-Zzzz").getTextInfo().direction,
+  undefined,
+  `with locale "abcdefgh-Zzzz"`
+);

--- a/test/intl402/Locale/prototype/getTextInfo/script-metadata-rtl-is-unknown.js
+++ b/test/intl402/Locale/prototype/getTextInfo/script-metadata-rtl-is-unknown.js
@@ -1,0 +1,57 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getTextInfo
+description: >
+  Returns undefined if the RTL field in scriptMetadata.txt is UNKNOWN.
+info: |
+  TextDirectionOfLocale ( loc )
+  ...
+  4. If the default general ordering of characters within a line in script is right-to-left, return "rtl".
+  5. If the default general ordering of characters within a line in script is left-to-right, return "ltr".
+  6. Return undefined.
+
+  NOTE 1:
+  When the direction of default general ordering of characters within a line in
+  the script cannot be determined, or the direction is neither right-to-left nor
+  left-to-right, then undefined will be returned.
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// All scripts whose RTL field in scriptMetadata.txt is UNKNOWN.
+const scripts = [
+  "Zyyy",
+  "Zinh",
+  "Zzzz",
+  "Brai",
+];
+
+const languages = [
+  // Undetermined language.
+  "und",
+
+  // English as a sample language whose default script is left-to-right.
+  "en",
+
+  // Arabic as a sample language whose default script is right-to-left.
+  "ar",
+
+  // Klingon as sample constructed language.
+  "tlh",
+
+  // "qfz" as a CLDR private use, excluded language subtag.
+  "qfz",
+];
+
+for (let script of scripts) {
+  for (let language of languages) {
+    let locale = `${language}-${script}`;
+
+    assert.sameValue(
+      new Intl.Locale(locale).getTextInfo().direction,
+      undefined,
+      `with locale "${locale}"`
+    );
+  }
+}

--- a/test/intl402/Locale/prototype/getTextInfo/script-metadata-unlisted-language-script-is-rtl.js
+++ b/test/intl402/Locale/prototype/getTextInfo/script-metadata-unlisted-language-script-is-rtl.js
@@ -1,0 +1,38 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getTextInfo
+description: >
+  Don't return "ltr" direction for scripts which aren't left-to-right.
+info: |
+  TextDirectionOfLocale ( loc )
+  ...
+  4. If the default general ordering of characters within a line in script is right-to-left, return "rtl".
+  5. If the default general ordering of characters within a line in script is left-to-right, return "ltr".
+  6. Return undefined.
+
+  NOTE 1:
+  When the direction of default general ordering of characters within a line in
+  the script cannot be determined, or the direction is neither right-to-left nor
+  left-to-right, then undefined will be returned.
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// Arabic, spoken-only content.
+//
+// Allow absent data, returning undefined, but reject "ltr".
+assert.notSameValue(
+  new Intl.Locale("ar-Zxxx").getTextInfo().direction,
+  "ltr",
+  `with locale "ar-Zxxx"`
+);
+
+// Urdu, with script Arabic (Nastaliq variant).
+//
+// Allow absent data, returning undefined, but reject "ltr".
+assert.notSameValue(
+  new Intl.Locale("ur-Aran").getTextInfo().direction,
+  "ltr",
+  `with locale "ur-Aran"`
+);

--- a/test/intl402/Locale/prototype/getTextInfo/script-subtag-missing.js
+++ b/test/intl402/Locale/prototype/getTextInfo/script-subtag-missing.js
@@ -1,0 +1,68 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getTextInfo
+description: >
+  Add likely subtags if the script subtag is missing.
+info: |
+  TextDirectionOfLocale ( loc )
+  ...
+  2. Let script be GetLocaleScript(locale).
+  3. If script is undefined, then
+    a. Let maximal be the result of the Add Likely Subtags algorithm applied to locale. If an error is signaled, return undefined.
+    b. Set script to GetLocaleScript(maximal).
+    c. If script is undefined, return undefined.
+  4. If the default general ordering of characters within a line in script is right-to-left, return "rtl".
+  5. If the default general ordering of characters within a line in script is left-to-right, return "ltr".
+  6. Return undefined.
+
+  NOTE 1:
+  When the direction of default general ordering of characters within a line in
+  the script cannot be determined, or the direction is neither right-to-left nor
+  left-to-right, then undefined will be returned.
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const locales = [
+  // Undetermined language.
+  "und",
+
+  // English as a sample language whose default script is left-to-right.
+  "en",
+
+  // Arabic as a sample language whose default script is right-to-left.
+  "ar",
+
+  // Klingon as sample constructed language.
+  "tlh",
+
+  // "qfz" as a CLDR private use, excluded language subtag.
+  "qfz",
+
+  // Region subtag can alter likely subtags: "pa" maximizes to "pa-Guru-IN",
+  // whereas "pa-PK" maximizes to "pa-Arab-PK". (Gurmukhi is written
+  // left-to-right, Arabic is written right-to-left.)
+  "pa",
+  "pa-PK",
+];
+
+for (let locale of locales) {
+  let loc = new Intl.Locale(locale);
+  let maximized = loc.maximize();
+
+  let direction = loc.getTextInfo().direction;
+  assert.sameValue(
+    direction,
+    maximized.getTextInfo().direction,
+    `same direction as maximized locale, with locale "${locale}"`
+  );
+
+  if (maximized.script === undefined) {
+    assert.sameValue(
+      direction,
+      undefined,
+      `maximized script is undefined for locale "${locale}"`
+    );
+  }
+}

--- a/test/intl402/Locale/prototype/getTextInfo/script-subtag-present.js
+++ b/test/intl402/Locale/prototype/getTextInfo/script-subtag-present.js
@@ -1,0 +1,59 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getTextInfo
+description: >
+  Determine text direction from script subtag, ignore the language subtag.
+info: |
+  TextDirectionOfLocale ( loc )
+  ...
+  2. Let script be GetLocaleScript(locale).
+  ...
+  4. If the default general ordering of characters within a line in script is right-to-left, return "rtl".
+  5. If the default general ordering of characters within a line in script is left-to-right, return "ltr".
+  6. Return undefined.
+
+  NOTE 1:
+  When the direction of default general ordering of characters within a line in
+  the script cannot be determined, or the direction is neither right-to-left nor
+  left-to-right, then undefined will be returned.
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const languages = [
+  // Undetermined language.
+  "und",
+
+  // English as a sample language whose default script is left-to-right.
+  "en",
+
+  // Arabic as a sample language whose default script is right-to-left.
+  "ar",
+
+  // Klingon as a sample constructed language.
+  "tlh",
+
+  // "qfz" as a CLDR private use, excluded language subtag.
+  "qfz",
+];
+
+const scripts = {
+  // Latin script is written left-to-right.
+  Latn: "ltr",
+
+  // Arabic script is written right-to-left.
+  Arab: "rtl",
+};
+
+for (let [script, direction] of Object.entries(scripts)) {
+  for (let language of languages) {
+    let locale = `${language}-${script}`;
+
+    assert.sameValue(
+      new Intl.Locale(locale).getTextInfo().direction,
+      direction,
+      `with locale "${locale}"`
+    );
+  }
+}

--- a/test/intl402/Locale/prototype/getTextInfo/script-unregistered-or-privateuse.js
+++ b/test/intl402/Locale/prototype/getTextInfo/script-unregistered-or-privateuse.js
@@ -1,0 +1,65 @@
+// Copyright 2026 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getTextInfo
+description: >
+  Returns undefined for unregistered and private-use script codes.
+info: |
+  TextDirectionOfLocale ( loc )
+  ...
+  4. If the default general ordering of characters within a line in script is right-to-left, return "rtl".
+  5. If the default general ordering of characters within a line in script is left-to-right, return "ltr".
+  6. Return undefined.
+
+  NOTE 1:
+  When the direction of default general ordering of characters within a line in
+  the script cannot be determined, or the direction is neither right-to-left nor
+  left-to-right, then undefined will be returned.
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+const scripts = [
+  // "Aaaa" is not a registered script code.
+  //
+  // https://www.unicode.org/iso15924/iso15924-codes.html
+  "Aaaa",
+
+  // Use the private use script code "Qaaq", because it's guaranteed to never
+  // get particular semantics in CLDR.
+  //
+  // https://unicode.org/reports/tr35/tr35.html#Private_Use_Codes
+  "Qaaq",
+
+  // Exceptionally reserved by ISO 15924, will not be assigned for any purpose.
+  "True",
+];
+
+const languages = [
+  // Undetermined language.
+  "und",
+
+  // English as a sample language whose default script is left-to-right.
+  "en",
+
+  // Arabic as a sample language whose default script is right-to-left.
+  "ar",
+
+  // Klingon as a sample constructed language.
+  "tlh",
+
+  // "qfz" as a CLDR private use, excluded language subtag.
+  "qfz",
+];
+
+for (let script of scripts) {
+  for (let language of languages) {
+    let locale = `${language}-${script}`;
+
+    assert.sameValue(
+      new Intl.Locale(locale).getTextInfo().direction,
+      undefined,
+      `with locale "${locale}"`
+    );
+  }
+}


### PR DESCRIPTION
Add coverage for:
- Language subtag has more than three letters.
- Script meta data's RTL field is `UNKNOWN`.
- Don't default to `"ltr"` when script meta data has no entry for script.
- Missing script is added through add-likely-subtags algorithm.
- Script subtag is present and script's general ordering of characters is known.
- Script subtag doesn't refer to a valid registered script.