### PR TITLE
linter: Handle harness files without a `defines` key

### DIFF
--- a/tools/lint/lib/checks/includes.py
+++ b/tools/lint/lib/checks/includes.py
@@ -28,7 +28,7 @@ class CheckIncludes(Check):
             CheckIncludes._cache[include_name] = {
                 'name': include_name,
                 'source': CheckIncludes._remove_frontmatter(source),
-                'defines': parsed['defines'],
+                'defines': parsed.get('defines', []),
                 'allow_unused': parsed.get('allow_unused', False),
             }
 

--- a/tools/lint/test/fixtures/harness/noDefines.js
+++ b/tools/lint/test/fixtures/harness/noDefines.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2026 Igalia, S.L.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Fake harness file with no defines.
+---*/

--- a/tools/lint/test/fixtures/harness/noDefinesAllowUnused.js
+++ b/tools/lint/test/fixtures/harness/noDefinesAllowUnused.js
@@ -1,0 +1,8 @@
+// Copyright (C) 2026 Igalia, S.L.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Fake harness file with empty defines, but allow_unused to avoid warnings.
+defines: []
+allow_unused: true
+---*/

--- a/tools/lint/test/fixtures/test/includes_no_defines.js
+++ b/tools/lint/test/fixtures/test/includes_no_defines.js
@@ -1,0 +1,13 @@
+INCLUDES
+^ expected errors | v input
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-foobar
+description: >
+  Includes a harness file that doesn't have any defines (e.g. deprecated
+  compareArray.js)
+includes: [noDefines.js]
+---*/
+
+void 0;

--- a/tools/lint/test/fixtures/test/includes_no_defines_allow_unused.js
+++ b/tools/lint/test/fixtures/test/includes_no_defines_allow_unused.js
@@ -1,0 +1,12 @@
+^ expected errors | v input
+// Copyright (C) 2026 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-foobar
+description: >
+  Includes a harness file that doesn't have any defines (e.g. deprecated
+  compareArray.js)
+includes: [noDefinesAllowUnused.js]
+---*/
+
+void 0;


### PR DESCRIPTION
compareArray.js doesn't have a `defines` key anymore since 0a2badaa. I didn't realize the linter can't handle this.

Rather than adding the missing key, better to make the linter more lenient, since the keys for harness files aren't documented anywhere.