### PR TITLE
Excluding "immutable" from TA tests with mutable expectations.

### DIFF
--- a/test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js
+++ b/test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js
@@ -42,4 +42,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.compareArray(result, [
     20, 20, 20, 60,
   ]);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/GetOwnProperty/BigInt/index-prop-desc.js
+++ b/test/built-ins/TypedArrayConstructors/internals/GetOwnProperty/BigInt/index-prop-desc.js
@@ -33,4 +33,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(descriptor1.configurable, true);
   assert.sameValue(descriptor1.enumerable, true);
   assert.sameValue(descriptor1.writable, true);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/GetOwnProperty/index-prop-desc.js
+++ b/test/built-ins/TypedArrayConstructors/internals/GetOwnProperty/index-prop-desc.js
@@ -35,4 +35,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.sameValue(descriptor1.configurable, true);
   assert.sameValue(descriptor1.enumerable, true);
   assert.sameValue(descriptor1.writable, true);
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/null-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/null-tobigint.js
@@ -58,4 +58,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray[0] = null;
   });
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/number-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/number-tobigint.js
@@ -82,4 +82,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray[0] = NaN;
   });
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/string-nan-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/string-nan-tobigint.js
@@ -62,4 +62,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray[0] = "definately not a number";
   });
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/symbol-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/symbol-tobigint.js
@@ -60,4 +60,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray[0] = s;
   });
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/tonumber-value-throws.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/tonumber-value-throws.js
@@ -57,4 +57,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample['2'] = obj;
   }, '`sample["2"] = obj` throws Test262Error');
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/undefined-tobigint.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/undefined-tobigint.js
@@ -59,4 +59,4 @@ testWithBigIntTypedArrayConstructors(function(TA, makeCtorArg) {
     typedArray[0] = undefined;
   });
 
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/bigint-tonumber.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/bigint-tonumber.js
@@ -56,4 +56,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(TypeError, function() {
     typedArray[0] = 1n;
   });
-});
+}, null, null, ["immutable"]);

--- a/test/built-ins/TypedArrayConstructors/internals/Set/tonumber-value-throws.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/tonumber-value-throws.js
@@ -58,4 +58,4 @@ testWithTypedArrayConstructors(function(TA, makeCtorArg) {
   assert.throws(Test262Error, function() {
     sample["2"] = obj;
   });
-});
+}, null, null, ["immutable"]);


### PR DESCRIPTION
Disables the usage of immutable `ArrayBuffer`s in `TypedArray`-related tests that have "mutable" expectations:

* `TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js`: expects slice to copy into a species-created result backed by the same buffer. With an immutable buffer, the species-created result is not a valid write target, so slice throws instead of producing the mutable-copy result.

* `TypedArrayConstructors/internals/GetOwnProperty/index-prop-desc.js`, `TypedArrayConstructors/internals/GetOwnProperty/BigInt/index-prop-desc.js`: expect indexed property descriptors to be writable and configurable. For immutable-backed TypedArrays, indexed properties are not writable/configurable.

* `TypedArrayConstructors/internals/Set/bigint-tonumber.js`,
`TypedArrayConstructors/internals/Set/BigInt/null-tobigint.js`,
`TypedArrayConstructors/internals/Set/BigInt/number-tobigint.js`,
`TypedArrayConstructors/internals/Set/BigInt/string-nan-tobigint.js`, `TypedArrayConstructors/internals/Set/BigInt/symbol-tobigint.js`,
`TypedArrayConstructors/internals/Set/BigInt/tonumber-value-throws.js`,
`TypedArrayConstructors/internals/Set/BigInt/undefined-tobigint.js`,
`TypedArrayConstructors/internals/Set/tonumber-value-throws.js`: validate value-conversion abrupt completions during indexed assignment, such as `ToNumber`, `ToBigInt`, or user-defined coercion hooks throwing. For immutable-backed `TypedArray`s, indexed `[[Set]]` short-circuits before value conversion, so those mutable-buffer conversion expectations do not apply.