### PR TITLE
add tests for various ArrayBuffer methods not consulting constructor

### DIFF
--- a/test/built-ins/ArrayBuffer/prototype/resize/constructor-property-ignored.js
+++ b/test/built-ins/ArrayBuffer/prototype/resize/constructor-property-ignored.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.resize
+description: ArrayBuffer.prototype.resize does not consult .constructor
+features: [resizable-arraybuffer]
+---*/
+
+var source = new ArrayBuffer(4, { maxByteLength: 4 });
+
+var gotConstructor = false;
+Object.defineProperty(source, "constructor", {
+  get: function () {
+    gotConstructor = true;
+    throw new Test262Error("constructor should not be looked up");
+  }
+});
+
+try {
+  result = source.resize(4);
+} catch (error) {
+  // Hosts may choose to throw; this does not affect the test either way.
+  // We cannot assert on the type of error but we can rely on it not being Test262Error.
+  assert.sameValue(error instanceof Test262Error, false);
+}
+
+assert.sameValue(gotConstructor, false, 'source.constructor should not be looked up');

--- a/test/built-ins/ArrayBuffer/prototype/sliceToImmutable/constructor-property-ignored.js
+++ b/test/built-ins/ArrayBuffer/prototype/sliceToImmutable/constructor-property-ignored.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.slicetoimmutable
+description: ArrayBuffer.prototype.slicetoimmutable does not consult .constructor
+features: [immutable-arraybuffer]
+---*/
+
+var source = new ArrayBuffer(4);
+Object.defineProperty(source, "constructor", {
+  get: function () {
+    throw new Test262Error("constructor should not be looked up");
+  }
+});
+
+var dest = source.sliceToImmutable();
+assert.sameValue(source.byteLength, 0, 'source.byteLength');
+assert.sameValue(dest.byteLength, 4, 'dest.byteLength');

--- a/test/built-ins/ArrayBuffer/prototype/transfer/constructor-property-ignored.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/constructor-property-ignored.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfer
+description: ArrayBuffer.prototype.transfer does not consult .constructor
+features: [arraybuffer-transfer]
+---*/
+
+var source = new ArrayBuffer(4);
+Object.defineProperty(source, "constructor", {
+  get: function () {
+    throw new Test262Error("constructor should not be looked up");
+  }
+});
+
+var dest = source.transfer();
+assert.sameValue(source.byteLength, 0, 'source.byteLength');
+assert.sameValue(dest.byteLength, 4, 'dest.byteLength');

--- a/test/built-ins/ArrayBuffer/prototype/transferToFixedLength/constructor-property-ignored.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToFixedLength/constructor-property-ignored.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertofixedlength
+description: ArrayBuffer.prototype.transferToFixedLength does not consult .constructor
+features: [arraybuffer-transfer]
+---*/
+
+var source = new ArrayBuffer(4);
+Object.defineProperty(source, "constructor", {
+  get: function () {
+    throw new Test262Error("constructor should not be looked up");
+  }
+});
+
+var dest = source.transferToFixedLength();
+assert.sameValue(source.byteLength, 0, 'source.byteLength');
+assert.sameValue(dest.byteLength, 4, 'dest.byteLength');

--- a/test/built-ins/ArrayBuffer/prototype/transferToImmutable/constructor-property-ignored.js
+++ b/test/built-ins/ArrayBuffer/prototype/transferToImmutable/constructor-property-ignored.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.transfertoimmutable
+description: ArrayBuffer.prototype.transferToImmutable does not consult .constructor
+features: [immutable-arraybuffer]
+---*/
+
+var source = new ArrayBuffer(4);
+Object.defineProperty(source, "constructor", {
+  get: function () {
+    throw new Test262Error("constructor should not be looked up");
+  }
+});
+
+var dest = source.transferToImmutable();
+assert.sameValue(source.byteLength, 0, 'source.byteLength');
+assert.sameValue(dest.byteLength, 4, 'dest.byteLength');


### PR DESCRIPTION
Fixes https://github.com/tc39/test262/issues/5064.

Note that I'm asserting on `.constructor`, not `Symbol.species`, because the first step of the species lookup is always to look up `instance.constructor`. But I think this still exercises the thing we want exercise.

I also included `.resize`; not sure why it was left out of the list in that issue.