### PR TITLE
CI: Update of CI actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,8 +1,10 @@
 name: Checks
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
           cache: pip
@@ -30,7 +30,7 @@ jobs:
       - name: Identify new or changed tests
         id: changed_tests
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47.0.6
         with:
           files: test/
 
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Create stable copy of linting tools
         run: |
@@ -75,7 +75,7 @@ jobs:
           ./tools/web-features-stable/lint.py --manifest WEB_FEATURES-manifest-pr.json
 
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
           # The `clean` option must be unset in order to retain the first
@@ -92,7 +92,7 @@ jobs:
       # Checking out the original branch ensures that if the patch under review
       # modified `check-coverage.py` itself, that modified version is used.
       - name: Checkout original branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # The `clean` option must be unset in order to retain the manifest
           # files.
@@ -112,10 +112,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
           cache: pip
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install test262-harness
         run: npm install

--- a/.github/workflows/create-release-for-web-features-manifest.yml
+++ b/.github/workflows/create-release-for-web-features-manifest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/esmeta-test262.yml
+++ b/.github/workflows/esmeta-test262.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -33,7 +33,7 @@ jobs:
 
       - name: Identify new or changed tests
         id: changed_tests
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47.0.6
         with:
           files: test/
 

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -4,72 +4,95 @@ on:
   push:
     branches:
       - main
-    files:
-      - 'tools/**'
   pull_request:
-    files:
-      - 'tools/**'
 
 jobs:
+  changed-tools:
+    name: Check for tools changes
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed.outputs.any_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Identify changed tools files
+        id: changed
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: tools/**
+
   lint:
     name: Test the lint tool
+    needs: changed-tools
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
       - name: Set up Python
+        if: needs.changed-tools.outputs.any_changed == 'true'
         uses: actions/setup-python@v7
         with:
           python-version: '3.x'
           cache: pip
 
       - name: Install dependencies
+        if: needs.changed-tools.outputs.any_changed == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r tools/lint/requirements.txt
 
       - name: Test the lint tool
+        if: needs.changed-tools.outputs.any_changed == 'true'
         run: ./tools/lint/test/run.py
 
   generation:
     name: Test the generation tool
+    needs: changed-tools
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
       - name: Set up Python
+        if: needs.changed-tools.outputs.any_changed == 'true'
         uses: actions/setup-python@v7
         with:
           python-version: '3.x'
           cache: pip
 
       - name: Install dependencies for generation tool
+        if: needs.changed-tools.outputs.any_changed == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r tools/generation/requirements.txt
 
       - name: Test the generation tool
+        if: needs.changed-tools.outputs.any_changed == 'true'
         run: ./tools/generation/test/run.py
 
   web-features:
     name: Test the web-features tooling
+    needs: changed-tools
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
       - name: Set up Python
+        if: needs.changed-tools.outputs.any_changed == 'true'
         uses: actions/setup-python@v7
         with:
           python-version: '3.x'
           cache: pip
 
       - name: Install dependencies for web-features tooling
+        if: needs.changed-tools.outputs.any_changed == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r tools/web-features/requirements.txt
 
       - name: Test the web-features tooling
+        if: needs.changed-tools.outputs.any_changed == 'true'
         run: ./tools/web-features/test/run.py

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
           cache: pip
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
           cache: pip
@@ -56,10 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
           cache: pip

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -2,6 +2,8 @@ name: Test tools
 
 on:
   push:
+    branches:
+      - main
     files:
       - 'tools/**'
   pull_request:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -4,16 +4,29 @@ on:
   push:
     branches:
       - main
-    files:
-      - 'tools/**'
   pull_request:
-    files:
-      - 'tools/**'
 
 jobs:
+  changed-tools:
+    name: Check for tools changes
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed.outputs.any_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Identify changed tools files
+        id: changed
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: tools/**
+
   lint:
     name: Test the lint tool
     runs-on: ubuntu-latest
+    needs: changed-tools
+    if: needs.changed-tools.outputs.any_changed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -35,6 +48,8 @@ jobs:
   generation:
     name: Test the generation tool
     runs-on: ubuntu-latest
+    needs: changed-tools
+    if: needs.changed-tools.outputs.any_changed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -56,6 +71,8 @@ jobs:
   web-features:
     name: Test the web-features tooling
     runs-on: ubuntu-latest
+    needs: changed-tools
+    if: needs.changed-tools.outputs.any_changed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
These new versions should eliminate all of the warnings about actions running on Node 20 rather than Node 24. I looked at the changelogs and it seems that no further changes are needed to the invocations of the actions.

**Edit:** I tacked on a few improvements to the workflow definitions, fixing my own mistake in confusing `files:` and `paths:`, and removing duplicate job runs if the PR is from the same repo. The tools tests are now skipped if no files in the `tools/` folder were changed, ~~but due to a limitation in GitHub (https://github.com/orgs/community/discussions/44490) they still show up as "passed".~~