### PR TITLE
Add return abrupt from LengthOfArrayLike in toLocaleString

### DIFF
--- a/test/built-ins/Array/prototype/toLocaleString/return-abrupt-from-this-length.js
+++ b/test/built-ins/Array/prototype/toLocaleString/return-abrupt-from-this-length.js
@@ -6,15 +6,15 @@ esid: sec-array.prototype.tolocalestring
 description: >
   Return abrupt from ToLength(Get(obj, "length")).
 info: |
-  Array.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] )
+  Array.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )
 
-  1. Let array be ? ToObject(this value).
-  2. Let length be ? LengthOfArrayLike(array).
+  1. Let _array_ be ? ToObject(*this* value).
+  2. Let _length_ be ? LengthOfArrayLike(_array_).
   [...]
 
-  LengthOfArrayLike ( obj )
+  LengthOfArrayLike ( _obj_ )
 
-  1. Return ℝ(? ToLength(? Get(obj, "length"))).
+  1. Return ℝ(? ToLength(? Get(_obj_, *"length"*))).
 ---*/
 
 var o1 = {

--- a/test/built-ins/Array/prototype/toLocaleString/return-abrupt-from-this-length.js
+++ b/test/built-ins/Array/prototype/toLocaleString/return-abrupt-from-this-length.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 MooGoong Lee. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.tolocalestring
+description: >
+  Return abrupt from ToLength(Get(obj, "length")).
+info: |
+  Array.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] )
+
+  1. Let array be ? ToObject(this value).
+  2. Let length be ? LengthOfArrayLike(array).
+  [...]
+
+  LengthOfArrayLike ( obj )
+
+  1. Return ℝ(? ToLength(? Get(obj, "length"))).
+---*/
+
+var o1 = {
+  get length() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  Array.prototype.toLocaleString.call(o1);
+});
+
+var o2 = {
+  length: {
+    valueOf: function() {
+      throw new Test262Error();
+    }
+  }
+};
+
+assert.throws(Test262Error, function() {
+  Array.prototype.toLocaleString.call(o2);
+});


### PR DESCRIPTION
This PR adds coverage for cases where [LengthOfArrayLike](https://tc39.es/ecma262/#sec-lengthofarraylike), called in step 2 of [Array.prototype.toLocaleString](https://tc39.es/ecma262/#sec-array.prototype.tolocalestring), returns an abrupt completion originating from [Get](https://tc39.es/ecma262/#sec-get-o-p) or [ToLength](https://tc39.es/ecma262/#sec-tolength).

Array.prototype.toLocaleString converts its this value to an object and obtains that object's length by calling LengthOfArrayLike. Because the method is generic, a caller may supply an arbitrary array-like object as the this value, so an exception must be propagated in both of the following cases:

 - reading the "length" property invokes a getter that throws
 - coercing the retrieved length value invokes a "valueOf" method that throws

The equivalent case is covered for other methods that reach LengthOfArrayLike in the same way: Array.prototype.fill in [test/built-ins/Array/prototype/fill/return-abrupt-from-this-length.js](https://github.com/tc39/test262/blob/main/test/built-ins/Array/prototype/fill/return-abrupt-from-this-length.js). However, it seems that current test cases in Array.prototype.toLocaleString are not checking whether abrupt completion of LengthOfArrayLike function is correctly propagated.