### PR TITLE
Temporal: Test Duration.prototype.{round,total} with zoned property bags -> out-of-epoch-range

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-large-time-component-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-large-time-component-out-of-range.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Rudolph Gottesheim. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Duration with an overly large time component rounded relative to a property
+  bag with a time zone
+info: |
+  GetTemporalRelativeToOption ( _options_ )
+
+  12. Return the Record { [[PlainRelativeTo]]: *undefined*,
+    [[ZonedRelativeTo]]: _zonedRelativeTo_ }.
+
+  Temporal.Duration.prototype.round ( _roundTo_ )
+
+  27.e. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_,
+    _calendar_, _internalDuration_, ~constrain~).
+features: [Temporal]
+---*/
+
+// A property bag with a time zone yields a [[ZonedRelativeTo]] just as a
+// Temporal.ZonedDateTime or a zoned ISO string does, so the epoch limits apply
+// to it identically.
+const relativeTo = { year: 2000, month: 1, day: 1, timeZone: "UTC" };
+
+const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, Number.MAX_SAFE_INTEGER);
+
+[
+  "nanosecond",
+  "second",
+  "hour",
+  "day",
+  "week",
+  "month",
+  "year",
+].forEach((smallestUnit) => {
+  assert.throws(
+    RangeError,
+    () => d.round({ smallestUnit, relativeTo }),
+    `smallestUnit ${smallestUnit}`
+  );
+});

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-timezone-large-time-component-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-timezone-large-time-component-out-of-range.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Rudolph Gottesheim. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  Duration with an overly large time component total relative to a property bag
+  with a time zone
+info: |
+  GetTemporalRelativeToOption ( _options_ )
+
+  12. Return the Record { [[PlainRelativeTo]]: *undefined*,
+    [[ZonedRelativeTo]]: _zonedRelativeTo_ }.
+
+  Temporal.Duration.prototype.total ( _totalOf_ )
+
+  12.e. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_,
+    _calendar_, _internalDuration_, ~constrain~).
+features: [Temporal]
+---*/
+
+// A property bag with a time zone yields a [[ZonedRelativeTo]] just as a
+// Temporal.ZonedDateTime or a zoned ISO string does, so the epoch limits apply
+// to it identically.
+const relativeTo = { year: 2000, month: 1, day: 1, timeZone: "UTC" };
+
+const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, Number.MAX_SAFE_INTEGER);
+
+[
+  "nanosecond",
+  "second",
+  "hour",
+  "day",
+  "week",
+  "month",
+  "year",
+].forEach((unit) => {
+  assert.throws(RangeError, () => d.total({ unit, relativeTo }), `unit ${unit}`);
+});


### PR DESCRIPTION
While working on increasing coverage of [my PHP port of Temporal](https://github.com/MidnightDesign/temporal-php), my agent (Claude Code) encountered a gap in this test suite: calling `round` or `total` on out-of-epoch-range `Duration`s is never tested with zoned property bags. This adds those tests. The tests were AI-generated.

V8 passes both new tests.