### PR TITLE
Handle auto-rebase actions in CI table

### DIFF
--- a/.github/workflows/engine-tests-report.yml
+++ b/.github/workflows/engine-tests-report.yml
@@ -42,6 +42,23 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
+      - name: Download PR number
+        uses: actions/download-artifact@v8
+        with:
+          name: pr_number.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR number
+        id: pr
+        run: |
+          PR_NUMBER="$(head pr_number.txt -n1)"
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Unexpected contents of pr_number.txt: $PR_NUMBER"
+            exit 1
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
       - name: Check for results
         id: check
         run: |
@@ -63,4 +80,4 @@ jobs:
         with:
           path: comment-body.txt
           header: test262-engine-results
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/engine-tests.yml
+++ b/.github/workflows/engine-tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   changed-tests:
-    name: Identify changed tests
+    name: Prepare engine tests run
     runs-on: ubuntu-latest
     outputs:
       any_changed: ${{ steps.changed.outputs.any_changed }}
@@ -19,6 +19,15 @@ jobs:
         uses: tj-actions/changed-files@v47.0.6
         with:
           files: test/
+
+      - name: Record PR number
+        run: echo "${{ github.event.number }}" > pr_number.txt
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@v7
+        with:
+          path: pr_number.txt
+          archive: false
 
   # Future work:
   # - Run each step of the matrix on main as well, and indicate in the table


### PR DESCRIPTION
A limitation of the engine-tests-report workflow running as a separate, trusted workflow was that if you rebased a branch in the GitHub UI using the "Update branch" button, it wouldn't have access to the PR number in github.event.workflow_run.pull_requests. This array is allowed to be empty according to the GitHub Actions docs. So the table wouldn't get created or updated.

So instead save the PR number while preparing to run the engine-tests jobs (the original, untrusted workflow always has a PR number) and upload it as an artifact, which is downloaded by the engine-tests-report workflow.

Another option might be to use the jwalton/gh-find-current-pr action, but I wasn't super confident it would be actively maintained.

LLM disclosure: I used a bot to evaluate a couple of potential solutions, generated one, then hand-edited the generated code (it initially didn't work)