### PR TITLE
Fix duplicate include directive in TypedArray set test

### DIFF
--- a/test/built-ins/TypedArray/prototype/set/BigInt/src-typedarray-not-big-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/src-typedarray-not-big-throws.js
@@ -15,7 +15,7 @@ info: |
       other does not, throw a TypeError exception.
   ...
 
-includes: [testTypedArray.js, testTypedArray.js]
+includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/set/src-typedarray-big-throws.js
+++ b/test/built-ins/TypedArray/prototype/set/src-typedarray-big-throws.js
@@ -15,7 +15,7 @@ info: |
       other does not, throw a TypeError exception.
   ...
 
-includes: [testTypedArray.js, testTypedArray.js]
+includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArrayConstructors/ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
+++ b/test/built-ins/TypedArrayConstructors/ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
@@ -17,7 +17,7 @@ info: |
     c. If one of srcType and elementType contains the substring "Big" and the other
        does not, throw a TypeError exception.
 
-includes: [testTypedArray.js, testTypedArray.js]
+includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/src-typedarray-big-throws.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/src-typedarray-big-throws.js
@@ -17,7 +17,7 @@ info: |
     c. If one of srcType and elementType contains the substring "Big" and the other
        does not, throw a TypeError exception.
 
-includes: [testTypedArray.js, testTypedArray.js]
+includes: [testTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 
@@ -34,4 +34,3 @@ testWithBigIntTypedArrayConstructors(function(BTA, makeCtorArg) {
   });
 
 });
-


### PR DESCRIPTION
Remove duplicate 'testTypedArray.js' from the includes list in src-typedarray-not-big-throws.js.

The includes directive had the same file listed twice, which is unnecessary.