### PR TITLE
Update ESMeta version to v0.8.0

### DIFF
--- a/.github/workflows/esmeta-test262.yml
+++ b/.github/workflows/esmeta-test262.yml
@@ -25,7 +25,7 @@ jobs:
       - name: download esmeta
         run: |
           mkdir -p "${ESMETA_HOME}"
-          git clone --branch v0.7.1 --depth 1 https://github.com/es-meta/esmeta.git "${ESMETA_HOME}"
+          git clone --branch v0.8.0 --depth 1 https://github.com/es-meta/esmeta.git "${ESMETA_HOME}"
           cd "${ESMETA_HOME}" && git submodule update --init --depth 1
       - name: build esmeta
         working-directory: ${{ env.ESMETA_HOME }}


### PR DESCRIPTION
The latest version [v0.8.0](https://github.com/es-meta/esmeta/releases/tag/v0.8.0) of ESMeta supports ES2026 ([es-meta/esmeta#345](https://github.com/es-meta/esmeta/pull/345)). 

It also adds support for features such as `Array.fromAsync` and `Error.isError`, so this update could cover more tests.