### PR TITLE
Fix a harmless bug in test/built-ins/TypedArray/prototype/includes/searchelement-not-integer.js

### DIFF
--- a/test/built-ins/TypedArray/prototype/includes/searchelement-not-integer.js
+++ b/test/built-ins/TypedArray/prototype/includes/searchelement-not-integer.js
@@ -18,13 +18,7 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
-function CustomError() {}
-
-function throwError() {
-  throw new CustomError();
-}
-
 testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample = new TA(makeCtorArg(10));
-  assert.sameValue(sample.includes({ valueOf: throwError }), false);
+  assert.sameValue(sample.includes({ valueOf: Test262Error.thrower }), false);
 });

--- a/test/built-ins/TypedArray/prototype/includes/searchelement-not-integer.js
+++ b/test/built-ins/TypedArray/prototype/includes/searchelement-not-integer.js
@@ -18,12 +18,13 @@ includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 
+function CustomError() {}
+
+function throwError() {
+  throw new CustomError();
+}
+
 testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   var sample = new TA(makeCtorArg(10));
-  function throwFunc(){
-    throw Test262Error()
-    return 0;
-  }
-
-    assert.sameValue(sample.includes({valueOf : throwFunc}), false);
+  assert.sameValue(sample.includes({ valueOf: throwError }), false);
 });


### PR DESCRIPTION
`throw new Test262Error()` does what it appears to do, but `throw Test262Error()` throws `undefined`.