### PR TITLE
Temporal: Add ZonedDateTime tests for repeated midnight

### DIFF
--- a/test/intl402/Temporal/ZonedDateTime/prototype/hoursInDay/same-date-starts-twice.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/hoursInDay/same-date-starts-twice.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-temporal.zoneddatetime.prototype.hoursinday
 description: Handles dates with offset transitions where midnight occurs twice.
+includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
@@ -17,3 +18,23 @@ const zdt3 = Temporal.ZonedDateTime.from('2010-11-08T23:00:00-03:30[America/St_J
 assert.sameValue(zdt1.hoursInDay, 24);
 assert.sameValue(zdt2.hoursInDay, 25);
 assert.sameValue(zdt3.hoursInDay, 24);
+
+const zdt4 = Temporal.ZonedDateTime.from("2010-03-04T23:10:00+11:00[Antarctica/Casey]");
+const zdt5 = Temporal.ZonedDateTime.from("2010-03-05T00:45:00+11:00[Antarctica/Casey]");
+// 3h backwards shift from +11 to +08 at 2010-03-05 02:00
+const zdt6 = Temporal.ZonedDateTime.from("2010-03-04T23:10:00+08:00[Antarctica/Casey]");
+const zdt7 = Temporal.ZonedDateTime.from("2010-03-05T00:45:00+08:00[Antarctica/Casey]");
+
+assert.sameValue(zdt4.hoursInDay, 24, "March 4 has 24 hours (excluding discontiguous piece)");
+assert.sameValue(zdt5.hoursInDay, 27, "March 5 has 27 hours (calculated from discontiguous piece)");
+assert.sameValue(zdt6.hoursInDay, 24, "March 4 has 24 hours (calculated from discontiguous piece)");
+assert.sameValue(zdt7.hoursInDay, 27, "March 5 has 27 hours (including discontiguous piece of March 4)");
+
+const startOfMarch4 = Temporal.ZonedDateTime.from("2010-03-04T00:00:00+11:00[Antarctica/Casey]");
+const startOfMarch5 = Temporal.ZonedDateTime.from("2010-03-05T00:00:00+11:00[Antarctica/Casey]");
+
+TemporalHelpers.assertZonedDateTimesEqual(
+  startOfMarch4.add({ hours: startOfMarch4.hoursInDay }),
+  startOfMarch5,
+  "start of day + hours in day = start of next day"
+);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/round/same-date-starts-twice.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/round/same-date-starts-twice.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.round
+description: Always rounds to a startOfDay, even when midnight occurs twice
+info: |
+  https://github.com/tc39/proposal-temporal/issues/2938
+  https://github.com/tc39/proposal-temporal/issues/3312
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const zdt1 = Temporal.ZonedDateTime.from('2010-03-04T23:10:00+11:00[Antarctica/Casey]');
+const zdt2 = Temporal.ZonedDateTime.from('2010-03-05T00:45:00+11:00[Antarctica/Casey]');
+// 3h backwards shift from +11 to +08 at 2010-03-05 02:00
+const zdt3 = Temporal.ZonedDateTime.from('2010-03-04T23:10:00+08:00[Antarctica/Casey]');
+const zdt4 = Temporal.ZonedDateTime.from('2010-03-05T00:45:00+08:00[Antarctica/Casey]');
+
+const startOfMarch4 = Temporal.ZonedDateTime.from("2010-03-04T00:00:00+11:00[Antarctica/Casey]");
+const startOfMarch5 = Temporal.ZonedDateTime.from("2010-03-05T00:00:00+11:00[Antarctica/Casey]");
+const startOfMarch6 = Temporal.ZonedDateTime.from("2010-03-06T00:00:00+08:00[Antarctica/Casey]");
+
+// Rounding down
+
+for (const roundingMode of ["floor", "trunc"]) {
+  const options = { smallestUnit: "days", roundingMode };
+  TemporalHelpers.assertZonedDateTimesEqual(zdt1.round(options), startOfMarch4, `${zdt1} ${roundingMode}`);
+  TemporalHelpers.assertZonedDateTimesEqual(zdt2.round(options), startOfMarch5, `${zdt2} ${roundingMode}`);
+  TemporalHelpers.assertZonedDateTimesEqual(zdt3.round(options), startOfMarch4, `${zdt3} ${roundingMode}`);
+  TemporalHelpers.assertZonedDateTimesEqual(zdt4.round(options), startOfMarch5, `${zdt4} ${roundingMode}`);
+}
+
+// Rounding to nearest
+
+for (const roundingMode of ["halfCeil", "halfEven", "halfExpand", "halfFloor", "halfTrunc"]) {
+  const options = { smallestUnit: "days", roundingMode };
+  TemporalHelpers.assertZonedDateTimesEqual(zdt1.round(options), startOfMarch5, `${zdt1} ${roundingMode}`);
+  TemporalHelpers.assertZonedDateTimesEqual(zdt2.round(options), startOfMarch5, `${zdt2} ${roundingMode}`);
+  TemporalHelpers.assertZonedDateTimesEqual(zdt3.round(options), startOfMarch5, `${zdt3} ${roundingMode}`);
+  TemporalHelpers.assertZonedDateTimesEqual(zdt4.round(options), startOfMarch5, `${zdt4} ${roundingMode}`);
+}
+
+// Rounding up
+
+for (const roundingMode of ["ceil", "expand"]) {
+  const options = { smallestUnit: "days", roundingMode };
+  TemporalHelpers.assertZonedDateTimesEqual(zdt1.round(options), startOfMarch5, `${zdt1} ${roundingMode}`);
+  TemporalHelpers.assertZonedDateTimesEqual(zdt2.round(options), startOfMarch6, `${zdt2} ${roundingMode}`);
+  TemporalHelpers.assertZonedDateTimesEqual(zdt3.round(options), startOfMarch5, `${zdt3} ${roundingMode}`);
+  TemporalHelpers.assertZonedDateTimesEqual(zdt4.round(options), startOfMarch6, `${zdt4} ${roundingMode}`);
+}

--- a/test/intl402/Temporal/ZonedDateTime/prototype/startOfDay/same-date-starts-twice.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/startOfDay/same-date-starts-twice.js
@@ -21,3 +21,17 @@ const startOfDay3 = Temporal.ZonedDateTime.from('2010-11-08T00:00:00-03:30[Ameri
 TemporalHelpers.assertZonedDateTimesEqual(zdt1.startOfDay(), zdt1);
 TemporalHelpers.assertZonedDateTimesEqual(zdt2.startOfDay(), startOfDay2);
 TemporalHelpers.assertZonedDateTimesEqual(zdt3.startOfDay(), startOfDay3);
+
+const zdt4 = Temporal.ZonedDateTime.from("2010-03-04T23:10:00+11:00[Antarctica/Casey]");
+const zdt5 = Temporal.ZonedDateTime.from("2010-03-05T00:45:00+11:00[Antarctica/Casey]");
+// 3h backwards shift from +11 to +08 at 2010-03-05 02:00
+const zdt6 = Temporal.ZonedDateTime.from("2010-03-04T23:10:00+08:00[Antarctica/Casey]");
+const zdt7 = Temporal.ZonedDateTime.from("2010-03-05T00:45:00+08:00[Antarctica/Casey]");
+
+const startOfMarch4 = Temporal.ZonedDateTime.from("2010-03-04T00:00:00+11:00[Antarctica/Casey]");
+const startOfMarch5 = Temporal.ZonedDateTime.from("2010-03-05T00:00:00+11:00[Antarctica/Casey]");
+
+TemporalHelpers.assertZonedDateTimesEqual(zdt4.startOfDay(), startOfMarch4, "start of March 4");
+TemporalHelpers.assertZonedDateTimesEqual(zdt5.startOfDay(), startOfMarch5, "start of March 5, calculated from discontiguous piece");
+TemporalHelpers.assertZonedDateTimesEqual(zdt6.startOfDay(), startOfMarch4, "start of March 4, calculated from discontiguous piece");
+TemporalHelpers.assertZonedDateTimesEqual(zdt7.startOfDay(), startOfMarch5, "start of March 5");


### PR DESCRIPTION
In an Antarctica time zone, in 2010, there was a time zone shift that went from 02:00 to 23:00, repeating midnight twice. This was handled in ZonedDateTime.prototype.startOfDay() and .hoursInDay, but not in .round({ smallestUnit: 'days' }), where the spec text had an assertion. We'll remove that assertion as it is faulty. This PR adds test coverage for the situation.

See: https://github.com/tc39/proposal-temporal/issues/3312