### PR TITLE
Add deferred-reexports to features.txt

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -63,7 +63,7 @@ import-defer
 
 # Deferred re-exports
 # https://tc39.es/proposal-deferred-reexports/
-deferred-reexports
+export-defer
 
 # Import Text
 # https://github.com/tc39/proposal-import-text

--- a/features.txt
+++ b/features.txt
@@ -61,6 +61,10 @@ Atomics.pause
 # https://tc39.es/proposal-defer-import-eval
 import-defer
 
+# Deferred re-exports
+# https://tc39.es/proposal-deferred-reexports/
+deferred-reexports
+
 # Import Text
 # https://github.com/tc39/proposal-import-text
 import-text


### PR DESCRIPTION
This PR adds a new flag for tests coming to [deferred re-exports](https://github.com/tc39/proposal-deferred-reexports) proposal. This flag is going to be used by tests that will be included by https://github.com/tc39/test262/issues/5010.