### PR TITLE
Add a test for an abrupt completion when getting "flags" property in String.prototype.matchAll

### DIFF
--- a/test/built-ins/String/prototype/matchAll/flags-getter-throws.js
+++ b/test/built-ins/String/prototype/matchAll/flags-getter-throws.js
@@ -6,7 +6,7 @@ esid: sec-string.prototype.matchall
 description: >
   Throws error when getting *"flags"* property.
 info: |
-  22.1.3.14 String.prototype.matchAll ( _regexpOrPattern_ )
+  String.prototype.matchAll ( _regexpOrPattern_ )
 
   [...]
   3. If _regexpOrPattern_ is an Object, then

--- a/test/built-ins/String/prototype/matchAll/flags-getter-throws.js
+++ b/test/built-ins/String/prototype/matchAll/flags-getter-throws.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 MooGoong Lee. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-string.prototype.matchall
+description: >
+  Throws error when getting *"flags"* property.
+info: |
+  22.1.3.14 String.prototype.matchAll ( _regexpOrPattern_ )
+
+  [...]
+  3. If _regexpOrPattern_ is an Object, then
+    a. Let _isRegexp_ be ? IsRegExp(_regexpOrPattern_).
+    b. If _isRegexp_ is *true*, then
+      i. Let _flags_ be ? Get(_regexpOrPattern_, *"flags"*).
+  [...]
+features: [Symbol.match]
+---*/
+
+var regexp = {
+  [Symbol.match]: true,
+  get flags() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  ''.matchAll(regexp);
+});


### PR DESCRIPTION
This PR adds a test for abrupt completion propagation resulting from the [Get](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-get-o-p) operation performed in step 3.b.i of [String.prototype.matchAll](https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.matchall).

String.prototype.matchAll determines whether `regexpOrPattern` is a regular expression by performing [IsRegExp](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-isregexp) operation. If IsRegExp returns `true`, it retrieves the "flags" property of `regexpOrPattern`.

This test sets the "Symbol.match" property to `true`, causing IsRegExp to return `true`, and defines "flags" property as a throwing getter. So, accessing this property causes the Get operation to return an abrupt completion, which is then propagated.

Existing [test/built-ins/String/prototype/matchAll/flags-nonglobal-throws.js](https://github.com/tc39/test262/blob/main/test/built-ins/String/prototype/matchAll/flags-nonglobal-throws.js) and [test/built-ins/String/prototype/matchAll/flags-undefined-throws.js](https://github.com/tc39/test262/blob/main/test/built-ins/String/prototype/matchAll/flags-undefined-throws.js) cover failures after the "flags" property has been successfully retrieved. They do not cover an abrupt completion from retrieving the property itself.