### PR TITLE
Add tests for iterator close semantics of Array.fromAsync

### DIFF
--- a/test/built-ins/Array/fromAsync/does-not-close-exhausted-async-iterator.js
+++ b/test/built-ins/Array/fromAsync/does-not-close-exhausted-async-iterator.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Divy Srivastava. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.fromasync
+description: >
+  The iterator of an asynchronous iterable is not closed when the iterator
+  reports it is done.
+info: |
+  3.j.ii.4.a. If _next_ is *false*, then
+    ...
+    iii. Return Completion Record { [[Type]]: ~return~, [[Value]]: _A_,
+         [[Target]]: ~empty~ }.
+
+  A normal completion of the iteration never calls AsyncIteratorClose, so
+  the iterator's return method is not invoked.
+flags: [async]
+includes: [asyncHelpers.js]
+features: [Array.fromAsync]
+---*/
+
+let returnCalled = false;
+const iterator = {
+  i: 0,
+  next() {
+    return Promise.resolve(
+      this.i < 2 ? { value: this.i++, done: false } : { value: undefined, done: true }
+    );
+  },
+  return() {
+    returnCalled = true;
+    return Promise.resolve({ done: true });
+  },
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+};
+
+asyncTest(async () => {
+  const result = await Array.fromAsync(iterator);
+  assert.compareArray(result, [0, 1]);
+  assert.sameValue(
+    returnCalled,
+    false,
+    "return() must not be called when the iterator is exhausted"
+  );
+});

--- a/test/built-ins/Array/fromAsync/does-not-close-exhausted-sync-iterator.js
+++ b/test/built-ins/Array/fromAsync/does-not-close-exhausted-sync-iterator.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Divy Srivastava. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.fromasync
+description: >
+  The iterator of a synchronous iterable is not closed when the iterator
+  reports it is done.
+info: |
+  3.j.ii.4.a. If _next_ is *false*, then
+    ...
+    iii. Return Completion Record { [[Type]]: ~return~, [[Value]]: _A_,
+         [[Target]]: ~empty~ }.
+
+  A normal completion of the iteration never calls AsyncIteratorClose, so
+  the iterator's return method is not invoked.
+flags: [async]
+includes: [asyncHelpers.js]
+features: [Array.fromAsync]
+---*/
+
+let returnCalled = false;
+const iterator = {
+  i: 0,
+  next() {
+    return this.i < 2 ? { value: this.i++, done: false } : { value: undefined, done: true };
+  },
+  return() {
+    returnCalled = true;
+    return { done: true };
+  },
+  [Symbol.iterator]() {
+    return this;
+  }
+};
+
+asyncTest(async () => {
+  const result = await Array.fromAsync(iterator);
+  assert.compareArray(result, [0, 1]);
+  assert.sameValue(
+    returnCalled,
+    false,
+    "return() must not be called when the iterator is exhausted"
+  );
+});

--- a/test/built-ins/Array/fromAsync/mapfn-throws-close-async-iterator-awaited.js
+++ b/test/built-ins/Array/fromAsync/mapfn-throws-close-async-iterator-awaited.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 Divy Srivastava. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.fromasync
+description: >
+  When the mapping function throws, the promise returned by the asynchronous
+  iterator's return method is awaited before the promise returned by
+  Array.fromAsync is rejected.
+info: |
+  3.j.ii.6. If _mapping_ is *true*, then
+    a. Let _mappedValue_ be Call(_mapfn_, _thisArg_, « _nextValue_, 𝔽(_k_) »).
+    b. IfAbruptCloseAsyncIterator(_mappedValue_, _iteratorRecord_).
+
+  AsyncIteratorClose ( iteratorRecord, completion )
+    4.d. If _innerResult_ is a normal completion, set _innerResult_ to
+         Completion(Await(_innerResult_.[[Value]])).
+flags: [async]
+includes: [asyncHelpers.js]
+features: [Array.fromAsync]
+---*/
+
+const order = [];
+const iterator = {
+  next() {
+    return Promise.resolve({ value: 1, done: false });
+  },
+  return() {
+    order.push("return called");
+    return new Promise((resolve) => {
+      Promise.resolve().then(() => {
+        order.push("return settled");
+        resolve({ done: true });
+      });
+    });
+  },
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+};
+
+asyncTest(async () => {
+  await assert.throwsAsync(
+    Test262Error,
+    () => Array.fromAsync(iterator, () => { throw new Test262Error("mapfn throws"); }),
+    "mapfn throwing should cause fromAsync to reject"
+  );
+  order.push("fromAsync rejected");
+  assert.compareArray(order, ["return called", "return settled", "fromAsync rejected"]);
+});

--- a/test/built-ins/Array/fromAsync/mapfn-throws-close-rejection-not-masked.js
+++ b/test/built-ins/Array/fromAsync/mapfn-throws-close-rejection-not-masked.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Divy Srivastava. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.fromasync
+description: >
+  When the mapping function throws and closing the asynchronous iterator
+  also fails, the promise returned by Array.fromAsync is rejected with the
+  mapping function's error.
+info: |
+  3.j.ii.6. If _mapping_ is *true*, then
+    a. Let _mappedValue_ be Call(_mapfn_, _thisArg_, « _nextValue_, 𝔽(_k_) »).
+    b. IfAbruptCloseAsyncIterator(_mappedValue_, _iteratorRecord_).
+
+  AsyncIteratorClose ( iteratorRecord, completion )
+    5. If _completion_ is a throw completion, return ? _completion_.
+flags: [async]
+includes: [asyncHelpers.js]
+features: [Array.fromAsync]
+---*/
+
+let returnCalled = false;
+const iterator = {
+  next() {
+    return Promise.resolve({ value: 1, done: false });
+  },
+  return() {
+    returnCalled = true;
+    return Promise.reject(new Error("return rejects"));
+  },
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+};
+
+asyncTest(async () => {
+  await assert.throwsAsync(
+    Test262Error,
+    () => Array.fromAsync(iterator, () => { throw new Test262Error("mapfn throws"); }),
+    "fromAsync must reject with the mapfn error, not the return() rejection"
+  );
+  assert(returnCalled, "return() should have been called");
+});


### PR DESCRIPTION
The existing `Array.fromAsync` tests cover that an abrupt mapper completion closes the iterator (`mapfn-*-throws-close-*-iterator.js`), but not the surrounding close semantics:

- **`does-not-close-exhausted-async-iterator.js` / `does-not-close-exhausted-sync-iterator.js`**: a normal completion (`done: true`) must not call `return()`; iteration ends with a return completion, never AsyncIteratorClose.
- **`mapfn-throws-close-async-iterator-awaited.js`**: the close is awaited, so the promise from `return()` settles before the promise returned by `Array.fromAsync` is rejected (AsyncIteratorClose step 5.d).
- **`mapfn-throws-close-rejection-not-masked.js`**: when both the mapper and `return()` fail, the promise rejects with the mapper's error (AsyncIteratorClose step 6 returns the original completion).

These distinguish implementations today: quickjs-ng closed exhausted iterators without awaiting the result (fix in quickjs-ng/quickjs#1596, which prompted these tests), and V8 (Node 24.14) never settles the returned promise at all when `return()` throws or rejects during an abrupt close, so the last test currently hangs there.