### PR TITLE
Temporal: Add coverage for error case in Duration.round/total

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-plaindate-large-time-component-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-plaindate-large-time-component-out-of-range.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Duration with an overly large time component rounded to a calendar unit
+  relative to a PlainDate
+info: |
+  28.d. Let _dateDuration_ be ? AdjustDateDurationRecord(
+    _internalDuration_.[[Date]], _targetTime_.[[Days]]).
+features: [Temporal]
+---*/
+
+const relativeTo = new Temporal.PlainDate(2020, 1, 1);
+
+[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER].forEach((seconds) => {
+  const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, seconds);
+  assert.throws(RangeError, () => d.round({ smallestUnit: "year", relativeTo }));
+  assert.throws(RangeError, () => d.round({ smallestUnit: "month", relativeTo }));
+  assert.throws(RangeError, () => d.round({ smallestUnit: "week", relativeTo }));
+});

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-zoneddatetime-large-time-component-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-zoneddatetime-large-time-component-out-of-range.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Duration with an overly large time component rounded to a calendar unit
+  relative to a ZonedDateTime
+info: |
+  27.e. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_,
+    _calendar_, _internalDuration_, ~constrain~).
+features: [Temporal]
+---*/
+
+const relativeTo = new Temporal.ZonedDateTime(0n, "UTC");
+
+[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER].forEach((seconds) => {
+  const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, seconds);
+  assert.throws(RangeError, () => d.round({ smallestUnit: "year", relativeTo }));
+  assert.throws(RangeError, () => d.round({ smallestUnit: "month", relativeTo }));
+  assert.throws(RangeError, () => d.round({ smallestUnit: "week", relativeTo }));
+});

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-plaindate-large-time-component-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-plaindate-large-time-component-out-of-range.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  Duration with an overly large time component total of a calendar unit relative
+  to a PlainDate
+info: |
+  13.d. Let _dateDuration_ be ? AdjustDateDurationRecord(
+    _internalDuration_.[[Date]], _targetTime_.[[Days]]).
+features: [Temporal]
+---*/
+
+const relativeTo = new Temporal.PlainDate(2020, 1, 1);
+
+[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER].forEach((seconds) => {
+  const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, seconds);
+  assert.throws(RangeError, () => d.total({ unit: "year", relativeTo }));
+  assert.throws(RangeError, () => d.total({ unit: "month", relativeTo }));
+  assert.throws(RangeError, () => d.total({ unit: "week", relativeTo }));
+});

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-zoneddatetime-large-time-component-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-zoneddatetime-large-time-component-out-of-range.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  Duration with an overly large time component total of a calendar unit relative
+  to a ZonedDateTime
+info: |
+  12.e. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_,
+    _calendar_, _internalDuration_, ~constrain~).
+features: [Temporal]
+---*/
+
+const relativeTo = new Temporal.ZonedDateTime(0n, "UTC");
+
+[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER].forEach((seconds) => {
+  const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, seconds);
+  assert.throws(RangeError, () => d.total({ unit: "year", relativeTo }));
+  assert.throws(RangeError, () => d.total({ unit: "month", relativeTo }));
+  assert.throws(RangeError, () => d.total({ unit: "week", relativeTo }));
+});


### PR DESCRIPTION
These error cases were previously uncovered. In the PlainDate relativeTo cases, there was an incorrect assertion in the spec. There was no problem with the ZonedDateTime relativeTo code path in the spec, but this particular situation didn't have test coverage either, so this adds coverage for that as well.

See https://github.com/tc39/proposal-temporal/issues/3309

LLM disclosure: I used a bot to make a first draft of these, then hand-edited them until I was satisfied.