### PR TITLE
Test that %Intl%.[[FallbackSymbol]] is per-realm

### DIFF
--- a/test/intl402/DateTimeFormat/intl-legacy-constructed-symbol-on-unwrap.js
+++ b/test/intl402/DateTimeFormat/intl-legacy-constructed-symbol-on-unwrap.js
@@ -12,21 +12,14 @@ features: [intl-normative-optional]
 let object = new Intl.DateTimeFormat();
 let newObject = Intl.DateTimeFormat.call(object);
 let symbol = null;
-let error = null;
-try {
-    let proxy = new Proxy(newObject, {
-        get(target, property) {
-            symbol = property;
-            return target[property];
-        }
-    });
-    Intl.DateTimeFormat.prototype.resolvedOptions.call(proxy);
-} catch (e) {
-    // If normative optional is not implemented, an error will be thrown.
-    error = e;
-    assert(error instanceof TypeError);
-}
-if (error === null) {
-      assert.sameValue(typeof symbol, "symbol");
-      assert.sameValue(symbol.description, "IntlLegacyConstructedSymbol");
-}
+
+let proxy = new Proxy(newObject, {
+  get(target, property) {
+    symbol = property;
+    return target[property];
+  }
+});
+Intl.DateTimeFormat.prototype.resolvedOptions.call(proxy);
+
+assert.sameValue(typeof symbol, "symbol");
+assert.sameValue(symbol.description, "IntlLegacyConstructedSymbol");

--- a/test/intl402/DateTimeFormat/intl-legacy-constructed-symbol-property.js
+++ b/test/intl402/DateTimeFormat/intl-legacy-constructed-symbol-property.js
@@ -1,0 +1,37 @@
+// Copyright 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.datetimeformat
+description: Property descriptor of %Intl%.[[FallbackSymbol]]
+info: |
+  ChainDateTimeFormat ( dateTimeFormat, newTarget, this )
+
+  1.a. Perform ? DefinePropertyOrThrow(_this_, %Intl%.[[FallbackSymbol]],
+       PropertyDescriptor{ [[Value]]: _dateTimeFormat_, [[Writable]]: *false*,
+       [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+includes: [propertyHelper.js]
+features: [intl-normative-optional]
+---*/
+
+const object = Object.create(Intl.DateTimeFormat.prototype);
+const fallbackDTF = Intl.DateTimeFormat.call(object);
+assert.sameValue(object, fallbackDTF, "return value of Intl.DateTimeFormat constructor");
+
+const symbolProps = Object.getOwnPropertySymbols(fallbackDTF);
+const fallbackSymbol = symbolProps.find((sym) => sym.description === "IntlLegacyConstructedSymbol");
+
+assert(
+  fallbackDTF[fallbackSymbol] instanceof Intl.DateTimeFormat,
+  "value of legacy symbol property must be an Intl.DateTimeFormat"
+);
+verifyProperty(
+  fallbackDTF,
+  fallbackSymbol,
+  {
+    writable: false,
+    enumerable: false,
+    configurable: false
+  },
+  { label: "%Intl%.[[FallbackSymbol]]" }
+);

--- a/test/intl402/DateTimeFormat/intl-legacy-constructed-symbol.js
+++ b/test/intl402/DateTimeFormat/intl-legacy-constructed-symbol.js
@@ -12,7 +12,5 @@ features: [intl-normative-optional]
 let object = new Intl.DateTimeFormat();
 let newObject = Intl.DateTimeFormat.call(object);
 let symbols = Object.getOwnPropertySymbols(newObject);
-if (symbols.length !== 0) {
-    assert.sameValue(symbols.length, 1);
-    assert.sameValue(symbols[0].description, "IntlLegacyConstructedSymbol");
-}
+
+assert(symbols.some((symbol) => symbol.description === "IntlLegacyConstructedSymbol"));

--- a/test/intl402/FallbackSymbol/description.js
+++ b/test/intl402/FallbackSymbol/description.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: intl-object
+description: "%Intl%.[[FallbackSymbol]] description"
+info: |
+  The Intl object:
+  - has a [[FallbackSymbol]] internal slot, which is a new %Symbol% in the
+    current realm with the [[Description]] *"IntlLegacyConstructedSymbol"*.
+features: [intl-normative-optional]
+---*/
+
+const fallbackDTF = Intl.DateTimeFormat.call(Object.create(Intl.DateTimeFormat.prototype));
+const symbolProps = Object.getOwnPropertySymbols(fallbackDTF);
+const fallbackSymbol = symbolProps.find((sym) => sym.description === "IntlLegacyConstructedSymbol");
+
+assert.notSameValue(
+  fallbackSymbol,
+  undefined,
+  "%Intl%.[[FallbackSymbol]] with description IntlLegacyConstructedSymbol should exist"
+);

--- a/test/intl402/FallbackSymbol/per-realm.js
+++ b/test/intl402/FallbackSymbol/per-realm.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: intl-object
+description: "%Intl%.[[FallbackSymbol]] is per-realm"
+info: |
+  The Intl object:
+  - has a [[FallbackSymbol]] internal slot, which is a new %Symbol% in the
+    current realm with the [[Description]] *"IntlLegacyConstructedSymbol"*.
+features: [intl-normative-optional]
+---*/
+
+const fallbackDTF = Intl.DateTimeFormat.call(Object.create(Intl.DateTimeFormat.prototype));
+const symbolProps = Object.getOwnPropertySymbols(fallbackDTF);
+const fallbackSymbol = symbolProps.find((sym) => sym.description === "IntlLegacyConstructedSymbol");
+
+assert.notSameValue(fallbackSymbol, undefined, "%Intl%.[[FallbackSymbol]] should exist in original realm");
+
+const other = $262.createRealm();
+const otherFallbackSymbol = other.evalScript(`
+  const fallbackDTF = Intl.DateTimeFormat.call(Object.create(Intl.DateTimeFormat.prototype));
+  const symbolProps = Object.getOwnPropertySymbols(fallbackDTF);
+  symbolProps.find((sym) => sym.description === "IntlLegacyConstructedSymbol");
+`);
+
+assert.notSameValue(otherFallbackSymbol, undefined, "%Intl%.[[FallbackSymbol]] should exist in new realm");
+
+assert.notSameValue(fallbackSymbol, otherFallbackSymbol, "%Intl%.[[FallbackSymbol]] should be different per-realm");

--- a/test/intl402/NumberFormat/intl-legacy-constructed-symbol-on-unwrap.js
+++ b/test/intl402/NumberFormat/intl-legacy-constructed-symbol-on-unwrap.js
@@ -12,21 +12,14 @@ features: [intl-normative-optional]
 let object = new Intl.NumberFormat();
 let newObject = Intl.NumberFormat.call(object);
 let symbol = null;
-let error = null;
-try {
-    let proxy = new Proxy(newObject, {
-        get(target, property) {
-            symbol = property;
-            return target[property];
-        }
-    });
-    Intl.NumberFormat.prototype.resolvedOptions.call(proxy);
-} catch (e) {
-    // If normative optional is not implemented, an error will be thrown.
-    error = e;
-    assert(error instanceof TypeError);
-}
-if (error === null) {
-      assert.sameValue(typeof symbol, "symbol");
-      assert.sameValue(symbol.description, "IntlLegacyConstructedSymbol");
-}
+
+let proxy = new Proxy(newObject, {
+  get(target, property) {
+    symbol = property;
+    return target[property];
+  }
+});
+Intl.NumberFormat.prototype.resolvedOptions.call(proxy);
+
+assert.sameValue(typeof symbol, "symbol");
+assert.sameValue(symbol.description, "IntlLegacyConstructedSymbol");

--- a/test/intl402/NumberFormat/intl-legacy-constructed-symbol-property.js
+++ b/test/intl402/NumberFormat/intl-legacy-constructed-symbol-property.js
@@ -1,0 +1,37 @@
+// Copyright 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat
+description: Property descriptor of %Intl%.[[FallbackSymbol]]
+info: |
+  ChainNumberFormat ( numberFormat, newTarget, this )
+
+  1.a. Perform ? DefinePropertyOrThrow(_this_, %Intl%.[[FallbackSymbol]],
+       PropertyDescriptor{ [[Value]]: _numberFormat_, [[Writable]]: *false*,
+       [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+includes: [propertyHelper.js]
+features: [intl-normative-optional]
+---*/
+
+const object = Object.create(Intl.NumberFormat.prototype);
+const fallbackNF = Intl.NumberFormat.call(object);
+assert.sameValue(object, fallbackNF, "return value of Intl.NumberFormat constructor");
+
+const symbolProps = Object.getOwnPropertySymbols(fallbackNF);
+const fallbackSymbol = symbolProps.find((sym) => sym.description === "IntlLegacyConstructedSymbol");
+
+assert(
+  fallbackNF[fallbackSymbol] instanceof Intl.NumberFormat,
+  "value of legacy symbol property must be an Intl.NumberFormat"
+);
+verifyProperty(
+  fallbackNF,
+  fallbackSymbol,
+  {
+    writable: false,
+    enumerable: false,
+    configurable: false
+  },
+  { label: "%Intl%.[[FallbackSymbol]]" }
+);

--- a/test/intl402/NumberFormat/intl-legacy-constructed-symbol.js
+++ b/test/intl402/NumberFormat/intl-legacy-constructed-symbol.js
@@ -12,7 +12,5 @@ features: [intl-normative-optional]
 let object = new Intl.NumberFormat();
 let newObject = Intl.NumberFormat.call(object);
 let symbols = Object.getOwnPropertySymbols(newObject);
-if (symbols.length !== 0) {
-    assert.sameValue(symbols.length, 1);
-    assert.sameValue(symbols[0].description, "IntlLegacyConstructedSymbol");
-}
+
+assert(symbols.some((symbol) => symbol.description === "IntlLegacyConstructedSymbol"));


### PR DESCRIPTION
Adds a test that ensures the Intl fallback symbol is not shared between realms. Also while we are here adds verification of the property descriptor for legacy-constructed DateTimeFormat and NumberFormat instances.