### PR TITLE
Add Temporal duration and DateTimeFormat regression coverage

### DIFF
--- a/test/built-ins/Temporal/Duration/from/argument-string-invalid.js
+++ b/test/built-ins/Temporal/Duration/from/argument-string-invalid.js
@@ -18,6 +18,7 @@ const tests = [
   "P1Y1M1W1DT1H0.5M0.5S",
   "P",
   "PT",
+  "P1DT",
   "-P",
   "-PT",
   "+P",

--- a/test/intl402/DateTimeFormat/prototype/format/temporal-objects-exotic-options.js
+++ b/test/intl402/DateTimeFormat/prototype/format/temporal-objects-exotic-options.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Adam Shaw. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-datetime-format-functions
+description: Inherited and non-enumerable options apply when formatting Temporal objects
+features: [Temporal]
+locale: [en]
+---*/
+
+const date = new Temporal.PlainDate(2020, 5, 15);
+
+// Baseline, using ordinary own enumerable properties.
+const expected = new Intl.DateTimeFormat("en", { month: "long", day: "numeric" }).format(date);
+
+function assertMonthLongDayNumeric(options, description) {
+  const formatter = new Intl.DateTimeFormat("en", options);
+  const resolved = formatter.resolvedOptions();
+
+  assert.sameValue(resolved.month, "long", `${description}: month option`);
+  assert.sameValue(resolved.day, "numeric", `${description}: day option`);
+  assert.sameValue(formatter.format(date), expected, `${description}: formatting a PlainDate`);
+}
+
+// Options living on the prototype chain instead of being own properties.
+assertMonthLongDayNumeric(
+  Object.create({ month: "long", day: "numeric" }),
+  "inherited options"
+);
+
+// Own properties that are not enumerable.
+assertMonthLongDayNumeric(
+  Object.defineProperties({}, {
+    month: { value: "long", enumerable: false },
+    day: { value: "numeric", enumerable: false },
+  }),
+  "non-enumerable options"
+);


### PR DESCRIPTION
Adds Test262 coverage for two previously uncovered behaviors:

- `Temporal.Duration.from()` rejects duration strings with a date component followed by a dangling time designator, such as `P1DT`.
- `Intl.DateTimeFormat` honors inherited and non-enumerable options when formatting a `Temporal.PlainDate`.

The DateTimeFormat test compares against a reference formatter instead of hard-coding locale-specific output.

CC @ptomato 