### PR TITLE
harness: Allow including compareArray.js

### DIFF
--- a/harness/compareArray.js
+++ b/harness/compareArray.js
@@ -3,4 +3,5 @@
 /*---
 description: |
     Deprecated now that compareArray is defined in assert.js.
+allow_unused: true
 ---*/


### PR DESCRIPTION
Otherwise the lint check on all files fails, since many files still include this harness file.