### PR TITLE
Intl.Locale cleanups

### DIFF
--- a/test/intl402/Locale/constructor-apply-options-canonicalizes-twice.js
+++ b/test/intl402/Locale/constructor-apply-options-canonicalizes-twice.js
@@ -2,25 +2,47 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-apply-options-to-tag
+esid: sec-Intl.Locale
 description: >
-    ApplyOptionsToTag canonicalises the language tag two times.
+    Intl.Locale constructor canonicalises the language tag two times.
 info: |
-    10.1.1 ApplyOptionsToTag( tag, options )
+    ...
+    12. NOTE: Because LanguageId canonicalization can alter _tag_ in arbitrary
+        ways according to Alias Rules from supplementalMetadata.xml, it is
+        necessary to perform such canonicalization before applying overrides
+        from _options_.
+    13. Set tag to CanonicalizeUnicodeLocaleId(tag).
+    14. Set tag to ? UpdateLanguageId(tag, options).
+    ...
+
+    UpdateLanguageId ( _tag_, _options_ )
 
     ...
-    9. Set tag to CanonicalizeUnicodeLocaleId(tag).
-    10. If language is not undefined,
-        ...
-        b. Set tag to tag with the substring corresponding to the unicode_language_subtag
-           production of the unicode_language_id replaced by the string language.
+    11. Let _newTag_ be _language_.
+    12. If _script_ is not *undefined*, set _newTag_ to the string-concatenation
+        of _newTag_, *"-"*, and _script_.
+    13. If _region_ is not *undefined*, set _newTag_ to the string-concatenation
+        of _newTag_, *"-"*, and _region_.
+    14. If _variants_ is not *undefined*, set _newTag_ to the string-
+        concatenation of _newTag_, *"-"*, and _variants_.
+    15. Set _newTag_ to the string-concatenation of _newTag_ and
+        _allExtensions_.
+    16. Return _newTag_.
+
+    MakeLocaleRecord ( _tag_, _options_, _localeExtensionKeys_ )
+
     ...
-    13. Return CanonicalizeUnicodeLocaleId(tag).
+    6. If _attributes_ is not empty or _keywords_ is not empty, then
+      a. Set _result_.[[locale]] to InsertUnicodeExtensionAndCanonicalize(
+         _locale_, _attributes_, _keywords_).
+    7. Else,
+      a. Set _result_.[[locale]] to CanonicalizeUnicodeLocaleId(_locale_).
+    8. Return _result_.
 features: [Intl.Locale]
 ---*/
 
-// ApplyOptionsToTag canonicalises the locale identifier before applying the
-// options. That means "und-Armn-SU" is first canonicalised to "und-Armn-AM",
-// then the language is changed to "ru". If "ru" were applied first, the result
-// would be "ru-Armn-RU" instead.
+// Intl.Locale constructor canonicalises the locale identifier before applying
+// the options. That means "und-Armn-SU" is first canonicalised to
+// "und-Armn-AM", then the language is changed to "ru". If "ru" were applied
+// first, the result would be "ru-Armn-RU" instead.
 assert.sameValue(new Intl.Locale("und-Armn-SU", {language: "ru"}).toString(), "ru-Armn-AM");

--- a/test/intl402/Locale/likely-subtags-grandfathered.js
+++ b/test/intl402/Locale/likely-subtags-grandfathered.js
@@ -89,16 +89,16 @@ const regularGrandfathered = [
 
 for (const {tag, canonical, maximized = canonical, minimized = canonical} of regularGrandfathered) {
     const loc = new Intl.Locale(tag);
-    assert.sameValue(loc.toString(), canonical);
+    assert.sameValue(loc.toString(), canonical, "canonical");
 
-    assert.sameValue(loc.maximize().toString(), maximized);
-    assert.sameValue(loc.maximize().maximize().toString(), maximized);
+    assert.sameValue(loc.maximize().toString(), maximized, "maximized once");
+    assert.sameValue(loc.maximize().maximize().toString(), maximized, "maximized twice");
 
-    assert.sameValue(loc.minimize().toString(), minimized);
-    assert.sameValue(loc.minimize().minimize().toString(), minimized);
+    assert.sameValue(loc.minimize().toString(), minimized, "minimized once");
+    assert.sameValue(loc.minimize().minimize().toString(), minimized, "minimized twice");
 
-    assert.sameValue(loc.maximize().minimize().toString(), minimized);
-    assert.sameValue(loc.minimize().maximize().toString(), maximized);
+    assert.sameValue(loc.maximize().minimize().toString(), minimized, "maximized then minimized");
+    assert.sameValue(loc.minimize().maximize().toString(), maximized, "minimized then maximized");
 }
 
 const regularGrandfatheredWithExtLang = [

--- a/test/intl402/Locale/prototype/calendar/canonicalize.js
+++ b/test/intl402/Locale/prototype/calendar/canonicalize.js
@@ -17,7 +17,7 @@ features: [Intl.Locale]
 const loc = new Intl.Locale('en', {calendar: 'islamicc'});
 
 assert.sameValue(loc.toString(), "en-u-ca-islamic-civil",
-    "'islamicc' should be canonicalize to 'islamic-civil'");
+    "'islamicc' should be canonicalized to 'islamic-civil'");
 
 assert.sameValue(loc.calendar, "islamic-civil",
-    "'islamicc' should be canonicalize to 'islamic-civil'");
+    "'islamicc' should be canonicalized to 'islamic-civil'");

--- a/test/intl402/Locale/prototype/calendar/canonicalize.js
+++ b/test/intl402/Locale/prototype/calendar/canonicalize.js
@@ -2,12 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-apply-unicode-extension-to-tag
-description: Checks canonicalize value of extension in ApplyUnicodeExtensionToTag.
+esid: sec-makelocalerecord
+description: Checks canonicalization of option.
 info: |
-    ApplyUnicodeExtensionToTag
-     1. Let _optionsUValue_ be the ASCII-lowercase of _optionsValue_.
-     1. Set _value_ to the String value resulting from canonicalizing _optionsUValue_ as a value of key _key_ per <a href="https://unicode.org/reports/tr35/#processing-localeids">Unicode Technical Standard #35 Part 1 Core, Annex C LocaleId Canonicalization Section 5 Canonicalizing Syntax, Processing LocaleIds</a>.
+    MakeLocaleRecord ( _tag_, _options_, _localeExtensionKeys_ )
+    ...
+    4.e. If _overrideValue is not *undefined*, then
+        i. Set _value_ to CanonicalizeUValue(_key_, _overrideValue_).
+    ...
+      f. Set _result_.[[<_key_>]] to _value_.
 features: [Intl.Locale]
 ---*/
 


### PR DESCRIPTION
A few cleanups I made while working on Intl.Locale. No semantic changes to tests.