### PR TITLE
Increase coverage of iterator helpers on abrupt completion

### DIFF
--- a/test/built-ins/Iterator/concat/completed-after-abrupt-completion.js
+++ b/test/built-ins/Iterator/concat/completed-after-abrupt-completion.js
@@ -1,0 +1,129 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.concat
+description: >
+  The iterator helper is completed after an abrupt completion
+features: [iterator-sequencing]
+---*/
+
+// The closure of Iterator.concat is the body of a generator, so an abrupt
+// completion from it completes the generator: a later next() returns an
+// undefined, done result without stepping the iterator again, the iterables that
+// follow are never opened, and a later return() is not forwarded either.
+function concatWithStep(next) {
+  const calls = {
+    nextCalls: 0,
+    returnCalls: 0,
+    openCalls: 0,
+  };
+
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          ++calls.nextCalls;
+          return next();
+        },
+        return() {
+          ++calls.returnCalls;
+          return {};
+        },
+      };
+    }
+  };
+
+  const laterIterable = {
+    [Symbol.iterator]() {
+      ++calls.openCalls;
+      return {
+        next() {
+          return {
+            done: false,
+            value: 1,
+          };
+        },
+      };
+    }
+  };
+
+  return {
+    calls,
+    iterator: Iterator.concat(iterable, laterIterable),
+  };
+}
+
+function assertCompleted(concat) {
+  const resultAfterThrow = concat.iterator.next();
+
+  assert.sameValue(resultAfterThrow.done, true, 'the iterator helper is completed');
+  assert.sameValue(resultAfterThrow.value, undefined, 'the iterator helper is completed');
+  assert.sameValue(concat.calls.nextCalls, 1, 'the underlying iterator is not stepped again');
+  assert.sameValue(concat.calls.openCalls, 0, 'the remaining iterables are never opened');
+
+  // Only the calls made from here on are counted, so that this assertion does
+  // not overlap with the one made in
+  // underlying-iterator-not-closed-when-step-throws.js.
+  const returnCallsBefore = concat.calls.returnCalls;
+  const resultAfterReturn = concat.iterator.return();
+
+  assert.sameValue(resultAfterReturn.done, true, 'the iterator helper is completed');
+  assert.sameValue(resultAfterReturn.value, undefined, 'the iterator helper is completed');
+  assert.sameValue(concat.calls.returnCalls, returnCallsBefore,
+                   'return is not forwarded to the underlying iterator');
+}
+
+// Underlying iterator has a throwing next method.
+const concatWithThrowingNext = concatWithStep(function() {
+  throw new Test262Error();
+});
+
+assert.throws(Test262Error, function() {
+  concatWithThrowingNext.iterator.next();
+});
+
+assertCompleted(concatWithThrowingNext);
+
+// Underlying iterator next returns an object with a throwing done getter.
+const concatWithThrowingDoneGetter = concatWithStep(function() {
+  return {
+    get done() {
+      throw new Test262Error();
+    },
+    value: 1,
+  };
+});
+
+assert.throws(Test262Error, function() {
+  concatWithThrowingDoneGetter.iterator.next();
+});
+
+assertCompleted(concatWithThrowingDoneGetter);
+
+// Underlying iterator next returns an object with a throwing value getter.
+const concatWithThrowingValueGetter = concatWithStep(function() {
+  return {
+    done: false,
+    get value() {
+      throw new Test262Error();
+    },
+  };
+});
+
+assert.throws(Test262Error, function() {
+  concatWithThrowingValueGetter.iterator.next();
+});
+
+assertCompleted(concatWithThrowingValueGetter);
+
+// Underlying iterator next returns a non-object.
+const concatWithNonObjectResult = concatWithStep(function() {
+  return null;
+});
+
+assert.throws(TypeError, function() {
+  concatWithNonObjectResult.iterator.next();
+});
+
+assertCompleted(concatWithNonObjectResult);

--- a/test/built-ins/Iterator/concat/iterator-has-no-return.js
+++ b/test/built-ins/Iterator/concat/iterator-has-no-return.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.concat
+description: >
+  The underlying iterator is sometimes unable to be closed (has no return method)
+features: [iterator-sequencing]
+---*/
+
+// GetMethod returns undefined for a missing return property and for a null one,
+// and IteratorClose then leaves the iterator alone and evaluates to the return
+// completion it was given.
+function concatWithIterator(testIterator) {
+  return Iterator.concat({
+    [Symbol.iterator]() {
+      return testIterator;
+    }
+  });
+}
+
+function next() {
+  return {
+    done: false,
+    value: 1,
+  };
+}
+
+// No return property at all.
+const iteratorWithoutReturn = concatWithIterator({ next });
+iteratorWithoutReturn.next();
+
+const resultWithoutReturn = iteratorWithoutReturn.return();
+
+assert.sameValue(resultWithoutReturn.done, true);
+assert.sameValue(resultWithoutReturn.value, undefined);
+
+// An undefined return property.
+const iteratorWithUndefinedReturn = concatWithIterator({ next, return: undefined });
+iteratorWithUndefinedReturn.next();
+
+const resultWithUndefinedReturn = iteratorWithUndefinedReturn.return();
+
+assert.sameValue(resultWithUndefinedReturn.done, true);
+assert.sameValue(resultWithUndefinedReturn.value, undefined);
+
+// A null return property.
+const iteratorWithNullReturn = concatWithIterator({ next, return: null });
+iteratorWithNullReturn.next();
+
+const resultWithNullReturn = iteratorWithNullReturn.return();
+
+assert.sameValue(resultWithNullReturn.done, true);
+assert.sameValue(resultWithNullReturn.value, undefined);

--- a/test/built-ins/Iterator/concat/result-is-iterator-helper.js
+++ b/test/built-ins/Iterator/concat/result-is-iterator-helper.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.concat
+description: >
+  The return value of Iterator.concat is an Iterator Helper
+features: [iterator-sequencing, iterator-helpers]
+---*/
+
+// Iterator.concat builds its result with %IteratorHelperPrototype%, so it shares
+// its prototype, and with it its next and return methods and its @@toStringTag,
+// with the iterator helpers returned by %Iterator.prototype%.map and friends.
+const iteratorHelperPrototype = Object.getPrototypeOf([].values().map(v => v));
+
+const iteratorWithoutArguments = Iterator.concat();
+
+assert.sameValue(
+  Object.getPrototypeOf(iteratorWithoutArguments),
+  iteratorHelperPrototype,
+  'Object.getPrototypeOf(Iterator.concat()) must return %IteratorHelperPrototype%'
+);
+assert.sameValue(iteratorWithoutArguments.next, iteratorHelperPrototype.next);
+assert.sameValue(iteratorWithoutArguments.return, iteratorHelperPrototype.return);
+assert.sameValue(Object.prototype.toString.call(iteratorWithoutArguments), '[object Iterator Helper]');
+
+const iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return {
+          done: true,
+          value: undefined,
+        };
+      },
+    };
+  }
+};
+
+const iteratorWithIterable = Iterator.concat(iterable);
+
+assert.sameValue(
+  Object.getPrototypeOf(iteratorWithIterable),
+  iteratorHelperPrototype,
+  'Object.getPrototypeOf(Iterator.concat(iterable)) must return %IteratorHelperPrototype%'
+);
+assert.sameValue(iteratorWithIterable.next, iteratorHelperPrototype.next);
+assert.sameValue(iteratorWithIterable.return, iteratorHelperPrototype.return);
+assert.sameValue(Object.prototype.toString.call(iteratorWithIterable), '[object Iterator Helper]');

--- a/test/built-ins/Iterator/concat/return-method-not-callable.js
+++ b/test/built-ins/Iterator/concat/return-method-not-callable.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.concat
+description: >
+  Throws a TypeError when the underlying iterator's return property is not callable
+features: [iterator-sequencing]
+---*/
+
+const testIterator = {
+  next() {
+    return {
+      done: false,
+      value: 1,
+    };
+  },
+  return: 1,
+};
+
+const iterator = Iterator.concat({
+  [Symbol.iterator]() {
+    return testIterator;
+  }
+});
+
+iterator.next();
+
+assert.throws(TypeError, function() {
+  iterator.return();
+});
+
+// The iterator helper is completed even though closing the underlying iterator
+// failed.
+const resultAfterThrow = iterator.next();
+
+assert.sameValue(resultAfterThrow.done, true);
+assert.sameValue(resultAfterThrow.value, undefined);
+
+const resultAfterReturn = iterator.return();
+
+assert.sameValue(resultAfterReturn.done, true);
+assert.sameValue(resultAfterReturn.value, undefined);

--- a/test/built-ins/Iterator/concat/return-method-returns-non-object.js
+++ b/test/built-ins/Iterator/concat/return-method-returns-non-object.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.concat
+description: >
+  Throws a TypeError when the underlying iterator's return method returns a non-object
+features: [iterator-sequencing]
+---*/
+
+let returnCalls = 0;
+
+const testIterator = {
+  next() {
+    return {
+      done: false,
+      value: 1,
+    };
+  },
+  return() {
+    ++returnCalls;
+    return 1;
+  },
+};
+
+const iterator = Iterator.concat({
+  [Symbol.iterator]() {
+    return testIterator;
+  }
+});
+
+iterator.next();
+
+assert.throws(TypeError, function() {
+  iterator.return();
+});
+
+assert.sameValue(returnCalls, 1);
+
+// The iterator helper is completed even though closing the underlying iterator
+// failed.
+const resultAfterThrow = iterator.next();
+
+assert.sameValue(resultAfterThrow.done, true);
+assert.sameValue(resultAfterThrow.value, undefined);
+
+const resultAfterReturn = iterator.return();
+
+assert.sameValue(resultAfterReturn.done, true);
+assert.sameValue(resultAfterReturn.value, undefined);
+assert.sameValue(returnCalls, 1, 'return is not called again on the underlying iterator');

--- a/test/built-ins/Iterator/concat/return-method-throws.js
+++ b/test/built-ins/Iterator/concat/return-method-throws.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.concat
+description: >
+  Underlying iterator has a throwing return method
+features: [iterator-sequencing]
+---*/
+
+let returnCalls = 0;
+
+const testIterator = {
+  next() {
+    return {
+      done: false,
+      value: 1,
+    };
+  },
+  return() {
+    ++returnCalls;
+    throw new Test262Error();
+  },
+};
+
+const iterator = Iterator.concat({
+  [Symbol.iterator]() {
+    return testIterator;
+  }
+});
+
+iterator.next();
+
+assert.throws(Test262Error, function() {
+  iterator.return();
+});
+
+assert.sameValue(returnCalls, 1);
+
+// The iterator helper is completed even though closing the underlying iterator
+// failed.
+const resultAfterThrow = iterator.next();
+
+assert.sameValue(resultAfterThrow.done, true);
+assert.sameValue(resultAfterThrow.value, undefined);
+
+const resultAfterReturn = iterator.return();
+
+assert.sameValue(resultAfterReturn.done, true);
+assert.sameValue(resultAfterReturn.value, undefined);
+assert.sameValue(returnCalls, 1, 'return is not called again on the underlying iterator');

--- a/test/built-ins/Iterator/concat/return-result-is-fresh-iterator-result.js
+++ b/test/built-ins/Iterator/concat/return-result-is-fresh-iterator-result.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.concat
+description: >
+  return returns a fresh iterator result object, whatever the underlying iterator's return method returned
+features: [iterator-sequencing]
+---*/
+
+const innerIterResult = {
+  done: false,
+  value: 'inner',
+};
+
+const testIterator = {
+  next() {
+    return {
+      done: false,
+      value: 1,
+    };
+  },
+  return() {
+    return innerIterResult;
+  },
+};
+
+const iterable = {
+  [Symbol.iterator]() {
+    return testIterator;
+  }
+};
+
+const iterator = Iterator.concat(iterable);
+iterator.next();
+
+const iterResult = iterator.return();
+
+assert.notSameValue(iterResult, innerIterResult);
+assert.sameValue(iterResult.done, true);
+assert.sameValue(iterResult.value, undefined);
+
+// The argument of return is not observable in the result either.
+const iteratorCalledWithArgument = Iterator.concat(iterable);
+iteratorCalledWithArgument.next();
+
+const iterResultWithArgument = iteratorCalledWithArgument.return('argument');
+
+assert.sameValue(iterResultWithArgument.done, true);
+assert.sameValue(iterResultWithArgument.value, undefined);

--- a/test/built-ins/Iterator/concat/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/concat/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.concat
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-sequencing]
+---*/
+
+// The only IteratorClose in the closure of Iterator.concat is the one performed
+// when the yield completes abruptly. An abrupt completion from stepping the
+// iterator of an iterable is propagated as is, so the iterator is never closed
+// in this file.
+let returnCalls = 0;
+
+function concatWithStep(next) {
+  return Iterator.concat({
+    [Symbol.iterator]() {
+      return {
+        next,
+        return() {
+          ++returnCalls;
+          return {};
+        },
+      };
+    }
+  });
+}
+
+// Underlying iterator has a throwing next method.
+const iteratorWithThrowingNext = concatWithStep(function() {
+  throw new Test262Error();
+});
+
+assert.throws(Test262Error, function() {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter.
+const iteratorWithThrowingDoneGetter = concatWithStep(function() {
+  return {
+    get done() {
+      throw new Test262Error();
+    },
+    value: 1,
+  };
+});
+
+assert.throws(Test262Error, function() {
+  iteratorWithThrowingDoneGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter.
+const iteratorWithThrowingValueGetter = concatWithStep(function() {
+  return {
+    done: false,
+    get value() {
+      throw new Test262Error();
+    },
+  };
+});
+
+assert.throws(Test262Error, function() {
+  iteratorWithThrowingValueGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object.
+const iteratorWithNonObjectResult = concatWithStep(function() {
+  return null;
+});
+
+assert.throws(TypeError, function() {
+  iteratorWithNonObjectResult.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/chunks/completed-after-abrupt-completion.js
+++ b/test/built-ins/Iterator/prototype/chunks/completed-after-abrupt-completion.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.chunks
+description: >
+  The iterator helper is completed after an abrupt completion
+features: [iterator-chunking, class]
+---*/
+
+// The closure of an iterator helper is the body of a generator, so an abrupt
+// completion from it completes the generator: a later next() returns an
+// undefined, done result without stepping the underlying iterator again, and a
+// later return() is not forwarded to it either.
+let throwingIteratorNextCalls = 0;
+let throwingIteratorReturnCalls = 0;
+
+class ThrowingIterator extends Iterator {
+  next() {
+    ++throwingIteratorNextCalls;
+    throw new Test262Error();
+  }
+  return() {
+    ++throwingIteratorReturnCalls;
+    return {};
+  }
+}
+
+const iteratorWithThrowingNext = new ThrowingIterator().chunks(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(throwingIteratorNextCalls, 1);
+
+const resultAfterThrow = iteratorWithThrowingNext.next();
+
+assert.sameValue(resultAfterThrow.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterThrow.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorNextCalls, 1, 'the underlying iterator is not stepped again');
+
+const resultAfterReturn = iteratorWithThrowingNext.return();
+
+assert.sameValue(resultAfterReturn.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterReturn.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorReturnCalls, 0, 'return is not forwarded to the underlying iterator');

--- a/test/built-ins/Iterator/prototype/chunks/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/chunks/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.chunks
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-chunking, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator().chunks(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator().chunks(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator().chunks(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator().chunks(1);
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/drop/completed-after-abrupt-completion.js
+++ b/test/built-ins/Iterator/prototype/drop/completed-after-abrupt-completion.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.drop
+description: >
+  The iterator helper is completed after an abrupt completion
+features: [iterator-helpers, class]
+---*/
+
+// The closure of an iterator helper is the body of a generator, so an abrupt
+// completion from it completes the generator: a later next() returns an
+// undefined, done result without stepping the underlying iterator again, and a
+// later return() is not forwarded to it either.
+let throwingIteratorNextCalls = 0;
+let throwingIteratorReturnCalls = 0;
+
+class ThrowingIterator extends Iterator {
+  next() {
+    ++throwingIteratorNextCalls;
+    throw new Test262Error();
+  }
+  return() {
+    ++throwingIteratorReturnCalls;
+    return {};
+  }
+}
+
+const iteratorWithThrowingNext = new ThrowingIterator().drop(0);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(throwingIteratorNextCalls, 1);
+
+const resultAfterThrow = iteratorWithThrowingNext.next();
+
+assert.sameValue(resultAfterThrow.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterThrow.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorNextCalls, 1, 'the underlying iterator is not stepped again');
+
+const resultAfterReturn = iteratorWithThrowingNext.return();
+
+assert.sameValue(resultAfterReturn.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterReturn.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorReturnCalls, 0, 'return is not forwarded to the underlying iterator');

--- a/test/built-ins/Iterator/prototype/drop/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/drop/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,126 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.drop
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNextDroppingZero = new ThrowingNextIterator().drop(0);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNextDroppingZero.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNextDroppingOne = new ThrowingNextIterator().drop(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNextDroppingOne.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetterDroppingZero = new ThrowingDoneIterator().drop(0);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetterDroppingZero.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetterDroppingOne = new ThrowingDoneIterator().drop(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetterDroppingOne.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetterDroppingZero = new ThrowingValueIterator().drop(0);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetterDroppingZero.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetterDroppingOne = new ThrowingValueIterator().drop(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetterDroppingOne.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResultDroppingZero = new NonObjectIterator().drop(0);
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResultDroppingZero.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResultDroppingOne = new NonObjectIterator().drop(1);
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResultDroppingOne.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/every/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/every/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.every
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.every(() => true);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.every(() => true);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.every(() => true);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator();
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.every(() => true);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/filter/completed-after-abrupt-completion.js
+++ b/test/built-ins/Iterator/prototype/filter/completed-after-abrupt-completion.js
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.filter
+description: >
+  The iterator helper is completed after an abrupt completion
+features: [iterator-helpers, class]
+---*/
+
+// The closure of an iterator helper is the body of a generator, so an abrupt
+// completion from it completes the generator: a later next() returns an
+// undefined, done result without stepping the underlying iterator again, and a
+// later return() is not forwarded to it either.
+let throwingIteratorNextCalls = 0;
+let throwingIteratorReturnCalls = 0;
+
+class ThrowingIterator extends Iterator {
+  next() {
+    ++throwingIteratorNextCalls;
+    throw new Test262Error();
+  }
+  return() {
+    ++throwingIteratorReturnCalls;
+    return {};
+  }
+}
+
+const iteratorWithThrowingNext = new ThrowingIterator().filter(() => true);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(throwingIteratorNextCalls, 1);
+
+const resultAfterThrow = iteratorWithThrowingNext.next();
+
+assert.sameValue(resultAfterThrow.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterThrow.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorNextCalls, 1, 'the underlying iterator is not stepped again');
+
+const resultAfterReturn = iteratorWithThrowingNext.return();
+
+assert.sameValue(resultAfterReturn.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterReturn.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorReturnCalls, 0, 'return is not forwarded to the underlying iterator');
+
+// A throw from the predicate closes the underlying iterator and completes the
+// iterator helper as well.
+let testIteratorNextCalls = 0;
+let testIteratorReturnCalls = 0;
+
+class TestIterator extends Iterator {
+  next() {
+    ++testIteratorNextCalls;
+    return {
+      done: false,
+      value: 1,
+    };
+  }
+  return() {
+    ++testIteratorReturnCalls;
+    return {};
+  }
+}
+
+const iteratorWithThrowingPredicate = new TestIterator().filter(() => {
+  throw new Test262Error();
+});
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingPredicate.next();
+});
+
+assert.sameValue(testIteratorNextCalls, 1);
+assert.sameValue(testIteratorReturnCalls, 1, 'the underlying iterator is closed');
+
+const resultAfterPredicateThrow = iteratorWithThrowingPredicate.next();
+
+assert.sameValue(resultAfterPredicateThrow.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterPredicateThrow.value, undefined, 'the iterator helper is completed');
+assert.sameValue(testIteratorNextCalls, 1, 'the underlying iterator is not stepped again');
+assert.sameValue(testIteratorReturnCalls, 1, 'the underlying iterator is not closed twice');

--- a/test/built-ins/Iterator/prototype/filter/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/filter/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.filter
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator().filter(() => true);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator().filter(() => true);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator().filter(() => true);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator().filter(() => true);
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/find/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/find/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.find
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.find(() => false);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.find(() => false);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.find(() => false);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator();
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.find(() => false);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/flatMap/completed-after-abrupt-completion.js
+++ b/test/built-ins/Iterator/prototype/flatMap/completed-after-abrupt-completion.js
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.flatMap
+description: >
+  The iterator helper is completed after an abrupt completion
+features: [iterator-helpers, class]
+---*/
+
+// The closure of an iterator helper is the body of a generator, so an abrupt
+// completion from it completes the generator: a later next() returns an
+// undefined, done result without stepping the underlying iterator again, and a
+// later return() is not forwarded to it either.
+let throwingIteratorNextCalls = 0;
+let throwingIteratorReturnCalls = 0;
+
+class ThrowingIterator extends Iterator {
+  next() {
+    ++throwingIteratorNextCalls;
+    throw new Test262Error();
+  }
+  return() {
+    ++throwingIteratorReturnCalls;
+    return {};
+  }
+}
+
+const iteratorWithThrowingNext = new ThrowingIterator().flatMap(v => [v]);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(throwingIteratorNextCalls, 1);
+
+const resultAfterThrow = iteratorWithThrowingNext.next();
+
+assert.sameValue(resultAfterThrow.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterThrow.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorNextCalls, 1, 'the underlying iterator is not stepped again');
+
+const resultAfterReturn = iteratorWithThrowingNext.return();
+
+assert.sameValue(resultAfterReturn.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterReturn.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorReturnCalls, 0, 'return is not forwarded to the underlying iterator');
+
+// A throw from the mapper closes the underlying iterator and completes the
+// iterator helper as well.
+let testIteratorNextCalls = 0;
+let testIteratorReturnCalls = 0;
+
+class TestIterator extends Iterator {
+  next() {
+    ++testIteratorNextCalls;
+    return {
+      done: false,
+      value: 1,
+    };
+  }
+  return() {
+    ++testIteratorReturnCalls;
+    return {};
+  }
+}
+
+const iteratorWithThrowingMapper = new TestIterator().flatMap(() => {
+  throw new Test262Error();
+});
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingMapper.next();
+});
+
+assert.sameValue(testIteratorNextCalls, 1);
+assert.sameValue(testIteratorReturnCalls, 1, 'the underlying iterator is closed');
+
+const resultAfterMapperThrow = iteratorWithThrowingMapper.next();
+
+assert.sameValue(resultAfterMapperThrow.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterMapperThrow.value, undefined, 'the iterator helper is completed');
+assert.sameValue(testIteratorNextCalls, 1, 'the underlying iterator is not stepped again');
+assert.sameValue(testIteratorReturnCalls, 1, 'the underlying iterator is not closed twice');

--- a/test/built-ins/Iterator/prototype/flatMap/inner-iterator-not-closed-when-inner-step-throws.js
+++ b/test/built-ins/Iterator/prototype/flatMap/inner-iterator-not-closed-when-inner-step-throws.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.flatMap
+description: >
+  Only the underlying iterator is closed when stepping the inner iterator throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the inner iterator goes through
+// IfAbruptCloseIterator, which closes the underlying iterator, but not the
+// inner iterator itself.
+let outerReturnCalls = 0;
+let innerReturnCalls = 0;
+
+class TestIterator extends Iterator {
+  next() {
+    return {
+      done: false,
+      value: 1,
+    };
+  }
+  return() {
+    ++outerReturnCalls;
+    return {};
+  }
+}
+
+const innerIterator = {
+  [Symbol.iterator]() {
+    return this;
+  },
+  next() {
+    throw new Test262Error();
+  },
+  return() {
+    ++innerReturnCalls;
+    return {};
+  },
+};
+
+const iterator = new TestIterator().flatMap(() => innerIterator);
+
+assert.throws(Test262Error, function () {
+  iterator.next();
+});
+
+assert.sameValue(outerReturnCalls, 1, 'the underlying iterator is closed');
+assert.sameValue(innerReturnCalls, 0, 'the inner iterator is not closed');

--- a/test/built-ins/Iterator/prototype/flatMap/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/flatMap/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.flatMap
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator().flatMap(v => [v]);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator().flatMap(v => [v]);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator().flatMap(v => [v]);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator().flatMap(v => [v]);
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/forEach/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/forEach/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.forEach
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.forEach(() => {});
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.forEach(() => {});
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.forEach(() => {});
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator();
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.forEach(() => {});
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/map/completed-after-abrupt-completion.js
+++ b/test/built-ins/Iterator/prototype/map/completed-after-abrupt-completion.js
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.map
+description: >
+  The iterator helper is completed after an abrupt completion
+features: [iterator-helpers, class]
+---*/
+
+// The closure of an iterator helper is the body of a generator, so an abrupt
+// completion from it completes the generator: a later next() returns an
+// undefined, done result without stepping the underlying iterator again, and a
+// later return() is not forwarded to it either.
+let throwingIteratorNextCalls = 0;
+let throwingIteratorReturnCalls = 0;
+
+class ThrowingIterator extends Iterator {
+  next() {
+    ++throwingIteratorNextCalls;
+    throw new Test262Error();
+  }
+  return() {
+    ++throwingIteratorReturnCalls;
+    return {};
+  }
+}
+
+const iteratorWithThrowingNext = new ThrowingIterator().map(() => 0);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(throwingIteratorNextCalls, 1);
+
+const resultAfterThrow = iteratorWithThrowingNext.next();
+
+assert.sameValue(resultAfterThrow.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterThrow.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorNextCalls, 1, 'the underlying iterator is not stepped again');
+
+const resultAfterReturn = iteratorWithThrowingNext.return();
+
+assert.sameValue(resultAfterReturn.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterReturn.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorReturnCalls, 0, 'return is not forwarded to the underlying iterator');
+
+// A throw from the mapper closes the underlying iterator and completes the
+// iterator helper as well.
+let testIteratorNextCalls = 0;
+let testIteratorReturnCalls = 0;
+
+class TestIterator extends Iterator {
+  next() {
+    ++testIteratorNextCalls;
+    return {
+      done: false,
+      value: 1,
+    };
+  }
+  return() {
+    ++testIteratorReturnCalls;
+    return {};
+  }
+}
+
+const iteratorWithThrowingMapper = new TestIterator().map(() => {
+  throw new Test262Error();
+});
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingMapper.next();
+});
+
+assert.sameValue(testIteratorNextCalls, 1);
+assert.sameValue(testIteratorReturnCalls, 1, 'the underlying iterator is closed');
+
+const resultAfterMapperThrow = iteratorWithThrowingMapper.next();
+
+assert.sameValue(resultAfterMapperThrow.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterMapperThrow.value, undefined, 'the iterator helper is completed');
+assert.sameValue(testIteratorNextCalls, 1, 'the underlying iterator is not stepped again');
+assert.sameValue(testIteratorReturnCalls, 1, 'the underlying iterator is not closed twice');

--- a/test/built-ins/Iterator/prototype/map/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/map/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.map
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator().map(() => 0);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator().map(() => 0);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator().map(() => 0);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator().map(() => 0);
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/reduce/empty-iterator-not-closed-without-initial-value.js
+++ b/test/built-ins/Iterator/prototype/reduce/empty-iterator-not-closed-without-initial-value.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.reduce
+description: >
+  Underlying iterator is not closed when reduce throws for an empty iterator
+features: [iterator-helpers, class]
+---*/
+
+// The iterator has been exhausted by the time reduce throws for the missing
+// initial value, so it is not closed.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  next() {
+    return {
+      done: true,
+      value: undefined,
+    };
+  }
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+const iterator = new TestIterator();
+
+assert.throws(TypeError, function () {
+  iterator.reduce(() => {});
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/reduce/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/reduce/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.reduce
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.reduce((a, b) => a + b, 0);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.reduce((a, b) => a + b, 0);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.reduce((a, b) => a + b, 0);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator();
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.reduce((a, b) => a + b, 0);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/some/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/some/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.some
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.some(() => false);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.some(() => false);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.some(() => false);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator();
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.some(() => false);
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/take/completed-after-abrupt-completion.js
+++ b/test/built-ins/Iterator/prototype/take/completed-after-abrupt-completion.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.take
+description: >
+  The iterator helper is completed after an abrupt completion
+features: [iterator-helpers, class]
+---*/
+
+// The closure of an iterator helper is the body of a generator, so an abrupt
+// completion from it completes the generator: a later next() returns an
+// undefined, done result without stepping the underlying iterator again, and a
+// later return() is not forwarded to it either.
+let throwingIteratorNextCalls = 0;
+let throwingIteratorReturnCalls = 0;
+
+class ThrowingIterator extends Iterator {
+  next() {
+    ++throwingIteratorNextCalls;
+    throw new Test262Error();
+  }
+  return() {
+    ++throwingIteratorReturnCalls;
+    return {};
+  }
+}
+
+const iteratorWithThrowingNext = new ThrowingIterator().take(5);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(throwingIteratorNextCalls, 1);
+
+const resultAfterThrow = iteratorWithThrowingNext.next();
+
+assert.sameValue(resultAfterThrow.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterThrow.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorNextCalls, 1, 'the underlying iterator is not stepped again');
+
+const resultAfterReturn = iteratorWithThrowingNext.return();
+
+assert.sameValue(resultAfterReturn.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterReturn.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorReturnCalls, 0, 'return is not forwarded to the underlying iterator');

--- a/test/built-ins/Iterator/prototype/take/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/take/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.take
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator().take(5);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator().take(5);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator().take(5);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator().take(5);
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/toArray/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/toArray/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iteratorprototype.toArray
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-helpers, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.toArray();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.toArray();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator();
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.toArray();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator();
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.toArray();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');

--- a/test/built-ins/Iterator/prototype/windows/completed-after-abrupt-completion.js
+++ b/test/built-ins/Iterator/prototype/windows/completed-after-abrupt-completion.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.windows
+description: >
+  The iterator helper is completed after an abrupt completion
+features: [iterator-chunking, class]
+---*/
+
+// The closure of an iterator helper is the body of a generator, so an abrupt
+// completion from it completes the generator: a later next() returns an
+// undefined, done result without stepping the underlying iterator again, and a
+// later return() is not forwarded to it either.
+let throwingIteratorNextCalls = 0;
+let throwingIteratorReturnCalls = 0;
+
+class ThrowingIterator extends Iterator {
+  next() {
+    ++throwingIteratorNextCalls;
+    throw new Test262Error();
+  }
+  return() {
+    ++throwingIteratorReturnCalls;
+    return {};
+  }
+}
+
+const iteratorWithThrowingNext = new ThrowingIterator().windows(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(throwingIteratorNextCalls, 1);
+
+const resultAfterThrow = iteratorWithThrowingNext.next();
+
+assert.sameValue(resultAfterThrow.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterThrow.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorNextCalls, 1, 'the underlying iterator is not stepped again');
+
+const resultAfterReturn = iteratorWithThrowingNext.return();
+
+assert.sameValue(resultAfterReturn.done, true, 'the iterator helper is completed');
+assert.sameValue(resultAfterReturn.value, undefined, 'the iterator helper is completed');
+assert.sameValue(throwingIteratorReturnCalls, 0, 'return is not forwarded to the underlying iterator');

--- a/test/built-ins/Iterator/prototype/windows/underlying-iterator-not-closed-when-step-throws.js
+++ b/test/built-ins/Iterator/prototype/windows/underlying-iterator-not-closed-when-step-throws.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Saúl Ibarra Corretgé. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-iterator.prototype.windows
+description: >
+  Underlying iterator is not closed when stepping it throws
+features: [iterator-chunking, class]
+---*/
+
+// An abrupt completion from stepping the underlying iterator is propagated as
+// is, so the iterator is never closed in this file: only an abrupt completion
+// from the callback goes through IfAbruptCloseIterator.
+let returnCalls = 0;
+
+class TestIterator extends Iterator {
+  return() {
+    ++returnCalls;
+    return {};
+  }
+}
+
+class ThrowingNextIterator extends TestIterator {
+  next() {
+    throw new Test262Error();
+  }
+}
+
+class ThrowingDoneIterator extends TestIterator {
+  next() {
+    return {
+      get done() {
+        throw new Test262Error();
+      },
+      value: 1,
+    };
+  }
+}
+
+class ThrowingValueIterator extends TestIterator {
+  next() {
+    return {
+      done: false,
+      get value() {
+        throw new Test262Error();
+      },
+    };
+  }
+}
+
+class NonObjectIterator extends TestIterator {
+  next() {
+    return null;
+  }
+}
+
+// Underlying iterator has a throwing next method
+const iteratorWithThrowingNext = new ThrowingNextIterator().windows(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingNext.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing done getter
+const iteratorWithThrowingDoneGetter = new ThrowingDoneIterator().windows(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingDoneGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns an object with a throwing value getter
+const iteratorWithThrowingValueGetter = new ThrowingValueIterator().windows(1);
+
+assert.throws(Test262Error, function () {
+  iteratorWithThrowingValueGetter.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');
+
+// Underlying iterator next returns a non-object
+const iteratorWithNonObjectResult = new NonObjectIterator().windows(1);
+
+assert.throws(TypeError, function () {
+  iteratorWithNonObjectResult.next();
+});
+
+assert.sameValue(returnCalls, 0, 'return is not called on the underlying iterator');


### PR DESCRIPTION
- **Add tests for iterator helpers not closing the underlying iterator**
- **Add tests for iterator consumers not closing the underlying iterator**
- **Add tests for iterator helpers completed after an abrupt completion**
- **Add throw path tests for Iterator.prototype.chunks and windows**
- **Add tests for closing the underlying iterator in Iterator.concat**
- **Add a test for Iterator.concat completed after an abrupt completion**
- **Add a test for Iterator.concat returning an Iterator Helper**
- **Add a test for Iterator.concat not closing the underlying iterator**

---

Disclaimer: this PR was made with AI assiatance while working on iterator helpers on QuickJS-NG.

