### PR TITLE
Fix check in break tests

### DIFF
--- a/test/language/statements/break/S12.8_A3.js
+++ b/test/language/statements/break/S12.8_A3.js
@@ -13,7 +13,7 @@ LABEL_DO_LOOP : do {
     LABEL_IN : x=2;
     break ;
     LABEL_IN_2 : var y=2;
-    
+
     function IN_DO_FUNC(){}
 } while(0);
 
@@ -25,7 +25,7 @@ function OUT_FUNC(){}
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-if ((x!==2)&&(y!==0)) {
+if ((x!==2)||(y!==0)) {
 	throw new Test262Error('#1: x === 2 and y === 0. Actual:  x ==='+x+' and y ==='+y);
 }
 //

--- a/test/language/statements/break/S12.8_A4_T1.js
+++ b/test/language/statements/break/S12.8_A4_T1.js
@@ -16,7 +16,7 @@ LABEL_DO_LOOP : do {
     if(x===10)return;
     break LABEL_DO_LOOP;
     LABEL_IN_2 : y++;
-    
+
     function IN_DO_FUNC(){}
 } while(0);
 
@@ -28,7 +28,7 @@ function OUT_FUNC(){}
 })();
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-if ((x!==1)&&(y!==0)) {
+if ((x!==1)||(y!==0)) {
 	throw new Test262Error('#1: x === 1 and y === 0. Actual:  x === '+x+' and y ==='+ y  );
 }
 //

--- a/test/language/statements/break/S12.8_A4_T2.js
+++ b/test/language/statements/break/S12.8_A4_T2.js
@@ -20,9 +20,9 @@ LABEL_DO_LOOP : do {
         break LABEL_NESTED_LOOP;
         LABEL_IN_NESTED_2 : yy++;
     } while (0);
-    
+
     LABEL_IN_2 : y++;
-    
+
     function IN_DO_FUNC(){}
 } while(0);
 
@@ -34,7 +34,7 @@ function OUT_FUNC(){}
 })();
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-if ((x!==1)&&(y!==1)&&(xx!==1)&(yy!==0)) {
+if ((x!==1)||(y!==1)||(xx!==1)||(yy!==0)) {
 	throw new Test262Error('#1: x === 1 and y === 1 and xx === 1 and yy === 0. Actual:  x==='+x+' and y==='+y+' and xx==='+xx+' and yy==='+yy );
 }
 //

--- a/test/language/statements/break/S12.8_A4_T3.js
+++ b/test/language/statements/break/S12.8_A4_T3.js
@@ -20,9 +20,9 @@ LABEL_DO_LOOP : do {
         break LABEL_DO_LOOP;
         LABEL_IN_NESTED_2 : yy++;
     } while (0);
-    
+
     LABEL_IN_2 : y++;
-    
+
     function IN_DO_FUNC(){}
 } while(0);
 
@@ -34,7 +34,7 @@ function OUT_FUNC(){}
 })();
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-if ((x!==1)&&(y!==0)&&(xx!==1)&(yy!==0)) {
+if ((x!==1)||(y!==0)||(xx!==1)||(yy!==0)) {
 	throw new Test262Error('#1: x === 1 and y === 0 and xx === 1 and yy === 0. Actual:  x==='+x+' and y==='+y+' and xx==='+xx+' and yy==='+yy );
 }
 //


### PR DESCRIPTION
Change "&&" to "||" in the test condition of some break tests.

The reason is that violating one of the individual conditions would already indicate a bug.