### PR TITLE
Temporal: Add regression tests for Firefox crash

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-rounding-near-minimum-date.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-rounding-near-minimum-date.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Rounding with largestUnit "year" with relativeTo near the earlier date limit
+  correctly rounds the day even though year boundaries fall outside the valid
+  range
+info: Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=2036259
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const relativeTo = new Temporal.PlainDate(-271821, 5, 19);
+const duration = new Temporal.Duration(0, 0, 0, 0, -23);
+
+const result = duration.round({
+  largestUnit: "year",
+  smallestUnit: "day",
+  roundingMode: "expand",
+  relativeTo,
+});
+
+TemporalHelpers.assertDuration(result, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0,
+  "-23 hours rounds to -1 day near minimum date");

--- a/test/built-ins/Temporal/PlainDate/prototype/since/rounding-near-minimum-date.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/rounding-near-minimum-date.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+  Rounding with largestUnit "year" near the earlier date limit correctly rounds
+  the day increment even though year boundaries fall outside the valid range
+info: Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=2036259
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const d1 = new Temporal.PlainDate(-271821, 5, 19);
+const d2 = new Temporal.PlainDate(-271821, 5, 18);
+
+const result = d1.since(d2, {
+  largestUnit: "year",
+  smallestUnit: "day",
+  roundingIncrement: 2,
+  roundingMode: "expand",
+});
+
+TemporalHelpers.assertDuration(result, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0,
+  "expand rounding of 1 day to increment 2 near minimum date gives 2 days");

--- a/test/built-ins/Temporal/PlainDate/prototype/until/rounding-near-minimum-date.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/rounding-near-minimum-date.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+  Rounding with largestUnit "year" near the earlier date limit correctly rounds
+  the day increment even though year boundaries fall outside the valid range
+info: Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=2036259
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const d1 = new Temporal.PlainDate(-271821, 5, 19);
+const d2 = new Temporal.PlainDate(-271821, 5, 18);
+
+const result = d1.until(d2, {
+  largestUnit: "year",
+  smallestUnit: "day",
+  roundingIncrement: 2,
+  roundingMode: "expand",
+});
+
+TemporalHelpers.assertDuration(result, 0, 0, 0, -2, 0, 0, 0, 0, 0, 0,
+  "expand rounding of -1 day to increment 2 near minimum date gives -2 days");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/rounding-near-minimum-date.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/rounding-near-minimum-date.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  Rounding with largestUnit "year" near the earlier date limit correctly rounds
+  the day increment even though year boundaries fall outside the valid range
+info: Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=2036259
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const dt1 = new Temporal.PlainDateTime(-271821, 5, 19, 0, 0, 0);
+const dt2 = new Temporal.PlainDateTime(-271821, 5, 18, 0, 0, 0);
+
+const result = dt1.since(dt2, {
+  largestUnit: "year",
+  smallestUnit: "day",
+  roundingIncrement: 2,
+  roundingMode: "expand",
+});
+
+TemporalHelpers.assertDuration(result, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0,
+  "expand rounding of 1 day to increment 2 near minimum date gives 2 days");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/rounding-near-minimum-date.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/rounding-near-minimum-date.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  Rounding with largestUnit "year" near the earlier date limit correctly rounds
+  the day increment even though year boundaries fall outside the valid range
+info: Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=2036259
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const dt1 = new Temporal.PlainDateTime(-271821, 5, 19, 0, 0, 0);
+const dt2 = new Temporal.PlainDateTime(-271821, 5, 18, 0, 0, 0);
+
+const result = dt1.until(dt2, {
+  largestUnit: "year",
+  smallestUnit: "day",
+  roundingIncrement: 2,
+  roundingMode: "expand",
+});
+
+TemporalHelpers.assertDuration(result, 0, 0, 0, -2, 0, 0, 0, 0, 0, 0,
+  "expand rounding of -1 day to increment 2 near minimum date gives -2 days");


### PR DESCRIPTION
Firefox fuzzing found a crash when rounding durations relative to dates near the early limit, with roundingMode expand:
https://bugzilla.mozilla.org/show_bug.cgi?id=2036259

This was an implementation bug, but it wasn't triggered by any existing test262 test, so we should have coverage for it.

LLM disclosure: I used a bot to make a first draft of these, then hand-edited them until I was satisfied.