### PR TITLE
Correct block-decl-func-skip-arguments for the current FunctionDeclarationInstantiation

### DIFF
--- a/test/annexB/language/function-code/block-decl-func-skip-arguments.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-arguments.js
@@ -11,15 +11,19 @@ info: |
     FunctionDeclarationInstantiation ( _func_, _argumentsList_ )
 
     [...]
-    4. Let _paramNames_ be the BoundNames of _formals_.
+    5. Let _paramNames_ be the BoundNames of _formals_.
     [...]
     22. If _argumentsObjectNeeded_ is *true*, then
       [...]
-      h. Let _paramBindings_ be the list-concatenation of _paramNames_ and
+      f. Let _paramBindings_ be the list-concatenation of _paramNames_ and
          « *"arguments"* ».
     [...]
-    35. If _strict_ is *false*, then
-      a. [normative-optional] If the host is a web browser [...], then
+    31. If _strict_ is *true*, then
+      [...]
+    32. Else,
+      a. [normative-optional] If the host is a web browser or otherwise supports
+         Block-Level Function Declarations Web Legacy Compatibility Semantics,
+         then
         i. For each |FunctionDeclaration| _funcDecl_ that is directly contained in
            the |StatementList| of any |Block|, |CaseClause|, or |DefaultClause| _x_
            such that _code_ Contains _x_ is *true*, do
@@ -36,14 +40,16 @@ info: |
                following steps in place of the |FunctionDeclaration| Evaluation
                algorithm provided in 15.2.6:
               [...]
-              iii. Perform ! _funcEnv_.SetMutableBinding(_funcName_, _funcObj_, *false*).
+              iv. Perform ! _funcEnv_.SetMutableBinding(_funcName_, _funcObj_, *false*).
 
-    The eligibility test in step 2 consults _paramNames_, which does not include the
-    implicit *"arguments"* added to _paramBindings_ by step 22.h. A block-level
-    `function arguments(){}` is therefore eligible, and only the creation of a *new*
-    var binding is skipped for that name -- the binding already exists, holding the
-    arguments object. The assignment in step c.iii still runs, so the arguments object
-    is replaced once the declaration is evaluated.
+    The eligibility test in step 32.a.i.2 consults _paramNames_, which does not
+    include the implicit *"arguments"* added to _paramBindings_ by step 22.f. A
+    block-level `function arguments(){}` is therefore eligible for the
+    |FunctionDeclaration| Evaluation changes, and only the creation of a *new*
+    var binding is skipped for that name -- the binding already exists,
+    initially holding the arguments object. The assignment in step 32.a.i.2.c.iv
+    still runs, so the arguments object is replaced once the declaration is
+    evaluated.
 ---*/
 
 // Simple parameters
@@ -79,8 +85,8 @@ info: |
   assert.sameValue(typeof arguments, "function");
 }());
 
-// A formal parameter really named 'arguments' IS in paramNames, so the
-// declaration is not eligible and the parameter is left alone.
+// A formal parameter named `arguments` *is* in paramNames, so the block-scoped
+// function declaration does not affect outer scope.
 (function(arguments) {
   assert.sameValue(typeof arguments, "number");
   {

--- a/test/annexB/language/function-code/block-decl-func-skip-arguments.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-arguments.js
@@ -2,25 +2,48 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: Functions named 'arguments' have legacy hoisting semantics
+description: >
+    A block-level function named 'arguments' gets no new var binding, but the
+    assignment performed when its declaration is evaluated still runs
 esid: sec-web-compat-functiondeclarationinstantiation
 flags: [noStrict]
 info: |
     FunctionDeclarationInstantiation ( _func_, _argumentsList_ )
 
     [...]
-    7. Let _parameterNames_ be the BoundNames of _formals_.
+    4. Let _paramNames_ be the BoundNames of _formals_.
     [...]
-    22. If argumentsObjectNeeded is true, then
-      f. Append "arguments" to parameterNames.
-
-    Changes to FunctionDeclarationInstantiation
-
-    [...]
-    ii. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_
-        as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is
-        not an element of _parameterNames_, then
+    22. If _argumentsObjectNeeded_ is *true*, then
       [...]
+      h. Let _paramBindings_ be the list-concatenation of _paramNames_ and
+         « *"arguments"* ».
+    [...]
+    35. If _strict_ is *false*, then
+      a. [normative-optional] If the host is a web browser [...], then
+        i. For each |FunctionDeclaration| _funcDecl_ that is directly contained in
+           the |StatementList| of any |Block|, |CaseClause|, or |DefaultClause| _x_
+           such that _code_ Contains _x_ is *true*, do
+          1. Let _funcName_ be the StringValue of the |BindingIdentifier| of _funcDecl_.
+          2. If replacing the |FunctionDeclaration| _funcDecl_ with a |VariableStatement|
+             that has _funcName_ as a |BindingIdentifier| would not produce any Early
+             Errors for _func_ and _paramNames_ does not contain _funcName_, then
+            [...]
+            b. If _instantiatedVariableNames_ does not contain _funcName_ and _funcName_
+               is not *"arguments"*, then
+              i. Perform ! _variableEnv_.CreateMutableBinding(_funcName_, *false*).
+              [...]
+            c. When the |FunctionDeclaration| _funcDecl_ is evaluated, perform the
+               following steps in place of the |FunctionDeclaration| Evaluation
+               algorithm provided in 15.2.6:
+              [...]
+              iii. Perform ! _funcEnv_.SetMutableBinding(_funcName_, _funcObj_, *false*).
+
+    The eligibility test in step 2 consults _paramNames_, which does not include the
+    implicit *"arguments"* added to _paramBindings_ by step 22.h. A block-level
+    `function arguments(){}` is therefore eligible, and only the creation of a *new*
+    var binding is skipped for that name -- the binding already exists, holding the
+    arguments object. The assignment in step c.iii still runs, so the arguments object
+    is replaced once the declaration is evaluated.
 ---*/
 
 // Simple parameters
@@ -31,7 +54,7 @@ info: |
     function arguments() {}
     assert.sameValue(arguments(), undefined);
   }
-  assert.sameValue(arguments.toString(), "[object Arguments]");
+  assert.sameValue(typeof arguments, "function");
 }());
 
 // Single named parameter
@@ -42,7 +65,7 @@ info: |
     function arguments() {}
     assert.sameValue(arguments(), undefined);
   }
-  assert.sameValue(arguments.toString(), "[object Arguments]");
+  assert.sameValue(typeof arguments, "function");
 }());
 
 // Non-simple parameters
@@ -53,5 +76,15 @@ info: |
     function arguments() {}
     assert.sameValue(arguments(), undefined);
   }
-  assert.sameValue(arguments.toString(), "[object Arguments]");
+  assert.sameValue(typeof arguments, "function");
 }());
+
+// A formal parameter really named 'arguments' IS in paramNames, so the
+// declaration is not eligible and the parameter is left alone.
+(function(arguments) {
+  assert.sameValue(typeof arguments, "number");
+  {
+    function arguments() {}
+  }
+  assert.sameValue(typeof arguments, "number");
+}(1));


### PR DESCRIPTION
Fixes #5113

`annexB/language/function-code/block-decl-func-skip-arguments.js` was written in 2017 against an edition of FunctionDeclarationInstantiation that appended `"arguments"` to `parameterNames` — which its own `info` block quotes:

> 22. If argumentsObjectNeeded is true, then
>   f. Append "arguments" to parameterNames.

Under that edition a block-level `function arguments(){}` was ineligible for the Annex B var alias entirely, so the arguments object survived the block. That step no longer exists.

The current algorithm keeps **two** lists. [Step 22.h](https://tc39.es/ecma262/#sec-functiondeclarationinstantiation) builds `paramBindings` as "the list-concatenation of _paramNames_ and « *"arguments"* »", while the web-compat eligibility test consults `paramNames`:

> If replacing the FunctionDeclaration funcDecl with a VariableStatement that has funcName as a BindingIdentifier would not produce any Early Errors for func and **_paramNames_ does not contain _funcName_**, then

So a block-level function named `arguments` **is** eligible. Within that branch, the `funcName is not "arguments"` guard covers only the creation of a *new* var binding — that binding already exists, holding the arguments object — while the alternative declaration-evaluation step is a sibling step that still runs:

> iii. Perform ! funcEnv.SetMutableBinding(funcName, funcObj, false).

The arguments object is therefore replaced once the declaration is evaluated, and the three assertions after the block are wrong.

### This file contradicts another test in this suite

`staging/sm/lexical-environment/block-scoped-functions-annex-b-arguments.js` asserts the opposite for the identical shape:

```js
assert.sameValue(typeof arguments, "object");
{ function arguments() {} }
assert.sameValue(typeof arguments, "function");
```

### Implementations

Both engines side with the staging file. On V8 (node 24.19.0):

```
(function(){ { function arguments(){} } return typeof arguments })()        // "function"
(function(x){ { function arguments(){} } return typeof arguments })()       // "function"
(function(..._){ { function arguments(){} } return typeof arguments })()    // "function"
(function(arguments){ { function arguments(){} } return typeof arguments })(1)  // "number"
```

SpiderMonkey agrees — the staging file is its own test, contributed upstream.

### What this PR changes

- The three post-block assertions now expect the function.
- The `info` block is rewritten against the current text, with a note explaining why the eligibility test and the `"arguments"` guard consult different things.
- Adds a fourth case pinning the other side of the distinction: a formal parameter *really* named `arguments` **is** in `paramNames`, so the declaration is not eligible and the parameter is left alone. That case had no coverage and is what makes the two lists observably different.

The assertions before and inside the block are unchanged and were already correct. The edited file passes on V8; the filename is left alone to avoid breaking downstream exclusion lists.

Found while enabling `staging/` in [Jint](https://github.com/sebastienros/jint) (sebastienros/jint#3021), where the two files cannot both pass.