### PR TITLE
Add tests for out-of-order braced quantifier in regexp literals

### DIFF
--- a/test/language/literals/regexp/invalid-quantifier-out-of-order.js
+++ b/test/language/literals/regexp/invalid-quantifier-out-of-order.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 hexbinoct. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-patterns-static-semantics-early-errors
+description: >
+    Braced quantifier with a lower bound greater than its upper bound
+info: |
+    QuantifierPrefix :: { DecimalDigits , DecimalDigits }
+
+    It is a Syntax Error if the MV of the first DecimalDigits is strictly
+    greater than the MV of the second DecimalDigits.
+
+    Annex B replaces Term with an alternative that admits ExtendedAtom, but
+    B.1.2.1 does not modify this rule, and the ExtendedAtom Quantifier
+    alternative is considered before the bare ExtendedAtom alternative. The
+    SyntaxError is therefore consistent between Annex-B and non-Annex-B
+    environments.
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+/a{2,1}/;

--- a/test/language/literals/regexp/u-invalid-quantifier-out-of-order.js
+++ b/test/language/literals/regexp/u-invalid-quantifier-out-of-order.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 hexbinoct. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-patterns-static-semantics-early-errors
+description: >
+    Braced quantifier with a lower bound greater than its upper bound (`u` flag)
+info: |
+    QuantifierPrefix :: { DecimalDigits , DecimalDigits }
+
+    It is a Syntax Error if the MV of the first DecimalDigits is strictly
+    greater than the MV of the second DecimalDigits.
+
+    The Annex B pattern grammar does not change the syntax of patterns parsed
+    with the [UnicodeMode] parameter, so this rule applies unmodified.
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+/a{2,1}/u;


### PR DESCRIPTION
Fixes #819.

test262 currently covers the `{n,m}` case where n > m only through the RegExp
constructor, in `test/built-ins/RegExp/15.10.2.5-3-1.js` (`new
RegExp("0{2,1}")`), which is a runtime error. The regexp literal form is the
early error, and it has no coverage. There is also an incidental use in
`test/annexB/built-ins/RegExp/prototype/compile/pattern-string-invalid.js`, but
that test is about `compile`.

This adds two tests in `test/language/literals/regexp/`:

* `invalid-quantifier-out-of-order.js` for `/a{2,1}/`
* `u-invalid-quantifier-out-of-order.js` for `/a{2,1}/u`

One note on the issue text. When this was filed in 2017 the rule lived in step 3
of the runtime semantics for `Term :: Atom Quantifier`, and the observation there
was that it looked like a runtime error rather than an early error, with V8 the
only engine treating it that way. In the current spec it is an early error, in
22.2.1.1:

    QuantifierPrefix :: { DecimalDigits , DecimalDigits }
    It is a Syntax Error if the MV of the first DecimalDigits is strictly
    greater than the MV of the second DecimalDigits.

so `phase: parse` is right for both files.

Annex B does not change this. B.1.2.1 adds the `ExtendedAtom ::
InvalidBracedQuantifier` error and modifies the NonemptyClassRanges rules, but
leaves the QuantifierPrefix rule alone, and the Annex B `Term` ordering considers
`ExtendedAtom Quantifier` before bare `ExtendedAtom`, so `a{2,1}` still binds as
an atom with a quantifier. The SyntaxError is the same in Annex-B and
non-Annex-B environments.

Verified with the repo linter, and run against V8 and engine262. I also checked
that swapping `{2,1}` for `{1,2}` makes both tests fail, so they are not passing
because of an unrelated parse error.

The Test262 CLA is signed. I have used my GitHub handle on the copyright lines;
happy to change them to my legal name from the CLA if you would prefer that.
