### PR TITLE
harness: Make `Test262Error()` work without `new`, just like built-in error constructors

### DIFF
--- a/harness/sta.js
+++ b/harness/sta.js
@@ -11,6 +11,7 @@ defines: [Test262Error, $DONOTEVALUATE]
 
 
 function Test262Error(message) {
+  if (!(this instanceof Test262Error)) return new Test262Error(message);
   this.message = message || "";
 }
 


### PR DESCRIPTION
cf. https://github.com/tc39/test262/pull/5046#issuecomment-4454926920
> since for all builtin error types, [`throw new Test262Error()` and `throw Test262Error()` are] identical, why don't we just fix Test262Error to work properly?