### PR TITLE
docs: stop claiming python 2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -393,7 +393,9 @@ asyncTest(async function() {
 
 ## A Note on Python-based tools
 
-This project's internal tooling is built with Python. Contributors seeking to interact with these tools should begin by installing [Python version 2](https://www.python.org/) and [PIP](https://pypi.org/project/pip/). This guide includes instructions for installing packages using PIP directly, but contributors are welcomed to use utilities such as [virtualenv](https://pypi.org/project/virtualenv/), [pyenv](https://github.com/pyenv/pyenv), or [pipenv](https://pypi.org/project/pipenv/) should they have more advanced package management needs.
+This project's internal tooling is built with Python. Contributors seeking to interact with these tools should begin by installing [Python 3](https://www.python.org/) and [pip](https://pypi.org/project/pip/). This guide includes instructions for installing packages using PIP directly, but contributors are welcomed to use utilities such as [virtualenv](https://pypi.org/project/virtualenv/), [pyenv](https://github.com/pyenv/pyenv), or [pipenv](https://pypi.org/project/pipenv/) should they have more advanced package management needs.
+
+Some older scripts that are no longer in active use require Python 2.
 
 ## Linting
 


### PR DESCRIPTION
Probably we should clean up the old python-2-requiring stuff ([e.g.](https://github.com/tc39/test262/tree/main/tools/packaging)) that's not in use but at least we shouldn't claim to require python 2 since all the stuff we actually use is written for (and sometimes requires) python 3.