### PR TITLE
Intl Era Month Code: Test not-yet-supported calendars in Intl.DateTimeFormat and Temporal

### DIFF
--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -113,6 +113,23 @@ var TemporalHelpers = {
     ],
   },
 
+
+  /**
+   * Apple's fork of ICU contains code for these calendars, but they are not yet
+   * allowed to be supported in AvailableCalendars. See
+   * https://github.com/tc39/ecma402/blob/main/meetings/notes-2025-12-04.md#datetimeformatconstructor-options-calendar-islamic-fallbackjs-should-allow-other-fallback-values-4677
+   */
+  NotYetSupportedCalendars: [
+    "bangla",
+    "gujarati",
+    "kannada",
+    "marathi",
+    "odia",
+    "tamil",
+    "telugu",
+    "vikram",
+  ],
+
   /*
    * Return the canonical era code.
    */

--- a/test/intl402/DateTimeFormat/constructor-options-calendar-future-fallback.js
+++ b/test/intl402/DateTimeFormat/constructor-options-calendar-future-fallback.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.datetimeformat
+description: >
+  Tests that fallbacks for not-yet-adopted calendars are selected from one of
+  the values returned from `AvailableCalendars`.
+locale: [en]
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode]
+---*/
+
+const availableCalendars = [
+  "buddhist",
+  "chinese",
+  "coptic",
+  "dangi",
+  "ethioaa",
+  "ethiopic",
+  "gregory",
+  "hebrew",
+  "indian",
+  "islamic-civil",
+  "islamic-tbla",
+  "islamic-umalqura",
+  "iso8601",
+  "japanese",
+  "persian",
+  "roc",
+];
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  const option = new Intl.DateTimeFormat("en", { calendar });
+  assert(
+    availableCalendars.includes(option.resolvedOptions().calendar),
+    `${calendar} should fall back to an available calendar`
+  );
+
+  const uExtension = new Intl.DateTimeFormat(`en-u-ca-${calendar}`);
+  assert(
+    availableCalendars.includes(uExtension.resolvedOptions().calendar),
+    `${calendar} should fall back to an available calendar`
+  );
+}

--- a/test/intl402/Temporal/PlainDate/compare/future-calendar.js
+++ b/test/intl402/Temporal/PlainDate/compare/future-calendar.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.PlainDate(1970, 1, 1);
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    Temporal.PlainDate.compare(`1970-01-01[u-ca=${calendar}]`, okDate);
+  }, `${calendar} is not yet supported (first argument, string)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainDate.compare({ year: 1970, month: 1, day: 1, calendar }, okDate);
+  }, `${calendar} is not yet supported (first argument, property bag)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainDate.compare(okDate, `1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (second argument, string)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainDate.compare(okDate, { year: 1970, month: 1, day: 1, calendar });
+  }, `${calendar} is not yet supported (second argument, property bag)`);
+}

--- a/test/intl402/Temporal/PlainDate/from/future-calendar.js
+++ b/test/intl402/Temporal/PlainDate/from/future-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    Temporal.PlainDate.from(`1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (string)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainDate.from({ year: 1970, month: 1, day: 1, calendar });
+  }, `${calendar} is not yet supported (property bag)`);
+}

--- a/test/intl402/Temporal/PlainDate/future-calendar.js
+++ b/test/intl402/Temporal/PlainDate/future-calendar.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    new Temporal.PlainDate(1970, 1, 1, calendar);
+  }, `${calendar} is not yet supported`);
+}

--- a/test/intl402/Temporal/PlainDate/prototype/equals/future-calendar.js
+++ b/test/intl402/Temporal/PlainDate/prototype/equals/future-calendar.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.PlainDate(1970, 1, 1);
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    okDate.equals(`1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (string)`);
+  assert.throws(RangeError, function () {
+    okDate.equals({ year: 1970, month: 1, day: 1, calendar });
+  }, `${calendar} is not yet supported (property bag)`);
+}

--- a/test/intl402/Temporal/PlainDate/prototype/withCalendar/future-calendar.js
+++ b/test/intl402/Temporal/PlainDate/prototype/withCalendar/future-calendar.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.withcalendar
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.PlainDate(1970, 1, 1);
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    okDate.withCalendar(calendar);
+  }, `${calendar} is not yet supported`);
+}

--- a/test/intl402/Temporal/PlainDateTime/compare/future-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/compare/future-calendar.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.PlainDateTime(1970, 1, 1);
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    Temporal.PlainDateTime.compare(`1970-01-01[u-ca=${calendar}]`, okDate);
+  }, `${calendar} is not yet supported (first argument, string)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainDateTime.compare({ year: 1970, month: 1, day: 1, calendar }, okDate);
+  }, `${calendar} is not yet supported (first argument, property bag)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainDateTime.compare(okDate, `1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (second argument, string)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainDateTime.compare(okDate, { year: 1970, month: 1, day: 1, calendar });
+  }, `${calendar} is not yet supported (second argument, property bag)`);
+}

--- a/test/intl402/Temporal/PlainDateTime/from/future-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/from/future-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    Temporal.PlainDateTime.from(`1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (string)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainDateTime.from({ year: 1970, month: 1, day: 1, calendar });
+  }, `${calendar} is not yet supported (property bag)`);
+}

--- a/test/intl402/Temporal/PlainDateTime/future-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/future-calendar.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    new Temporal.PlainDateTime(1970, 1, 1, 0, 0, 0, 0, 0, 0, calendar);
+  }, `${calendar} is not yet supported`);
+}

--- a/test/intl402/Temporal/PlainDateTime/prototype/equals/future-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/equals/future-calendar.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.PlainDateTime(1970, 1, 1);
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    okDate.equals(`1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (string)`);
+  assert.throws(RangeError, function () {
+    okDate.equals({ year: 1970, month: 1, day: 1, calendar });
+  }, `${calendar} is not yet supported (property bag)`);
+}

--- a/test/intl402/Temporal/PlainDateTime/prototype/withCalendar/future-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/withCalendar/future-calendar.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withcalendar
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.PlainDateTime(1970, 1, 1);
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    okDate.withCalendar(calendar);
+  }, `${calendar} is not yet supported`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/from/future-calendar.js
+++ b/test/intl402/Temporal/PlainMonthDay/from/future-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    Temporal.PlainMonthDay.from(`1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (string)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainMonthDay.from({ monthCode: "M01", day: 1, calendar });
+  }, `${calendar} is not yet supported (property bag)`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/future-calendar.js
+++ b/test/intl402/Temporal/PlainMonthDay/future-calendar.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    new Temporal.PlainMonthDay(1, 1, calendar, 1970);
+  }, `${calendar} is not yet supported`);
+}

--- a/test/intl402/Temporal/PlainMonthDay/prototype/equals/future-calendar.js
+++ b/test/intl402/Temporal/PlainMonthDay/prototype/equals/future-calendar.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.PlainMonthDay(1, 1);
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    okDate.equals(`1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (string)`);
+  assert.throws(RangeError, function () {
+    okDate.equals({ monthCode: "M01", day: 1, calendar });
+  }, `${calendar} is not yet supported (property bag)`);
+}

--- a/test/intl402/Temporal/PlainYearMonth/compare/future-calendar.js
+++ b/test/intl402/Temporal/PlainYearMonth/compare/future-calendar.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.PlainYearMonth(1970, 1);
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    Temporal.PlainYearMonth.compare(`1970-01-01[u-ca=${calendar}]`, okDate);
+  }, `${calendar} is not yet supported (first argument, string)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainYearMonth.compare({ year: 1970, month: 1, calendar }, okDate);
+  }, `${calendar} is not yet supported (first argument, property bag)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainYearMonth.compare(okDate, `1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (second argument, string)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainYearMonth.compare(okDate, { year: 1970, month: 1, calendar });
+  }, `${calendar} is not yet supported (second argument, property bag)`);
+}

--- a/test/intl402/Temporal/PlainYearMonth/from/future-calendar.js
+++ b/test/intl402/Temporal/PlainYearMonth/from/future-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    Temporal.PlainYearMonth.from(`1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (string)`);
+  assert.throws(RangeError, function () {
+    Temporal.PlainYearMonth.from({ year: 1970, month: 1, calendar });
+  }, `${calendar} is not yet supported (property bag)`);
+}

--- a/test/intl402/Temporal/PlainYearMonth/future-calendar.js
+++ b/test/intl402/Temporal/PlainYearMonth/future-calendar.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    new Temporal.PlainYearMonth(1970, 1, calendar, 1);
+  }, `${calendar} is not yet supported`);
+}

--- a/test/intl402/Temporal/PlainYearMonth/prototype/equals/future-calendar.js
+++ b/test/intl402/Temporal/PlainYearMonth/prototype/equals/future-calendar.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.PlainYearMonth(1970, 1);
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    okDate.equals(`1970-01-01[u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (string)`);
+  assert.throws(RangeError, function () {
+    okDate.equals({ year: 1970, month: 1, calendar });
+  }, `${calendar} is not yet supported (property bag)`);
+}

--- a/test/intl402/Temporal/ZonedDateTime/compare/future-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/compare/future-calendar.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.ZonedDateTime(0n, "UTC");
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    Temporal.ZonedDateTime.compare(`1970-01-01[UTC][u-ca=${calendar}]`, okDate);
+  }, `${calendar} is not yet supported (first argument, string)`);
+  assert.throws(RangeError, function () {
+    Temporal.ZonedDateTime.compare({ year: 1970, month: 1, day: 1, timeZone: "UTC", calendar }, okDate);
+  }, `${calendar} is not yet supported (first argument, property bag)`);
+  assert.throws(RangeError, function () {
+    Temporal.ZonedDateTime.compare(okDate, `1970-01-01[UTC][u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (second argument, string)`);
+  assert.throws(RangeError, function () {
+    Temporal.ZonedDateTime.compare(okDate, { year: 1970, month: 1, day: 1, timeZone: "UTC", calendar });
+  }, `${calendar} is not yet supported (second argument, property bag)`);
+}

--- a/test/intl402/Temporal/ZonedDateTime/from/future-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/future-calendar.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    Temporal.ZonedDateTime.from(`1970-01-01[UTC][u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (string)`);
+  assert.throws(RangeError, function () {
+    Temporal.ZonedDateTime.from({ year: 1970, month: 1, day: 1, timeZone: "UTC", calendar });
+  }, `${calendar} is not yet supported (property bag)`);
+}

--- a/test/intl402/Temporal/ZonedDateTime/future-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/future-calendar.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    new Temporal.ZonedDateTime(0n, "UTC", calendar);
+  }, `${calendar} is not yet supported`);
+}

--- a/test/intl402/Temporal/ZonedDateTime/prototype/equals/future-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/equals/future-calendar.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.ZonedDateTime(0n, "UTC");
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    okDate.equals(`1970-01-01[UTC][u-ca=${calendar}]`);
+  }, `${calendar} is not yet supported (string)`);
+  assert.throws(RangeError, function () {
+    okDate.equals({ year: 1970, month: 1, day: 1, timeZone: "UTC", calendar });
+  }, `${calendar} is not yet supported (property bag)`);
+}

--- a/test/intl402/Temporal/ZonedDateTime/prototype/withCalendar/future-calendar.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/withCalendar/future-calendar.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withcalendar
+description: Not-yet-adopted calendar IDs are rejected
+includes: [temporalHelpers.js]
+features: [Intl.Era-monthcode, Temporal]
+---*/
+
+const okDate = new Temporal.ZonedDateTime(0n, "UTC");
+
+for (const calendar of TemporalHelpers.NotYetSupportedCalendars) {
+  assert.throws(RangeError, function () {
+    okDate.withCalendar(calendar);
+  }, `${calendar} is not yet supported`);
+}


### PR DESCRIPTION
As per https://github.com/tc39/ecma402/blob/main/meetings/notes-2025-12-04.md#datetimeformatconstructor-options-calendar-islamic-fallbackjs-should-allow-other-fallback-values-4677 the supported calendars in Intl and Temporal must be a closed set for implementations conforming to ECMA-402. Unlike most other Intl entries such as number formats, implementations may not support extra calendars until they've gone through the process to define month codes and era codes interoperably.

Apple's fork of ICU contains code for some South Asian calendars not in other versions of ICU. These calendars therefore form good test data for the above, since they technically could be supported in implementations using that version of ICU in the future, but must not (yet) be.

See: https://github.com/tc39/proposal-intl-era-monthcode/issues/128