### PR TITLE
linter: catch duplicated items in includes array

### DIFF
--- a/tools/lint/lib/checks/includes.py
+++ b/tools/lint/lib/checks/includes.py
@@ -53,10 +53,13 @@ class CheckIncludes(Check):
         if meta['includes'] != CheckIncludes._get_includes_flow_list(source):
             return 'If present, the `includes` tag must use flow style, eg. includes: [include1.js, include2.js]'
 
-        harness_files = [self._load(name) for name in meta['includes']]
-
-        if len(harness_files) == 0:
+        if len(meta['includes']) == 0:
             return 'If present, the `includes` tag must have at least one member'
+
+        if len(set(meta['includes'])) != len(meta['includes']):
+            return 'The `includes` tag must not include duplicate entries'
+
+        harness_files = [self._load(name) for name in meta['includes']]
 
         without_frontmatter = self._remove_frontmatter(source)
 

--- a/tools/lint/test/fixtures/test/includes_duplicated.js
+++ b/tools/lint/test/fixtures/test/includes_duplicated.js
@@ -1,0 +1,11 @@
+INCLUDES
+^ expected errors | v input
+// Copyright (C) 2026 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: Minimal test
+includes: [detachArrayBuffer.js, detachArrayBuffer.js]
+---*/
+
+$DETACHBUFFER();


### PR DESCRIPTION
Would have caught the tests in https://github.com/tc39/test262/pull/5119.