### PR TITLE
Test fallbacks in RegionPreference

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -5,6 +5,7 @@ description: |
     Collection of assertion functions used throughout test262
 defines:
   - assert
+  - compareArray
   - formatIdentityFreeValue
   - formatSimpleValue
   - isNegativeZero

--- a/harness/compareArray.js
+++ b/harness/compareArray.js
@@ -3,5 +3,4 @@
 /*---
 description: |
     Deprecated now that compareArray is defined in assert.js.
-defines: [compareArray]
 ---*/

--- a/test/intl402/Locale/prototype/getCalendars/likely-subtags-region.js
+++ b/test/intl402/Locale/prototype/getCalendars/likely-subtags-region.js
@@ -1,0 +1,66 @@
+// Copyright 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getCalendars
+description: >
+  When the locale has no region, the Add Likely Subtags algorithm is used to
+  derive the region whose calendar preference is returned.
+info: |
+  RegionPreference ( locale )
+  ...
+  2. If _region_ is *undefined*, then
+    a. Set _region_ to CanonicalUnicodeSubdivision(_locale_, *"sd"*).
+    b. If _region_ is *undefined*, then
+      i. Let _maximal_ be the result of the Add Likely Subtags algorithm applied
+         to _locale_. If an error is signaled, set _maximal_ to _locale_.
+      ii. Set _maximal_ to CanonicalizeUnicodeLocaleId(_maximal_).
+      iii. Set _region_ to GetLocaleRegion(_maximal_).
+      iv. If _region_ is *undefined*, then
+        1. Set _region_ to *"001"*.
+  ...
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// In order not to rely on a particular implementation's locale data, this test
+// searches for a suitable locale without a region subtag, but where the likely
+// region would influence the supported calendars.
+//
+// Each candidate below is a language subtag together with the region that the
+// Add Likely Subtags algorithm derives for it (e.g. "th" maximizes to
+// "th-Thai-TH", so "th-TH"). A language tag without a region, subdivision ("sd"
+// keyword), or region override ("rg" keyword) passed to RegionPreference must
+// apply Add Likely Subtags and arrive at the paired region. Its calendars must
+// therefore be identical to those of the candidate locale. An incorrect
+// implementation might instead fall back to the region "001" in step 2.b.iv.
+//
+// We could assume even less about the locale data by not hardcoding these
+// likely regions and instead checking all available locales with the result of
+// maximize() on each one, but that assumes the implementation has a working
+// maximize(), and if that's the case then it probably implements this step
+// correctly as well.
+function findSuitableTestData() {
+  const candidates = ["th-TH", "fa-IR", "ja-JP", "sa-IN", "ps-AF"];
+
+  for (const candidate of candidates) {
+    const locale = new Intl.Locale(candidate);
+    const calendarsWithLikelyRegion = locale.getCalendars();
+
+    const bareLanguage = locale.language;
+    const fallbackLocale = new Intl.Locale(`${bareLanguage}-001`);
+    if (!compareArray(fallbackLocale.getCalendars(), calendarsWithLikelyRegion)) {
+      return [bareLanguage, calendarsWithLikelyRegion];
+    }
+  }
+
+  assert(false, "No suitable test data found in this implementation. Consider updating the candidate list");
+}
+
+const [language, expectedCalendars] = findSuitableTestData();
+
+const locale = new Intl.Locale(language);
+assert.compareArray(
+  locale.getCalendars(),
+  expectedCalendars,
+  `getCalendars() for "${language}" should equal getCalendars() for locale with likely region`
+);

--- a/test/intl402/Locale/prototype/getCalendars/region-override.js
+++ b/test/intl402/Locale/prototype/getCalendars/region-override.js
@@ -1,0 +1,68 @@
+// Copyright 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getCalendars
+description: >
+  When the locale has a region override ("rg") keyword, its region overrides
+  the region subtag when deriving the calendar preference.
+info: |
+  CalendarsOfLocale ( loc )
+  ...
+  2. Let _preference_ be RegionPreference(_loc_.[[Locale]]).
+  3. Let _region_ be _preference_.[[Region]].
+  4. Let _regionOverride_ be _preference_.[[RegionOverride]].
+  5. If _regionOverride_ is not *undefined* and calendar preference data for
+     _regionOverride_ are available, then
+    a. Let _lookupRegion_ be _regionOverride_.
+  6. Else,
+    a. Let _lookupRegion_ be _region_.
+  ...
+
+  RegionPreference ( locale )
+  ...
+  3. Let _regionOverride_ be CanonicalUnicodeSubdivision(_locale_, *"rg"*).
+  4. Return { [[Region]]: _region_, [[RegionOverride]]: _regionOverride_ }.
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// In order not to rely on a particular implementation's locale data, this test
+// searches for a suitable locale with a region subtag together with a region
+// override ("rg" extension) whose region would influence the supported
+// calendars.
+//
+// Each candidate below is a locale with a region override extension, together
+// with a locale that names the override's region explicitly (e.g.
+// "en-US-u-rg-thzzzz" overrides the region with "TH", so "en-TH"). Because the
+// region override is set, CalendarsOfLocale must use it as the lookup region
+// instead of the region subtag. Its calendars must therefore be identical to
+// those of the paired override-region locale. An incorrect implementation might
+// instead ignore the "rg" keyword and use the region subtag.
+function findSuitableTestData() {
+  const candidates = [
+    ["en-US-u-rg-thzzzz", "en-TH"],
+    ["en-US-u-rg-jpzzzz", "en-JP"],
+    ["en-US-u-rg-inzzzz", "en-IN"],
+    ["en-US-u-rg-irzzzz", "en-IR"],
+  ];
+
+  for (const [overrideTag, regionTag] of candidates) {
+    const calendarsWithOverrideRegion = new Intl.Locale(regionTag).getCalendars();
+
+    const withoutOverride = new Intl.Locale(new Intl.Locale(overrideTag).baseName);
+    if (!compareArray(withoutOverride.getCalendars(), calendarsWithOverrideRegion)) {
+      return [overrideTag, calendarsWithOverrideRegion];
+    }
+  }
+
+  assert(false, "No suitable test data found in this implementation. Consider updating the candidate list");
+}
+
+const [overrideTag, expectedCalendars] = findSuitableTestData();
+
+const locale = new Intl.Locale(overrideTag);
+assert.compareArray(
+  locale.getCalendars(),
+  expectedCalendars,
+  `getCalendars() for "${overrideTag}" should equal getCalendars() for the override region`
+);

--- a/test/intl402/Locale/prototype/getCalendars/region-priority.js
+++ b/test/intl402/Locale/prototype/getCalendars/region-priority.js
@@ -1,0 +1,86 @@
+// Copyright 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getCalendars
+description: >
+  The region used to look up the calendar preference is chosen from the
+  available signals in the correct priority order.
+info: |
+  CalendarsOfLocale ( loc )
+  ...
+  2. Let _preference_ be RegionPreference(_loc_.[[Locale]]).
+  3. Let _region_ be _preference_.[[Region]].
+  4. Let _regionOverride_ be _preference_.[[RegionOverride]].
+  5. If _regionOverride_ is not *undefined* and calendar preference data for
+     _regionOverride_ are available, then
+    a. Let _lookupRegion_ be _regionOverride_.
+  6. Else,
+    a. Let _lookupRegion_ be _region_.
+  ...
+
+  RegionPreference ( locale )
+  1. Let _region_ be GetLocaleRegion(_locale_).
+  2. If _region_ is *undefined*, then
+    a. Set _region_ to CanonicalUnicodeSubdivision(_locale_, *"sd"*).
+    b. If _region_ is *undefined*, then
+      i. Let _maximal_ be the result of the Add Likely Subtags algorithm applied
+         to _locale_. If an error is signaled, set _maximal_ to _locale_.
+      ii. Set _maximal_ to CanonicalizeUnicodeLocaleId(_maximal_).
+      iii. Set _region_ to GetLocaleRegion(_maximal_).
+      iv. If _region_ is *undefined*, then
+        1. Set _region_ to *"001"*.
+  3. Let _regionOverride_ be CanonicalUnicodeSubdivision(_locale_, *"rg"*).
+  4. Return { [[Region]]: _region_, [[RegionOverride]]: _regionOverride_ }.
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// Together, CalendarsOfLocale and RegionPreference select the region used to
+// look up the calendar preference from the available signals in this priority
+// order (highest first):
+//
+//   1. the "rg" region override keyword (when calendar data for it exists)
+//   2. the region subtag
+//   3. the "sd" subdivision keyword
+//   4. the region computed by the Add Likely Subtags algorithm
+//   5. the "001" (world) region
+//
+// Each entry below is a locale that carries the signal for its priority level
+// on top of all lower-priority signals, paired with a locale that names the
+// region that signal must resolve to. The paired locale uses the same base
+// language so that any language-dependent locale data is held constant. For
+// example, "fa-JP-u-sd-inka-rg-thzzzz" carries an "rg" override of region "TH",
+// a region subtag "JP", an "sd" subdivision in region "IN", and a base language
+// "fa" whose likely region is "IR"; the "rg" override has the highest priority,
+// so the locale must behave like "fa-TH".
+//
+// The last entry has no lower-priority signals: the language "eo" (Esperanto)
+// has no likely region, so its region falls back to "001".
+const levels = [
+  { description: 'the "rg" region override', locale: "fa-JP-u-sd-inka-rg-thzzzz", region: "fa-TH" },
+  { description: "the region subtag", locale: "fa-JP-u-sd-inka", region: "fa-JP" },
+  { description: 'the "sd" subdivision', locale: "fa-u-sd-inka", region: "fa-IN" },
+  { description: "the Add Likely Subtags region", locale: "fa", region: "fa-IR" },
+  { description: 'the "001" region', locale: "eo", region: "eo-001" },
+];
+
+// For each priority level to be observable, the region it selects must have
+// different calendars than the region selected by the next lower level in this
+// implementation; otherwise the test could not tell them apart.
+for (let i = 0; i < levels.length - 1; i++) {
+  const higher = new Intl.Locale(levels[i].region).getCalendars();
+  const lower = new Intl.Locale(levels[i + 1].region).getCalendars();
+  assert(
+    !compareArray(higher, lower),
+    `Inconclusive: ${levels[i].description} and ${levels[i + 1].description} ` +
+    "select regions with identical calendars in this implementation. Consider updating the test data"
+  );
+}
+
+for (const { description, locale, region } of levels) {
+  assert.compareArray(
+    new Intl.Locale(locale).getCalendars(),
+    new Intl.Locale(region).getCalendars(),
+    `getCalendars() for "${locale}" should use ${description}, like "${region}"`
+  );
+}

--- a/test/intl402/Locale/prototype/getCalendars/subdivision-region.js
+++ b/test/intl402/Locale/prototype/getCalendars/subdivision-region.js
@@ -1,0 +1,63 @@
+// Copyright 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getCalendars
+description: >
+  When the locale has no region but has a subdivision ("sd") keyword, the
+  subdivision's region is used to derive the calendar preference.
+info: |
+  RegionPreference ( locale )
+  1. Let _region_ be GetLocaleRegion(_locale_).
+  2. If _region_ is *undefined*, then
+    a. Set _region_ to CanonicalUnicodeSubdivision(_locale_, *"sd"*).
+    b. If _region_ is *undefined*, then
+      i. Let _maximal_ be the result of the Add Likely Subtags algorithm applied
+         to _locale_. If an error is signaled, set _maximal_ to _locale_.
+      ...
+  ...
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// In order not to rely on a particular implementation's locale data, this test
+// searches for a suitable locale without a region subtag, but with a
+// subdivision ("sd" extension) whose region would influence the supported
+// calendars.
+//
+// Each candidate below is a locale with a subdivision extension but no region
+// subtag, together with a locale that names that subdivision's region
+// explicitly (e.g. "en-u-sd-th10" has subdivision "th10", whose region is "TH",
+// so "en-TH"). Because such a locale has no region subtag, RegionPreference
+// must derive its region from the subdivision. Its calendars must therefore be
+// identical to those of the paired region locale. An incorrect implementation
+// might instead ignore the "sd" extension and apply Add Likely Subtags to the
+// bare language, giving "en-Latn-US".
+function findSuitableTestData() {
+  const candidates = [
+    ["en-u-sd-th10", "en-TH"],
+    ["en-u-sd-jp13", "en-JP"],
+    ["en-u-sd-inka", "en-IN"],
+    ["en-u-sd-irthr", "en-IR"],
+  ];
+
+  for (const [subdivisionTag, regionTag] of candidates) {
+    const calendarsWithSubdivisionRegion = new Intl.Locale(regionTag).getCalendars();
+
+    const bareLanguage = new Intl.Locale(subdivisionTag).baseName;
+    const fallbackLocale = new Intl.Locale(bareLanguage).maximize();
+    if (!compareArray(fallbackLocale.getCalendars(), calendarsWithSubdivisionRegion)) {
+      return [subdivisionTag, calendarsWithSubdivisionRegion];
+    }
+  }
+
+  assert(false, "No suitable test data found in this implementation. Consider updating the candidate list");
+}
+
+const [subdivisionTag, expectedCalendars] = findSuitableTestData();
+
+const locale = new Intl.Locale(subdivisionTag);
+assert.compareArray(
+  locale.getCalendars(),
+  expectedCalendars,
+  `getCalendars() for "${subdivisionTag}" should equal getCalendars() for the subdivision's region`
+);

--- a/test/intl402/Locale/prototype/getHourCycles/likely-subtags-region.js
+++ b/test/intl402/Locale/prototype/getHourCycles/likely-subtags-region.js
@@ -1,0 +1,75 @@
+// Copyright 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getHourCycles
+description: >
+  When the locale has no region, the Add Likely Subtags algorithm is used to
+  derive the region whose hour cycle preference is returned.
+info: |
+  RegionPreference ( locale )
+  ...
+  2. If _region_ is *undefined*, then
+    a. Set _region_ to CanonicalUnicodeSubdivision(_locale_, *"sd"*).
+    b. If _region_ is *undefined*, then
+      i. Let _maximal_ be the result of the Add Likely Subtags algorithm applied
+         to _locale_. If an error is signaled, set _maximal_ to _locale_.
+      ii. Set _maximal_ to CanonicalizeUnicodeLocaleId(_maximal_).
+      iii. Set _region_ to GetLocaleRegion(_maximal_).
+      iv. If _region_ is *undefined*, then
+        1. Set _region_ to *"001"*.
+  ...
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// In order not to rely on a particular implementation's locale data, this test
+// searches for a suitable locale without a region subtag, but where the likely
+// region would influence the supported hour cycles.
+//
+// Each candidate below is a language subtag together with the region that the
+// Add Likely Subtags algorithm derives for it (e.g. "am" maximizes to
+// "am-Ethi-ET", so "am-ET"). A language tag without a region, subdivision ("sd"
+// keyword), or region override ("rg" keyword) passed to RegionPreference must
+// apply Add Likely Subtags and arrive at the paired region. Its hour cycles
+// must therefore be identical to those of the candidate locale. An incorrect
+// implementation might instead fall back to the region "001" in step 2.b.iv.
+//
+// We could assume even less about the locale data by not hardcoding these
+// likely regions and instead checking all available locales with the result of
+// maximize() on each one, but that assumes the implementation has a working
+// maximize(), and if that's the case then it probably implements this step
+// correctly as well.
+function findSuitableTestData() {
+  const candidates = [
+    "am-ET",
+    "bn-BD",
+    "el-GR",
+    "fil-PH",
+    "hi-IN",
+    "ko-KR",
+    "ms-MY",
+    "ur-PK",
+  ];
+
+  for (const candidate of candidates) {
+    const locale = new Intl.Locale(candidate);
+    const hourCyclesWithLikelyRegion = locale.getHourCycles();
+
+    const bareLanguage = locale.language;
+    const fallbackLocale = new Intl.Locale(`${bareLanguage}-001`);
+    if (!compareArray(fallbackLocale.getHourCycles(), hourCyclesWithLikelyRegion)) {
+      return [bareLanguage, hourCyclesWithLikelyRegion];
+    }
+  }
+
+  assert(false, "No suitable test data found in this implementation. Consider updating the candidate list");
+}
+
+const [language, expectedHourCycles] = findSuitableTestData();
+
+const locale = new Intl.Locale(language);
+assert.compareArray(
+  locale.getHourCycles(),
+  expectedHourCycles,
+  `getHourCycles() for "${language}" should equal getHourCycles() for locale with likely region`
+);

--- a/test/intl402/Locale/prototype/getHourCycles/region-override.js
+++ b/test/intl402/Locale/prototype/getHourCycles/region-override.js
@@ -1,0 +1,67 @@
+// Copyright 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getHourCycles
+description: >
+  When the locale has a region override ("rg") keyword, its region overrides
+  the region subtag when deriving the hour cycle preference.
+info: |
+  HourCyclesOfLocale ( loc )
+  ...
+  2. Let _preference_ be RegionPreference(_loc_.[[Locale]]).
+  3. Let _region_ be _preference_.[[Region]].
+  4. Let _regionOverride_ be _preference_.[[RegionOverride]].
+  5. If _regionOverride_ is not *undefined* and time data for _regionOverride_
+     are available, then
+    a. Let _lookupRegion_ be _regionOverride_.
+  6. Else,
+    a. Let _lookupRegion_ be _region_.
+  ...
+
+  RegionPreference ( locale )
+  ...
+  3. Let _regionOverride_ be CanonicalUnicodeSubdivision(_locale_, *"rg"*).
+  4. Return { [[Region]]: _region_, [[RegionOverride]]: _regionOverride_ }.
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// In order not to rely on a particular implementation's locale data, this test
+// searches for a suitable locale with a region subtag together with a region
+// override ("rg" extension) whose region would influence the supported hour
+// cycles.
+//
+// Each candidate below is a locale with a region override extension, together
+// with a locale that names the override's region explicitly (e.g.
+// "en-US-u-rg-gbzzzz" overrides the region with "GB", so "en-GB"). Because the
+// region override is set, HourCyclesOfLocale must use it as the lookup region
+// instead of the region subtag. Its hour cycles must therefore be identical to
+// those of the paired override-region locale. An incorrect implementation might
+// instead ignore the "rg" keyword and use the region subtag.
+function findSuitableTestData() {
+  const candidates = [
+    ["en-US-u-rg-gbzzzz", "en-GB"],
+    ["en-US-u-rg-dezzzz", "en-DE"],
+    ["en-US-u-rg-frzzzz", "en-FR"],
+  ];
+
+  for (const [overrideTag, regionTag] of candidates) {
+    const hourCyclesWithOverrideRegion = new Intl.Locale(regionTag).getHourCycles();
+
+    const withoutOverride = new Intl.Locale(new Intl.Locale(overrideTag).baseName);
+    if (!compareArray(withoutOverride.getHourCycles(), hourCyclesWithOverrideRegion)) {
+      return [overrideTag, hourCyclesWithOverrideRegion];
+    }
+  }
+
+  assert(false, "No suitable test data found in this implementation. Consider updating the candidate list");
+}
+
+const [overrideTag, expectedHourCycles] = findSuitableTestData();
+
+const locale = new Intl.Locale(overrideTag);
+assert.compareArray(
+  locale.getHourCycles(),
+  expectedHourCycles,
+  `getHourCycles() for "${overrideTag}" should equal getHourCycles() for the override region`
+);

--- a/test/intl402/Locale/prototype/getHourCycles/region-priority.js
+++ b/test/intl402/Locale/prototype/getHourCycles/region-priority.js
@@ -1,0 +1,86 @@
+// Copyright 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getHourCycles
+description: >
+  The region used to look up the hour cycle preference is chosen from the
+  available signals in the correct priority order.
+info: |
+  HourCyclesOfLocale ( loc )
+  ...
+  2. Let _preference_ be RegionPreference(_loc_.[[Locale]]).
+  3. Let _region_ be _preference_.[[Region]].
+  4. Let _regionOverride_ be _preference_.[[RegionOverride]].
+  5. If _regionOverride_ is not *undefined* and time data for _regionOverride_
+     are available, then
+    a. Let _lookupRegion_ be _regionOverride_.
+  6. Else,
+    a. Let _lookupRegion_ be _region_.
+  ...
+
+  RegionPreference ( locale )
+  1. Let _region_ be GetLocaleRegion(_locale_).
+  2. If _region_ is *undefined*, then
+    a. Set _region_ to CanonicalUnicodeSubdivision(_locale_, *"sd"*).
+    b. If _region_ is *undefined*, then
+      i. Let _maximal_ be the result of the Add Likely Subtags algorithm applied
+         to _locale_. If an error is signaled, set _maximal_ to _locale_.
+      ii. Set _maximal_ to CanonicalizeUnicodeLocaleId(_maximal_).
+      iii. Set _region_ to GetLocaleRegion(_maximal_).
+      iv. If _region_ is *undefined*, then
+        1. Set _region_ to *"001"*.
+  3. Let _regionOverride_ be CanonicalUnicodeSubdivision(_locale_, *"rg"*).
+  4. Return { [[Region]]: _region_, [[RegionOverride]]: _regionOverride_ }.
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// Together, HourCyclesOfLocale and RegionPreference select the region used to
+// look up the hour cycle preference from the available signals in this priority
+// order (highest first):
+//
+//   1. the "rg" region override keyword (when time data for it exists)
+//   2. the region subtag
+//   3. the "sd" subdivision keyword
+//   4. the region computed by the Add Likely Subtags algorithm
+//   5. the "001" (world) region
+//
+// Each entry below is a locale that carries the signal for its priority level
+// on top of all lower-priority signals, paired with a locale that names the
+// region that signal must resolve to. The paired locale uses the same base
+// language so that any language-dependent locale data is held constant. For
+// example, "en-US-u-sd-gbeng-rg-gbzzzz" carries an "rg" override of region "GB",
+// a region subtag "US", an "sd" subdivision in region "GB", and a base language
+// "en" whose likely region is "US"; the "rg" override has the highest priority,
+// so the locale must behave like "en-GB".
+//
+// The last entry has no lower-priority signals: the language "eo" (Esperanto)
+// has no likely region, so its region falls back to "001".
+const levels = [
+  { description: 'the "rg" region override', locale: "en-US-u-sd-gbeng-rg-gbzzzz", region: "en-GB" },
+  { description: "the region subtag", locale: "en-US-u-sd-gbeng", region: "en-US" },
+  { description: 'the "sd" subdivision', locale: "en-u-sd-gbeng", region: "en-GB" },
+  { description: "the Add Likely Subtags region", locale: "en", region: "en-US" },
+  { description: 'the "001" region', locale: "eo", region: "eo-001" },
+];
+
+// For each priority level to be observable, the region it selects must have
+// different hour cycles than the region selected by the next lower level in this
+// implementation; otherwise the test could not tell them apart.
+for (let i = 0; i < levels.length - 1; i++) {
+  const higher = new Intl.Locale(levels[i].region).getHourCycles();
+  const lower = new Intl.Locale(levels[i + 1].region).getHourCycles();
+  assert(
+    !compareArray(higher, lower),
+    `Inconclusive: ${levels[i].description} and ${levels[i + 1].description} ` +
+    "select regions with identical hour cycles in this implementation. Consider updating the test data"
+  );
+}
+
+for (const { description, locale, region } of levels) {
+  assert.compareArray(
+    new Intl.Locale(locale).getHourCycles(),
+    new Intl.Locale(region).getHourCycles(),
+    `getHourCycles() for "${locale}" should use ${description}, like "${region}"`
+  );
+}

--- a/test/intl402/Locale/prototype/getHourCycles/subdivision-region.js
+++ b/test/intl402/Locale/prototype/getHourCycles/subdivision-region.js
@@ -1,0 +1,62 @@
+// Copyright 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.getHourCycles
+description: >
+  When the locale has no region but has a subdivision ("sd") keyword, the
+  subdivision's region is used to derive the hour cycle preference.
+info: |
+  RegionPreference ( locale )
+  1. Let _region_ be GetLocaleRegion(_locale_).
+  2. If _region_ is *undefined*, then
+    a. Set _region_ to CanonicalUnicodeSubdivision(_locale_, *"sd"*).
+    b. If _region_ is *undefined*, then
+      i. Let _maximal_ be the result of the Add Likely Subtags algorithm applied
+         to _locale_. If an error is signaled, set _maximal_ to _locale_.
+      ...
+  ...
+features: [Intl.Locale, Intl.Locale-info]
+---*/
+
+// In order not to rely on a particular implementation's locale data, this test
+// searches for a suitable locale without a region subtag, but with a
+// subdivision ("sd" extension) whose region would influence the supported hour
+// cycles.
+//
+// Each candidate below is a locale with a subdivision extension but no region
+// subtag, together with a locale that names that subdivision's region
+// explicitly (e.g. "en-u-sd-gbeng" has subdivision "gbeng", whose region is
+// "GB", so "en-GB"). Because such a locale has no region subtag,
+// RegionPreference must derive its region from the subdivision. Its hour cycles
+// must therefore be identical to those of the paired region locale. An
+// incorrect implementation might instead ignore the "sd" extension and apply
+// Add Likely Subtags to the bare language, giving "en-Latn-US".
+function findSuitableTestData() {
+  const candidates = [
+    ["en-u-sd-gbeng", "en-GB"],
+    ["en-u-sd-fridf", "en-FR"],
+    ["en-u-sd-debe", "en-DE"],
+  ];
+
+  for (const [subdivisionTag, regionTag] of candidates) {
+    const hourCyclesWithSubdivisionRegion = new Intl.Locale(regionTag).getHourCycles();
+
+    const bareLanguage = new Intl.Locale(subdivisionTag).baseName;
+    const fallbackLocale = new Intl.Locale(bareLanguage).maximize();
+    if (!compareArray(fallbackLocale.getHourCycles(), hourCyclesWithSubdivisionRegion)) {
+      return [subdivisionTag, hourCyclesWithSubdivisionRegion];
+    }
+  }
+
+  assert(false, "No suitable test data found in this implementation. Consider updating the candidate list");
+}
+
+const [subdivisionTag, expectedHourCycles] = findSuitableTestData();
+
+const locale = new Intl.Locale(subdivisionTag);
+assert.compareArray(
+  locale.getHourCycles(),
+  expectedHourCycles,
+  `getHourCycles() for "${subdivisionTag}" should equal getHourCycles() for the subdivision's region`
+);


### PR DESCRIPTION
Intl.Locale.p.getCalendars and getHourCycles call RegionPreference which has several untested steps. The "sd" extension must be taken into account, the likely region must be looked up, and the "rg" extension must override the given region if locale data exists for it.

LLM disclosure: I used a bot to draft these tests, then hand-edited them until I was satisfied.

Note: I found it a bit hard to understand the observable implications of RegionPreference, so I left more of the LLM overexplanation intact in the comments than I usually would. I did edit the prose to be less chirpy and verified that it matches my understanding. If you'd prefer to have less of it, I'm happy to edit the comments down further or remove them.