### PR TITLE
[import-defer] Checking SCC sync readiness of a cycle with TLA

### DIFF
--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/a-tla_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/a-tla_FIXTURE.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2026 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import "./b_FIXTURE.js";
+
+globalThis.evaluations.push("A-before-await");
+
+await Promise.resolve(0);
+
+globalThis.evaluations.push("A-after-await");

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/a-tla_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/a-tla_FIXTURE.js
@@ -1,10 +1,10 @@
 // Copyright (C) 2026 Caio Lima. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
+import { blocker, aStarted } from "./setup_FIXTURE.js";
 import "./b_FIXTURE.js";
 
 globalThis.evaluations.push("A-before-await");
-
-await Promise.resolve(0);
-
+aStarted.resolve();
+await blocker.promise;
 globalThis.evaluations.push("A-after-await");

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/b_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/b_FIXTURE.js
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import "./a-tla_FIXTURE.js";
+
+globalThis.evaluations.push("B");

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/c_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/c_FIXTURE.js
@@ -1,0 +1,7 @@
+// Copyright (C) 2026 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Middle's Evaluate is invoked first, while A is still suspended on the
+// blocker, and only then is the blocker resolved to let A finish.
+import "./middle_FIXTURE.js";
+import "./resolve-blocker_FIXTURE.js";

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/c_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/c_FIXTURE.js
@@ -5,3 +5,5 @@
 // blocker, and only then is the blocker resolved to let A finish.
 import "./middle_FIXTURE.js";
 import "./resolve-blocker_FIXTURE.js";
+
+globalThis.evaluations.push("C");

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/d_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/d_FIXTURE.js
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import "./b_FIXTURE.js";
+
+globalThis.evaluations.push("D");

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js
@@ -8,13 +8,16 @@ description: >
 info: |
   In this test, the module A contains top-level await and forms a cycle with
   the module B, and the module Middle defers the module D, whose only
-  dependency is B. The first dynamic import starts evaluating the graph from
-  A, so A becomes the [[CycleRoot]] of the strongly connected component
-  {A, B}. When the concurrent dynamic import of Middle then starts
-  evaluating, B is already EVALUATED, but its cycle root A is still
-  EVALUATING-ASYNC. Middle's body must therefore only execute after the cycle
-  {A, B} has been fully evaluated, and accessing the deferred namespace of D
-  must then only evaluate D itself.
+  dependency is B. This test first dynamically imports A and waits until A's
+  evaluation has started and is suspended on the "blocker" promise, so A is
+  the [[CycleRoot]] of the strongly connected component {A, B} and is
+  guaranteed to still be EVALUATING-ASYNC. It then dynamically imports C,
+  which imports Middle followed by ResolveBlocker. When Middle's evaluation
+  starts, B is already EVALUATED, but its cycle root A is still
+  EVALUATING-ASYNC, so Middle must wait for the whole cycle {A, B} instead of
+  considering only B's individual status. ResolveBlocker then resolves the
+  blocker, allowing A to finish; only after that may Middle's body execute,
+  and accessing the deferred namespace of D must then only evaluate D itself.
 
   IsModuleSCCEvaluated ( _module_ )
     1. If _module_.[[CycleRoot]] is not EMPTY, then
@@ -55,24 +58,29 @@ info: |
           1. Return false.
     1. Return true.
 flags: [module, async]
-features: [import-defer, top-level-await, dynamic-import]
+features: [import-defer, top-level-await, dynamic-import, promise-with-resolvers]
 includes: [compareArray.js]
 ---*/
 
-import "./setup_FIXTURE.js";
+import { aStarted } from "./setup_FIXTURE.js";
 
 const pA = import("./a-tla_FIXTURE.js");
-const pMiddle = import("./middle_FIXTURE.js");
 
-Promise.all([pA, pMiddle])
-  .then(() => {
-    assert.compareArray(globalThis.evaluations, [
-      "B",
-      "A-before-await",
-      "A-after-await",
-      "Middle-before-nsD.z",
-      "D",
-      "Middle-after-nsD.z",
-    ]);
-  })
-  .then($DONE, $DONE);
+// Wait until A's evaluation has started and is suspended on the blocker, so
+// that A is guaranteed to be EVALUATING-ASYNC when Middle starts evaluating.
+await aStarted.promise;
+
+const pC = import("./c_FIXTURE.js");
+
+await Promise.all([pA, pC]);
+
+assert.compareArray(globalThis.evaluations, [
+  "B",
+  "A-before-await",
+  "A-after-await",
+  "Middle-before-nsD.z",
+  "D",
+  "Middle-after-nsD.z",
+]);
+
+$DONE();

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js
@@ -59,7 +59,6 @@ info: |
     1. Return true.
 flags: [module, async]
 features: [import-defer, top-level-await, dynamic-import, promise-with-resolvers]
-includes: [compareArray.js]
 ---*/
 
 import { aStarted } from "./setup_FIXTURE.js";

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-IsModuleSCCEvaluated
+description: >
+  Deferred evaluation waits for an in-flight async cycle in the deferred graph
+info: |
+  In this test, the module A contains top-level await and forms a cycle with
+  the module B, and the module Middle defers the module D, whose only
+  dependency is B. The first dynamic import starts evaluating the graph from
+  A, so A becomes the [[CycleRoot]] of the strongly connected component
+  {A, B}. When the concurrent dynamic import of Middle then starts
+  evaluating, B is already EVALUATED, but its cycle root A is still
+  EVALUATING-ASYNC. Middle's body must therefore only execute after the cycle
+  {A, B} has been fully evaluated, and accessing the deferred namespace of D
+  must then only evaluate D itself.
+
+  IsModuleSCCEvaluated ( _module_ )
+    1. If _module_.[[CycleRoot]] is not EMPTY, then
+      1. If _module_.[[CycleRoot]].[[Status]] is EVALUATED, return true.
+      1. Return false.
+    1. If _module_.[[Status]] is EVALUATED, return true.
+    1. Return false.
+
+  GatherAsynchronousTransitiveDependencies ( _module_, [ _seen_ ] )
+    1. If _seen_ is not specified, let _seen_ be a new empty List.
+    1. Let _result_ be a new empty List.
+    1. If _seen_ contains _module_, return _result_.
+    1. Append _module_ to _seen_.
+    1. If _module_ is not a Cyclic Module Record, return _result_.
+    1. If _module_.[[Status]] is either EVALUATING or IsModuleSCCEvaluated(_module_), return _result_.
+    1. If _module_.[[HasTLA]] is *true*, then
+      1. Append _module_ to _result_.
+      1. Return _result_.
+    1. For each ModuleRequest Record _required_ of _module_.[[RequestedModules]], do
+      1. Let _requiredModule_ be GetImportedModule(_module_, _required_.[[Specifier]]).
+      1. Let _additionalModules_ be GatherAsynchronousTransitiveDependencies(_requiredModule_, _seen_).
+      1. For each Module Record _m_ of _additionalModules_, do
+        1. If _result_ does not contain _m_, append _m_ to _result_.
+    1. Return _result_.
+
+  ReadyForSyncExecution ( _module_ [ , _seen_ ] )
+    1. If _module_ is not a Cyclic Module Record, return true.
+    1. If _seen_ is not present, set _seen_ to a new empty List.
+    1. If _seen_ contains module, return true.
+    1. Append _module_ to _seen_.
+    1. If IsModuleSCCEvaluated(_module_), return true.
+    1. If _module_.[[Status]] is EVALUATING or EVALUATING-ASYNC, return false.
+    1. Assert: _module_.[[Status]] is LINKED.
+    1. If _module_.[[HasTLA]] is true, return false.
+    1. For each ModuleRequest Record request of _module_.[[RequestedModules]], do
+       1. Let _requiredModule_ be GetImportedModule(_module_, _request_).
+       1. If ReadyForSyncExecution(_requiredModule_, _seen_) is false, then
+          1. Return false.
+    1. Return true.
+flags: [module, async]
+features: [import-defer, top-level-await, dynamic-import]
+includes: [compareArray.js]
+---*/
+
+import "./setup_FIXTURE.js";
+
+const pA = import("./a-tla_FIXTURE.js");
+const pMiddle = import("./middle_FIXTURE.js");
+
+Promise.all([pA, pMiddle])
+  .then(() => {
+    assert.compareArray(globalThis.evaluations, [
+      "B",
+      "A-before-await",
+      "A-after-await",
+      "Middle-before-nsD.z",
+      "D",
+      "Middle-after-nsD.z",
+    ]);
+  })
+  .then($DONE, $DONE);

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js
@@ -77,10 +77,12 @@ await Promise.all([pA, pC]);
 assert.compareArray(globalThis.evaluations, [
   "B",
   "A-before-await",
+  "resolve-blocker",
   "A-after-await",
   "Middle-before-nsD.z",
   "D",
   "Middle-after-nsD.z",
+  "C",
 ]);
 
 $DONE();

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/middle_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/middle_FIXTURE.js
@@ -1,0 +1,8 @@
+// Copyright (C) 2026 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import defer * as nsD from "./d_FIXTURE.js";
+
+globalThis.evaluations.push("Middle-before-nsD.z");
+nsD.z;
+globalThis.evaluations.push("Middle-after-nsD.z");

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/resolve-blocker_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/resolve-blocker_FIXTURE.js
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import { blocker } from "./setup_FIXTURE.js";
+
+blocker.resolve();

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/resolve-blocker_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/resolve-blocker_FIXTURE.js
@@ -3,4 +3,5 @@
 
 import { blocker } from "./setup_FIXTURE.js";
 
+globalThis.evaluations.push("resolve-blocker");
 blocker.resolve();

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/setup_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/setup_FIXTURE.js
@@ -2,3 +2,9 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 globalThis.evaluations = [];
+
+// Promise that keeps A suspended until resolve-blocker_FIXTURE.js runs.
+export const blocker = Promise.withResolvers();
+
+// Promise used to signal that A's evaluation has started.
+export const aStarted = Promise.withResolvers();

--- a/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/setup_FIXTURE.js
+++ b/test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/setup_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2026 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+globalThis.evaluations = [];


### PR DESCRIPTION
This is the case for the changes on [1]. In this dependency graph, we have a situation where the cycle root of {A (TLA), B} cycle is A (TLA) and B gets to EVALUATED state before its cycle root. In such scneario, an `import defer` of B (in this case it gets there through D -> B) needs to wait until B's SCC gets to `EVALUATED` state.

[1] - https://github.com/tc39/proposal-defer-import-eval/pull/85