### PR TITLE
Add a test for abrupt completion from the target's length getter in Function.prototype.bind

### DIFF
--- a/test/built-ins/Function/prototype/bind/instance-length-error.js
+++ b/test/built-ins/Function/prototype/bind/instance-length-error.js
@@ -6,14 +6,14 @@ esid: sec-function.prototype.bind
 description: >
   Error thrown when accessing target's `length` property.
 info: |
-  Function.prototype.bind ( thisArg, ...args )
+  Function.prototype.bind ( _thisArg_, ..._args_ )
 
-  1. Let target be the this value.
-  2. If IsCallable(target) is false, throw a TypeError exception.
+  1. Let _target_ be the *this* value.
+  2. If IsCallable(_target_) is *false*, throw a *TypeError* exception.
   [...]
-  5. Let targetHasLength be ? HasOwnProperty(target, "length").
-  6. If targetHasLength is true, then
-    a. Let targetLength be ? Get(target, "length").
+  5. Let _targetHasLength_ be ? HasOwnProperty(_target_, *"length"*).
+  6. If _targetHasLength_ is *true*, then
+    a. Let _targetLength_ be ? Get(_target_, *"length"*).
     [...]
 ---*/
 

--- a/test/built-ins/Function/prototype/bind/instance-length-error.js
+++ b/test/built-ins/Function/prototype/bind/instance-length-error.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 MooGoong Lee. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-function.prototype.bind
+description: >
+  Error thrown when accessing target's `length` property.
+info: |
+  Function.prototype.bind ( thisArg, ...args )
+
+  1. Let target be the this value.
+  2. If IsCallable(target) is false, throw a TypeError exception.
+  [...]
+  5. Let targetHasLength be ? HasOwnProperty(target, "length").
+  6. If targetHasLength is true, then
+    a. Let targetLength be ? Get(target, "length").
+    [...]
+---*/
+
+function fn() {}
+
+Object.defineProperty(fn, "length", {
+  get() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  fn.bind();
+});


### PR DESCRIPTION
This PR adds a test case verifying that [Function.prototype.bind](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype.bind) propagates an abrupt completion produced by [Get](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-get-o-p) in step 6.a.

Function.prototype.bind checks whether `target` (`this` value) has an own "length" property. If it does, step 6.a obtains `targetLength` by performing `Get(target, "length")`. Therefore, if the target's "length" property is an accessor property whose getter throws an exception, Function.prototype.bind must propagate that exception.

The filename and test structure mirror [test/built-ins/Function/prototype/bind/instance-name-error.js](https://github.com/tc39/test262/blob/main/test/built-ins/Function/prototype/bind/instance-name-error.js), which verifies abrupt completion propagation while accessing the target's "name" property, while this PR adds the corresponding test for the target's "length" property.