### PR TITLE
Drop duplicate isPrimitive() in harness/testTypedArray.js

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -3,7 +3,7 @@
 /*---
 description: |
     Collection of assertion functions used throughout test262
-defines: [assert]
+defines: [assert, isPrimitive]
 ---*/
 
 

--- a/harness/testTypedArray.js
+++ b/harness/testTypedArray.js
@@ -63,10 +63,6 @@ var allTypedArrayConstructors = typedArrayConstructors.concat(bigIntArrayConstru
  */
 var TypedArray = Object.getPrototypeOf(Int8Array);
 
-function isPrimitive(val) {
-  return !val || (typeof val !== "object" && typeof val !== "function");
-}
-
 function makePassthrough(TA, primitiveOrIterable) {
   return primitiveOrIterable;
 }


### PR DESCRIPTION
It's already defined in `harness/assert.js`, included in every test.

Some engines/runtimes e.g. deno complain about redeclarations in the same scope and abort execution.