### PR TITLE
Add test for unambiguous re-export of source-phase import

### DIFF
--- a/test/language/module-code/ambiguous-export-bindings/namespace-import-source-and-export-1_FIXTURE.js
+++ b/test/language/module-code/ambiguous-export-bindings/namespace-import-source-and-export-1_FIXTURE.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2026 Guy Bedford. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import source mod from '<module source>';
+export { mod };

--- a/test/language/module-code/ambiguous-export-bindings/namespace-import-source-and-export-2_FIXTURE.js
+++ b/test/language/module-code/ambiguous-export-bindings/namespace-import-source-and-export-2_FIXTURE.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2026 Guy Bedford. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import source mod from '<module source>';
+export { mod };

--- a/test/language/module-code/ambiguous-export-bindings/namespace-import-source-and-export-reexport_FIXTURE.js
+++ b/test/language/module-code/ambiguous-export-bindings/namespace-import-source-and-export-reexport_FIXTURE.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2026 Guy Bedford. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export * from './namespace-import-source-and-export-1_FIXTURE.js';
+export * from './namespace-import-source-and-export-2_FIXTURE.js';

--- a/test/language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-import-source-and-export.js
+++ b/test/language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-import-source-and-export.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 Guy Bedford. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Re-exporting the same source-phase import via `import source mod from
+  '<module source>'; export { mod }` from two different modules produces an
+  unambiguous binding.
+esid: sec-resolveexport
+info: |
+  When ParseModule encounters `export { mod }` where `mod` is a local binding
+  introduced by `import source mod from "..."`, the ExportEntry is
+  reclassified as an indirect ExportEntry whose [[ImportName]] is ~source~.
+
+  ResolveExport ( exportName, resolveSet )
+
+    [...]
+    For each ExportEntry Record e of module.[[IndirectExportEntries]], do
+      a. If e.[[ExportName]] is exportName, then
+         [...]
+         iii. If e.[[ImportName]] is namespace, then [...]
+         iv. Else if e.[[ImportName]] is source, then
+            1. Assert: module does not provide the direct binding for this export.
+            2. Return ResolvedBinding Record { [[Module]]: importedModule,
+               [[BindingName]]: source }.
+         [...]
+
+    [...]
+    For each ExportEntry Record e of module.[[StarExportEntries]], do
+      a. Let importedModule be GetImportedModule(module, e.[[ModuleRequest]]).
+      b. Let resolution be ? importedModule.ResolveExport(exportName, resolveSet).
+      c. If resolution is ambiguous, return ambiguous.
+      d. If resolution is not null, then
+         i. If starResolution is null, set starResolution to resolution.
+         ii. Else,
+            1. Assert: there is more than one * import that includes the requested name.
+            2. If resolution.[[Module]] and starResolution.[[Module]] are not the
+               same Module Record, return ambiguous.
+            3. If resolution.[[BindingName]] is not starResolution.[[BindingName]],
+               return ambiguous.
+
+  Both fixtures contain `import source mod from '<module source>'; export { mod };`.
+  The host resolves '<module source>' to the same Module Record in both, so
+  the two ResolveExport results carry the same [[Module]] and the same
+  [[BindingName]] (~source~). The star-export ambiguity check therefore
+  succeeds, the named import of `mod` from the re-export resolves to a
+  ResolvedBinding Record with [[BindingName]] ~source~, and InitializeEnvironment
+  initializes `mod` to the underlying [[ModuleSource]].
+features: [source-phase-imports, source-phase-imports-module-source]
+flags: [module]
+---*/
+
+import { mod } from './namespace-import-source-and-export-reexport_FIXTURE.js';
+
+assert.sameValue(typeof mod, 'object',
+  'Re-exported source-phase binding should resolve to a ModuleSource object');
+assert(mod instanceof $262.AbstractModuleSource,
+  '`mod` should be an instance of %AbstractModuleSource%');

--- a/test/language/module-code/source-phase-import/reexport-source-binding-named-import.js
+++ b/test/language/module-code/source-phase-import/reexport-source-binding-named-import.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Guy Bedford. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  A named import of a re-exported source-phase binding is initialized to the
+  imported module's ModuleSource object.
+esid: sec-source-text-module-record-initialize-environment
+info: |
+  When a module does `import source x from "..."; export { x };`, ParseModule
+  reclassifies the local re-export to an indirect ExportEntry whose
+  [[ImportName]] is ~source~. ResolveExport on the re-exporting module returns
+  a ResolvedBinding Record with [[BindingName]] ~source~ and [[Module]] set to
+  the source-phase target module.
+
+  InitializeEnvironment ( )
+
+    7. For each ImportEntry Record in of module.[[ImportEntries]], do
+       [...]
+       d. Else,
+          i. Assert: in.[[ImportName]] is a String.
+          ii. Let resolution be importedModule.ResolveExport(in.[[ImportName]]).
+          iii. If resolution is either null or ambiguous, throw a SyntaxError.
+          iv. If resolution.[[BindingName]] is namespace, then [...]
+          v. Else if resolution.[[BindingName]] is source, then
+             1. Let moduleSourceObject be resolution.[[Module]].[[ModuleSource]].
+             2. If moduleSourceObject is empty, throw a SyntaxError exception.
+             3. Perform ! env.CreateImmutableBinding(in.[[LocalName]], true).
+             4. Perform ! env.InitializeBinding(in.[[LocalName]], moduleSourceObject).
+
+  The named import `x` is therefore bound directly to the ModuleSource object
+  of the underlying module, an instance of %AbstractModuleSource%.
+features: [source-phase-imports, source-phase-imports-module-source]
+flags: [module]
+---*/
+
+import { x } from './reexport-source-binding_FIXTURE.js';
+
+assert.sameValue(typeof x, 'object',
+  'Named import of a re-exported source binding should be bound to an object');
+assert(x instanceof $262.AbstractModuleSource,
+  'x should be a %AbstractModuleSource% instance (the underlying ModuleSource)');

--- a/test/language/module-code/source-phase-import/reexport-source-binding-namespace-get.js
+++ b/test/language/module-code/source-phase-import/reexport-source-binding-namespace-get.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Guy Bedford. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Namespace [[Get]] of a re-exported source-phase binding returns the
+  imported module's ModuleSource object.
+esid: sec-module-namespace-exotic-objects-get-p-receiver
+info: |
+  When a module does `import source x from "..."; export { x };`, ParseModule
+  reclassifies the local re-export to an indirect ExportEntry whose
+  [[ImportName]] is ~source~. ResolveExport on the re-exporting module returns
+  a ResolvedBinding Record with [[BindingName]] ~source~ and [[Module]] set to
+  the source-phase target module.
+
+  Module Namespace Exotic Object [[Get]] ( P, Receiver )
+
+    [...]
+    7. If binding.[[BindingName]] is namespace, then
+      a. Return GetModuleNamespace(targetModule).
+    8. If binding.[[BindingName]] is source, then
+      a. Let moduleSourceObject be targetModule.[[ModuleSource]].
+      b. If moduleSourceObject is empty, throw a ReferenceError exception.
+      c. Return moduleSourceObject.
+    9. [...]
+
+  Accessing the re-exported binding via `ns.x` therefore returns the
+  ModuleSource object of the underlying module, an instance of
+  %AbstractModuleSource%.
+features: [source-phase-imports, source-phase-imports-module-source]
+flags: [module]
+---*/
+
+import * as ns from './reexport-source-binding_FIXTURE.js';
+
+assert.sameValue(typeof ns.x, 'object',
+  'Namespace [[Get]] of a re-exported source binding should return an object');
+assert(ns.x instanceof $262.AbstractModuleSource,
+  'ns.x should be a %AbstractModuleSource% instance (the underlying ModuleSource)');

--- a/test/language/module-code/source-phase-import/reexport-source-binding_FIXTURE.js
+++ b/test/language/module-code/source-phase-import/reexport-source-binding_FIXTURE.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2026 Guy Bedford. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import source x from '<module source>';
+export { x };


### PR DESCRIPTION
This adds the test-262 test for the normative change to the Source Phase Imports proposal, which obtained consensus at the TC39 meeting this week. This change allows source phase bindings to participate in ambiguous re-export deduplication, which is tested here that an ambiguous error is not thrown when reexports resolve to the same module's module source binding.

In addition new tests are also added to exercise the new binding paths that may be affected by the corresponding refactoring of the source binding handling.