### PR TITLE
Fix unit related hardcoded patterns for AppleICU

### DIFF
--- a/harness/testIntlNumberFormat.js
+++ b/harness/testIntlNumberFormat.js
@@ -1,0 +1,36 @@
+// Copyright 2026 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: |
+    Collection of functions used to assert the correctness of Intl.NumberFormat objects.
+defines: [getUnitSeparators]
+---*/
+
+/**
+ * @description Determine the unit/number separator(s) used by an
+ *   Intl.NumberFormat implementation, which are not specified by ECMA-402 and
+ *   generally come from CLDR (and observable in e.g. Japanese long display
+ *   `時速 2 キロメートル` vs. `時速2キロメートル`).
+ * @param {string} locale
+ * @param {'narrow' | 'short' | 'long'} unitDisplay
+ * @return {{ prefix: string, suffix: string }}
+ */
+function getUnitSeparators(locale, unitDisplay) {
+  var nf = new Intl.NumberFormat(locale, { style: "unit", unit: "kilometer-per-hour", unitDisplay: unitDisplay });
+  var parts = nf.formatToParts(1);
+  var unitIndices = [];
+  for (var i = 0; i < parts.length; i++) {
+    if (parts[i].type === "unit") unitIndices.push(i);
+  }
+
+  var prefix = unitIndices[0] === 0 && parts[1] && parts[1].type === "literal"
+    ? parts[1].value
+    : "";
+
+  var lastUnitIndex = unitIndices[unitIndices.length - 1];
+  var suffix = lastUnitIndex === parts.length - 1 && parts[lastUnitIndex - 1] && parts[lastUnitIndex - 1].type === "literal"
+    ? parts[lastUnitIndex - 1].value
+    : "";
+
+  return { prefix: prefix, suffix: suffix };
+}

--- a/test/intl402/NumberFormat/prototype/format/unit-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/format/unit-ja-JP.js
@@ -6,56 +6,63 @@ esid: sec-intl.numberformat.prototype.format
 description: Checks handling of the unit style.
 locale: [ja-JP]
 features: [Intl.NumberFormat-unified]
+includes: [testIntlNumberFormat.js]
 ---*/
 
+// The unit/number separator is CLDR data, not specified by ECMA-402, so
+// read it from the implementation instead of hardcoding it.
+// (e.g. "時速 987 キロメートル" vs. "時速987キロメートル")
+const shortSep = getUnitSeparators("ja-JP", "short");
+const narrowSep = getUnitSeparators("ja-JP", "narrow");
+const longSep = getUnitSeparators("ja-JP", "long");
 
 const tests = [
   [
     -987,
     {
-      "short": "-987 km/h",
-      "narrow": "-987km/h",
-      "long": "時速 -987 キロメートル",
+      "short": `-987${shortSep.suffix}km/h`,
+      "narrow": `-987${narrowSep.suffix}km/h`,
+      "long": `時速${longSep.prefix}-987${longSep.suffix}キロメートル`,
     }
   ],
   [
     -0.001,
     {
-      "short": "-0.001 km/h",
-      "narrow": "-0.001km/h",
-      "long": "時速 -0.001 キロメートル",
+      "short": `-0.001${shortSep.suffix}km/h`,
+      "narrow": `-0.001${narrowSep.suffix}km/h`,
+      "long": `時速${longSep.prefix}-0.001${longSep.suffix}キロメートル`,
     }
   ],
   [
     -0,
     {
-      "short": "-0 km/h",
-      "narrow": "-0km/h",
-      "long": "時速 -0 キロメートル",
+      "short": `-0${shortSep.suffix}km/h`,
+      "narrow": `-0${narrowSep.suffix}km/h`,
+      "long": `時速${longSep.prefix}-0${longSep.suffix}キロメートル`,
     }
   ],
   [
     0,
     {
-      "short": "0 km/h",
-      "narrow": "0km/h",
-      "long": "時速 0 キロメートル",
+      "short": `0${shortSep.suffix}km/h`,
+      "narrow": `0${narrowSep.suffix}km/h`,
+      "long": `時速${longSep.prefix}0${longSep.suffix}キロメートル`,
     }
   ],
   [
     0.001,
     {
-      "short": "0.001 km/h",
-      "narrow": "0.001km/h",
-      "long": "時速 0.001 キロメートル",
+      "short": `0.001${shortSep.suffix}km/h`,
+      "narrow": `0.001${narrowSep.suffix}km/h`,
+      "long": `時速${longSep.prefix}0.001${longSep.suffix}キロメートル`,
     }
   ],
   [
     987,
     {
-      "short": "987 km/h",
-      "narrow": "987km/h",
-      "long": "時速 987 キロメートル",
+      "short": `987${shortSep.suffix}km/h`,
+      "narrow": `987${narrowSep.suffix}km/h`,
+      "long": `時速${longSep.prefix}987${longSep.suffix}キロメートル`,
     }
   ],
 ];
@@ -66,4 +73,3 @@ for (const [number, expectedData] of tests) {
     assert.sameValue(nf.format(number), expected);
   }
 }
-

--- a/test/intl402/NumberFormat/prototype/format/unit-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/format/unit-zh-TW.js
@@ -6,56 +6,63 @@ esid: sec-intl.numberformat.prototype.format
 description: Checks handling of the unit style.
 locale: [zh-TW]
 features: [Intl.NumberFormat-unified]
+includes: [testIntlNumberFormat.js]
 ---*/
 
+// The unit/number separator is CLDR data, not specified by ECMA-402, so
+// read it from the implementation instead of hardcoding it.
+// (e.g. "-987 公里/小時" vs. "-987公里/小時")
+const shortSep = getUnitSeparators("zh-TW", "short");
+const narrowSep = getUnitSeparators("zh-TW", "narrow");
+const longSep = getUnitSeparators("zh-TW", "long");
 
 const tests = [
   [
     -987,
     {
-      "short": "-987 公里/小時",
-      "narrow": "-987公里/小時",
-      "long": "每小時 -987 公里",
+      "short": `-987${shortSep.suffix}公里/小時`,
+      "narrow": `-987${narrowSep.suffix}公里/小時`,
+      "long": `每小時${longSep.prefix}-987${longSep.suffix}公里`,
     }
   ],
   [
     -0.001,
     {
-      "short": "-0.001 公里/小時",
-      "narrow": "-0.001公里/小時",
-      "long": "每小時 -0.001 公里",
+      "short": `-0.001${shortSep.suffix}公里/小時`,
+      "narrow": `-0.001${narrowSep.suffix}公里/小時`,
+      "long": `每小時${longSep.prefix}-0.001${longSep.suffix}公里`,
     }
   ],
   [
     -0,
     {
-      "short": "-0 公里/小時",
-      "narrow": "-0公里/小時",
-      "long": "每小時 -0 公里",
+      "short": `-0${shortSep.suffix}公里/小時`,
+      "narrow": `-0${narrowSep.suffix}公里/小時`,
+      "long": `每小時${longSep.prefix}-0${longSep.suffix}公里`,
     }
   ],
   [
     0,
     {
-      "short": "0 公里/小時",
-      "narrow": "0公里/小時",
-      "long": "每小時 0 公里",
+      "short": `0${shortSep.suffix}公里/小時`,
+      "narrow": `0${narrowSep.suffix}公里/小時`,
+      "long": `每小時${longSep.prefix}0${longSep.suffix}公里`,
     }
   ],
   [
     0.001,
     {
-      "short": "0.001 公里/小時",
-      "narrow": "0.001公里/小時",
-      "long": "每小時 0.001 公里",
+      "short": `0.001${shortSep.suffix}公里/小時`,
+      "narrow": `0.001${narrowSep.suffix}公里/小時`,
+      "long": `每小時${longSep.prefix}0.001${longSep.suffix}公里`,
     }
   ],
   [
     987,
     {
-      "short": "987 公里/小時",
-      "narrow": "987公里/小時",
-      "long": "每小時 987 公里",
+      "short": `987${shortSep.suffix}公里/小時`,
+      "narrow": `987${narrowSep.suffix}公里/小時`,
+      "long": `每小時${longSep.prefix}987${longSep.suffix}公里`,
     }
   ],
 ];
@@ -66,4 +73,3 @@ for (const [number, expectedData] of tests) {
     assert.sameValue(nf.format(number), expected);
   }
 }
-

--- a/test/intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js
@@ -20,9 +20,6 @@ function verifyFormatParts(actual, expected, message) {
   }
 }
 
-// The unit/number separator is CLDR data, not specified by ECMA-402, so
-// read it from the implementation instead of hardcoding it.
-// (e.g. a literal " " part between the number and unit parts, or none)
 function makePart(type, value) {
   return value ? [{ "type": type, "value": value }] : [];
 }
@@ -37,6 +34,9 @@ function addUnitParts(numberParts, separators, prefixText, suffixText) {
   );
 }
 
+// The unit/number separator is CLDR data, not specified by ECMA-402, so
+// read it from the implementation instead of hardcoding it.
+// (e.g. a literal " " part between the number and unit parts, or none)
 const shortSep = getUnitSeparators("ja-JP", "short");
 const narrowSep = getUnitSeparators("ja-JP", "narrow");
 const longSep = getUnitSeparators("ja-JP", "long");
@@ -44,27 +44,26 @@ const longSep = getUnitSeparators("ja-JP", "long");
 const tests = [
   [
     -987,
-    [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}],
+    [{ type: "minusSign", value: "-" }, { type: "integer", value: "987" }],
   ],
   [
     -0.001,
-    [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"}],
+    [{ type: "minusSign", value: "-" }, { type: "integer", value: "0" }, { type: "decimal", value: "." }, { type: "fraction", value: "001" }],
   ],
   [
     -0,
-    [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}],
+    [{ type: "minusSign", value: "-" }, { type: "integer", value: "0" }],
   ],
   [
     0,
-    [{"type":"integer","value":"0"}],
-  ],
+    [{ type: "integer", value: "0" }]],
   [
     0.001,
-    [{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"}],
+    [{ type: "integer", value: "0" }, { type: "decimal", value: "." }, { type: "fraction", value: "001" }],
   ],
   [
     987,
-    [{"type":"integer","value":"987"}],
+    [{ type: "integer", value: "987" }],
   ],
 ];
 

--- a/test/intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js
@@ -6,6 +6,7 @@ esid: sec-intl.numberformat.prototype.formattoparts
 description: Checks handling of the unit style.
 locale: [ja-JP]
 features: [Intl.NumberFormat-unified]
+includes: [testIntlNumberFormat.js]
 ---*/
 
 function verifyFormatParts(actual, expected, message) {
@@ -19,79 +20,63 @@ function verifyFormatParts(actual, expected, message) {
   }
 }
 
+// The unit/number separator is CLDR data, not specified by ECMA-402, so
+// read it from the implementation instead of hardcoding it.
+// (e.g. a literal " " part between the number and unit parts, or none)
+function makePart(type, value) {
+  return value ? [{ "type": type, "value": value }] : [];
+}
+
+function addUnitParts(numberParts, separators, prefixText, suffixText) {
+  return [].concat(
+    makePart("unit", prefixText),
+    makePart("literal", separators.prefix),
+    numberParts,
+    makePart("literal", separators.suffix),
+    makePart("unit", suffixText)
+  );
+}
+
+const shortSep = getUnitSeparators("ja-JP", "short");
+const narrowSep = getUnitSeparators("ja-JP", "narrow");
+const longSep = getUnitSeparators("ja-JP", "long");
+
 const tests = [
   [
     -987,
-    {
-      "short":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"km/h"}],
-      "narrow":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"},{"type":"unit","value":"km/h"}],
-      "long":
-        [{"type":"unit","value":"時速"},{"type":"literal","value":" "},{"type":"minusSign","value":"-"},{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"キロメートル"}],
-    }
+    [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}],
   ],
   [
     -0.001,
-    {
-      "short":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"literal","value":" "},{"type":"unit","value":"km/h"}],
-      "narrow":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"unit","value":"km/h"}],
-      "long":
-        [{"type":"unit","value":"時速"},{"type":"literal","value":" "},{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"literal","value":" "},{"type":"unit","value":"キロメートル"}],
-    }
+    [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"}],
   ],
   [
     -0,
-    {
-      "short":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"literal","value":" "},{"type":"unit","value":"km/h"}],
-      "narrow":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"unit","value":"km/h"}],
-      "long":
-        [{"type":"unit","value":"時速"},{"type":"literal","value":" "},{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"literal","value":" "},{"type":"unit","value":"キロメートル"}],
-    }
+    [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}],
   ],
   [
     0,
-    {
-      "short":
-        [{"type":"integer","value":"0"},{"type":"literal","value":" "},{"type":"unit","value":"km/h"}],
-      "narrow":
-        [{"type":"integer","value":"0"},{"type":"unit","value":"km/h"}],
-      "long":
-        [{"type":"unit","value":"時速"},{"type":"literal","value":" "},{"type":"integer","value":"0"},{"type":"literal","value":" "},{"type":"unit","value":"キロメートル"}],
-    }
+    [{"type":"integer","value":"0"}],
   ],
   [
     0.001,
-    {
-      "short":
-        [{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"literal","value":" "},{"type":"unit","value":"km/h"}],
-      "narrow":
-        [{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"unit","value":"km/h"}],
-      "long":
-        [{"type":"unit","value":"時速"},{"type":"literal","value":" "},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"literal","value":" "},{"type":"unit","value":"キロメートル"}],
-    }
+    [{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"}],
   ],
   [
     987,
-    {
-      "short":
-        [{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"km/h"}],
-      "narrow":
-        [{"type":"integer","value":"987"},{"type":"unit","value":"km/h"}],
-      "long":
-        [{"type":"unit","value":"時速"},{"type":"literal","value":" "},{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"キロメートル"}],
-    }
+    [{"type":"integer","value":"987"}],
   ],
 ];
 
-for (const [number, expectedData] of tests) {
+for (const [number, numberParts] of tests) {
+  const expectedData = {
+    "short": addUnitParts(numberParts, shortSep, "", "km/h"),
+    "narrow": addUnitParts(numberParts, narrowSep, "", "km/h"),
+    "long": addUnitParts(numberParts, longSep, "時速", "キロメートル"),
+  };
+
   for (const [unitDisplay, expected] of Object.entries(expectedData)) {
     const nf = new Intl.NumberFormat("ja-JP", { style: "unit", unit: "kilometer-per-hour", unitDisplay });
-    verifyFormatParts(nf.formatToParts(number), expected);
+    verifyFormatParts(nf.formatToParts(number), expected, `${number} ${unitDisplay}`);
   }
 }
-

--- a/test/intl402/NumberFormat/prototype/formatToParts/unit-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/unit-zh-TW.js
@@ -20,9 +20,6 @@ function verifyFormatParts(actual, expected, message) {
   }
 }
 
-// The unit/number separator is CLDR data, not specified by ECMA-402, so
-// read it from the implementation instead of hardcoding it.
-// (e.g. a literal " " part between the number and unit parts, or none)
 function makePart(type, value) {
   return value ? [{ "type": type, "value": value }] : [];
 }
@@ -37,6 +34,9 @@ function addUnitParts(numberParts, separators, prefixText, suffixText) {
   );
 }
 
+// The unit/number separator is CLDR data, not specified by ECMA-402, so
+// read it from the implementation instead of hardcoding it.
+// (e.g. a literal " " part between the number and unit parts, or none)
 const shortSep = getUnitSeparators("zh-TW", "short");
 const narrowSep = getUnitSeparators("zh-TW", "narrow");
 const longSep = getUnitSeparators("zh-TW", "long");
@@ -44,27 +44,27 @@ const longSep = getUnitSeparators("zh-TW", "long");
 const tests = [
   [
     -987,
-    [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}],
+    [{ type: "minusSign", value: "-" }, { type: "integer", value: "987" }],
   ],
   [
     -0.001,
-    [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"}],
+    [{ type: "minusSign", value: "-" }, { type: "integer", value: "0" }, { type: "decimal", value: "." }, { type: "fraction", value: "001" }],
   ],
   [
     -0,
-    [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}],
+    [{ type: "minusSign", value: "-" }, { type: "integer", value: "0" }],
   ],
   [
     0,
-    [{"type":"integer","value":"0"}],
+    [{ type: "integer", value: "0" }],
   ],
   [
     0.001,
-    [{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"}],
+    [{ type: "integer", value: "0" }, { type: "decimal", value: "." }, { type: "fraction", value: "001" }],
   ],
   [
     987,
-    [{"type":"integer","value":"987"}],
+    [{ type: "integer", value: "987" }],
   ],
 ];
 

--- a/test/intl402/NumberFormat/prototype/formatToParts/unit-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/unit-zh-TW.js
@@ -6,6 +6,7 @@ esid: sec-intl.numberformat.prototype.formattoparts
 description: Checks handling of the unit style.
 locale: [zh-TW]
 features: [Intl.NumberFormat-unified]
+includes: [testIntlNumberFormat.js]
 ---*/
 
 function verifyFormatParts(actual, expected, message) {
@@ -19,79 +20,63 @@ function verifyFormatParts(actual, expected, message) {
   }
 }
 
+// The unit/number separator is CLDR data, not specified by ECMA-402, so
+// read it from the implementation instead of hardcoding it.
+// (e.g. a literal " " part between the number and unit parts, or none)
+function makePart(type, value) {
+  return value ? [{ "type": type, "value": value }] : [];
+}
+
+function addUnitParts(numberParts, separators, prefixText, suffixText) {
+  return [].concat(
+    makePart("unit", prefixText),
+    makePart("literal", separators.prefix),
+    numberParts,
+    makePart("literal", separators.suffix),
+    makePart("unit", suffixText)
+  );
+}
+
+const shortSep = getUnitSeparators("zh-TW", "short");
+const narrowSep = getUnitSeparators("zh-TW", "narrow");
+const longSep = getUnitSeparators("zh-TW", "long");
+
 const tests = [
   [
     -987,
-    {
-      "short":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"公里/小時"}],
-      "narrow":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"},{"type":"unit","value":"公里/小時"}],
-      "long":
-        [{"type":"unit","value":"每小時"},{"type":"literal","value":" "},{"type":"minusSign","value":"-"},{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"公里"}],
-    }
+    [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}],
   ],
   [
     -0.001,
-    {
-      "short":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"literal","value":" "},{"type":"unit","value":"公里/小時"}],
-      "narrow":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"unit","value":"公里/小時"}],
-      "long":
-        [{"type":"unit","value":"每小時"},{"type":"literal","value":" "},{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"literal","value":" "},{"type":"unit","value":"公里"}],
-    }
+    [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"}],
   ],
   [
     -0,
-    {
-      "short":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"literal","value":" "},{"type":"unit","value":"公里/小時"}],
-      "narrow":
-        [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"unit","value":"公里/小時"}],
-      "long":
-        [{"type":"unit","value":"每小時"},{"type":"literal","value":" "},{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"literal","value":" "},{"type":"unit","value":"公里"}],
-    }
+    [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}],
   ],
   [
     0,
-    {
-      "short":
-        [{"type":"integer","value":"0"},{"type":"literal","value":" "},{"type":"unit","value":"公里/小時"}],
-      "narrow":
-        [{"type":"integer","value":"0"},{"type":"unit","value":"公里/小時"}],
-      "long":
-        [{"type":"unit","value":"每小時"},{"type":"literal","value":" "},{"type":"integer","value":"0"},{"type":"literal","value":" "},{"type":"unit","value":"公里"}],
-    }
+    [{"type":"integer","value":"0"}],
   ],
   [
     0.001,
-    {
-      "short":
-        [{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"literal","value":" "},{"type":"unit","value":"公里/小時"}],
-      "narrow":
-        [{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"unit","value":"公里/小時"}],
-      "long":
-        [{"type":"unit","value":"每小時"},{"type":"literal","value":" "},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"},{"type":"literal","value":" "},{"type":"unit","value":"公里"}],
-    }
+    [{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"001"}],
   ],
   [
     987,
-    {
-      "short":
-        [{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"公里/小時"}],
-      "narrow":
-        [{"type":"integer","value":"987"},{"type":"unit","value":"公里/小時"}],
-      "long":
-        [{"type":"unit","value":"每小時"},{"type":"literal","value":" "},{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"公里"}],
-    }
+    [{"type":"integer","value":"987"}],
   ],
 ];
 
-for (const [number, expectedData] of tests) {
+for (const [number, numberParts] of tests) {
+  const expectedData = {
+    "short": addUnitParts(numberParts, shortSep, "", "公里/小時"),
+    "narrow": addUnitParts(numberParts, narrowSep, "", "公里/小時"),
+    "long": addUnitParts(numberParts, longSep, "每小時", "公里"),
+  };
+
   for (const [unitDisplay, expected] of Object.entries(expectedData)) {
     const nf = new Intl.NumberFormat("zh-TW", { style: "unit", unit: "kilometer-per-hour", unitDisplay });
-    verifyFormatParts(nf.formatToParts(number), expected);
+    verifyFormatParts(nf.formatToParts(number), expected, `${number} ${unitDisplay}`);
   }
 }
-


### PR DESCRIPTION
ECMA-402 allows customized formatting for i18n output, and these tests are relying on a particular format in ICU, which is changed in AppleICU to align the output to Apple HIG. This patch makes them tolerant against the difference between ICU and AppleICU output.