### PR TITLE
update Iterator.prototype.{take,drop} for new RangeError

### DIFF
--- a/test/built-ins/Iterator/prototype/drop/argument-effect-order.js
+++ b/test/built-ins/Iterator/prototype/drop/argument-effect-order.js
@@ -1,11 +1,11 @@
 // Copyright (C) 2023 Michael Ficarra. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-iteratorprototype.drop
+esid: sec-iterator.prototype.drop
 description: >
   Arguments and this value are evaluated in the correct order
 info: |
-  %Iterator.prototype%.drop ( limit )
+  Iterator.prototype.drop ( limit )
 
 includes: [compareArray.js]
 features: [iterator-helpers]
@@ -44,6 +44,29 @@ assert.throws(TypeError, function () {
 });
 
 assert.compareArray(effects, []);
+
+effects = [];
+
+assert.throws(RangeError, function () {
+  Iterator.prototype.drop.call(
+    {
+      get next() {
+        effects.push('get next');
+        return function () {
+          return { done: true, value: undefined };
+        };
+      },
+    },
+    {
+      valueOf() {
+        effects.push('ToNumber limit');
+        return Number.MAX_SAFE_INTEGER + 1;
+      },
+    }
+  );
+});
+
+assert.compareArray(effects, ['ToNumber limit']);
 
 effects = [];
 

--- a/test/built-ins/Iterator/prototype/drop/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/drop/argument-validation-failure-closes-underlying.js
@@ -1,11 +1,11 @@
 // Copyright (C) 2024 Kevin Gibbons. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-iteratorprototype.drop
+esid: sec-iterator.prototype.drop
 description: >
   Underlying iterator is closed when argument validation fails
 info: |
-  %Iterator.prototype%.drop ( limit )
+  Iterator.prototype.drop ( limit )
 
 features: [iterator-helpers]
 flags: []
@@ -31,6 +31,12 @@ assert.sameValue(closed, true);
 closed = false;
 assert.throws(RangeError, function() {
   closable.drop(NaN);
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(RangeError, function() {
+  closable.drop(Number.MAX_SAFE_INTEGER + 1);
 });
 assert.sameValue(closed, true);
 

--- a/test/built-ins/Iterator/prototype/drop/limit-rangeerror.js
+++ b/test/built-ins/Iterator/prototype/drop/limit-rangeerror.js
@@ -1,15 +1,23 @@
 // Copyright (C) 2020 Rick Waldron. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-iteratorprototype.drop
+esid: sec-iterator.prototype.drop
 description: >
-  Throws a RangeError exception when limit argument is NaN or less than 0.
+  Throws a RangeError exception when limit argument is NaN, less than 0, or
+  finite and greater than Number.MAX_SAFE_INTEGER.
 info: |
-  %Iterator.prototype%.drop ( limit )
+  Iterator.prototype.drop ( limit )
 
-  3. If numLimit is NaN, throw a RangeError exception.
-  4. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
-  5. If integerLimit < 0, throw a RangeError exception.
+  6. If numLimit is NaN, then
+     a. Let error be ThrowCompletion(a newly created RangeError object).
+     b. Return ? IteratorClose(iterated, error).
+  7. If numLimit is finite and numLimit > 𝔽(2**53 - 1), then
+     a. Let error be ThrowCompletion(a newly created RangeError object).
+     b. Return ? IteratorClose(iterated, error).
+  8. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
+  9. If integerLimit < 0, then
+     a. Let error be ThrowCompletion(a newly created RangeError object).
+     b. Return ? IteratorClose(iterated, error).
 
 features: [iterator-helpers]
 ---*/
@@ -18,6 +26,8 @@ let iterator = (function* () {})();
 iterator.drop(0);
 iterator.drop(-0.5);
 iterator.drop(null);
+iterator.drop(Number.MAX_SAFE_INTEGER);
+iterator.drop(Infinity);
 
 assert.throws(RangeError, () => {
   iterator.drop(-1);
@@ -33,4 +43,8 @@ assert.throws(RangeError, () => {
 
 assert.throws(RangeError, () => {
   iterator.drop(NaN);
+});
+
+assert.throws(RangeError, () => {
+  iterator.drop(Number.MAX_SAFE_INTEGER + 1);
 });

--- a/test/built-ins/Iterator/prototype/take/argument-effect-order.js
+++ b/test/built-ins/Iterator/prototype/take/argument-effect-order.js
@@ -1,19 +1,28 @@
 // Copyright (C) 2023 Michael Ficarra. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-iteratorprototype.take
+esid: sec-iterator.prototype.take
 description: >
   Arguments and this value are evaluated in the correct order
 info: |
-  %Iterator.prototype%.take ( limit )
+  Iterator.prototype.take ( limit )
 
-  1. Let O be the this value.
-  2. If O is not an Object, throw a TypeError exception.
-  3. Let numLimit be ? ToNumber(limit).
-  4. If numLimit is NaN, throw a RangeError exception.
-  5. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
-  6. If integerLimit < 0, throw a RangeError exception.
-  7. Let iterated be ? GetIteratorDirect(O).
+  1. Let obj be the this value.
+  2. If obj is not an Object, throw a TypeError exception.
+  3. Let iterated be the Iterator Record { [[Iterator]]: obj, [[NextMethod]]: undefined, [[Done]]: false }.
+  4. Let numLimit be Completion(ToNumber(limit)).
+  5. IfAbruptCloseIterator(numLimit, iterated).
+  6. If numLimit is NaN, then
+     a. Let error be ThrowCompletion(a newly created RangeError object).
+     b. Return ? IteratorClose(iterated, error).
+  7. If numLimit is finite and numLimit > 𝔽(2**53 - 1), then
+     a. Let error be ThrowCompletion(a newly created RangeError object).
+     b. Return ? IteratorClose(iterated, error).
+  8. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
+  9. If integerLimit < 0, then
+     a. Let error be ThrowCompletion(a newly created RangeError object).
+     b. Return ? IteratorClose(iterated, error).
+  10. Set iterated to ? GetIteratorDirect(obj).
 
 includes: [compareArray.js]
 features: [iterator-helpers]
@@ -52,6 +61,29 @@ assert.throws(TypeError, function () {
 });
 
 assert.compareArray(effects, []);
+
+effects = [];
+
+assert.throws(RangeError, function () {
+  Iterator.prototype.take.call(
+    {
+      get next() {
+        effects.push('get next');
+        return function () {
+          return { done: true, value: undefined };
+        };
+      },
+    },
+    {
+      valueOf() {
+        effects.push('ToNumber limit');
+        return Number.MAX_SAFE_INTEGER + 1;
+      },
+    }
+  );
+});
+
+assert.compareArray(effects, ['ToNumber limit']);
 
 effects = [];
 

--- a/test/built-ins/Iterator/prototype/take/argument-validation-failure-closes-underlying.js
+++ b/test/built-ins/Iterator/prototype/take/argument-validation-failure-closes-underlying.js
@@ -1,11 +1,11 @@
 // Copyright (C) 2024 Kevin Gibbons. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-iteratorprototype.take
+esid: sec-iterator.prototype.take
 description: >
   Underlying iterator is closed when argument validation fails
 info: |
-  %Iterator.prototype%.take ( limit )
+  Iterator.prototype.take ( limit )
 
 features: [iterator-helpers]
 flags: []
@@ -31,6 +31,12 @@ assert.sameValue(closed, true);
 closed = false;
 assert.throws(RangeError, function() {
   closable.take(NaN);
+});
+assert.sameValue(closed, true);
+
+closed = false;
+assert.throws(RangeError, function() {
+  closable.take(Number.MAX_SAFE_INTEGER + 1);
 });
 assert.sameValue(closed, true);
 

--- a/test/built-ins/Iterator/prototype/take/limit-rangeerror.js
+++ b/test/built-ins/Iterator/prototype/take/limit-rangeerror.js
@@ -1,15 +1,23 @@
 // Copyright (C) 2020 Rick Waldron. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-iteratorprototype.take
+esid: sec-iterator.prototype.take
 description: >
-  Throws a RangeError exception when limit argument is NaN or less than 0.
+  Throws a RangeError exception when limit argument is NaN, less than 0, or
+  finite and greater than Number.MAX_SAFE_INTEGER.
 info: |
-  %Iterator.prototype%.take ( limit )
+  Iterator.prototype.take ( limit )
 
-  4. If numLimit is NaN, throw a RangeError exception.
-  5. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
-  6. If integerLimit < 0, throw a RangeError exception.
+  6. If numLimit is NaN, then
+    a. Let error be ThrowCompletion(a newly created RangeError object).
+    b. Return ? IteratorClose(iterated, error).
+  7. If numLimit is finite and numLimit > 𝔽(2**53 - 1), then
+    a. Let error be ThrowCompletion(a newly created RangeError object).
+    b. Return ? IteratorClose(iterated, error).
+  8. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
+  9. If integerLimit < 0, then
+    a. Let error be ThrowCompletion(a newly created RangeError object).
+    b. Return ? IteratorClose(iterated, error).
 
 features: [iterator-helpers]
 ---*/
@@ -18,6 +26,8 @@ let iterator = (function* () {})();
 iterator.take(0);
 iterator.take(-0.5);
 iterator.take(null);
+iterator.take(Number.MAX_SAFE_INTEGER);
+iterator.take(Infinity);
 
 assert.throws(RangeError, () => {
   iterator.take(-1);
@@ -33,4 +43,8 @@ assert.throws(RangeError, () => {
 
 assert.throws(RangeError, () => {
   iterator.take(NaN);
+});
+
+assert.throws(RangeError, () => {
+  iterator.take(Number.MAX_SAFE_INTEGER + 1);
 });


### PR DESCRIPTION
https://github.com/tc39/ecma262/pull/3776 updates these two methods to throw a RangeError during parameter evaluation for very large finite Number values.

While I was in there, I fixed up the metadata for each of the files I touched. If that's unwanted, I can revert it.

Disclaimer: I used AI in the process of creating this PR.