### PR TITLE
Verify argument counts when forwarding dispose/asyncDispose to return

### DIFF
--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/invokes-return.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/invokes-return.js
@@ -13,7 +13,7 @@ info: |
   5. If return is undefined, then
     a. Perform ! Call(promiseCapability.[[Resolve]], undefined, « undefined »).
   6. Else,
-    a. Let result be Call(return, O, « undefined »).
+    a. Let result be Call(return, O, « »).
     b. IfAbruptRejectPromise(result, promiseCapability).
     c. Let resultWrapper be Completion(PromiseResolve(%Promise%, result)).
     d. IfAbruptRejectPromise(resultWrapper, promiseCapability).

--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/invokes-return.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/invokes-return.js
@@ -34,11 +34,14 @@ asyncTest(async function () {
 
   const iter = Object.create(AsyncIteratorPrototype);
   var returnCalled = false;
+  var argumentCount = 0;
   iter.return = async function () {
+    argumentCount = arguments.length;
     returnCalled = true;
     return { done: true };
   };
 
   await iter[Symbol.asyncDispose]();
   assert.sameValue(returnCalled, true);
+  assert.sameValue(argumentCount, 0);
 });

--- a/test/built-ins/Iterator/prototype/Symbol.dispose/invokes-return.js
+++ b/test/built-ins/Iterator/prototype/Symbol.dispose/invokes-return.js
@@ -21,10 +21,13 @@ const IteratorPrototype = Object.getPrototypeOf(
 
 const iter = Object.create(IteratorPrototype);
 var returnCalled = false;
+var argumentCount = 0;
 iter.return = function () {
+  argumentCount = arguments.length;
   returnCalled = true;
   return { done: true };
 };
 
 iter[Symbol.dispose]();
 assert.sameValue(returnCalled, true);
+assert.sameValue(argumentCount, 0);


### PR DESCRIPTION
There was no validation for argument count in the tests for when either `Iterator.prototype[Symbol.dispose]()` or `AsyncIterator.prototype[Symbol.asyncDispose]()` invoke `this.return();`. 

This currently expects both to be `0`, to match the Needs Consensus PR https://github.com/rbuckton/ecma262/pull/17. If this PR does not advance, this test can be adjusted to expect `0` for `Iterator.prototype[Symbol.dispose]()` and `1` for `AsyncIterator.prototype[Symbol.asyncDispose]()`.

Related: rbuckton/ecma262#17
Related: tc39/proposal-explicit-resource-management#273