### PR TITLE
Temporal: Add tests for duration rounding edge case near +24h UTC shift

### DIFF
--- a/test/intl402/Temporal/Duration/prototype/round/skipped-day-collapses-bounding-window.js
+++ b/test/intl402/Temporal/Duration/prototype/round/skipped-day-collapses-bounding-window.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Rounding a negative duration where skipped day collapses bounding window
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const relativeTo = Temporal.ZonedDateTime.from("2012-01-01T12:00:00+14:00[Pacific/Apia]");
+const d = new Temporal.Duration(0, 0, 0, -1);
+TemporalHelpers.assertDuration(
+  d.round({ smallestUnit: "days", relativeTo }),
+  0, 0, 0, -1, 0, 0, 0, 0, 0, 0,
+  "-P1D rounded to days with bounding window spanning a skipped calendar day"
+);
+
+const d2 = new Temporal.Duration(0, 0, 0, 0, -25);
+TemporalHelpers.assertDuration(
+  d2.round({ smallestUnit: "days", relativeTo }),
+  0, 0, 0, -1, 0, 0, 0, 0, 0, 0,
+  "-PT25H rounded to 1 day, bounding window extending into a skipped calendar day"
+);
+
+const d3 = new Temporal.Duration(0, 0, 0, 0, -36);
+TemporalHelpers.assertDuration(
+  d3.round({ smallestUnit: "days", relativeTo }),
+  0, 0, 0, -2, 0, 0, 0, 0, 0, 0,
+  "-PT36H rounded to 2 days, bounding window extending into a skipped calendar day"
+);
+
+const d4 = new Temporal.Duration(0, 0, 0, -2, -6);
+TemporalHelpers.assertDuration(
+  d4.round({ smallestUnit: "days", roundingIncrement: 2, relativeTo }),
+  0, 0, 0, -2, 0, 0, 0, 0, 0, 0,
+  "-P2DT6H rounded with increment 2 to 2 days, bounding window extending into a skipped calendar day"
+);
+
+const relativeTo2 = Temporal.ZonedDateTime.from("2012-01-06T12:00:00+14:00[Pacific/Apia]");
+const d5 = new Temporal.Duration(0, 0, 0, -6, -3);
+TemporalHelpers.assertDuration(
+  d5.round({ smallestUnit: "weeks", relativeTo: relativeTo2 }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "-P6DT3H rounded to weeks, bounding window extending into a skipped calendar day"
+);

--- a/test/intl402/Temporal/Duration/prototype/round/skipped-day-collapses-day-boundary.js
+++ b/test/intl402/Temporal/Duration/prototype/round/skipped-day-collapses-day-boundary.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Rounding time units when day boundary collapses to zero due to skipped
+  calendar day
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const relativeTo = Temporal.ZonedDateTime.from("2012-01-01T12:00:00+14:00[Pacific/Apia]");
+
+const d = new Temporal.Duration(0, 0, 0, -1);
+TemporalHelpers.assertDuration(
+  d.round({ smallestUnit: "hours", relativeTo }),
+  0, 0, 0, -1, 0, 0, 0, 0, 0, 0,
+  "-P1D rounded to hours: day boundary falls on skipped calendar day"
+);

--- a/test/intl402/Temporal/Duration/prototype/total/skipped-day-collapses-bounding-window.js
+++ b/test/intl402/Temporal/Duration/prototype/total/skipped-day-collapses-bounding-window.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  Totalling a negative duration where skipped day collapses bounding window
+features: [Temporal]
+---*/
+
+const relativeTo = Temporal.ZonedDateTime.from("2012-01-01T12:00:00+14:00[Pacific/Apia]");
+const d = new Temporal.Duration(0, 0, 0, -1);
+assert.sameValue(
+  d.total({ unit: "days", relativeTo }),
+  -1,
+  "-1 day total in days with bounding window spanning a skipped calendar day"
+);
+
+const d2 = new Temporal.Duration(0, 0, 0, 0, -25);
+assert.sameValue(
+  d2.total({ unit: "days", relativeTo }),
+  -25 / 24,
+  "-25 hours total in days, bounding window extending into a skipped calendar day"
+);
+
+const d3 = new Temporal.Duration(0, 0, 0, 0, -36);
+assert.sameValue(
+  d3.total({ unit: "days", relativeTo }),
+  -1.5,
+  "-36 hours total in days, bounding window extending into a skipped calendar day"
+);
+
+const relativeTo2 = Temporal.ZonedDateTime.from("2012-01-06T12:00:00+14:00[Pacific/Apia]");
+const d4 = new Temporal.Duration(0, 0, 0, -6, -3);
+assert.sameValue(
+  d4.total({ unit: "weeks", relativeTo: relativeTo2 }),
+  -(168 + 3) / 168,
+  "-6 days 3 hours total in weeks, bounding window extending into a skipped calendar day, making a 6-day week"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/skipped-day-collapses-bounding-window.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/skipped-day-collapses-bounding-window.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: since() result where skipped day collapses bounding window
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const start = Temporal.ZonedDateTime.from("2012-01-01T12:00:00+14:00[Pacific/Apia]");
+const end = Temporal.ZonedDateTime.from("2011-12-31T12:00:00+14:00[Pacific/Apia]");
+TemporalHelpers.assertDuration(
+  start.since(end, { smallestUnit: "days" }),
+  0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+  "since spanning a skipped calendar day"
+);
+
+const end2 = Temporal.ZonedDateTime.from("2011-12-31T11:00:00+14:00[Pacific/Apia]");
+TemporalHelpers.assertDuration(
+  start.since(end2, { smallestUnit: "days" }),
+  0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+  "bounding window extending into a skipped calendar day"
+);
+
+const start2 = Temporal.ZonedDateTime.from("2012-01-06T12:00:00+14:00[Pacific/Apia]");
+const end3 = Temporal.ZonedDateTime.from("2011-12-31T09:00:00+14:00[Pacific/Apia]");
+TemporalHelpers.assertDuration(
+  start2.since(end3, { smallestUnit: "weeks" }),
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+  "week bounding window extending into a skipped calendar day"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/skipped-day-collapses-day-boundary.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/skipped-day-collapses-day-boundary.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  Difference with rounding to time smallestUnit where day boundary collapses to
+  zero due to skipped calendar day
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const start = Temporal.ZonedDateTime.from("2012-01-01T12:00:00+14:00[Pacific/Apia]");
+const end = Temporal.ZonedDateTime.from("2011-12-31T12:00:00+14:00[Pacific/Apia]");
+TemporalHelpers.assertDuration(
+  start.since(end, { largestUnit: "days", smallestUnit: "hours" }),
+  0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+  "spanning a skipped calendar day, rounded to hours"
+);
+
+const end2 = Temporal.ZonedDateTime.from("2011-12-31T11:00:00+14:00[Pacific/Apia]");
+TemporalHelpers.assertDuration(
+  start.since(end2, { largestUnit: "days", smallestUnit: "hours" }),
+  0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+  "spanning a skipped calendar day with 1-hour remainder, rounded to hours"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/skipped-day-collapses-bounding-window.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/skipped-day-collapses-bounding-window.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: until() result where skipped day collapses bounding window
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const start = Temporal.ZonedDateTime.from("2012-01-01T12:00:00+14:00[Pacific/Apia]");
+const end = Temporal.ZonedDateTime.from("2011-12-31T12:00:00+14:00[Pacific/Apia]");
+TemporalHelpers.assertDuration(
+  start.until(end, { smallestUnit: "days" }),
+  0, 0, 0, -1, 0, 0, 0, 0, 0, 0,
+  "until spanning a skipped calendar day"
+);
+
+const end2 = Temporal.ZonedDateTime.from("2011-12-31T11:00:00+14:00[Pacific/Apia]");
+TemporalHelpers.assertDuration(
+  start.until(end2, { smallestUnit: "days" }),
+  0, 0, 0, -1, 0, 0, 0, 0, 0, 0,
+  "bounding window extending into a skipped calendar day"
+);
+
+const start2 = Temporal.ZonedDateTime.from("2012-01-06T12:00:00+14:00[Pacific/Apia]");
+const end3 = Temporal.ZonedDateTime.from("2011-12-31T09:00:00+14:00[Pacific/Apia]");
+TemporalHelpers.assertDuration(
+  start2.until(end3, { smallestUnit: "weeks" }),
+  0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+  "week bounding window extending into a skipped calendar day"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/skipped-day-collapses-day-boundary.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/skipped-day-collapses-day-boundary.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  Difference with rounding to time smallestUnit where day boundary collapses to
+  zero due to skipped calendar day
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const start = Temporal.ZonedDateTime.from("2012-01-01T12:00:00+14:00[Pacific/Apia]");
+const end = Temporal.ZonedDateTime.from("2011-12-31T12:00:00+14:00[Pacific/Apia]");
+TemporalHelpers.assertDuration(
+  start.until(end, { largestUnit: "days", smallestUnit: "hours" }),
+  0, 0, 0, -1, 0, 0, 0, 0, 0, 0,
+  "spanning a skipped calendar day, rounded to hours"
+);
+
+const end2 = Temporal.ZonedDateTime.from("2011-12-31T11:00:00+14:00[Pacific/Apia]");
+TemporalHelpers.assertDuration(
+  start.until(end2, { largestUnit: "days", smallestUnit: "hours" }),
+  0, 0, 0, -1, -1, 0, 0, 0, 0, 0,
+  "spanning a skipped calendar day with 1-hour remainder, rounded to hours"
+);


### PR DESCRIPTION
This edge case was discovered thanks to Firefox fuzzing: https://bugzilla.mozilla.org/show_bug.cgi?id=2029455

See https://github.com/tc39/proposal-temporal/issues/3310

LLM disclosure: I used a bot to make a first draft of these, then hand-edited them until I was satisfied.